### PR TITLE
feat: v0.1 code stabilization — error hierarchy, spec loader, robust pipeline

### DIFF
--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -1,277 +1,326 @@
 # API Contract — KPubData Builder
 
-KPubData Builder는 터미널(CLI)과 파이썬 코드(Service-level API) 두 가지 방식으로 사용할 수 있습니다.
+## 1. 문서 목적
 
-## 1. CLI Commands (명령줄 도구)
+이 문서는 **Studio 중심 계약이 아니라 Builder 중심 계약**을 정의합니다.
 
-터미널에서 `kpubdata-builder` 명령어를 통해 실행할 수 있습니다.
+- Builder는 BuildSpec 검증, preview, build 실행, manifest 조회, publish 실행을 제공하는 실행 서비스입니다.
+- Studio는 이 계약을 호출하는 외부 UI 클라이언트일 뿐입니다.
+- CLI와 향후 HTTP service mode는 같은 도메인 계약을 공유해야 합니다.
 
-```mermaid
-flowchart TD
-    V[validate] -- "Spec YAML" --> P[preview]
-    P -- "Sample Data" --> B[build]
-    B -- "Files + Manifest" --> PUB[publish]
-    
-    subgraph "Input / Output"
-        V1[YAML File] -.-> V
-        V -- "Result" -.-> V2[OK / Error Msg]
-        P -- "Output" -.-> P2[Schema + 5 Rows]
-        B -- "Output" -.-> B2[Artifacts + manifest.json]
-        PUB -- "Output" -.-> PUB2[URL / Success]
-    end
-```
+## 2. 실행 모델
 
-### 1.1 validate (검증)
-작성한 빌드 기획서(BuildSpec YAML)에 문법 오류나 논리적 오류가 없는지 확인합니다.
-- **사용 예시:** `kpubdata-builder validate spec.yaml`
-- **옵션:** `--strict` (더 엄격한 규칙 적용)
-- **출력:** "Success" 또는 상세 오류 메시지
+Builder는 두 가지 실행 모델을 가집니다.
 
-### 1.2 preview (미리보기)
-데이터를 아주 조금만 가져와서, 실제로 어떤 항목들이 들어있고 어떤 모양으로 파일이 만들어질지 살짝 보여줍니다.
-- **사용 예시:** `kpubdata-builder preview spec.yaml`
-- **출력:** 데이터 스키마(항목 이름들)와 처음 5건의 샘플 데이터
+| 모델 | 설명 | 적합한 작업 |
+| :--- | :--- | :--- |
+| **Sync** | 요청-응답 안에서 결과를 바로 반환 | `/datasets`, `/spec/validate`, `/preview` |
+| **Async** | build를 생성하고 상태를 폴링 | `/builds`, `/builds/{id}`, `/builds/{id}/manifest`, `/builds/{id}/artifacts`, `/publish` |
 
-### 1.3 build (빌드 실행)
-실제로 공공데이터를 모두 가져와서 파일을 만들고, 결과 보고서(Manifest)까지 생성합니다.
-- **사용 예시:** `kpubdata-builder build spec.yaml --output-dir ./dist`
-- **출력:** 생성된 파일 목록 및 `manifest.json`
+원칙:
 
-### 1.4 publish (배포)
-빌드가 완료된 파일들을 외부 저장소(Hugging Face 등)로 올립니다.
-- **사용 예시:** `kpubdata-builder publish spec.yaml`
+- **검증과 preview는 동기식**으로 제공 가능합니다.
+- **실제 build와 publish는 비동기식**으로 모델링하는 것을 기본값으로 둡니다.
 
----
+## 3. 표준 에러 응답
 
-## 2. Service-level Operations (파이썬 코드 API)
+모든 실패 응답은 아래 형태를 따릅니다.
 
-다른 파이썬 프로그램에서 Builder의 기능을 가져와 쓰고 싶을 때 사용합니다.
-
-```mermaid
-sequenceDiagram
-    participant C as Client (App)
-    participant B as Builder Service
-    participant V as Validator
-    participant E as Executor
-    participant EX as Exporter
-    participant M as ManifestWriter
-
-    C->>B: execute_build(spec_path, output_dir)
-    B->>V: validate_spec(spec)
-    V-->>B: OK or SpecValidationError
-    B->>E: source_executor(spec, client)
-    E-->>B: ExecutionResult (records + errors)
-    alt errors 없음
-        B->>EX: export_all(dataset, output_dir)
-        EX-->>B: List of file paths
-    end
-    B->>M: build_manifest(spec, results)
-    M-->>B: BuildManifest object
-    B->>M: manifest_writer(manifest, path)
-    B-->>C: Return BuildManifest
-```
-
-### 2.1 validate_spec
-- **시그니처:** `validate_spec(spec_path: str) -> ValidationResult`
-- **파라미터:** `spec_path` (YAML 파일 경로)
-- **반환값:** 오류 목록을 포함한 결과 객체
-
-### 2.2 preview_build
-- **시그니처:** `preview_build(spec_path: str) -> ArtifactDataset`
-- **파라미터:** `spec_path` (YAML 파일 경로)
-- **반환값:** 샘플 데이터가 들어있는 데이터셋 객체
-
-### 2.3 execute_build
-- **시그니처:** `execute_build(spec_path: str, output_dir: str) -> BuildManifest`
-- **파라미터:** `spec_path` (기획서 경로), `output_dir` (저장할 폴더 경로)
-- **반환값:** 빌드 실행 요약 정보가 담긴 Manifest 객체
-
-### 2.4 publish_build
-- **시그니처:** `publish_build(spec_path: str, target: Optional[str] = None) -> bool`
-- **파라미터:** `target` (특정 배포처 이름)
-- **반환값:** 배포 성공 여부 (True/False)
-
----
-
-## 3. Manifest Contract (결과 명세서 예시)
-
-빌드가 성공하면 항상 `manifest.json` 파일이 생성됩니다. 이 파일은 빌드가 제대로 되었는지 확인하는 영수증과 같습니다.
-
-```mermaid
-graph TD
-    M[manifest.json] --> B[build_id]
-    M --> S[spec_digest]
-    M --> T[timestamps]
-    M --> SRC[sources]
-    M --> ART[artifact_paths]
-    M --> RC[record_count]
-    M --> WE[warnings_errors]
-    
-    T --> SA[started_at]
-    T --> FA[finished_at]
-    
-    SRC --> PRV[provider]
-    SRC --> DST[dataset]
-    SRC --> RF[records_fetched]
-```
-
-### 3.1 JSON Output 예시 (성공)
 ```json
 {
-  "build_id": "bld-20250401-abc1234",
-  "status": "succeeded",
-  "spec_digest": "sha256:d8e8f8...",
-  "started_at": "2025-04-01T10:00:00Z",
-  "finished_at": "2025-04-01T10:05:30Z",
-  "sources": [
-    {
-      "provider": "datago",
-      "dataset": "village_fcst",
-      "status": "succeeded",
-      "records_fetched": 1500
-    }
-  ],
-  "artifact_paths": [
-    "artifacts/weather_report.md",
-    "artifacts/data.jsonl"
-  ],
-  "record_count": 1500,
-  "warnings": [],
-  "errors": []
+  "error": {
+    "code": "INVALID_BUILD_SPEC",
+    "message": "source.provider is required",
+    "details": [
+      {"field": "source.provider", "reason": "missing"}
+    ]
+  }
 }
 ```
 
-### 3.2 핵심 필드 설명
-- `build_id`: 이번 빌드에 부여된 고유 번호
-- `spec_digest`: 어떤 기획서로 빌드했는지 식별하는 지문 (기획서가 바뀌면 이 값도 바뀝니다)
-- `record_count`: 최종적으로 수집된 데이터의 총 개수
-- `warnings`: 빌드 중에 발생한 사소한 문제들 (데이터 항목 누락 등)
+| 필드 | 타입 | 설명 |
+| :--- | :--- | :--- |
+| `error.code` | string | 안정적인 기계 판독용 오류 코드 |
+| `error.message` | string | 사람이 읽는 요약 메시지 |
+| `error.details` | array<object> | 필드별 세부 정보 |
 
-### 3.3 빌드 실패 시 Manifest
+## 4. 엔드포인트 요약
 
-빌드가 실패하더라도 `manifest.json`은 항상 생성됩니다. 실패 manifest는 감사 추적과 디버깅에 사용됩니다.
+| 엔드포인트 | 메서드 | 목적 | 실행 모델 |
+| :--- | :--- | :--- | :--- |
+| `/datasets` | `GET` | 사용 가능한 dataset/source 메타데이터 조회 | Sync |
+| `/spec/validate` | `POST` | BuildSpec 검증 | Sync |
+| `/preview` | `POST` | 샘플 실행 및 export preview | Sync |
+| `/builds` | `POST` | 새로운 build 실행 시작 | Async |
+| `/builds/{id}` | `GET` | build 상태 조회 | Async |
+| `/builds/{id}/manifest` | `GET` | build manifest 조회 | Async |
+| `/builds/{id}/artifacts` | `GET` | build artifact 목록 조회 | Async |
+| `/publish` | `POST` | artifact 게시 실행 | Async |
+
+## 5. 엔드포인트 상세
+
+### 5.1 `GET /datasets`
+
+Builder가 실행 가능한 dataset/source 카탈로그를 반환합니다.
+
+#### Response `200`
 
 ```json
 {
-  "build_id": "bld-20250401-abc1234",
-  "status": "failed",
-  "spec_digest": "sha256:d8e8f8...",
-  "started_at": "2025-04-01T10:00:00Z",
-  "finished_at": "2025-04-01T10:00:12Z",
-  "sources": [
+  "datasets": [
     {
       "provider": "datago",
       "dataset": "village_fcst",
-      "status": "failed",
-      "error": "TransportTimeoutError: Request timed out after 3 attempts"
+      "supports_preview": true,
+      "supported_exports": ["markdown", "jsonl", "parquet"]
     }
-  ],
-  "artifact_paths": [],
-  "record_count": 0,
-  "warnings": [],
-  "errors": [
-    "Source 'datago.village_fcst' fetch failed: Request timed out after 3 attempts"
   ]
 }
 ```
 
-### 3.4 부분 실패(Partial Failure) 시 Manifest
+### 5.2 `POST /spec/validate`
 
-`sources`에 여러 provider를 넣었을 때, 일부 source만 실패하는 경우:
+BuildSpec을 실행 전에 검증합니다.
+
+#### Request
 
 ```json
 {
-  "build_id": "bld-20250401-def5678",
-  "status": "failed",
-  "spec_digest": "sha256:a1b2c3...",
-  "started_at": "2025-04-01T10:00:00Z",
-  "finished_at": "2025-04-01T10:01:30Z",
-  "sources": [
-    {
+  "spec": {
+    "version": "1",
+    "dataset": "weather-village-forecast",
+    "source": {
       "provider": "datago",
-      "dataset": "village_fcst",
-      "status": "succeeded",
-      "records_fetched": 1500
+      "dataset": "village_fcst"
     },
-    {
+    "export": {
+      "format": "markdown"
+    },
+    "output": {
+      "dir": "./dist/weather"
+    }
+  }
+}
+```
+
+#### Response `200`
+
+```json
+{
+  "valid": true,
+  "issues": []
+}
+```
+
+#### Response `422`
+
+```json
+{
+  "error": {
+    "code": "INVALID_BUILD_SPEC",
+    "message": "source.provider is required",
+    "details": [
+      {"field": "source.provider", "reason": "missing"}
+    ]
+  }
+}
+```
+
+### 5.3 `POST /preview`
+
+BuildSpec을 바탕으로 제한된 샘플 실행 결과와 export preview를 반환합니다.
+
+#### Request
+
+```json
+{
+  "spec": {
+    "version": "1",
+    "dataset": "weather-village-forecast",
+    "source": {
       "provider": "datago",
-      "dataset": "air_quality",
-      "status": "failed",
-      "error": "AuthError: Invalid API key"
+      "dataset": "village_fcst",
+      "params": {
+        "base_date": "20250401",
+        "nx": 55,
+        "ny": 127
+      }
+    },
+    "export": {
+      "format": "markdown"
+    },
+    "output": {
+      "dir": "./dist/weather"
+    }
+  },
+  "limit": 5
+}
+```
+
+#### Response `200`
+
+```json
+{
+  "records": [
+    {
+      "baseDate": "20250401",
+      "baseTime": "0500",
+      "category": "TMP",
+      "fcstValue": "15"
     }
   ],
-  "artifact_paths": [],
-  "record_count": 0,
-  "warnings": [],
-  "errors": [
-    "Source 'datago.air_quality' fetch failed: Invalid API key"
+  "schema": {
+    "baseDate": "string",
+    "baseTime": "string",
+    "category": "string",
+    "fcstValue": "string"
+  },
+  "export_preview": {
+    "format": "markdown",
+    "artifact_path": "./dist/weather/README.md"
+  }
+}
+```
+
+### 5.4 `POST /builds`
+
+새로운 build run을 생성합니다.
+
+#### Request
+
+```json
+{
+  "spec": {
+    "version": "1",
+    "dataset": "weather-village-forecast",
+    "source": {
+      "provider": "datago",
+      "dataset": "village_fcst"
+    },
+    "export": {
+      "format": "markdown"
+    },
+    "output": {
+      "dir": "./dist/weather"
+    }
+  }
+}
+```
+
+#### Response `202`
+
+```json
+{
+  "build_id": "bld_20260423_001",
+  "state": "validated",
+  "status_url": "/builds/bld_20260423_001"
+}
+```
+
+### 5.5 `GET /builds/{id}`
+
+build run 상태를 반환합니다.
+
+#### Response `200`
+
+```json
+{
+  "build_id": "bld_20260423_001",
+  "dataset": "weather-village-forecast",
+  "state": "running",
+  "started_at": "2026-04-23T09:00:00Z",
+  "updated_at": "2026-04-23T09:00:05Z"
+}
+```
+
+### 5.6 `GET /builds/{id}/manifest`
+
+manifest가 생성된 이후 manifest 본문을 반환합니다.
+
+#### Response `200`
+
+```json
+{
+  "build_id": "bld_20260423_001",
+  "state": "manifested",
+  "manifest": {
+    "spec_version": "1",
+    "dataset": "weather-village-forecast",
+    "artifacts": [
+      {
+        "path": "./dist/weather/README.md",
+        "format": "markdown"
+      }
+    ]
+  }
+}
+```
+
+### 5.7 `GET /builds/{id}/artifacts`
+
+artifact 목록과 메타데이터를 반환합니다.
+
+#### Response `200`
+
+```json
+{
+  "build_id": "bld_20260423_001",
+  "artifacts": [
+    {
+      "path": "./dist/weather/README.md",
+      "format": "markdown",
+      "size_bytes": 2048
+    }
   ]
 }
 ```
 
