### PR TITLE
docs: realign builder as dataset build engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,19 +3,19 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
-**KPubData Builder**는 재현 가능한 공공데이터 데이터셋 조립을 위한 **execution engine**입니다. `kpubdata`가 정규화한 레코드를 받아, BuildSpec에 따라 검증하고, 조립하고, 내보내고, Manifest로 기록합니다.
+**KPubData Builder**는 원시 공공데이터를 정제된, 검증된, 배포 가능한 데이터셋으로 변환하는 **dataset build engine**입니다. `kpubdata`가 정규화한 레코드를 받아, BuildSpec에 따라 검증하고, 조립하고, 내보내고, Manifest로 기록합니다.
 
 ---
 
 ## 소개
 
-`kpubdata-builder`는 **재현 가능한 공공데이터 데이터셋 조립을 위한 실행 엔진**입니다.
+`kpubdata-builder`는 **원시 공공데이터를 정제된, 검증된, 배포 가능한 데이터셋으로 변환하는 빌드 엔진**입니다.
 
 쉽게 말해:
 
 - `kpubdata`는 데이터를 **가져오고 정규화하는 코어**입니다.
-- `kpubdata-builder`는 그 데이터를 **BuildSpec에 따라 실행 가능한 산출물로 조립하는 엔진**입니다.
-- `kpubdata-studio`는 builder 위에 올라가는 **시각적 제어면(control surface)**입니다.
+- `kpubdata-builder`는 그 데이터를 **BuildSpec에 따라 정제 → 메타데이터 생성 → 분할 → 검증 → 배포하는 엔진**입니다.
+- `kpubdata-studio`는 builder 위에 올라가는 **데이터셋 워크벤치 UI**입니다.
 
 즉, Builder는 문서·데이터셋·배포 패키지 같은 결과물을 일관되게 만들어내는 파이프라인의 중심이며, **별도의 UI 제품이 아니라 실행 계층**입니다.
 
@@ -131,6 +131,6 @@ BuildSpec 계약은 [BUILD_SPEC.md](./BUILD_SPEC.md)를 참고하세요.
 
 | 패키지 | 역할 |
 | :--- | :--- |
-| [kpubdata](https://github.com/yeongseon/kpubdata) | 공공데이터 접근·정규화 코어 |
-| [kpubdata-builder](https://github.com/yeongseon/kpubdata-builder) | 재현 가능한 데이터셋 조립 실행 엔진 |
-| [kpubdata-studio](https://github.com/yeongseon/kpubdata-studio) | builder 위에서 동작하는 시각적 제어면 |
+| [kpubdata](https://github.com/yeongseon/kpubdata) | 공공데이터 접근·정규화 코어 + curated dataset collection 브랜드 |
+| [kpubdata-builder](https://github.com/yeongseon/kpubdata-builder) | 원시 데이터 → 정제·검증·배포 가능한 데이터셋 빌드 엔진 |
+| [kpubdata-studio](https://github.com/yeongseon/kpubdata-studio) | 데이터셋 워크벤치 UI (inspect, transform, preview, export) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,26 +1,98 @@
 # Roadmap — kpubdata-builder
 
+> kpubdata-builder는 **원시 공공데이터를 정제된, 검증된, 배포 가능한 데이터셋으로 변환하는 빌드 엔진**입니다.
+> raw public data → cleaned dataset → metadata → split → validation → publish
+
+## 개발 축
+
+| 축 | 설명 |
+| :--- | :--- |
+| **Build Pipeline** | spec 파싱 → 검증 → 실행 → export → manifest 핵심 흐름 |
+| **Export & Publish** | 출력 형식(Markdown, JSONL, Parquet, HF layout) + 배포 대상(HF Hub, Kaggle, 로컬) |
+| **Dataset Identity** | dataset card, schema summary, split, provenance, version history |
+
+---
+
 ## v0.1
 
-- BuildSpec 계약 안정화
-- BuildSpec 검증 흐름 안정화
+BuildSpec 계약과 핵심 파이프라인 안정화.
+
+- BuildSpec 계약 안정화 (YAML 파싱, 검증)
 - preview 계약 안정화
 - manifest 스키마 안정화
 - CLI 기반 build 실행 흐름 정리
+- BuildError 에러 계층 정리
+- spec loader, executor, assembler 에러 처리 강화
 
 ## v0.2
 
-- exporter 확장
-- publisher 확장
-- 추가 output 레이아웃 지원
-- 원격 게시 대상 다양화
+Export 확장과 Dataset Identity 도입.
+
+### Export & Publish
+- Markdown exporter (#5)
+- JSONL exporter (#6)
+- Parquet exporter (#8)
+- Hugging Face layout exporter (#9)
+- Publish command — 로컬 → 원격 배포 (#10)
+
+### Dataset Identity
+- Manifest를 **dataset release record**로 승격 — build manifest writer (#7)
+- Schema summary in manifest (#11)
+- Richer provenance tracking (#12)
+- **Dataset card 생성**: README / schema summary / sample preview / source attribution / license / version history
+
+### Build Pipeline
+- Build command and source execution (#4)
+- Validate command (#2)
+- Preview command (#3)
+- Build spec parsing (YAML) (#1)
 
 ## v0.3
 
-- service mode 도입
-- plugin model 확장
-- build diff/history 기능 도입
-- 장기 실행 상태 조회 개선
+Plugin 생태계와 고급 빌드 기능.
+
+- Plugin exporter API (#13)
+- Reusable build templates (#14)
+- Snapshot-aware builds (#15)
+- Build diff/compare tools (#16)
+- Exporter / Publisher 경계 분리 (#28)
+- **Split 지원**: train/validation/test, by year/region/category, distribution-aware segmentation
+- **Kaggle dataset export** 지원
+- **Data catalog page** 생성 — 브랜드 배포용 정적 페이지
+
+## v1.0 criteria
+
+- BuildSpec 계약 안정, 하위 호환성 보장
+- 3개 이상 exporter 안정 (Markdown, JSONL, Parquet)
+- 2개 이상 publish 대상 안정 (Hugging Face, Kaggle)
+- Dataset card + manifest가 모든 빌드에 자동 생성
+- Plugin exporter API로 외부 확장 가능
+- kpubdata-studio에서 전체 워크플로우 제어 가능
+
+---
+
+## 출력 타깃 (Output Targets)
+
+| 타깃 | 설명 | 버전 |
+| :--- | :--- | :--- |
+| Hugging Face datasets | ML/AI 친화적 데이터셋 배포 | v0.2 |
+| Kaggle datasets | 데이터 분석/경진대회 배포 | v0.3 |
+| CSV / Parquet package | 범용 데이터 패키지 | v0.2 |
+| Data catalog page | 브랜드 배포용 정적 카탈로그 페이지 | v0.3 |
+
+## Dataset Identity 개념
+
+Builder가 생성하는 모든 데이터셋에는 다음 정보가 포함됩니다:
+
+| 항목 | 설명 |
+| :--- | :--- |
+| source | 원본 데이터 출처 (provider, dataset, params) |
+| build date | 빌드 실행 일시 |
+| schema | 필드 정의 및 타입 |
+| split info | 데이터 분할 정보 |
+| validation result | 검증 결과 |
+| export targets | 출력 형식 및 대상 |
+| version | 데이터셋 버전 |
 
 ---
 


### PR DESCRIPTION
## Summary
- Reposition from 'execution engine' to 'dataset build engine'
- Add 3 development axes: Build Pipeline, Export & Publish, Dataset Identity
- Detail v0.1-v0.3 with issue references and output targets
- Add Dataset Identity concept: dataset card, split, provenance