### PR TITLE
feat: config-driven HuggingFace dataset publishing script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
 [project.optional-dependencies]
 parquet = ["pyarrow>=15,<18"]
 huggingface = ["huggingface-hub>=0.23,<1"]
+publish = ["polars>=1.0,<2", "huggingface-hub>=0.23,<1"]
 dev = [
   "build>=1.2,<2",
   "mypy>=1.10,<2",

--- a/scripts/configs/korea_base_rate.yaml
+++ b/scripts/configs/korea_base_rate.yaml
@@ -1,0 +1,59 @@
+# BOK Base Rate — HuggingFace Dataset Publishing Config
+# Dataset: kpubdata/korea-base-rate
+# Source: Bank of Korea ECOS base interest rate
+
+source:
+  provider: bok
+  dataset: base_rate
+  list_all: false
+  fetch_params:
+    - start_date: "200101"
+      end_date: "202412"
+
+transform:
+  column_mapping:
+    TIME: year_month
+    DATA_VALUE: base_rate_pct
+    STAT_NAME: stat_name
+    UNIT_NAME: unit
+
+  dtypes:
+    year_month: str
+    base_rate_pct: float
+    stat_name: str
+    unit: str
+
+  derived: []
+  filters: []
+
+output:
+  hf_repo: "kpubdata/korea-base-rate"
+  parquet_filename: "data/train.parquet"
+  staging_dir: "./staging/korea-base-rate"
+
+card:
+  title: "Korea Base Interest Rate (한국은행 기준금리)"
+  description: |
+    Historical base interest rate of the Bank of Korea (BOK),
+    sourced from the Economic Statistics System (ECOS) via
+    kpubdata.
+
+    Monthly time series suitable for economic analysis and
+    forecasting tasks.
+  license: "CC-BY-4.0"
+  language:
+    - ko
+  tags:
+    - economics
+    - interest-rate
+    - korea
+    - time-series
+  features:
+    - name: year_month
+      description: "YYYYMM format period identifier"
+    - name: base_rate_pct
+      description: "Base rate in annual percent (연%)"
+    - name: stat_name
+      description: "Statistic name from BOK"
+    - name: unit
+      description: "Unit description"

--- a/scripts/configs/korean_apartment_trades.yaml
+++ b/scripts/configs/korean_apartment_trades.yaml
@@ -1,0 +1,130 @@
+# Korean Apartment Trades — HuggingFace Dataset Publishing Config
+# Dataset: kpubdata/korean-apartment-trades
+# Source: data.go.kr MOLIT apartment trade real transaction data
+
+source:
+  provider: datago
+  dataset: apt_trade
+  # Each entry in fetch_params triggers a separate API call.
+  # Results are concatenated into a single dataset.
+  # Use list_all: true to auto-paginate each parameter set.
+  list_all: true
+  fetch_params:
+    - LAWD_CD: "11680"    # 강남구
+      DEAL_YMD: "202401"
+    - LAWD_CD: "11680"
+      DEAL_YMD: "202402"
+    - LAWD_CD: "11680"
+      DEAL_YMD: "202403"
+    - LAWD_CD: "11680"
+      DEAL_YMD: "202404"
+    - LAWD_CD: "11680"
+      DEAL_YMD: "202405"
+    - LAWD_CD: "11680"
+      DEAL_YMD: "202406"
+    - LAWD_CD: "11650"    # 서초구
+      DEAL_YMD: "202401"
+    - LAWD_CD: "11650"
+      DEAL_YMD: "202402"
+    - LAWD_CD: "11650"
+      DEAL_YMD: "202403"
+    - LAWD_CD: "11650"
+      DEAL_YMD: "202404"
+    - LAWD_CD: "11650"
+      DEAL_YMD: "202405"
+    - LAWD_CD: "11650"
+      DEAL_YMD: "202406"
+
+transform:
+  # Map raw API field names to clean English column names.
+  # Only mapped columns are kept in the final output.
+  column_mapping:
+    sggCd: district_code
+    umdNm: neighborhood
+    aptNm: apartment_name
+    excluUseAr: exclusive_area_m2
+    floor: floor
+    buildYear: build_year
+    dealYear: deal_year
+    dealMonth: deal_month
+    dealDay: deal_day
+    dealAmount: deal_amount_10k_krw
+    jibun: lot_number
+
+  # Type casting applied after column mapping.
+  # Supported types: int, float, str
+  # Special: "int_comma" strips commas before converting (e.g. "82,500" -> 82500)
+  dtypes:
+    district_code: str
+    neighborhood: str
+    apartment_name: str
+    exclusive_area_m2: float
+    floor: int
+    build_year: int
+    deal_year: int
+    deal_month: int
+    deal_day: int
+    deal_amount_10k_krw: int_comma
+    lot_number: str
+
+  # Optional derived columns computed after type casting.
+  derived:
+    - name: deal_date
+      expr: "concat_date(deal_year, deal_month, deal_day)"
+      dtype: str
+
+  # Optional row filter expressions (Polars filter syntax).
+  # Rows not matching ALL filters are dropped.
+  filters:
+    - "deal_amount_10k_krw > 0"
+
+output:
+  hf_repo: "kpubdata/korean-apartment-trades"
+  parquet_filename: "data/train.parquet"
+  # Local staging directory (relative to script working dir)
+  staging_dir: "./staging/korean-apartment-trades"
+
+card:
+  title: "Korean Apartment Trades (아파트매매 실거래가)"
+  description: |
+    Real transaction prices for apartment sales in South Korea,
+    sourced from the Ministry of Land, Infrastructure and Transport (MOLIT)
+    via data.go.kr public API.
+
+    This dataset is the Korean equivalent of the California Housing dataset —
+    a tabular regression benchmark where the target variable is the transaction
+    price (`deal_amount_10k_krw`, unit: 10,000 KRW).
+  license: "CC-BY-4.0"
+  language:
+    - ko
+  tags:
+    - real-estate
+    - housing-prices
+    - korea
+    - tabular
+    - regression
+  features:
+    - name: district_code
+      description: "시군구 코드 (5-digit administrative district code)"
+    - name: neighborhood
+      description: "읍면동 이름 (e.g. 개포동, 역삼동)"
+    - name: apartment_name
+      description: "아파트 단지명"
+    - name: exclusive_area_m2
+      description: "전용면적 (m², exclusive use area)"
+    - name: floor
+      description: "거래 층수"
+    - name: build_year
+      description: "건축년도"
+    - name: deal_year
+      description: "거래년도"
+    - name: deal_month
+      description: "거래월"
+    - name: deal_day
+      description: "거래일"
+    - name: deal_amount_10k_krw
+      description: "거래금액 (만원 단위, target variable for regression)"
+    - name: lot_number
+      description: "지번"
+    - name: deal_date
+      description: "거래일자 (YYYY-MM-DD, derived)"

--- a/scripts/publish_to_hf.py
+++ b/scripts/publish_to_hf.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+import yaml
+from kpubdata import Client
+
+logger = logging.getLogger("publish_to_hf")
+
+_FILTER_RE = re.compile(r"(\w+)\s*(>=|<=|!=|==|>|<)\s*(.+)")
+
+
+def load_config(config_path: str) -> dict[str, Any]:
+    with open(config_path, encoding="utf-8") as f:
+        data: dict[str, Any] = yaml.safe_load(f)
+        if not isinstance(data, dict):
+            logger.error("Config file is empty or not a YAML mapping: %s", config_path)
+            sys.exit(1)
+        return data
+
+
+def fetch_records(config: dict[str, Any]) -> list[dict[str, Any]]:
+    source = config["source"]
+    client = Client.from_env()
+    ds = client.dataset(f"{source['provider']}.{source['dataset']}")
+
+    all_records: list[dict[str, Any]] = []
+    use_list_all = source.get("list_all", False)
+
+    for i, params in enumerate(source["fetch_params"]):
+        logger.info("Fetching param set %d/%d: %s", i + 1, len(source["fetch_params"]), params)
+
+        if use_list_all:
+            for batch in ds.list_all(**params):
+                all_records.extend(batch.items)
+        else:
+            result = ds.list(**params)
+            all_records.extend(result.items)
+
+    logger.info("Fetched %d total records", len(all_records))
+    return all_records
+
+
+def transform_records(records: list[dict[str, Any]], config: dict[str, Any]) -> pl.DataFrame:
+    transform = config["transform"]
+    column_mapping: dict[str, str] = transform["column_mapping"]
+    dtypes: dict[str, str] = transform.get("dtypes", {})
+
+    mapped: list[dict[str, Any]] = []
+    for record in records:
+        row: dict[str, Any] = {}
+        for raw_key, clean_key in column_mapping.items():
+            row[clean_key] = record.get(raw_key)
+        mapped.append(row)
+
+    df = pl.DataFrame(mapped)
+    logger.info("Raw DataFrame: %d rows x %d cols", df.height, df.width)
+
+    for col, dtype_str in dtypes.items():
+        if col not in df.columns:
+            continue
+        df = _cast_column(df, col, dtype_str)
+
+    for derived in transform.get("derived", []):
+        df = _add_derived_column(df, derived)
+
+    pre_filter_count = df.height
+    for filter_expr in transform.get("filters", []):
+        df = _apply_filter(df, filter_expr)
+    if df.height != pre_filter_count:
+        logger.info("Filtered: %d -> %d rows", pre_filter_count, df.height)
+
+    logger.info("Transformed DataFrame: %d rows x %d cols", df.height, df.width)
+    return df
+
+
+def _apply_filter(df: pl.DataFrame, expr_str: str) -> pl.DataFrame:
+    """Apply a simple comparison filter: 'col >= value', 'col != value', etc."""
+    match = _FILTER_RE.match(expr_str.strip())
+    if not match:
+        logger.warning("Cannot parse filter expression: %s", expr_str)
+        return df
+
+    col, op, val_str = match.group(1), match.group(2), match.group(3).strip()
+
+    if col not in df.columns:
+        logger.warning("Filter references unknown column '%s', skipping", col)
+        return df
+
+    try:
+        val: int | float = int(val_str)
+    except ValueError:
+        val = float(val_str)
+
+    ops = {
+        ">": pl.col(col) > val,
+        "<": pl.col(col) < val,
+        ">=": pl.col(col) >= val,
+        "<=": pl.col(col) <= val,
+        "==": pl.col(col) == val,
+        "!=": pl.col(col) != val,
+    }
+    return df.filter(ops[op])
+
+
+_NULL_TOKENS = {"", "-", "N/A", "null", "None"}
+
+
+def _nullify_tokens(col: str) -> pl.Expr:
+    return (
+        pl.when(pl.col(col).cast(pl.Utf8).str.strip_chars().is_in(list(_NULL_TOKENS)))
+        .then(pl.lit(None, dtype=pl.Utf8))
+        .otherwise(pl.col(col).cast(pl.Utf8).str.strip_chars())
+        .alias(col)
+    )
+
+
+def _cast_column(df: pl.DataFrame, col: str, dtype_str: str) -> pl.DataFrame:
+    if dtype_str == "int_comma":
+        return df.with_columns(
+            pl.col(col)
+            .cast(pl.Utf8)
+            .str.replace_all(",", "")
+            .str.strip_chars()
+            .cast(pl.Int64, strict=False)
+            .alias(col)
+        )
+    if dtype_str == "int":
+        df = df.with_columns(_nullify_tokens(col))
+        return df.with_columns(pl.col(col).cast(pl.Int64, strict=False).alias(col))
+    if dtype_str == "float":
+        df = df.with_columns(_nullify_tokens(col))
+        return df.with_columns(pl.col(col).cast(pl.Float64, strict=False).alias(col))
+    if dtype_str == "str":
+        return df.with_columns(pl.col(col).cast(pl.Utf8).alias(col))
+    logger.warning("Unknown dtype '%s' for column '%s', skipping cast", dtype_str, col)
+    return df
+
+
+def _add_derived_column(df: pl.DataFrame, derived: dict[str, Any]) -> pl.DataFrame:
+    name = derived["name"]
+    expr = derived["expr"]
+    dtype_str = derived.get("dtype", "str")
+
+    if expr.startswith("concat_date("):
+        inner = expr[len("concat_date(") : -1]
+        col_refs = [p.strip() for p in inner.split(",")]
+        if len(col_refs) == 3:
+            year_col, month_col, day_col = col_refs
+            polars_expr = (
+                pl.col(year_col).cast(pl.Utf8)
+                + pl.lit("-")
+                + pl.col(month_col).cast(pl.Utf8).str.zfill(2)
+                + pl.lit("-")
+                + pl.col(day_col).cast(pl.Utf8).str.zfill(2)
+            ).alias(name)
+            df = df.with_columns(polars_expr)
+        else:
+            logger.warning("concat_date requires exactly 3 columns, got %d", len(col_refs))
+            return df
+    elif expr.startswith("format("):
+        inner = expr[len("format(") : -1]
+        parts = [p.strip() for p in inner.split(",")]
+        fmt_str = parts[0].strip("'\"")
+        col_refs = [p.strip() for p in parts[1:]]
+        polars_expr = pl.format(fmt_str, *[pl.col(c) for c in col_refs]).alias(name)
+        df = df.with_columns(polars_expr)
+    else:
+        logger.warning("Unsupported derived expression: %s", expr)
+        return df
+
+    if dtype_str != "str":
+        df = _cast_column(df, name, dtype_str)
+    return df
+
+
+def write_parquet(df: pl.DataFrame, output_path: Path) -> Path:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    df.write_parquet(output_path)
+    size_mb = output_path.stat().st_size / (1024 * 1024)
+    logger.info("Wrote parquet: %s (%.2f MB, %d rows)", output_path, size_mb, df.height)
+    return output_path
+
+
+def generate_dataset_card(df: pl.DataFrame, config: dict[str, Any], output_path: Path) -> Path:
+    card = config["card"]
+    output_cfg = config["output"]
+
+    features_table = _build_features_table(card.get("features", []))
+    sample_table = _build_sample_table(df, max_rows=5)
+    stats_section = _build_stats_section(df)
+
+    tags_yaml = "\n".join(f"- {t}" for t in card.get("tags", []))
+    languages_yaml = "\n".join(f"- {lang}" for lang in card.get("language", ["ko"]))
+    hf_repo = output_cfg["hf_repo"]
+    source_url = config["source"].get("source_url", "https://www.data.go.kr")
+
+    content = f"""---
+license: {card.get("license", "CC-BY-4.0")}
+language:
+{languages_yaml}
+tags:
+{tags_yaml}
+size_categories:
+- {_size_category(df.height)}
+---
+
+# {card["title"]}
+
+{card["description"]}
+
+## Dataset Summary
+
+- **Records**: {df.height:,}
+- **Features**: {df.width}
+- **Source**: [data.go.kr]({source_url})
+- **HuggingFace Repo**: [{hf_repo}](https://huggingface.co/datasets/{hf_repo})
+
+{stats_section}
+
+## Features
+
+{features_table}
+
+## Sample Data
+
+{sample_table}
+
+## Usage
+
+```python
+from datasets import load_dataset
+
+ds = load_dataset("{hf_repo}")
+df = ds["train"].to_pandas()
+print(df.head())
+```
+
+## Source
+
+This dataset was generated using [kpubdata](https://github.com/yeongseon/kpubdata)
+from public data APIs on data.go.kr.
+"""
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(content, encoding="utf-8")
+    logger.info("Wrote dataset card: %s", output_path)
+    return output_path
+
+
+def _build_features_table(features: list[dict[str, str]]) -> str:
+    if not features:
+        return ""
+    lines = ["| Feature | Description |", "| :--- | :--- |"]
+    for f in features:
+        escaped_desc = f["description"].replace("|", "\\|")
+        lines.append(f"| `{f['name']}` | {escaped_desc} |")
+    return "\n".join(lines)
+
+
+def _build_sample_table(df: pl.DataFrame, max_rows: int = 5) -> str:
+    sample = df.head(max_rows)
+    header = "| " + " | ".join(sample.columns) + " |"
+    separator = "| " + " | ".join("---" for _ in sample.columns) + " |"
+    rows: list[str] = []
+    for row in sample.iter_rows(named=True):
+        cells = " | ".join(str(v).replace("|", "\\|") for v in row.values())
+        rows.append(f"| {cells} |")
+    return "\n".join([header, separator, *rows])
+
+
+def _build_stats_section(df: pl.DataFrame) -> str:
+    numeric_cols = [
+        col for col, dtype in zip(df.columns, df.dtypes, strict=True) if dtype.is_numeric()
+    ]
+    if not numeric_cols:
+        return ""
+
+    lines = [
+        "## Statistics",
+        "",
+        "| Feature | Mean | Std | Min | Max |",
+        "| :--- | ---: | ---: | ---: | ---: |",
+    ]
+    for col in numeric_cols:
+        series = df[col].drop_nulls()
+        if series.is_empty():
+            continue
+        mean_val = series.mean()
+        std_val = series.std()
+        mean = float(str(mean_val)) if mean_val is not None else 0.0
+        std = float(str(std_val)) if std_val is not None else 0.0
+        min_val = str(series.min())
+        max_val = str(series.max())
+        lines.append(f"| `{col}` | {mean:,.2f} | {std:,.2f} | {min_val} | {max_val} |")
+    return "\n".join(lines)
+
+
+def _size_category(n: int) -> str:
+    if n < 1_000:
+        return "n<1K"
+    if n < 10_000:
+        return "1K<n<10K"
+    if n < 100_000:
+        return "10K<n<100K"
+    if n < 1_000_000:
+        return "100K<n<1M"
+    if n < 10_000_000:
+        return "1M<n<10M"
+    return "n>10M"
+
+
+def upload_to_hf(staging_dir: Path, hf_repo: str, *, dry_run: bool = False) -> None:
+    if dry_run:
+        logger.info("[DRY RUN] Would upload %s to %s", staging_dir, hf_repo)
+        return
+
+    try:
+        from huggingface_hub import HfApi
+    except ImportError:
+        logger.error(
+            "huggingface_hub not installed. Install with: pip install 'kpubdata-builder[publish]'"
+        )
+        sys.exit(1)
+
+    upload_dir = staging_dir / ".hf_upload"
+    if upload_dir.exists():
+        shutil.rmtree(upload_dir)
+    upload_dir.mkdir(parents=True)
+
+    readme = staging_dir / "README.md"
+    if readme.exists():
+        shutil.copy2(readme, upload_dir / "README.md")
+
+    data_dir = staging_dir / "data"
+    if data_dir.exists():
+        dest_data = upload_dir / "data"
+        dest_data.mkdir()
+        for parquet_file in data_dir.glob("*.parquet"):
+            shutil.copy2(parquet_file, dest_data / parquet_file.name)
+
+    api = HfApi()
+    api.create_repo(repo_id=hf_repo, repo_type="dataset", exist_ok=True)
+    api.upload_folder(
+        folder_path=str(upload_dir),
+        repo_id=hf_repo,
+        repo_type="dataset",
+    )
+    shutil.rmtree(upload_dir)
+    logger.info("Uploaded to https://huggingface.co/datasets/%s", hf_repo)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Publish kpubdata dataset to HuggingFace Hub")
+    parser.add_argument("config", help="Path to YAML config file")
+    parser.add_argument("--dry-run", action="store_true", help="Skip HF upload, generate locally")
+    parser.add_argument("--local-only", action="store_true", help="Only generate local files")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Enable debug logging")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+
+    config = load_config(args.config)
+    output_cfg = config["output"]
+    staging_dir = Path(output_cfg["staging_dir"])
+
+    records = fetch_records(config)
+    if not records:
+        logger.error("No records fetched. Check API key and fetch_params.")
+        sys.exit(1)
+
+    df = transform_records(records, config)
+    if df.is_empty():
+        logger.error("DataFrame empty after transform. Check filters.")
+        sys.exit(1)
+
+    parquet_path = staging_dir / output_cfg["parquet_filename"]
+    write_parquet(df, parquet_path)
+
+    card_path = staging_dir / "README.md"
+    generate_dataset_card(df, config, card_path)
+
+    if args.local_only:
+        logger.info("Local-only mode. Files at: %s", staging_dir)
+        return
+
+    upload_to_hf(staging_dir, output_cfg["hf_repo"], dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -282,7 +282,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -409,7 +409,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -427,7 +427,7 @@ wheels = [
 
 [[package]]
 name = "kpubdata"
-version = "0.1.0a0"
+version = "0.4.0"
 source = { editable = "../kpubdata" }
 dependencies = [
     { name = "httpx" },
@@ -475,13 +475,19 @@ huggingface = [
 parquet = [
     { name = "pyarrow" },
 ]
+publish = [
+    { name = "huggingface-hub" },
+    { name = "polars" },
+]
 
 [package.metadata]
 requires-dist = [
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.2,<2" },
     { name = "huggingface-hub", marker = "extra == 'huggingface'", specifier = ">=0.23,<1" },
+    { name = "huggingface-hub", marker = "extra == 'publish'", specifier = ">=0.23,<1" },
     { name = "kpubdata", editable = "../kpubdata" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10,<2" },
+    { name = "polars", marker = "extra == 'publish'", specifier = ">=1.0,<2" },
     { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=15,<18" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2,<9" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5,<6" },
@@ -489,7 +495,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5,<1" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
 ]
-provides-extras = ["parquet", "huggingface", "dev"]
+provides-extras = ["parquet", "huggingface", "publish", "dev"]
 
 [[package]]
 name = "librt"
@@ -815,6 +821,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "polars"
+version = "1.40.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8c/bc9bc948058348ed43117cecc3007cd608f395915dae8a00974579a5dab1/polars-1.40.1.tar.gz", hash = "sha256:ab2694134b137596b5a59bfd7b4c54ebbc9b59f9403127f18e32d363777552e8", size = 733574, upload-time = "2026-04-22T19:15:55.507Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/91/74fc60d94488685a92ac9d49d7ec55f3e91fe9b77942a6235a5fa7f249c3/polars-1.40.1-py3-none-any.whl", hash = "sha256:c0f861219d1319cdea45c4ce4d30355a47176b8f98dcedf95ea8269f131b8abd", size = 828723, upload-time = "2026-04-22T19:14:25.452Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.40.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ba/26d40f039be9f552b5fd7365a621bdfc0f8e912ef77094ae4693491b0bae/polars_runtime_32-1.40.1.tar.gz", hash = "sha256:37f3065615d1bf90d03b5326222df4c5c1f8a5d33e50470aa588e3465e6eb814", size = 2935843, upload-time = "2026-04-22T19:15:57.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/46/22c8af5eed68ac2eeb556e0fa3ca8a7b798e984ceff4450888f3b5ac61fd/polars_runtime_32-1.40.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:b748ef652270cc49e9e69f99a035e0eb4d5f856d42bcd6ac4d9d80a40142aa1e", size = 52098755, upload-time = "2026-04-22T19:14:28.555Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3e/48599a38009ca60ff82a6f38c8a621ce3c0286aa7397c7d79e741bd9060e/polars_runtime_32-1.40.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:d249b3743e05986060cec0a7aaa542d020df6c6b876e556023a310efd581f9be", size = 46367542, upload-time = "2026-04-22T19:14:32.433Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e9/384bc069367a1a36ee31c13782c178dbd039b2b873b772d4a0fc23a2373d/polars_runtime_32-1.40.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5987b30e7aa1059d069498496e8dda35afd592b0ac3d46ed87e3ff8df1ad652c", size = 50252104, upload-time = "2026-04-22T19:14:35.945Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ef/7d57ceb0651af74194e97ed6583e148d352f03d696090221b8059cdfc90b/polars_runtime_32-1.40.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d7f42a8b3f16fc66002cc0f6516f7dd7653396886ae0ed362ab95c0b3408b59", size = 56250788, upload-time = "2026-04-22T19:14:39.743Z" },
+    { url = "https://files.pythonhosted.org/packages/10/0f/e4b3ffc748827a14a474ec9c42e45c066050e440fec57e914091d9adda75/polars_runtime_32-1.40.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e5f7becc237a7ec9d9a10878dc8e54b73bbf4e2d94a2991c37d7a0b38590d8f9", size = 50432590, upload-time = "2026-04-22T19:14:43.388Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/0b/b8d95fbed869fa4caabe9c400e4210374913b376e925e96fdcfa9be6416b/polars_runtime_32-1.40.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:992d14cf191dde043d36fbdbc98a65e43fbc7e9a5024cecd45f838ac4988c1ee", size = 54155564, upload-time = "2026-04-22T19:14:47.239Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d9/d091d8fb5cbed5e9536adfed955c4c89987a4cc3b8e73ae4532402b91c74/polars_runtime_32-1.40.1-cp310-abi3-win_amd64.whl", hash = "sha256:f78bb2abd00101cbb23cc0cb068f7e36e081057a15d2ec2dde3dda280709f030", size = 51829755, upload-time = "2026-04-22T19:14:50.85Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ad/b33c3022a394f3eb55c3310597cec615412a8a33880055eee191d154a628/polars_runtime_32-1.40.1-cp310-abi3-win_arm64.whl", hash = "sha256:b5cbfaf6b085b420b4bfcbe24e8f665076d1cccfdb80c0484c02a023ce205537", size = 45822104, upload-time = "2026-04-22T19:14:54.192Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- YAML config 기반으로 **어떤 kpubdata 데이터셋이든** HuggingFace Hub에 퍼블리싱할 수 있는 reusable 스크립트 추가
- 학생들이 이 end-to-end 스크립트를 Builder의 Bronze/Silver/Gold/Exporter/Publisher 모듈로 분해하는 레퍼런스로 사용

## 변경 사항

### 새 파일
- `scripts/publish_to_hf.py` — fetch → transform (Polars) → parquet → dataset card → HF upload
- `scripts/configs/korean_apartment_trades.yaml` — 아파트 실거래가 (한국판 California Housing)
- `scripts/configs/korea_base_rate.yaml` — BOK 기준금리 (재사용성 증명용)

### 수정
- `pyproject.toml` — `publish` optional dependency group 추가 (`polars`, `huggingface-hub`)

## 주요 기능
- **Config-driven**: YAML로 source/transform/output/card 정의, 코드 수정 없이 새 데이터셋 퍼블리싱
- **Null-safe casting**: `strict=False` + null token 정규화로 실데이터의 빈값/"-"/"N/A" 안전 처리
- **Multi-char filter operators**: `>=`, `<=`, `!=`, `==` 정확한 regex 매칭
- **Upload whitelist**: staging 전체 대신 README.md + data/*.parquet만 HF에 업로드
- **3가지 실행 모드**: `--local-only` (파일만 생성), `--dry-run` (업로드 스킵), 기본 (전체 실행)

## Pipeline 흐름 (→ Builder 분해 매핑)
```
fetch_records()    → Bronze (raw data fetch via kpubdata)
transform_records() → Silver (Polars column mapping, type cast, derived, filter)  
write_parquet()    → Gold (parquet packaging)
generate_dataset_card() → Export (dataset card generation)
upload_to_hf()     → Publish (HF Hub upload)
```

## 실행 예시
```bash
pip install 'kpubdata-builder[publish]'
python scripts/publish_to_hf.py scripts/configs/korean_apartment_trades.yaml --local-only
```

## Quality gates
- [x] ruff check ✅
- [x] ruff format ✅
- [x] mypy --ignore-missing-imports ✅
- [x] Smoke test: transform, filter operators, null-safe cast 전부 통과
- [x] Oracle review 반영 완료