-> **기본 정책**: source 하나라도 실패하면 build 전체가 실패합니다. 부분 성공 artifact는 생성하지 않습니다.
+### 5.8 `POST /publish`
 
----
+이미 생성된 build artifact를 게시합니다.
 
-## 4. Error Contract (에러 응답 규약)
+#### Request
 
-### 4.1 예외 계층
-
-Builder의 모든 런타임 에러는 `BuildError` 하위 클래스로 표현됩니다.
-
-```text
-BuildError (base)
-├── SpecLoadError          — YAML 파일 I/O 또는 파싱 실패
-├── SpecValidationError    — 스펙 검증 실패 (여러 이슈 집계 가능)
-├── SourceExecutionError   — source 데이터 fetch 실패
-├── AssemblyError          — 데이터 조립 실패
-├── ExportError            — 파일 생성/쓰기 실패
-├── ManifestWriteError     — manifest 쓰기 실패
-└── PublishError           — 외부 저장소 배포 실패
+```json
+{
+  "build_id": "bld_20260423_001",
+  "target": {
+    "kind": "huggingface",
+    "repository": "org/weather-village-forecast"
+  }
+}
 ```
 
-### 4.2 에러 발생 시나리오
+#### Response `202`
 
-| 단계 | 에러 타입 | 발생 원인 |
-|:---|:---|:---|
-| Spec 로딩 | `SpecLoadError` | YAML 파일 없음, 읽기 권한 없음, YAML 문법 오류 |
-| Spec 검증 | `SpecValidationError` | dataset_id 비어 있음, sources 없음, alias 중복 등 |
-| Source 실행 | `SourceExecutionError` | API 무응답, 인증 실패, 응답 파싱 실패 등 |
-| 데이터 조립 | `AssemblyError` | source key 누락 |
-| 내보내기 | `ExportError` | 디스크 공간 부족, 파일 쓰기 권한 없음 |
-| Manifest 쓰기 | `ManifestWriteError` | 디스크 I/O 실패 |
-| 배포 | `PublishError` | 네트워크/인증 실패, 원격 저장소 오류 |
-
-### 4.3 validate_spec 에러 응답
-
-검증 실패 시 첫 번째 오류에서 즉시 중단하지 않고, 모든 이슈를 모아 한 번에 보고합니다.
-
-```python
-try:
-    validate_spec(spec)
-except SpecValidationError as e:
-    print(e.issues)
-    # ("dataset_id must be a non-empty string",
-    #  "source alias 'forecast' is duplicated",
-    #  "export output_path is empty")
+```json
+{
+  "publish_id": "pub_20260423_001",
+  "build_id": "bld_20260423_001",
+  "state": "queued"
+}
 ```
 
-> 자세한 에러 처리 설계는 [docs/ERROR_HANDLING.md](./docs/ERROR_HANDLING.md)를 참조하세요.
+## 6. 상태와 응답 원칙
 
----
+- `draft`, `validated`, `running`, `exported`, `manifested`, `published`, `failed` 상태는 [BUILD_STATE.md](./BUILD_STATE.md)를 따릅니다.
+- `manifest`는 `manifested` 이상 상태에서 조회 가능해야 합니다.
+- `artifacts`는 `exported` 이상 상태에서 조회 가능해야 합니다.
+- `published`는 publish 단계 성공을 의미하며 build artifact 생성 성공과는 구분됩니다.
 
-## 관련 문서
+## 7. CLI 대응 관계
 
-### 이 저장소 내 문서
+| CLI | 대응 API |
+| :--- | :--- |
+| `kpubdata-builder validate spec.yaml` | `POST /spec/validate` |
+| `kpubdata-builder preview spec.yaml` | `POST /preview` |
+| `kpubdata-builder build spec.yaml` | `POST /builds` + `GET /builds/{id}` |
+| `kpubdata-builder publish --build-id ...` | `POST /publish` |
+
+## 8. 관련 문서
+
 | 문서 | 설명 |
 | :--- | :--- |
-| [ARCHITECTURE.md](./ARCHITECTURE.md) | 시스템 아키텍처 설계 |
-| [DOMAIN_MODEL.md](./DOMAIN_MODEL.md) | 도메인 모델 정의 |
-| [EXPORT_MODEL.md](./EXPORT_MODEL.md) | 데이터 변환 모델 |
-| [docs/ERROR_HANDLING.md](./docs/ERROR_HANDLING.md) | 에러 처리 설계 |
-
-### KPubData Product Family
-| 저장소 | 문서 | 설명 |
-| :--- | :--- | :--- |
-| [kpubdata](https://github.com/yeongseon/kpubdata) | [API_SPEC.md](https://github.com/yeongseon/kpubdata/blob/main/API_SPEC.md) | Core API 명세 |
-| [kpubdata-studio](https://github.com/yeongseon/kpubdata-studio) | [API_CONTRACT.md](https://github.com/yeongseon/kpubdata-studio/blob/main/API_CONTRACT.md) | Studio 인터페이스 규약 |
+| [BUILD_SPEC.md](./BUILD_SPEC.md) | BuildSpec 입력 계약 |
+| [BUILD_STATE.md](./BUILD_STATE.md) | build 상태 머신 |
+| [BOUNDARY.md](./BOUNDARY.md) | Builder-Studio 경계 |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,251 +1,120 @@
 # Architecture — KPubData Builder
 
-## 0. "Builder가 뭔가요?" (초보자용 설명)
+## 1. 역할 정의
 
-KPubData Builder는 **"공공데이터 요리 주방"**과 같습니다.
+`kpubdata-builder`는 **재현 가능한 공공데이터 데이터셋 조립을 위한 실행 엔진**입니다.
 
-*   **요리 레시피 (BuildSpec):** 어떤 재료(공공데이터)를 가져와서, 어떻게 손질(변환)하고, 어떤 그릇(파일 형식)에 담을지 적어둔 문서입니다.
-*   **주방 (Builder):** 이 레시피를 읽고 실제로 데이터를 가져와서 요리를 완성해주는 시스템입니다.
-*   **완성된 요리 (Artifact):** 사용자가 바로 먹을 수 있게(읽을 수 있게) 완성된 데이터셋이나 보고서입니다.
+Builder의 핵심 역할은 다음과 같습니다.
 
-개발 경험이 없더라도, 레시피(YAML 파일)만 잘 작성하면 Builder가 복잡한 데이터 수집과 변환 과정을 대신 처리해줍니다.
+- BuildSpec을 읽고 검증한다.
+- `kpubdata`를 통해 source 실행을 위임한다.
+- 결과 레코드를 exporter에 전달해 artifact를 만든다.
+- 모든 실행을 manifest로 기록한다.
+- 필요 시 publisher를 통해 외부 대상에 게시한다.
 
-## 1. Role
+Builder는 다음을 하지 않습니다.
 
-KPubData Builder sits between `kpubdata` and publication targets.
+- provider별 API 접근 로직을 다시 구현하지 않습니다.
+- Studio 같은 UI 계층의 화면 상태를 소유하지 않습니다.
+- 임의의 범용 ETL 엔진이 되려고 하지 않습니다.
+
+## 2. BuildSpec 중심 설계 원칙
+
+이 시스템의 설계 중심은 **BuildSpec**입니다.
+
+1. **BuildSpec이 실행의 단일 진실 공급원(single source of truth)** 입니다.
+2. 실행 엔진은 spec을 해석하지만, 의미를 재정의하지 않습니다.
+3. exporter와 publisher는 spec이 결정한 실행 결과를 소비하는 하위 단계입니다.
+4. manifest는 실행 후 생성되는 기록물이지, 실행 규칙을 다시 정의하는 입력물이 아닙니다.
+5. Studio나 다른 클라이언트는 BuildSpec을 작성·전송할 수 있지만, 계약 자체를 소유하지 않습니다.
+
+## 3. 계층 분리
+
+### 3.1 Execution engine
+
+- BuildSpec 로딩/검증
+- `kpubdata` 호출
+- 레코드 수집 및 실행 상태 관리
+
+### 3.2 Exporter
+
+- 실행 결과를 파일/레이아웃 artifact로 변환
+- 로컬 파일 시스템 기준 결과물 생성
+- source fetch나 publish 정책은 직접 담당하지 않음
+
+### 3.3 Publisher
+
+- 이미 생성된 artifact를 원격 대상에 게시
+- 게시 성공/실패를 실행 결과에 반영
+- 파일 생성 책임은 없음
+
+### 3.4 Manifest
+
+- spec digest, 상태, artifact 목록, 실행 시각, 오류 요약 기록
+- 성공/실패 여부와 무관하게 build run을 설명하는 감사 기록
+- exporter/publisher를 대체하는 실행 단계가 아님
+
+## 4. 외부 통합 지점
+
+Builder는 외부와 다음 경계로 연결됩니다.
+
+| 외부 시스템 | Builder가 받는 것 | Builder가 제공하는 것 |
+| :--- | :--- | :--- |
+| `kpubdata` | 정규화된 레코드 접근 | source 실행 위임 |
+| 파일 시스템 | output 디렉터리 | artifact, manifest |
+| 원격 게시 대상 | 게시 대상 설정/자격 증명 | 게시 요청 |
+| `kpubdata-studio` | BuildSpec, 실행 요청 | 검증 결과, preview, build 상태, manifest |
+
+Studio는 여기서 **external UI client**로만 동작합니다.
+
+## 5. 파이프라인 흐름
 
 ```mermaid
-graph LR
-    subgraph Layers
-        P[Public APIs] --> K[kpubdata<br/>데이터 수집/표준화]
-        K --> B[kpubdata-builder<br/>데이터 조립/출판]
-        B --> F[Markdown / HF / files<br/>최종 결과물]
-    end
+flowchart LR
+    UI[External UI Client<br/>kpubdata-studio] -->|BuildSpec / build request| S[Builder Service]
+    S --> L[Spec Loader]
+    L --> V[Validator]
+    V --> X[Execution Engine]
+    X --> K[kpubdata]
+    X --> E[Exporter]
+    E --> A[Artifacts]
+    A --> M[Manifest Writer]
+    M --> P[Publisher optional]
+    M --> R[Manifest]
+    P --> O[Remote Target]
 ```
 
 ```text
-Public APIs
-  -> kpubdata (데이터 수집/표준화)
-  -> kpubdata-builder (데이터 조립/출판)
-  -> Markdown / HF / files (최종 결과물)
+Studio/UI -> Builder Service -> Spec Loader -> Validator -> Execution Engine
+           -> Exporter -> Artifacts -> Manifest Writer -> Publisher(optional)
 ```
 
-## 2. Architectural Principle
+## 6. 내부 책임 지도
 
-Builder is an orchestrator.
+| 단계 | 입력 | 출력 | 실패 시 영향 |
+| :--- | :--- | :--- | :--- |
+| Spec Loader | YAML/구조화된 spec | BuildSpec 객체 | build 시작 불가 |
+| Validator | BuildSpec | 검증 결과 | `failed`로 종료 |
+| Execution Engine | 검증된 BuildSpec | 정규화 레코드/실행 메타데이터 | export 이전에 중단 가능 |
+| Exporter | 레코드 + export 설정 | artifact 목록 | publish 이전에 중단 |
+| Manifest Writer | spec digest + 실행 결과 | manifest.json | 감사 기록 상실 위험 |
+| Publisher | artifact + publish 설정 | 게시 결과 | artifact는 유지될 수 있음 |
 
-```mermaid
-graph TD
-    subgraph "Responsibilities"
-        K[kpubdata] -- "Provides Records" --> B[kpubdata-builder]
-        B -- "Provides UI/Orchestration" --> S[kpubdata-studio]
-        
-        style K fill:#f9f,stroke:#333,stroke-width:2px
-        style B fill:#bbf,stroke:#333,stroke-width:4px
-        style S fill:#dfd,stroke:#333,stroke-width:2px
-    end
-    
-    subgraph "kpubdata-builder Internal"
-        B1[SpecLoader] --> B2[Validator]
-        B2 --> B3[Executor]
-        B3 --> B4[Assembler]
-        B4 --> B5[Exporter]
-        B5 --> B6[ManifestWriter]
-    end
-```
+## 7. Builder-Studio 연결 원칙
 
-It should not:
-- reimplement provider adapters (데이터 기관별 연결 로직은 `kpubdata`의 역할입니다)
-- own public API access logic (API 호출 자체는 `kpubdata`가 담당합니다)
-- become a general-purpose ETL framework (모든 종류의 데이터 처리가 아닌, 공공데이터 출판에 집중합니다)
+- Studio는 BuildSpec을 **작성하고 전송**할 수 있지만, BuildSpec 계약을 정의하지 않습니다.
+- Preview 계산은 Builder에서 수행되며 Studio는 결과를 렌더링합니다.
+- Build 상태 머신은 Builder가 소유하며 Studio는 조회/표시만 합니다.
+- Manifest 스키마는 Builder가 소유하며 Studio는 이를 소비합니다.
 
-It should:
-- load a build spec
-- fetch via `kpubdata`
-- assemble records
-- validate outputs
-- export artifacts
-- emit a manifest
+자세한 경계는 [BOUNDARY.md](./BOUNDARY.md)를 참고하세요.
 
-## 3. Layers (상세 설명)
+## 8. 관련 문서
 
-### 3.1 Spec Layer (기획 레이어)
-- **하는 일:** 사용자가 작성한 빌드 기획서(BuildSpec)를 읽고, 오타가 없는지 혹은 실행 불가능한 설정은 없는지 검사합니다.
-- **비유:** 요리사가 주문서를 읽고 재료가 다 있는지, 만들 수 있는 요리인지 확인하는 단계입니다.
-- **핵심 파일:** `spec.py`, `validator.py`
-- **수정해야 할 때:** 빌드 기획서에 새로운 설정 항목을 추가하고 싶을 때.
-
-### 3.2 Execution Layer (수행 레이어)
-- **하는 일:** `kpubdata`를 사용하여 실제로 공공데이터 API에 접속하고 데이터를 가져옵니다.
-- **비유:** 시장에 가서 신선한 재료(데이터)를 사오는 단계입니다.
-- **핵심 파일:** `executor.py`
-- **수정해야 할 때:** 데이터를 가져오는 방식이나 병렬 처리 로직을 개선하고 싶을 때.
-
-### 3.3 Assembly Layer (조립 레이어)
-- **하는 일:** 여러 곳에서 가져온 데이터들을 하나로 묶고, 공통된 메타데이터를 부여하여 '최종 결과물 직전의 데이터 뭉치'를 만듭니다.
-- **비유:** 사온 재료들을 씻고 다듬어서 요리 용기에 담기 좋게 준비하는 단계입니다.
-- **핵심 파일:** `assembler.py`, `artifact.py`
-- **수정해야 할 때:** 데이터를 합치는 규칙이나 통계 정보를 생성하는 로직을 바꿀 때.
-
-### 3.4 Export Layer (출력 레이어)
-- **하는 일:** 준비된 데이터 뭉치를 Markdown, JSONL, Parquet 등 실제 파일 형태로 변환합니다.
-- **비유:** 준비된 요리를 예쁜 그릇에 담고 장식하는 단계입니다.
-- **핵심 파일:** `exporters/` 디렉토리 내의 파일들
-- **수정해야 할 때:** 새로운 파일 형식(예: CSV, Excel)으로 저장하고 싶을 때.
-
-### 3.5 Publication Layer (배포 레이어)
-- **하는 일:** 생성된 파일들을 Hugging Face Hub나 GitHub 등 외부 저장소로 업로드합니다.
-- **비유:** 완성된 요리를 손님의 식탁으로 배달하거나 온라인 매장에 등록하는 단계입니다.
-- **핵심 파일:** `publishers/` 디렉토리 내의 파일들
-- **수정해야 할 때:** 새로운 외부 서비스로 자동 업로드를 하고 싶을 때.
-
-## 4. Major Components & Data Flow (데이터 흐름)
-
-데이터가 빌드 과정을 거쳐 결과물이 되는 흐름은 다음과 같습니다.
-
-```mermaid
-sequenceDiagram
-    participant User
-    participant SL as SpecLoader
-    participant V as Validator
-    participant E as Executor
-    participant KP as kpubdata
-    participant A as Assembler
-    participant EX as Exporter
-    participant MW as ManifestWriter
-
-    User->>SL: Load YAML BuildSpec
-    SL->>V: Validate Spec Configuration
-    V->>E: Start Execution
-    E->>KP: client.get(source_ref)
-    KP-->>E: Return Standard Records
-    E->>A: Send Raw Records
-    A->>EX: Prepare ArtifactDataset
-    EX->>EX: Convert to Target Format (MD/JSONL)
-    EX->>MW: Provide Build Results
-    MW->>User: Emit manifest.json & Files
-```
-
-```mermaid
-graph LR
-    subgraph "kpubdata_builder"
-        S[spec.py] --> V[validator.py]
-        V --> E[executor.py]
-        E --> A[assembler.py]
-        A --> AR[artifact.py]
-        AR --> EX[exporters/]
-        EX --> M[manifest.py]
-    end
-    
-    E -.-> K[kpubdata-core]
-    EX -.-> FS[Local FileSystem]
-    M -.-> MN[manifest.json]
-```
-
-1.  **BuildSpec YAML:** 사용자가 기획서를 작성합니다.
-2.  **Spec Loader:** `spec.py`의 모델을 사용하여 YAML을 파이썬 객체로 바꿉니다.
-3.  **Validator:** `validator.py`가 기획서의 오류를 찾아냅니다.
-4.  **Source Executor:** `executor.py`가 `kpubdata`를 호출하여 원시 데이터를 가져옵니다.
-5.  **Assembler:** `assembler.py`가 가져온 데이터를 `ArtifactDataset`(`artifact.py`)으로 조립합니다.
-6.  **Exporter(s):** `exporters/base.py`를 상속받은 개별 Exporter들이 물리적 파일을 생성합니다.
-7.  **Manifest Writer:** `manifest.py`가 빌드 결과와 통계를 `manifest.json`으로 기록합니다.
-
-## 5. Boundary with kpubdata (kpubdata와의 관계)
-
-Builder는 `kpubdata`를 내부적으로 **"사용"**하는 프로젝트입니다.
-
-### kpubdata responsibilities (재료 공급원)
-- 개별 공공데이터 기관(기상청, 공공데이터포털 등)과의 통신
-- 복잡한 XML/JSON 응답을 표준 형식으로 변환
-- API 인증 키 관리
-
-### kpubdata-builder responsibilities (요리사)
-- 어떤 데이터를 조합할지 정의
-- 수집된 데이터를 특정 목적(예: AI 학습용, 보고서용)에 맞게 포맷팅
-- 빌드 결과에 대한 이력 관리(Manifest)
-
-### 코드 연결점 예시
-```python
-# kpubdata-builder 내부의 executor.py 중 일부 (개념 예시)
-from kpubdata import Client
-
-def fetch_data(source_ref):
-    client = Client()
-    # kpubdata를 통해 데이터를 가져옴
-    records = client.get(
-        provider=source_ref.provider,
-        dataset=source_ref.dataset,
-        params=source_ref.params
-    )
-    return records
-```
-
-## 6. Boundary with Studio
-
-Builder must expose stable machine interfaces that Studio can call:
-- validate spec
-- preview build
-- execute build
-- inspect manifest
-- list exporters
-
-## 7. Error Handling (에러 처리 아키텍처)
-
-### 7.1 예외 계층
-
-Builder는 자체 예외 계층(`BuildError`)을 가집니다. `kpubdata`의 `PublicDataError`는 Builder 예외의 `__cause__`로 보존되며, 사용자에게 직접 노출되지 않습니다.
-
-```text
-BuildError
-├── SpecLoadError
-├── SpecValidationError
-├── SourceExecutionError
-├── AssemblyError
-├── ExportError
-├── ManifestWriteError
-└── PublishError
-```
-
-### 7.2 에러 전파 흐름
-
-```mermaid
-flowchart TD
-    SL[SpecLoader] -->|SpecLoadError| FAIL[Build Failed]
-    V[Validator] -->|SpecValidationError| FAIL
-    E[Executor] -->|SourceExecutionError| COLLECT[에러 수집]
-    COLLECT -->|errors 비어있음| A[Assembler]
-    COLLECT -->|errors 존재| FAIL
-    A -->|AssemblyError| FAIL
-    EX[Exporter] -->|ExportError| FAIL
-    MW[ManifestWriter] -->|ManifestWriteError| FAIL
-    FAIL --> MF[Manifest 생성 — 실패도 기록]
-```
-
-### 7.3 핵심 원칙
-
-1. **Manifest 생성 시도** — 실패한 빌드도 manifest 생성을 시도하여 감사 추적 가능 (`ManifestWriteError` 시에는 불가)
-2. **source별 에러 수집** — executor가 여러 source를 순회하며 에러를 모아 한 번에 보고
-3. **원인 보존** — `kpubdata` 예외를 `__cause__`로 항상 보존하여 디버깅 지원
-4. **retryable 계승** — `cause.retryable` 값을 그대로 계승, 예외 타입만으로 판단하지 않음
-
-> 자세한 에러 처리 설계는 [docs/ERROR_HANDLING.md](./docs/ERROR_HANDLING.md)를 참조하세요.
-
----
-
-## 관련 문서
-
-### 이 저장소 내 문서
 | 문서 | 설명 |
 | :--- | :--- |
-| [DOMAIN_MODEL.md](./DOMAIN_MODEL.md) | 도메인 모델 정의 |
-| [EXPORT_MODEL.md](./EXPORT_MODEL.md) | 데이터 변환 모델 |
-| [API_CONTRACT.md](./API_CONTRACT.md) | API 인터페이스 규약 |
-| [PRD.md](./PRD.md) | 제품 요구사항 정의서 |
-| [docs/ERROR_HANDLING.md](./docs/ERROR_HANDLING.md) | 에러 처리 설계 |
-
-### KPubData Product Family
-| 저장소 | 문서 | 설명 |
-| :--- | :--- | :--- |
-| **전체 제품군** | [product-family-architecture.md](https://github.com/yeongseon/kpubdata/blob/main/docs/product-family-architecture.md) | **3개 저장소 전체 시스템 아키텍처** |
-| [kpubdata](https://github.com/yeongseon/kpubdata) | [ARCHITECTURE.md](https://github.com/yeongseon/kpubdata/blob/main/ARCHITECTURE.md) | Core 아키텍처 |
-| [kpubdata-studio](https://github.com/yeongseon/kpubdata-studio) | [ARCHITECTURE.md](https://github.com/yeongseon/kpubdata-studio/blob/main/ARCHITECTURE.md) | Studio 아키텍처 |
+| [BUILD_SPEC.md](./BUILD_SPEC.md) | BuildSpec 계약 |
+| [API_CONTRACT.md](./API_CONTRACT.md) | Builder 중심 API 계약 |
+| [BUILD_STATE.md](./BUILD_STATE.md) | 빌드 상태 머신 |
+| [BOUNDARY.md](./BOUNDARY.md) | Builder-Studio 경계 |
+| [ROADMAP.md](./ROADMAP.md) | 향후 확장 계획 |

--- a/BOUNDARY.md
+++ b/BOUNDARY.md
@@ -1,0 +1,63 @@
+# Builder-Studio Boundary Rules — KPubData Builder
+
+## 1. 목적
+
+이 문서는 `kpubdata-builder`와 `kpubdata-studio` 사이의 책임 경계를 고정합니다. 목적은 중복 구현과 계약 드리프트를 막는 것입니다.
+
+## 2. 핵심 원칙
+
+1. **BuildSpec source of truth는 Builder입니다.**
+2. **Preview logic는 Builder가 계산하고 Studio는 표시만 합니다.**
+3. **Manifest schema는 Builder가 소유합니다.**
+4. **Publish workflow는 Builder가 실행하고 Studio는 요청합니다.**
+5. **Studio는 BuildSpec 계약이나 파이프라인 로직을 재정의할 수 없습니다.**
+
+## 3. 책임 분리표
+
+| 영역 | Builder 책임 | Studio 책임 |
+| :--- | :--- | :--- |
+| BuildSpec | 계약 정의, 버전 관리, 검증 | 작성 UI, 폼 입력, 저장/불러오기 보조 |
+| Preview | source 샘플 실행, schema 계산, export preview 생성 | preview 결과 렌더링 |
+| Build execution | 상태 전이, artifact 생성, manifest 기록 | 실행 요청, 상태 표시 |
+| Manifest | 스키마 정의, 직렬화, 보관 정책 | manifest 표시, 링크 제공 |
+| Publish | 원격 게시 수행, 성공/실패 기록 | publish 요청, 결과 표시 |
+
+## 4. Studio가 해서는 안 되는 일
+
+Studio는 다음을 구현하거나 소유하면 안 됩니다.
+
+- 자체 BuildSpec 문법 정의
+- Builder와 다른 별도 검증 규칙
+- 독자적인 preview 계산 엔진
+- manifest 스키마의 임의 확장/변형
+- exporter/publisher 파이프라인 로직 재구현
+
+## 5. 허용되는 Studio 역할
+
+Studio는 다음 역할을 수행할 수 있습니다.
+
+- BuildSpec 편집기 제공
+- Builder API 호출 래퍼 제공
+- 실행 상태 시각화
+- artifact/manifest 브라우징
+- publish 요청 UX 제공
+
+단, 계산 결과의 기준은 항상 Builder 응답이어야 합니다.
+
+## 6. 변경 관리 규칙
+
+- BuildSpec 변경은 Builder 문서와 구현에서 먼저 정의합니다.
+- Manifest 필드 변경은 Builder 릴리스 노트와 계약 문서에서 먼저 공지합니다.
+- Studio는 Builder 계약 버전을 따라가며, 선행 독자 확장을 금지합니다.
+
+## 7. 한 문장 요약
+
+> Builder는 파이프라인 엔진이고, Studio는 그 엔진을 조작하는 외부 UI 클라이언트입니다.
+
+## 8. 관련 문서
+
+| 문서 | 설명 |
+| :--- | :--- |
+| [ARCHITECTURE.md](./ARCHITECTURE.md) | 전체 레이어 구조 |
+| [API_CONTRACT.md](./API_CONTRACT.md) | Builder 서비스 계약 |
+| [BUILD_SPEC.md](./BUILD_SPEC.md) | Builder 소유 입력 계약 |

--- a/BUILD_SPEC.md
+++ b/BUILD_SPEC.md
@@ -1,0 +1,206 @@
+# BuildSpec Contract — KPubData Builder
+
+## 1. 목적
+
+BuildSpec은 Builder가 실행하는 모든 빌드의 **단일 입력 계약**입니다. Builder는 BuildSpec을 기준으로 source 실행, export, output 디렉터리 결정, publish 요청, manifest 기록을 수행합니다.
+
+## 2. 최소 필수 구조
+
+다음 구조가 최소 요구사항입니다.
+
+```yaml
+version: "1"
+dataset: weather-village-forecast
+
+source:
+  provider: datago
+  dataset: village_fcst
+  params:
+    base_date: "20250401"
+    nx: 55
+    ny: 127
+
+export:
+  format: markdown
+
+output:
+  dir: ./dist/weather
+```
+
+## 3. 필드 분류
+
+### 3.1 Required fields
+
+| 필드 | 타입 | 설명 |
+| :--- | :--- | :--- |
+| `version` | string | BuildSpec 계약 버전 |
+| `dataset` | string | 빌드 대상 데이터셋 식별자 |
+| `source` | object | source 실행 정의 |
+| `export` | object or array<object> | artifact 생성 방식 |
+| `output` | object | 로컬 출력 경로/정책 |
+
+### 3.2 Optional fields
+
+| 필드 | 타입 | 설명 |
+| :--- | :--- | :--- |
+| `transform` | object or array<object> | 필터링, 정렬, 매핑, 파생 필드 정의 |
+| `publish` | object or array<object> | 원격 게시 대상 정의 |
+| `metadata` | object | 제목, 설명, 라이선스, 태그 등 부가 메타데이터 |
+
+## 4. 필드 상세
+
+### 4.1 `version`
+
+- 타입: `string`
+- 예시: `"1"`
+- 의미: Builder가 어떤 계약 해석 규칙을 써야 하는지 결정합니다.
+
+### 4.2 `dataset`
+
+- 타입: `string`
+- 예시: `weather-village-forecast`
+- 의미: 빌드 전체를 식별하는 dataset ID입니다.
+
+### 4.3 `source`
+
+```yaml
+source:
+  provider: datago
+  dataset: village_fcst
+  params:
+    base_date: "20250401"
+    nx: 55
+    ny: 127
+```
+
+| 필드 | 타입 | 필수 | 설명 |
+| :--- | :--- | :--- | :--- |
+| `provider` | string | 예 | `kpubdata` provider 이름 |
+| `dataset` | string | 예 | provider 내부 dataset 이름 |
+| `params` | object | 아니오 | source 호출 파라미터 |
+| `auth` | object | 아니오 | 인증 관련 확장 필드 |
+
+### 4.4 `export`
+
+```yaml
+export:
+  format: markdown
+  filename: README.md
+```
+
+또는 다중 export:
+
+```yaml
+export:
+  - format: markdown
+    filename: README.md
+  - format: jsonl
+    filename: data.jsonl
+```
+
+| 필드 | 타입 | 필수 | 설명 |
+| :--- | :--- | :--- | :--- |
+| `format` | string | 예 | `markdown`, `jsonl`, `parquet` 등 |
+| `filename` | string | 아니오 | artifact 파일명 |
+| `options` | object | 아니오 | exporter별 옵션 |
+
+### 4.5 `output`
+
+```yaml
+output:
+  dir: ./dist/weather
+  overwrite: false
+```
+
+| 필드 | 타입 | 필수 | 설명 |
+| :--- | :--- | :--- | :--- |
+| `dir` | string | 예 | artifact가 생성될 루트 디렉터리 |
+| `overwrite` | boolean | 아니오 | 기존 출력 덮어쓰기 허용 여부 |
+
+### 4.6 `transform` (optional)
+
+```yaml
+transform:
+  filter:
+    field: category
+    equals: TMP
+  sort:
+    by: baseDate
+    order: asc
+```
+
+Builder는 transform을 **선언적으로** 받으며, 구현 가능한 범위만 지원해야 합니다.
+
+### 4.7 `publish` (optional)
+
+```yaml
+publish:
+  target: huggingface
+  repository: org/weather-village-forecast
+```
+
+게시 실행은 build와 구분되는 후속 단계일 수 있습니다.
+
+### 4.8 `metadata` (optional)
+
+```yaml
+metadata:
+  title: "2025년 동네예보 데이터셋"
+  description: "기상청 동네예보 기준 산출물"
+  license: "CC-BY-4.0"
+```
+
+## 5. 검증 규칙
+
+Builder는 최소한 다음 규칙을 검증해야 합니다.
+
+1. `version`은 지원되는 BuildSpec 버전이어야 합니다.
+2. `dataset`은 비어 있지 않은 문자열이어야 합니다.
+3. `source.provider`는 비어 있지 않아야 합니다.
+4. `source.dataset`은 비어 있지 않아야 합니다.
+5. `export`는 1개 이상 정의되어야 합니다.
+6. 모든 `export.format`은 Builder가 지원하는 exporter여야 합니다.
+7. `output.dir`은 비어 있지 않은 경로여야 합니다.
+8. `publish`가 존재하면 필요한 target별 필수 필드가 충족되어야 합니다.
+9. 지원하지 않는 필드 조합은 검증 단계에서 실패해야 합니다.
+
+### 예시 오류
+
+```json
+{
+  "error": {
+    "code": "INVALID_BUILD_SPEC",
+    "message": "source.provider is required",
+    "details": [
+      {"field": "source.provider", "reason": "missing"}
+    ]
+  }
+}
+```
+
+## 6. 버전 호환성
+
+| BuildSpec version | 상태 | 설명 |
+| :--- | :--- | :--- |
+| `1` | current | v0.1 기준 기본 계약 |
+
+호환성 원칙:
+
+- minor 문서 확장은 가능한 한 backward compatible하게 추가합니다.
+- breaking change는 새 `version` 값으로만 도입합니다.
+- Studio는 Builder가 지원하는 version만 전송해야 하며 임의 해석을 추가하면 안 됩니다.
+
+## 7. 계약 원칙 요약
+
+- BuildSpec은 Builder가 소유합니다.
+- BuildSpec은 실행 계획이지 UI 상태 저장 포맷이 아닙니다.
+- export/publish는 source 정의를 대체하지 않습니다.
+- manifest는 BuildSpec의 결과 기록물이지 입력이 아닙니다.
+
+## 8. 관련 문서
+
+| 문서 | 설명 |
+| :--- | :--- |
+| [ARCHITECTURE.md](./ARCHITECTURE.md) | BuildSpec 중심 설계 |
+| [API_CONTRACT.md](./API_CONTRACT.md) | BuildSpec을 받는 서비스 계약 |
+| [BOUNDARY.md](./BOUNDARY.md) | Builder-Studio 경계 |

--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -1,0 +1,115 @@
+# Build Run State Machine — KPubData Builder
+
+## 1. 상태 개요
+
+Builder의 build run은 다음 상태를 따릅니다.
+
+`draft → validated → running → exported → manifested → published`
+
+실패 시에는 어느 단계에서든 `failed`로 전이될 수 있습니다.
+
+## 2. 상태 전이 다이어그램
+
+```mermaid
+stateDiagram-v2
+    [*] --> draft
+    draft --> validated: spec validation success
+    draft --> failed: spec invalid
+    validated --> running: build started
+    running --> exported: artifacts written
+    running --> failed: source or execution error
+    exported --> manifested: manifest written
+    exported --> failed: manifest write failure
+    manifested --> published: publish success
+    manifested --> failed: publish failure if requested
+    manifested --> [*]: no publish requested
+    published --> [*]
+    failed --> [*]
+```
+
+## 3. 상태별 출력물
+
+| 상태 | 의미 | 기대 출력 |
+| :--- | :--- | :--- |
+| `draft` | spec가 아직 검증 전 | 원본 요청/spec |
+| `validated` | 실행 가능한 BuildSpec 확인 완료 | 검증 결과, spec digest 가능 |
+| `running` | source 실행 및 조립 진행 중 | 진행 상태, 임시 실행 메타데이터 |
+| `exported` | artifact 생성 완료 | artifact 목록, 파일 경로 |
+| `manifested` | manifest 생성 완료 | `manifest.json`, build 요약 |
+| `published` | publish까지 성공 | 게시 결과, 원격 참조 |
+| `failed` | 어느 단계에서든 실패 | 오류 코드/메시지, 가능하면 실패 manifest |
+
+## 4. 상태별 산출 정책
+
+### `draft`
+- BuildSpec은 접수되었지만 실행 전입니다.
+- artifact는 존재하지 않습니다.
+
+### `validated`
+- 필수 필드와 계약 규칙이 통과되었습니다.
+- 실행 큐 투입 전 상태로 사용할 수 있습니다.
+
+### `running`
+- Builder가 `kpubdata` 호출 및 조립을 수행합니다.
+- 외부 UI는 이 상태를 폴링하여 표시할 수 있습니다.
+
+### `exported`
+- 최소 하나 이상의 artifact가 로컬 출력 경로에 기록되었습니다.
+- 아직 manifest가 없을 수 있으므로 build 완료로 간주하지 않습니다.
+
+### `manifested`
+- manifest가 생성된 시점입니다.
+- publish가 없거나 나중에 수행되는 경우, 이 상태가 build 성공의 기본 완료 지점입니다.
+
+### `published`
+- publish 요청이 있었고 모든 게시 작업이 성공했습니다.
+
+### `failed`
+- 검증, 실행, export, manifest, publish 중 어느 단계에서든 실패한 상태입니다.
+
+## 5. Partial success 정책
+
+기본 정책은 다음과 같습니다.
+
+1. **source 일부 성공을 전체 성공으로 간주하지 않습니다.**
+2. 필수 source 중 하나라도 실패하면 build 상태는 `failed`입니다.
+3. export 완료 후 publish만 실패한 경우:
+   - artifact는 남을 수 있습니다.
+   - build run은 `failed`로 기록합니다.
+   - manifest에는 artifact 존재와 publish 실패를 함께 기록합니다.
+
+즉, Builder는 **부분 성공을 기록할 수는 있지만 성공 상태로 승격시키지 않습니다.**
+
+## 6. Retry 규칙
+
+| 실패 지점 | 재시도 가능성 | 규칙 |
+| :--- | :--- | :--- |
+| validation 실패 | 낮음 | spec 수정 후 새 build 생성 |
+| source 실행 실패 | 중간 | retryable 원인일 때 새 run 또는 재시도 가능 |
+| export 실패 | 중간 | 출력 경로/권한 수정 후 재실행 |
+| manifest 실패 | 낮음 | 동일 입력으로 새 build 권장 |
+| publish 실패 | 높음 | 기존 manifested build에서 publish만 재시도 가능 |
+
+재시도 원칙:
+
+- `draft`/`validated` 이전 오류는 같은 run을 복구하기보다 새 run을 생성하는 것이 명확합니다.
+- `manifested` 이후 publish 실패는 **publish 재시도**를 별도 작업으로 허용할 수 있습니다.
+
+## 7. Manifest 생성 시점
+
+Manifest는 **artifact 생성 직후, publish 이전**에 생성하는 것을 기본으로 합니다.
+
+이유:
+
+- publish 실패 여부와 무관하게 build 결과를 감사 가능하게 남길 수 있습니다.
+- publish 단계가 후속 비동기 작업일 때도 build 산출 자체는 안정적으로 기록됩니다.
+
+publish가 요청된 경우에는 publish 결과를 반영한 후 manifest를 업데이트하거나, publish 기록을 별도 항목으로 추가할 수 있습니다. 단, **manifest 스키마 소유권은 항상 Builder에 있습니다.**
+
+## 8. 관련 문서
+
+| 문서 | 설명 |
+| :--- | :--- |
+| [API_CONTRACT.md](./API_CONTRACT.md) | 상태 조회 API |
+| [BUILD_SPEC.md](./BUILD_SPEC.md) | 입력 계약 |
+| [BOUNDARY.md](./BOUNDARY.md) | UI와의 경계 |

--- a/DOMAIN_MODEL.md
+++ b/DOMAIN_MODEL.md
@@ -74,7 +74,7 @@ stateDiagram-v2
     FailedManifest --> [*]
 ```
 
-> 모든 실패 상태에서도 Manifest는 생성됩니다. 자세한 에러 계층은 [docs/ERROR_HANDLING.md](./docs/ERROR_HANDLING.md)를 참조하세요.
+> 모든 실패 상태에서도 Manifest는 생성됩니다. 상태 전이와 실패 처리 기준은 [BUILD_STATE.md](./BUILD_STATE.md)를 참조하세요.
 
 ### 2. SourceRef (데이터 출처 정보)
 - **무엇인가요?** `kpubdata` 라이브러리를 통해 가져올 구체적인 공공데이터 정보입니다.

--- a/README.md
+++ b/README.md
@@ -3,241 +3,134 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
-**KPubData Builder (Korea Public Data Builder)**는 [`kpubdata`](https://github.com/yeongseon/kpubdata)가 수집한 한국 공공데이터를 다양한 형식의 결과물로 만들어주는 데이터셋 빌드 파이프라인입니다.
+**KPubData Builder**는 재현 가능한 공공데이터 데이터셋 조립을 위한 **execution engine**입니다. `kpubdata`가 정규화한 레코드를 받아, BuildSpec에 따라 검증하고, 조립하고, 내보내고, Manifest로 기록합니다.
 
 ---
 
 ## 소개
 
-KPubData Builder는 `kpubdata` 사서가 가져온 원시 데이터를 사용자가 읽기 좋은 **책(보고서)이나 데이터셋 묶음으로 만들어주는 출판사**와 같습니다.
+`kpubdata-builder`는 **재현 가능한 공공데이터 데이터셋 조립을 위한 실행 엔진**입니다.
 
-데이터를 수집하고, 검증하고, 원하는 형식으로 예쁘게 포장하는 전체 과정을 담당합니다. 최종 결과물은 다음과 같은 형태로 만들어집니다:
+쉽게 말해:
 
-- [Markdown](https://ko.wikipedia.org/wiki/%EB%A7%88%ED%81%AC%EB%8B%A4%EC%9A%B4) 형식의 데이터셋 및 보고서
-- [Hugging Face](https://huggingface.co/) 데이터셋 레이아웃
-- [JSONL](https://jsonlines.org/) / [Parquet](https://parquet.apache.org/) / [CSV](https://ko.wikipedia.org/wiki/CSV) 형식의 데이터 파일
-- 데이터셋 카드 및 메타데이터 명세서(Manifest)
+- `kpubdata`는 데이터를 **가져오고 정규화하는 코어**입니다.
+- `kpubdata-builder`는 그 데이터를 **BuildSpec에 따라 실행 가능한 산출물로 조립하는 엔진**입니다.
+- `kpubdata-studio`는 builder 위에 올라가는 **시각적 제어면(control surface)**입니다.
 
-## 이 프로젝트가 존재하는 이유
+즉, Builder는 문서·데이터셋·배포 패키지 같은 결과물을 일관되게 만들어내는 파이프라인의 중심이며, **별도의 UI 제품이 아니라 실행 계층**입니다.
 
-`kpubdata`로 공공데이터를 수집했다면, 그 다음 단계가 필요합니다:
+## 왜 필요한가
 
-- **형식 변환**: 수집한 원시 데이터를 Markdown, CSV, Parquet 등 목적에 맞는 형식으로 바꿔야 합니다.
-- **데이터 검증**: 수집 과정에서 누락되거나 잘못된 데이터가 없는지 자동으로 확인해야 합니다.
-- **결과 추적**: 언제, 어떤 데이터를, 어떤 설정으로 빌드했는지 기록(Manifest)을 남겨야 합니다.
-- **반복 가능한 과정**: 같은 설정으로 언제든 동일한 결과를 다시 만들 수 있어야 합니다.
+공공데이터를 가져오는 것만으로는 충분하지 않습니다. 실제 데이터셋 작업에는 다음이 필요합니다.
 
-KPubData Builder는 이 모든 과정을 하나의 파이프라인(자동화된 처리 흐름)으로 묶어줍니다.
+- **명세 기반 실행**: 사람이 임의 스크립트를 쓰지 않아도 같은 BuildSpec으로 같은 빌드를 다시 실행할 수 있어야 합니다.
+- **산출물 생성**: Markdown, JSONL, Parquet, Hugging Face 레이아웃 같은 출력물을 같은 규칙으로 생성해야 합니다.
+- **추적 가능성**: 어떤 spec으로 어떤 결과물이 만들어졌는지 Manifest로 남겨야 합니다.
+- **배포 분리**: 파일을 만드는 단계와 외부 저장소로 보내는 단계를 구분해야 합니다.
 
-## 핵심 개념
+## 핵심 개념 관계
 
-| 용어 | 설명 |
-| :--- | :--- |
-| **BuildSpec** | 어떤 데이터를 어떻게 수집해서 어디로 보낼지 적힌 기획서 ([YAML](https://ko.wikipedia.org/wiki/YAML) 형식) |
-| **Artifact** | 빌드 과정을 통해 만들어진 최종 결과물 (파일 등) |
-| **Manifest** | 빌드 결과물에 대한 상세 명세서 (버전, 생성일, 설정값 등의 기록) |
-| **Exporter** | 데이터를 특정 형식(Markdown, [JSON](https://ko.wikipedia.org/wiki/JSON), Parquet 등)으로 변환하는 도구 |
-| **Publisher** | 완성된 결과물을 특정 장소([GitHub](https://github.com/), [Hugging Face Hub](https://huggingface.co/) 등)에 올리는 도구 |
+| 개념 | 역할 | 입력 | 출력 | 소유 주체 |
+| :--- | :--- | :--- | :--- | :--- |
+| **BuildSpec** | 빌드 실행의 단일 계약(source of truth) | YAML/구조화된 spec | 검증된 실행 계획 | Builder |
+| **Artifact** | 빌드가 만든 실제 파일/디렉터리 | 실행 결과 + export 설정 | `.md`, `.jsonl`, `.parquet`, 레이아웃 디렉터리 | Builder |
+| **Manifest** | 빌드 결과의 감사 기록 | spec digest, 상태, artifact 메타데이터 | `manifest.json` | Builder |
+| **Exporter** | 레코드를 구체적 파일 형식으로 변환 | 레코드/메타데이터 | Artifact 집합 | Builder 플러그인 |
+| **Publisher** | 생성된 artifact를 외부 대상으로 전송 | Artifact + publish 설정 | 게시 결과/원격 참조 | Builder 플러그인 |
 
-## 빌드 파이프라인 흐름
-
-데이터가 처리되는 전체 과정은 다음과 같습니다:
+## 빌드 흐름
 
 ```mermaid
-graph LR
-BS["BuildSpec<br/>(기획서 작성)"] --> V["Validate<br/>(검증)"]
-V --> E["Execute<br/>(데이터 수집)"]
-E --> EX["Export<br/>(형식 변환)"]
-EX --> M["Manifest<br/>(결과 기록)"]
+flowchart LR
+    BS[BuildSpec] --> V[Validate]
+    V --> X[Execute via kpubdata]
+    X --> E[Export]
+    E --> M[Manifest]
+    M --> P[Publish optional]
 ```
 
 ```text
-[BuildSpec 기획서] → [Validate 검증] → [Execute 데이터 수집] → [Export 형식 변환] → [Manifest 결과 기록]
+[BuildSpec] -> [Validate] -> [Execute] -> [Export] -> [Manifest] -> [Publish(optional)]
 ```
 
-1. **BuildSpec**: [YAML](https://ko.wikipedia.org/wiki/YAML)(들여쓰기로 구조를 표현하는 설정 파일) 형태로 "어떤 데이터를 가져와서 어떤 형식으로 내보낼지" 기획합니다.
-2. **Validate**: 기획서에 오류가 없는지 자동으로 확인합니다. 문제가 있으면 빌드를 시작하기 전에 알려줍니다.
-3. **Execute**: `kpubdata`를 사용하여 실제 공공데이터 [API](https://ko.wikipedia.org/wiki/API)에서 데이터를 수집합니다.
-4. **Export**: 수집된 데이터를 Markdown, JSONL, Parquet, CSV 등 원하는 형식으로 변환합니다.
-5. **Manifest**: 빌드 결과에 대한 상세 기록(버전, 생성일, 포함 항목 수 등)을 자동으로 생성합니다.
+## Builder와 Studio의 관계
 
-## 설치 방법
+`kpubdata-studio`는 Builder를 대체하는 별도 파이프라인 엔진이 아닙니다.
 
-[pip](https://pip.pypa.io/en/stable/)(파이썬 패키지 설치 도구)를 사용하여 설치합니다.
+> **Studio는 builder 위에 올라가는 시각적 control surface이며, 별도의 pipeline engine이 아닙니다.**
 
-```bash
-pip install kpubdata-builder
-```
+따라서:
+
+- BuildSpec 검증 로직은 Builder가 소유합니다.
+- Preview 계산 로직은 Builder가 소유합니다.
+- Manifest 스키마는 Builder가 소유합니다.
+- Publish 실행은 Builder가 수행하고, Studio는 이를 요청합니다.
+
+자세한 규칙은 [BOUNDARY.md](./BOUNDARY.md)를 참고하세요.
 
 ## 빠른 시작
 
-### CLI(명령줄) 사용
-
-터미널에서 빌드 기획서(YAML 파일)를 지정하여 실행합니다:
+### CLI 예시
 
 ```bash
-# 기획서 기반으로 빌드 실행
-kpubdata-builder build spec.yaml
+# BuildSpec 검증
+kpubdata-builder validate specs/weather.yaml
 
-# 기획서 검증만 실행 (실제 빌드 없이 오류 확인)
-kpubdata-builder validate spec.yaml
-```
-
-### Python API 사용
-
-코드에서 직접 빌드 과정을 제어할 수도 있습니다:
-
-```python
-from kpubdata_builder import Assembler, BuildSpec
-
-# YAML 기획서 불러오기
-spec = BuildSpec.from_yaml("spec.yaml")
+# 미리보기
+kpubdata-builder preview specs/weather.yaml --limit 5
 
 # 빌드 실행
-assembler = Assembler(spec)
-result = assembler.run()
-
-# 결과물 확인
-for artifact in result.artifacts:
-    print(artifact.path, artifact.format)
-
-# 매니페스트(빌드 기록) 확인
-print(result.manifest)
+kpubdata-builder build specs/weather.yaml --output-dir ./dist/weather
 ```
 
-### 빌드 기획서 예시 (spec.yaml)
+### 향후 API 예시(placeholder)
+
+서비스 모드가 정식 도입되면 아래와 같은 형태의 API 사용 예시가 추가될 예정입니다.
+
+```python
+# Future API example placeholder
+# from kpubdata_builder.service import BuilderService
+# result = BuilderService().build_from_file("specs/weather.yaml")
+```
+
+### 최소 BuildSpec 예시
 
 ```yaml
-# 어떤 데이터를 가져올지
+version: "1"
+dataset: weather-village-forecast
+
 source:
-  dataset: datago.village_fcst
+  provider: datago
+  dataset: village_fcst
   params:
     base_date: "20250401"
-    nx: "55"
-    ny: "127"
+    nx: 55
+    ny: 127
 
-# 어떤 형식으로 내보낼지
-exports:
-  - format: markdown
-  - format: csv
-  - format: jsonl
+export:
+  format: markdown
+
+output:
+  dir: ./dist/weather
 ```
 
-## 지원 내보내기 형식
+BuildSpec 계약은 [BUILD_SPEC.md](./BUILD_SPEC.md)를 참고하세요.
 
-| 형식 | 설명 | 용도 |
-| :--- | :--- | :--- |
-| **Markdown** | 사람이 읽기 좋은 텍스트 형식 | 보고서, 문서화 |
-| **CSV** | 쉼표로 구분된 표 형식 ([엑셀 호환](https://ko.wikipedia.org/wiki/CSV)) | 스프레드시트 분석 |
-| **JSONL** | 한 줄에 하나의 [JSON](https://ko.wikipedia.org/wiki/JSON) 객체 | 대용량 데이터 처리 |
-| **Parquet** | 열 기반 압축 형식 ([Apache Parquet](https://parquet.apache.org/)) | 빅데이터 분석, ML 학습 |
-| **Hugging Face** | [HF Datasets](https://huggingface.co/docs/datasets) 호환 레이아웃 | AI/ML 모델 학습 데이터 |
+## 주요 문서
 
-## 파일 구조 가이드
-
-```mermaid
-graph TD
-    ROOT[src/kpubdata_builder/] --> E[exporters/]
-    ROOT --> P[publishers/]
-    ROOT --> S[spec.py]
-    ROOT --> V[validator.py]
-    ROOT --> EX[executor.py]
-    ROOT --> A[assembler.py]
-    ROOT --> ART[artifact.py]
-    ROOT --> M[manifest.py]
-
-    E --> ME[markdown.py]
-    E --> JE[jsonl.py]
-    E --> PE[parquet.py]
-
-    P --> HP[huggingface.py]
-```
-
-```text
-src/kpubdata_builder/
-├── exporters/       # 데이터 형식 변환 (Markdown, JSONL 등)
-├── publishers/      # 결과물 업로드 (Hugging Face, GitHub 등)
-├── spec.py          # 빌드 기획서(BuildSpec) 정의
-├── validator.py     # 기획서 및 데이터 검증 로직
-├── executor.py      # kpubdata를 사용하여 실제 데이터 수집
-├── assembler.py     # 전체 빌드 과정을 조율하는 지휘자
-├── artifact.py      # 생성된 결과물 모델
-└── manifest.py      # 빌드 명세서 생성 로직
-```
-
----
-
-## 문서 가이드 (Document Guide)
-
-### 핵심 설계
-- [ARCHITECTURE.md](./ARCHITECTURE.md): 시스템 아키텍처 및 레이어 설계
-- [DOMAIN_MODEL.md](./DOMAIN_MODEL.md): 핵심 도메인 모델(BuildSpec, Artifact 등) 정의
-- [EXPORT_MODEL.md](./EXPORT_MODEL.md): 데이터 변환 및 Exporter 구현 모델
-- [API_CONTRACT.md](./API_CONTRACT.md): CLI 및 파이썬 인터페이스 규약
-
-### 개발 가이드
-- [AGENTS.md](./AGENTS.md): AI 에이전트를 위한 개발 규칙 및 가이드
-- [CONTRIBUTING.md](./CONTRIBUTING.md): 프로젝트 기여 방법 및 개발 환경 설정
-
-### 프로젝트 관리
-- [PRD.md](./PRD.md): 제품 요구사항 및 목표 정의
-- [ROADMAP.md](./ROADMAP.md): 향후 개발 계획 및 마일스톤
-- [PLAN.md](./PLAN.md): 초기 구축 및 작업 계획
-
-### 자세한 참고
-- [docs/adrs/0001-builder-as-orchestrator.md](./docs/adrs/0001-builder-as-orchestrator.md): 빌더 아키텍처 결정 기록
-- [제품군 전체 아키텍처](https://github.com/yeongseon/kpubdata/blob/main/docs/product-family-architecture.md): **KPubData 3개 저장소의 전체 시스템 아키텍처**
-
----
+| 문서 | 설명 |
+| :--- | :--- |
+| [ARCHITECTURE.md](./ARCHITECTURE.md) | BuildSpec 중심 설계와 레이어 분리 |
+| [BUILD_SPEC.md](./BUILD_SPEC.md) | BuildSpec 계약과 검증 규칙 |
+| [API_CONTRACT.md](./API_CONTRACT.md) | Builder 중심 API/Service 계약 |
+| [BUILD_STATE.md](./BUILD_STATE.md) | 빌드 실행 상태 머신 |
+| [BOUNDARY.md](./BOUNDARY.md) | Builder-Studio 경계 규칙 |
+| [ROADMAP.md](./ROADMAP.md) | 릴리스 단계별 계획 |
 
 ## KPubData Product Family
 
 | 패키지 | 역할 |
 | :--- | :--- |
-| [kpubdata](https://github.com/yeongseon/kpubdata) | 한국 공공데이터 접근 + 파싱 + 정규화 코어 |
-| [kpubdata-builder](https://github.com/yeongseon/kpubdata-builder) | 데이터셋 조립 + 내보내기 파이프라인 |
-| [kpubdata-studio](https://github.com/yeongseon/kpubdata-studio) | 빌드 작성 및 실행을 위한 시각적 인터페이스 |
-
----
-
-## 관련 문서
-
-### 이 저장소 내 문서
-| 문서 | 설명 |
-| :--- | :--- |
-| [ARCHITECTURE.md](./ARCHITECTURE.md) | 시스템 아키텍처 설계 |
-| [DOMAIN_MODEL.md](./DOMAIN_MODEL.md) | 도메인 모델 정의 |
-| [EXPORT_MODEL.md](./EXPORT_MODEL.md) | 데이터 변환 모델 |
-| [API_CONTRACT.md](./API_CONTRACT.md) | API 인터페이스 규약 |
-| [AGENTS.md](./AGENTS.md) | 에이전트 개발 가이드 |
-| [CONTRIBUTING.md](./CONTRIBUTING.md) | 프로젝트 기여 가이드 |
-| [PRD.md](./PRD.md) | 제품 요구사항 정의서 |
-| [ROADMAP.md](./ROADMAP.md) | 프로젝트 로드맵 |
-| [PLAN.md](./PLAN.md) | 작업 실행 계획 |
-
-### KPubData Product Family
-| 저장소 | 문서 | 설명 |
-| :--- | :--- | :--- |
-| [kpubdata](https://github.com/yeongseon/kpubdata) | [ARCHITECTURE.md](https://github.com/yeongseon/kpubdata/blob/main/ARCHITECTURE.md) | Core 아키텍처 |
-| [kpubdata-studio](https://github.com/yeongseon/kpubdata-studio) | [ARCHITECTURE.md](https://github.com/yeongseon/kpubdata-studio/blob/main/ARCHITECTURE.md) | Studio 아키텍처 |
-
----
-
-## 초기 배포 목표
-
-### v0.1
-- BuildSpec 모델 및 검증 로직 구현
-- `kpubdata`를 사용한 데이터 수집 실행기(Executor) 구현
-- [Markdown](https://ko.wikipedia.org/wiki/%EB%A7%88%ED%81%AC%EB%8B%A4%EC%9A%B4) 내보내기 기능
-- Manifest(빌드 기록) 자동 생성
-- 테스트 및 타입 검사 환경 구축
-
-### v0.2
-- [JSONL](https://jsonlines.org/) / [Parquet](https://parquet.apache.org/) 내보내기 기능 추가
-- [Hugging Face](https://huggingface.co/docs/datasets) 데이터셋 레이아웃 지원
-- 빌드 기획서 템플릿 제공
-
-### v0.3
-- 게시(Publish) 훅을 통한 자동 업로드 기능
-- 빌드 이력 관리 및 비교 기능
-- CI/CD 파이프라인 연동 지원
+| [kpubdata](https://github.com/yeongseon/kpubdata) | 공공데이터 접근·정규화 코어 |
+| [kpubdata-builder](https://github.com/yeongseon/kpubdata-builder) | 재현 가능한 데이터셋 조립 실행 엔진 |
+| [kpubdata-studio](https://github.com/yeongseon/kpubdata-studio) | builder 위에서 동작하는 시각적 제어면 |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,39 +1,34 @@
 # Roadmap — kpubdata-builder
 
 ## v0.1
-- spec parsing
-- validate command
-- preview command
-- build command
-- markdown exporter
-- jsonl exporter
-- manifest writer
+
+- BuildSpec 계약 안정화
+- BuildSpec 검증 흐름 안정화
+- preview 계약 안정화
+- manifest 스키마 안정화
+- CLI 기반 build 실행 흐름 정리
 
 ## v0.2
-- parquet exporter
-- huggingface layout exporter
-- publish command
-- schema summary
-- richer provenance
+
+- exporter 확장
+- publisher 확장
+- 추가 output 레이아웃 지원
+- 원격 게시 대상 다양화
 
 ## v0.3
-- plugin exporter API
-- reusable templates
-- snapshot-aware builds
-- better diff/compare tools
+
+- service mode 도입
+- plugin model 확장
+- build diff/history 기능 도입
+- 장기 실행 상태 조회 개선
 
 ---
 
 ## 관련 문서
 
-### 이 저장소 내 문서
 | 문서 | 설명 |
 | :--- | :--- |
-| [PRD.md](./PRD.md) | 제품 요구사항 정의서 |
-| [ARCHITECTURE.md](./ARCHITECTURE.md) | 시스템 아키텍처 설계 |
-
-### KPubData Product Family
-| 저장소 | 문서 | 설명 |
-| :--- | :--- | :--- |
-| [kpubdata](https://github.com/yeongseon/kpubdata) | [ROADMAP.md](https://github.com/yeongseon/kpubdata/blob/main/ROADMAP.md) | Core 로드맵 |
-| [kpubdata-studio](https://github.com/yeongseon/kpubdata-studio) | [ROADMAP.md](https://github.com/yeongseon/kpubdata-studio/blob/main/ROADMAP.md) | Studio 로드맵 |
+| [README.md](./README.md) | 프로젝트 포지셔닝 |
+| [ARCHITECTURE.md](./ARCHITECTURE.md) | 아키텍처 원칙 |
+| [BUILD_SPEC.md](./BUILD_SPEC.md) | BuildSpec 계약 |
+| [API_CONTRACT.md](./API_CONTRACT.md) | 서비스/API 계약 |

--- a/src/kpubdata_builder/__init__.py
+++ b/src/kpubdata_builder/__init__.py
@@ -3,6 +3,15 @@
 from __future__ import annotations
 
 from .artifact import ArtifactDataset
+from .errors import (
+    AssemblyError,
+    BuildError,
+    ExecutionError,
+    ExportError,
+    ManifestError,
+    SpecLoadError,
+    ValidationError,
+)
 from .manifest import BuildManifest, manifest_writer
 from .spec import BuildSpec, ExportTarget, SourceRef
 from .validator import validate_spec
@@ -11,10 +20,17 @@ __version__ = "0.1.0a0"
 
 __all__ = [
     "ArtifactDataset",
+    "BuildError",
     "BuildManifest",
     "BuildSpec",
+    "ExecutionError",
+    "ExportError",
+    "ManifestError",
     "ExportTarget",
     "SourceRef",
+    "SpecLoadError",
+    "ValidationError",
+    "AssemblyError",
     "__version__",
     "manifest_writer",
     "validate_spec",

--- a/src/kpubdata_builder/assembler.py
+++ b/src/kpubdata_builder/assembler.py
@@ -3,25 +3,47 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 from .artifact import ArtifactDataset
+from .errors import AssemblyError
 from .spec import BuildSpec, JsonValue
+
+
+@dataclass(frozen=True)
+class AssemblyResult:
+    artifact: ArtifactDataset
+    warnings: tuple[str, ...] = ()
 
 
 def assemble_artifact(
     spec: BuildSpec,
     records_by_source: dict[str, Sequence[dict[str, JsonValue]]],
-) -> ArtifactDataset:
+) -> AssemblyResult:
     """Assemble source records with minimal deterministic merge behavior."""
     merged_records: list[dict[str, JsonValue]] = []
+    warnings: list[str] = []
+    present_sources: list[str] = []
     for source in spec.sources:
         source_key = source.alias if source.alias else f"{source.provider}.{source.dataset}"
-        merged_records.extend(records_by_source.get(source_key, ()))
+        source_records = records_by_source.get(source_key)
+        if source_records is None:
+            warnings.append(f"Missing records for source: {source_key}")
+            continue
+        present_sources.append(source_key)
+        merged_records.extend(source_records)
+
+    if not present_sources:
+        raise AssemblyError(f"No source records available for dataset {spec.dataset_id}")
+
     statistics = {"record_count": len(merged_records)}
-    provenance = tuple(records_by_source.keys())
-    return ArtifactDataset(
+    artifact = ArtifactDataset(
         records=tuple(merged_records),
         metadata=dict(spec.metadata),
-        provenance=provenance,
+        provenance=tuple(present_sources),
         statistics=statistics,
     )
+    return AssemblyResult(artifact=artifact, warnings=tuple(warnings))
+
+
+__all__ = ["AssemblyResult", "assemble_artifact"]

--- a/src/kpubdata_builder/errors.py
+++ b/src/kpubdata_builder/errors.py
@@ -1,0 +1,46 @@
+"""Error hierarchy for builder pipeline failures."""
+
+from __future__ import annotations
+
+
+class BuildError(Exception):
+    """Base exception for all builder errors."""
+
+
+class SpecLoadError(BuildError):
+    """Failed to load or parse a build spec."""
+
+
+class ValidationError(BuildError):
+    """Build spec validation failed."""
+
+    def __init__(self, problems: list[str]) -> None:
+        self.problems = problems
+        super().__init__(f"Validation failed: {'; '.join(problems)}")
+
+
+class ExecutionError(BuildError):
+    """Source execution failed."""
+
+
+class AssemblyError(BuildError):
+    """Artifact assembly failed."""
+
+
+class ExportError(BuildError):
+    """Export operation failed."""
+
+
+class ManifestError(BuildError):
+    """Manifest write failed."""
+
+
+__all__ = [
+    "AssemblyError",
+    "BuildError",
+    "ExecutionError",
+    "ExportError",
+    "ManifestError",
+    "SpecLoadError",
+    "ValidationError",
+]

--- a/src/kpubdata_builder/executor.py
+++ b/src/kpubdata_builder/executor.py
@@ -2,13 +2,39 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from .artifact import ArtifactDataset
+from .errors import ExecutionError, ValidationError
 from .spec import BuildSpec
 from .validator import validate_spec
 
 
-def source_executor(spec: BuildSpec) -> ArtifactDataset:
+@dataclass(frozen=True)
+class ExecutionResult:
+    artifact: ArtifactDataset
+    warnings: tuple[str, ...] = ()
+    errors: tuple[str, ...] = ()
+
+
+def source_executor(spec: BuildSpec) -> ExecutionResult:
     """Execute declared sources and return a minimal assembled artifact stub."""
-    validate_spec(spec)
-    provenance = tuple(f"{source.provider}.{source.dataset}" for source in spec.sources)
-    return ArtifactDataset(metadata=dict(spec.metadata), provenance=provenance)
+    try:
+        validate_spec(spec)
+    except ValidationError:
+        raise
+    except ValueError as exc:
+        raise ValidationError([str(exc)]) from exc
+
+    try:
+        provenance = tuple(f"{source.provider}.{source.dataset}" for source in spec.sources)
+        artifact = ArtifactDataset(metadata=dict(spec.metadata), provenance=provenance)
+    except Exception as exc:
+        raise ExecutionError(
+            f"Failed to execute sources for dataset {spec.dataset_id}: {exc}"
+        ) from exc
+
+    return ExecutionResult(artifact=artifact)
+
+
+__all__ = ["ExecutionResult", "source_executor"]

--- a/src/kpubdata_builder/exporters/__init__.py
+++ b/src/kpubdata_builder/exporters/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .base import BaseExporter
+from .base import BaseExporter, ExportResult, ensure_output_dir
 from .jsonl import JsonlExporter
 from .markdown import MarkdownExporter
 
@@ -11,4 +11,11 @@ EXPORTER_REGISTRY: dict[str, BaseExporter] = {
     "markdown": MarkdownExporter(),
 }
 
-__all__ = ["BaseExporter", "EXPORTER_REGISTRY", "JsonlExporter", "MarkdownExporter"]
+__all__ = [
+    "BaseExporter",
+    "EXPORTER_REGISTRY",
+    "ExportResult",
+    "JsonlExporter",
+    "MarkdownExporter",
+    "ensure_output_dir",
+]

--- a/src/kpubdata_builder/exporters/base.py
+++ b/src/kpubdata_builder/exporters/base.py
@@ -3,10 +3,28 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from pathlib import Path
 
 from ..artifact import ArtifactDataset
+from ..errors import ExportError
 from ..spec import ExportTarget
+
+
+@dataclass(frozen=True)
+class ExportResult:
+    output_path: Path
+    file_size: int
+    format: str
+
+
+def ensure_output_dir(output_dir: Path, relative_output_path: str) -> Path:
+    destination = output_dir / relative_output_path
+    try:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise ExportError(f"Failed to prepare output directory for {destination}: {exc}") from exc
+    return destination
 
 
 class BaseExporter(ABC):
@@ -18,5 +36,10 @@ class BaseExporter(ABC):
         """Return exporter identifier used by registry and specs."""
 
     @abstractmethod
-    def export(self, artifact: ArtifactDataset, target: ExportTarget, output_dir: Path) -> Path:
-        """Write output artifact and return the generated file path."""
+    def export(
+        self, artifact: ArtifactDataset, target: ExportTarget, output_dir: Path
+    ) -> ExportResult:
+        pass
+
+
+__all__ = ["BaseExporter", "ExportResult", "ensure_output_dir"]

--- a/src/kpubdata_builder/exporters/jsonl.py
+++ b/src/kpubdata_builder/exporters/jsonl.py
@@ -6,8 +6,9 @@ import json
 from pathlib import Path
 
 from ..artifact import ArtifactDataset
+from ..errors import ExportError
 from ..spec import ExportTarget
-from .base import BaseExporter
+from .base import BaseExporter, ExportResult, ensure_output_dir
 
 
 class JsonlExporter(BaseExporter):
@@ -18,15 +19,22 @@ class JsonlExporter(BaseExporter):
         """Return exporter name."""
         return "jsonl"
 
-    def export(self, artifact: ArtifactDataset, target: ExportTarget, output_dir: Path) -> Path:
+    def export(
+        self, artifact: ArtifactDataset, target: ExportTarget, output_dir: Path
+    ) -> ExportResult:
         """Export canonical records to a JSONL file."""
-        destination = output_dir / target.output_path
-        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination = ensure_output_dir(output_dir, target.output_path)
         content = "\n".join(
             json.dumps(record, ensure_ascii=False, sort_keys=True) for record in artifact.records
         )
-        if content:
-            _ = destination.write_text(f"{content}\n", encoding="utf-8")
-        else:
-            _ = destination.write_text("", encoding="utf-8")
-        return destination
+        try:
+            if content:
+                _ = destination.write_text(f"{content}\n", encoding="utf-8")
+            else:
+                _ = destination.write_text("", encoding="utf-8")
+        except OSError as exc:
+            raise ExportError(f"Failed to export JSONL artifact to {destination}: {exc}") from exc
+
+        return ExportResult(
+            output_path=destination, file_size=destination.stat().st_size, format=self.name
+        )

--- a/src/kpubdata_builder/exporters/markdown.py
+++ b/src/kpubdata_builder/exporters/markdown.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from pathlib import Path
 
 from ..artifact import ArtifactDataset
+from ..errors import ExportError
 from ..spec import ExportTarget
-from .base import BaseExporter
+from .base import BaseExporter, ExportResult, ensure_output_dir
 
 
 class MarkdownExporter(BaseExporter):
@@ -17,15 +18,24 @@ class MarkdownExporter(BaseExporter):
         """Return exporter name."""
         return "markdown"
 
-    def export(self, artifact: ArtifactDataset, target: ExportTarget, output_dir: Path) -> Path:
+    def export(
+        self, artifact: ArtifactDataset, target: ExportTarget, output_dir: Path
+    ) -> ExportResult:
         """Export artifact metadata and row count as Markdown."""
-        destination = output_dir / target.output_path
-        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination = ensure_output_dir(output_dir, target.output_path)
         lines = [
             "# Dataset Artifact",
             "",
             f"- Records: {len(artifact.records)}",
             f"- Provenance entries: {len(artifact.provenance)}",
         ]
-        _ = destination.write_text("\n".join(lines) + "\n", encoding="utf-8")
-        return destination
+        try:
+            _ = destination.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        except OSError as exc:
+            raise ExportError(
+                f"Failed to export Markdown artifact to {destination}: {exc}"
+            ) from exc
+
+        return ExportResult(
+            output_path=destination, file_size=destination.stat().st_size, format=self.name
+        )

--- a/src/kpubdata_builder/manifest.py
+++ b/src/kpubdata_builder/manifest.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
+from .errors import ManifestError
+
 
 @dataclass(frozen=True)
 class BuildManifest:
@@ -35,5 +37,16 @@ def manifest_writer(manifest: BuildManifest, output_path: Path) -> None:
         "row_counts": manifest.row_counts,
     }
     serialized = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    _ = output_path.write_text(f"{serialized}\n", encoding="utf-8")
+    try:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        _ = output_path.write_text(f"{serialized}\n", encoding="utf-8")
+    except OSError as exc:
+        raise ManifestError(f"Failed to write manifest to {output_path}: {exc}") from exc
+
+
+def write_manifest(manifest: BuildManifest, output_path: Path) -> None:
+    """Write a build manifest as deterministic JSON to disk."""
+    manifest_writer(manifest, output_path)
+
+
+__all__ = ["BuildManifest", "manifest_writer", "write_manifest"]

--- a/src/kpubdata_builder/spec.py
+++ b/src/kpubdata_builder/spec.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TypeAlias
+
+import yaml
+
+from .errors import SpecLoadError
 
 JsonPrimitive: TypeAlias = str | int | float | bool | None
 JsonValue: TypeAlias = JsonPrimitive | list["JsonValue"] | dict[str, "JsonValue"]
@@ -41,3 +46,148 @@ class BuildSpec:
     transforms: tuple[str, ...] = ()
     metadata: dict[str, str] = field(default_factory=dict)
     publish: bool = False
+
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> BuildSpec:
+        return load_spec(Path(path))
+
+
+def parse_spec(data: dict[str, object]) -> BuildSpec:
+    try:
+        dataset_id = _require_string(data, "dataset_id")
+        title = _require_string(data, "title")
+        description = _require_string(data, "description")
+        transforms = _parse_string_list(data.get("transforms", []), field_name="transforms")
+        metadata = _parse_string_dict(data.get("metadata", {}), field_name="metadata")
+        publish = _parse_bool(data.get("publish", False), field_name="publish")
+        sources = _parse_sources(data.get("sources", []))
+        exports = _parse_exports(data.get("exports", []))
+    except (KeyError, TypeError, ValueError) as exc:
+        raise SpecLoadError(f"Failed to parse build spec: {exc}") from exc
+
+    return BuildSpec(
+        dataset_id=dataset_id,
+        title=title,
+        description=description,
+        sources=sources,
+        exports=exports,
+        transforms=transforms,
+        metadata=metadata,
+        publish=publish,
+    )
+
+
+def load_spec(path: Path) -> BuildSpec:
+    try:
+        raw_data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, yaml.YAMLError) as exc:
+        raise SpecLoadError(f"Failed to load build spec from {path}: {exc}") from exc
+
+    if not isinstance(raw_data, dict):
+        raise SpecLoadError(
+            f"Failed to parse build spec from {path}: top-level YAML must be a mapping"
+        )
+
+    return parse_spec(raw_data)
+
+
+def _require_string(data: dict[str, object], key: str) -> str:
+    value = data[key]
+    if not isinstance(value, str):
+        raise TypeError(f"{key} must be a string")
+    return value
+
+
+def _parse_bool(value: object, *, field_name: str) -> bool:
+    if not isinstance(value, bool):
+        raise TypeError(f"{field_name} must be a boolean")
+    return value
+
+
+def _parse_string_list(value: object, *, field_name: str) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise TypeError(f"{field_name} must be a list")
+    if not all(isinstance(item, str) for item in value):
+        raise TypeError(f"{field_name} entries must be strings")
+    return tuple(value)
+
+
+def _parse_string_dict(value: object, *, field_name: str) -> dict[str, str]:
+    if not isinstance(value, dict):
+        raise TypeError(f"{field_name} must be a mapping")
+    if not all(isinstance(key, str) and isinstance(item, str) for key, item in value.items()):
+        raise TypeError(f"{field_name} entries must be string pairs")
+    return dict(value)
+
+
+def _parse_json_mapping(value: object, *, field_name: str) -> dict[str, JsonValue]:
+    if not isinstance(value, dict):
+        raise TypeError(f"{field_name} must be a mapping")
+    if not all(isinstance(key, str) for key in value):
+        raise TypeError(f"{field_name} keys must be strings")
+    return {key: item for key, item in value.items()}
+
+
+def _parse_sources(value: object) -> tuple[SourceRef, ...]:
+    if not isinstance(value, list):
+        raise TypeError("sources must be a list")
+
+    parsed_sources: list[SourceRef] = []
+    for index, item in enumerate(value):
+        mapping = _ensure_mapping(item, field_name=f"sources[{index}]")
+        provider = _require_string(mapping, "provider")
+        dataset = _require_string(mapping, "dataset")
+        params = _parse_json_mapping(
+            mapping.get("params", {}), field_name=f"sources[{index}].params"
+        )
+        normalization_mode_obj = mapping.get("normalization_mode", "canonical")
+        alias_obj = mapping.get("alias", "")
+        if not isinstance(normalization_mode_obj, str):
+            raise TypeError(f"sources[{index}].normalization_mode must be a string")
+        if not isinstance(alias_obj, str):
+            raise TypeError(f"sources[{index}].alias must be a string")
+        parsed_sources.append(
+            SourceRef(
+                provider=provider,
+                dataset=dataset,
+                params=params,
+                normalization_mode=normalization_mode_obj,
+                alias=alias_obj,
+            )
+        )
+    return tuple(parsed_sources)
+
+
+def _parse_exports(value: object) -> tuple[ExportTarget, ...]:
+    if not isinstance(value, list):
+        raise TypeError("exports must be a list")
+
+    parsed_exports: list[ExportTarget] = []
+    for index, item in enumerate(value):
+        mapping = _ensure_mapping(item, field_name=f"exports[{index}]")
+        kind = _require_string(mapping, "kind")
+        output_path = _require_string(mapping, "output_path")
+        options = _parse_json_mapping(
+            mapping.get("options", {}), field_name=f"exports[{index}].options"
+        )
+        parsed_exports.append(ExportTarget(kind=kind, output_path=output_path, options=options))
+    return tuple(parsed_exports)
+
+
+def _ensure_mapping(value: object, *, field_name: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise TypeError(f"{field_name} must be a mapping")
+    if not all(isinstance(key, str) for key in value):
+        raise TypeError(f"{field_name} keys must be strings")
+    return {key: item for key, item in value.items()}
+
+
+__all__ = [
+    "BuildSpec",
+    "ExportTarget",
+    "JsonPrimitive",
+    "JsonValue",
+    "SourceRef",
+    "load_spec",
+    "parse_spec",
+]

--- a/src/kpubdata_builder/validator.py
+++ b/src/kpubdata_builder/validator.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+from .errors import ValidationError
 from .spec import BuildSpec
 
 
 def validate_spec(spec: BuildSpec) -> None:
-    """Validate a build specification and raise ValueError on invalid input."""
+    problems: list[str] = []
     if not spec.dataset_id.strip():
-        raise ValueError("dataset_id must be a non-empty string")
+        problems.append("dataset_id must be a non-empty string")
     if not spec.sources:
-        raise ValueError("at least one source is required")
+        problems.append("at least one source is required")
     if not spec.exports:
-        raise ValueError("at least one export target is required")
+        problems.append("at least one export target is required")
+    if problems:
+        raise ValidationError(problems)

--- a/tests/unit/test_assembler.py
+++ b/tests/unit/test_assembler.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+
+from kpubdata_builder import AssemblyError
+from kpubdata_builder.assembler import AssemblyResult, assemble_artifact
+from kpubdata_builder.spec import BuildSpec, ExportTarget, SourceRef
+
+
+def test_assemble_artifact_reports_missing_source_warning() -> None:
+    spec = BuildSpec(
+        dataset_id="dataset.sample",
+        title="Sample Dataset",
+        description="Sample description",
+        sources=(
+            SourceRef(provider="datago", dataset="air_quality", alias="present"),
+            SourceRef(provider="datago", dataset="village_fcst", alias="missing"),
+        ),
+        exports=(ExportTarget(kind="jsonl", output_path="out/data.jsonl"),),
+    )
+
+    result = assemble_artifact(spec, {"present": ({"id": "1"},)})
+
+    assert isinstance(result, AssemblyResult)
+    assert result.artifact.records == ({"id": "1"},)
+    assert result.artifact.provenance == ("present",)
+    assert result.warnings == ("Missing records for source: missing",)
+
+
+def test_assemble_artifact_raises_when_all_sources_missing() -> None:
+    spec = BuildSpec(
+        dataset_id="dataset.sample",
+        title="Sample Dataset",
+        description="Sample description",
+        sources=(SourceRef(provider="datago", dataset="air_quality", alias="missing"),),
+        exports=(ExportTarget(kind="jsonl", output_path="out/data.jsonl"),),
+    )
+
+    with pytest.raises(AssemblyError):
+        assemble_artifact(spec, {})

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from kpubdata_builder import (
+    AssemblyError,
+    BuildError,
+    ExecutionError,
+    ExportError,
+    ManifestError,
+    SpecLoadError,
+    ValidationError,
+)
+
+
+def test_all_builder_errors_inherit_from_build_error() -> None:
+    assert issubclass(SpecLoadError, BuildError)
+    assert issubclass(ValidationError, BuildError)
+    assert issubclass(ExecutionError, BuildError)
+    assert issubclass(AssemblyError, BuildError)
+    assert issubclass(ExportError, BuildError)
+    assert issubclass(ManifestError, BuildError)
+
+
+def test_validation_error_keeps_problem_list() -> None:
+    error = ValidationError(["problem one", "problem two"])
+
+    assert error.problems == ["problem one", "problem two"]
+    assert str(error) == "Validation failed: problem one; problem two"

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+
+from kpubdata_builder import ExecutionError, ValidationError
+from kpubdata_builder.executor import ExecutionResult, source_executor
+from kpubdata_builder.spec import BuildSpec, ExportTarget, SourceRef
+
+
+def test_source_executor_returns_execution_result() -> None:
+    spec = BuildSpec(
+        dataset_id="dataset.sample",
+        title="Sample Dataset",
+        description="Sample description",
+        sources=(SourceRef(provider="datago", dataset="air_quality"),),
+        exports=(ExportTarget(kind="jsonl", output_path="out/data.jsonl"),),
+        metadata={"owner": "team-data"},
+    )
+
+    result = source_executor(spec)
+
+    assert isinstance(result, ExecutionResult)
+    assert result.artifact.metadata == {"owner": "team-data"}
+    assert result.artifact.provenance == ("datago.air_quality",)
+    assert result.warnings == ()
+    assert result.errors == ()
+
+
+def test_source_executor_wraps_validation_failures() -> None:
+    spec = BuildSpec(
+        dataset_id=" ",
+        title="Sample Dataset",
+        description="Sample description",
+        sources=(),
+        exports=(),
+    )
+
+    with pytest.raises(ValidationError):
+        source_executor(spec)
+
+
+def test_source_executor_wraps_source_processing_failures() -> None:
+    class BrokenString(str):
+        def __str__(self) -> str:
+            raise RuntimeError("boom")
+
+    spec = BuildSpec(
+        dataset_id="dataset.sample",
+        title="Sample Dataset",
+        description="Sample description",
+        sources=(SourceRef(provider=BrokenString("datago"), dataset="air_quality"),),
+        exports=(ExportTarget(kind="jsonl", output_path="out/data.jsonl"),),
+    )
+
+    with pytest.raises(ExecutionError):
+        source_executor(spec)

--- a/tests/unit/test_exporters.py
+++ b/tests/unit/test_exporters.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kpubdata_builder import ArtifactDataset, ExportError
+from kpubdata_builder.exporters import JsonlExporter, MarkdownExporter
+from kpubdata_builder.spec import ExportTarget
+
+
+@pytest.mark.parametrize(
+    ("exporter", "target"),
+    [
+        (JsonlExporter(), ExportTarget(kind="jsonl", output_path="out/data.jsonl")),
+        (MarkdownExporter(), ExportTarget(kind="markdown", output_path="out/README.md")),
+    ],
+)
+def test_exporters_raise_export_error_on_bad_path(
+    exporter: JsonlExporter | MarkdownExporter,
+    target: ExportTarget,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = ArtifactDataset(records=({"id": "1"},), provenance=("datago.air_quality",))
+
+    def raise_io_error(self: Path, data: str, *, encoding: str) -> int:
+        del self, data, encoding
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "write_text", raise_io_error)
+
+    with pytest.raises(ExportError):
+        exporter.export(artifact, target, tmp_path)
+
+
+def test_markdown_exporter_returns_export_metadata(tmp_path: Path) -> None:
+    artifact = ArtifactDataset(records=({"id": "1"},), provenance=("datago.air_quality",))
+    target = ExportTarget(kind="markdown", output_path="out/README.md")
+
+    result = MarkdownExporter().export(artifact, target, tmp_path)
+
+    assert result.output_path == tmp_path / "out/README.md"
+    assert result.file_size > 0
+    assert result.format == "markdown"

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kpubdata_builder import SpecLoadError
+from kpubdata_builder.spec import load_spec
+
+
+def test_load_spec_reads_valid_yaml(tmp_path: Path) -> None:
+    spec_path = tmp_path / "spec.yaml"
+    spec_path.write_text(
+        """
+dataset_id: dataset.sample
+title: Sample Dataset
+description: Sample description
+sources:
+  - provider: datago
+    dataset: air_quality
+exports:
+  - kind: jsonl
+    output_path: out/data.jsonl
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    spec = load_spec(spec_path)
+
+    assert spec.dataset_id == "dataset.sample"
+    assert spec.sources[0].provider == "datago"
+    assert spec.exports[0].output_path == "out/data.jsonl"
+
+
+def test_load_spec_raises_for_invalid_yaml(tmp_path: Path) -> None:
+    spec_path = tmp_path / "spec.yaml"
+    spec_path.write_text("dataset_id: [unterminated\n", encoding="utf-8")
+
+    with pytest.raises(SpecLoadError):
+        load_spec(spec_path)
+
+
+def test_load_spec_raises_for_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(SpecLoadError):
+        load_spec(tmp_path / "missing.yaml")

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from pathlib import Path
 
-from kpubdata_builder.manifest import BuildManifest
+import pytest
+
+from kpubdata_builder import ManifestError
+from kpubdata_builder.manifest import BuildManifest, manifest_writer
 
 
 def test_build_manifest_instantiation() -> None:
@@ -15,3 +19,34 @@ def test_build_manifest_instantiation() -> None:
     manifest = BuildManifest(build_id="build-1", started_at=started_at, finished_at=finished_at)
 
     assert manifest.build_id == "build-1"
+
+
+def test_manifest_writer_creates_parent_directories(tmp_path: Path) -> None:
+    manifest = BuildManifest(
+        build_id="build-1",
+        started_at=datetime.now(tz=timezone.utc),
+        finished_at=datetime.now(tz=timezone.utc),
+    )
+    output_path = tmp_path / "nested" / "build" / "manifest.json"
+
+    manifest_writer(manifest, output_path)
+
+    assert output_path.exists()
+
+
+def test_manifest_writer_wraps_io_failures(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = BuildManifest(
+        build_id="build-1",
+        started_at=datetime.now(tz=timezone.utc),
+        finished_at=datetime.now(tz=timezone.utc),
+    )
+    output_path = tmp_path / "manifest.json"
+
+    def raise_io_error(self: Path, data: str, *, encoding: str) -> int:
+        del self, data, encoding
+        raise OSError("disk full")
+
+    monkeypatch.setattr(Path, "write_text", raise_io_error)
+
+    with pytest.raises(ManifestError):
+        manifest_writer(manifest, output_path)

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import pytest
+
+from kpubdata_builder import ValidationError
 from kpubdata_builder.spec import BuildSpec, ExportTarget, SourceRef
 from kpubdata_builder.validator import validate_spec
 
@@ -17,3 +20,46 @@ def test_validate_spec_accepts_valid_spec() -> None:
     )
 
     validate_spec(spec)
+
+
+@pytest.mark.parametrize(
+    ("dataset_id", "sources", "exports", "expected_problems"),
+    [
+        (
+            "   ",
+            (SourceRef(provider="datago", dataset="air_quality"),),
+            (ExportTarget(kind="markdown", output_path="README.md"),),
+            ["dataset_id must be a non-empty string"],
+        ),
+        (
+            "dataset.sample",
+            (),
+            (ExportTarget(kind="markdown", output_path="README.md"),),
+            ["at least one source is required"],
+        ),
+        (
+            "dataset.sample",
+            (SourceRef(provider="datago", dataset="air_quality"),),
+            (),
+            ["at least one export target is required"],
+        ),
+    ],
+)
+def test_validate_spec_rejects_invalid_spec(
+    dataset_id: str,
+    sources: tuple[SourceRef, ...],
+    exports: tuple[ExportTarget, ...],
+    expected_problems: list[str],
+) -> None:
+    spec = BuildSpec(
+        dataset_id=dataset_id,
+        title="Sample Dataset",
+        description="Sample description",
+        sources=sources,
+        exports=exports,
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        validate_spec(spec)
+
+    assert exc_info.value.problems == expected_problems


### PR DESCRIPTION
## Summary
- add a dedicated builder error hierarchy and wrap validation, execution, assembly, manifest, and exporter failures with explicit pipeline result objects
- add YAML spec loading support plus regression tests for invalid specs, loader failures, missing source warnings, manifest IO failures, and exporter write errors
- keep the executor stubbed while making the v0.1 pipeline deterministic, better surfaced for students, and safer to extend

Closes #17
Closes #18
Closes #19
Closes #20
Closes #21
Closes #22