### PR TITLE
feat: Kaggle 퍼블리싱 지원 추가

### DIFF
--- a/docs/hf-publishing-standards.md
+++ b/docs/hf-publishing-standards.md
@@ -1,6 +1,6 @@
-# HuggingFace 데이터셋 퍼블리싱 표준 규칙
+# 데이터셋 퍼블리싱 표준 규칙
 
-이 문서는 kpubdata-builder를 통해 한국 공공데이터를 HuggingFace Hub에 반복적으로 퍼블리싱할 때 따라야 할 **표준 규칙**을 정의한다.
+이 문서는 kpubdata-builder를 통해 한국 공공데이터를 HuggingFace Hub 및 Kaggle에 반복적으로 퍼블리싱할 때 따라야 할 **표준 규칙**을 정의한다.
 
 스크립트 사용법과 Config YAML 스키마는 [publishing.md](./publishing.md)를 참고한다.
 
@@ -368,3 +368,95 @@ Dataset Card에 다음을 반드시 명시한다:
 | [공공누리 이용허락 안내](https://www.kogl.or.kr/info/license.do) | 공공누리 유형별 이용 조건 |
 | [공공데이터법](https://www.law.go.kr/법령/공공데이터의제공및이용활성화에관한법률) | 법률 원문 |
 | [HuggingFace Dataset Card Guide](https://huggingface.co/docs/hub/datasets-cards) | HF 공식 Dataset Card 작성 가이드 |
+
+---
+
+## 10. Kaggle 퍼블리싱
+
+### 개요
+
+`publish_to_hf.py`는 `--target kaggle` 또는 `--target all` 옵션으로 Kaggle에도 동시 퍼블리싱을 지원한다. HuggingFace와 동일한 parquet 데이터를 재사용하며, 메타데이터 형식만 `dataset-metadata.json`으로 변환한다.
+
+### Kaggle Slug 네이밍
+
+```
+{kaggle-username}/{dataset-slug}
+```
+
+| 요소 | 설명 | 예시 |
+| :--- | :--- | :--- |
+| `kaggle-username` | Kaggle 계정 사용자명 | `yschoe` |
+| `dataset-slug` | HF repo의 dataset name과 동일하게 유지 | `seoul-apartment-trades` |
+
+> Kaggle은 organization 계정이 없으므로 개인 계정 소속이 된다. 브랜드 통일이 필요하면 전용 Kaggle 계정을 생성한다.
+
+### Config YAML 설정
+
+```yaml
+output:
+  hf_repo: "kpubdata/seoul-apartment-trades"
+  kaggle_slug: "yschoe/seoul-apartment-trades"
+  parquet_filename: "data/train.parquet"
+  staging_dir: "./staging/seoul-apartment-trades"
+```
+
+`kaggle_slug`이 없으면 Kaggle 업로드를 건너뛴다.
+
+### HuggingFace → Kaggle 라이선스 매핑
+
+| HuggingFace (소문자) | Kaggle |
+| :--- | :--- |
+| `cc-by-4.0` | `CC-BY-4.0` |
+| `cc0-1.0` | `CC0-1.0` |
+| `cc-by-sa-4.0` | `CC-BY-SA-4.0` |
+| `cc-by-nc-4.0` | `CC-BY-NC-4.0` |
+| `cc-by-nc-sa-4.0` | `CC-BY-NC-SA-4.0` |
+
+> HuggingFace는 소문자 강제, Kaggle은 대문자 허용. 스크립트가 자동 변환한다.
+
+### dataset-metadata.json 필수 필드
+
+| 필드 | 필수 | 설명 |
+| :--- | :--- | :--- |
+| `title` | ✅ | 6~50자, Config의 `card.title` 사용 |
+| `id` | ✅ | `{username}/{slug}` 형식 |
+| `licenses` | ✅ | 정확히 1개, `[{"name": "CC-BY-4.0"}]` |
+| `subtitle` | 권장 | 20~80자. 미지정 시 description 첫 줄에서 자동 생성 |
+| `description` | 권장 | Config의 `card.description` + `card.attribution` 결합 |
+| `keywords` | 권장 | Config의 `card.tags` 재사용 |
+
+### CLI 사용법
+
+```bash
+# HuggingFace + Kaggle 동시 퍼블리싱
+uv run python scripts/publish_to_hf.py scripts/configs/seoul_apartment_trades.yaml --target all
+
+# Kaggle만
+uv run python scripts/publish_to_hf.py scripts/configs/seoul_apartment_trades.yaml --target kaggle
+
+# HuggingFace만 (기존 동작)
+uv run python scripts/publish_to_hf.py scripts/configs/seoul_apartment_trades.yaml --target hf
+```
+
+### Kaggle 인증
+
+두 가지 방식 중 하나를 사용한다:
+
+1. **환경변수**: `KAGGLE_USERNAME` + `KAGGLE_KEY`
+2. **파일**: `~/.kaggle/kaggle.json` (`{"username":"...","key":"..."}`)
+
+### Kaggle 업데이트 동작
+
+- 데이터셋이 이미 존재하면 **새 버전**(`dataset_create_version`)으로 업데이트한다.
+- 존재하지 않으면 **신규 생성**(`dataset_create_new`)한다.
+- 스크립트가 자동으로 존재 여부를 판별한다.
+
+### HuggingFace와 Kaggle 차이점 요약
+
+| 항목 | HuggingFace | Kaggle |
+| :--- | :--- | :--- |
+| 메타데이터 형식 | `README.md` (YAML front matter) | `dataset-metadata.json` |
+| 라이선스 표기 | 소문자 (`cc-by-4.0`) | 대문자 허용 (`CC-BY-4.0`) |
+| Organization | 지원 (`kpubdata/...`) | 미지원 (개인 계정만) |
+| 버전 관리 | Git 기반 (commit history) | 명시적 버전 번호 |
+| Dataset Card | README.md 내장 | 별도 description 필드 |

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -1,6 +1,6 @@
-# HuggingFace 퍼블리싱 시행착오 기록
+# 데이터셋 퍼블리싱 시행착오 기록
 
-이 문서는 `publish_to_hf.py` 스크립트로 HuggingFace 데이터셋을 퍼블리싱하면서 발견한 시행착오를 기록한다. Builder의 Bronze/Silver/Gold/Publish 모듈 구현 시 동일한 실수를 방지하기 위한 참고 자료다.
+이 문서는 `publish_to_hf.py` 스크립트로 HuggingFace 및 Kaggle에 데이터셋을 퍼블리싱하면서 발견한 시행착오를 기록한다. Builder의 Bronze/Silver/Gold/Publish 모듈 구현 시 동일한 실수를 방지하기 위한 참고 자료다.
 
 ---
 
@@ -145,6 +145,81 @@ df = pl.DataFrame(mapped, schema=schema)
 - **Export 단계**: Dataset Card 템플릿을 영어로 기본 생성
 - **BuildSpec**: `features` 설명에 `{영어} ({한국어})` 패턴 강제
 - 상세 언어 규칙: `hf-publishing-standards.md` §4 참조
+
+---
+
+## 7. Kaggle SDK `dataset_view` API 없음
+
+### 증상
+
+```
+AttributeError: 'KaggleApi' object has no attribute 'dataset_view'
+```
+
+### 원인
+
+kaggle SDK 1.6+ 에서 `dataset_view()` 메서드가 제거됨. 공식 문서나 예제에는 여전히 언급되는 경우가 있어 혼동 유발.
+
+### 해결
+
+`dataset_list(mine=True, search=slug_name)` 으로 대체하여 존재 여부를 판별한다.
+
+```python
+results = api.dataset_list(mine=True, search=kaggle_slug.split("/")[-1])
+dataset_exists = any(str(d) == kaggle_slug for d in results)
+```
+
+### Builder 적용 포인트
+
+- **Publisher 모듈**: Kaggle API 호출 시 SDK 버전별 API 가용성을 방어적으로 처리
+- `dataset_view`는 사용하지 말 것. `dataset_list` + 필터링 패턴 사용
+
+---
+
+## 8. Kaggle API 401 인증 에러
+
+### 증상
+
+```
+ApiException: (401) Reason: Unauthorized
+```
+
+### 원인
+
+Kaggle에서 새 API 토큰을 발급하면 **이전 토큰이 즉시 폐기**됨. 환경변수(`KAGGLE_KEY`)와 `~/.kaggle/kaggle.json`에 저장된 값이 서로 다르거나, 둘 다 구 토큰인 경우 발생.
+
+### 해결
+
+1. https://www.kaggle.com/settings → API → **Create New Token** 으로 새 토큰 발급
+2. 환경변수(`KAGGLE_USERNAME`, `KAGGLE_KEY`)와 `~/.kaggle/kaggle.json` **모두** 갱신
+3. `source ~/.zshrc` 로 반영 확인
+
+### Builder 적용 포인트
+
+- **인증 검증**: Publish 시작 전 `api.authenticate()` 후 간단한 API 호출(`dataset_list(mine=True)`)로 토큰 유효성을 사전 검증
+- **에러 메시지**: 401 에러 발생 시 "토큰 재발급 필요" 안내 메시지 출력
+
+---
+
+## 9. Kaggle은 Organization 미지원
+
+### 증상
+
+HuggingFace에서 `kpubdata/seoul-apartment-trades` (org 네임스페이스)로 업로드한 것과 동일한 브랜딩을 Kaggle에서 사용 불가.
+
+### 원인
+
+Kaggle은 organization 계정을 지원하지 않음. 모든 데이터셋은 개인 계정 소속 (`username/dataset-name`).
+
+### 해결
+
+- Kaggle slug를 별도로 관리: `kaggle_slug: "yschoe/seoul-apartment-trades"`
+- HF slug과 Kaggle slug을 config에서 분리하여 관리
+
+### Builder 적용 포인트
+
+- **BuildSpec**: `hf_repo`와 `kaggle_slug`을 별도 필드로 유지 (네임스페이스가 다를 수 있음)
+- **문서화**: Dataset Card에 양쪽 플랫폼 URL을 모두 기재하여 cross-reference 제공
 
 ---
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,6 +1,6 @@
-# HuggingFace 데이터셋 퍼블리싱 가이드
+# 데이터셋 퍼블리싱 가이드
 
-이 문서는 `scripts/publish_to_hf.py` 스크립트를 사용하여 공공데이터를 HuggingFace Hub에 퍼블리싱하는 전체 과정을 설명합니다.
+이 문서는 `scripts/publish_to_hf.py` 스크립트를 사용하여 공공데이터를 HuggingFace Hub 및 Kaggle에 퍼블리싱하는 전체 과정을 설명합니다.
 
 ---
 
@@ -11,9 +11,9 @@
 이 스크립트는 향후 Builder의 Medallion Architecture(Bronze/Silver/Gold/Exporter/Publisher) 모듈로 분해될 레퍼런스 구현입니다.
 
 ```text
-[YAML Config] → fetch → transform → write_parquet → generate_card → upload_to_hf
+[YAML Config] → fetch → transform → write_parquet → generate_card → upload_to_hf / upload_to_kaggle
                   │          │            │                │              │
-               Bronze     Silver        Gold           Export         Publish
+               Bronze     Silver        Gold           Export         Publish (HF + Kaggle)
 ```
 
 ---
@@ -30,6 +30,10 @@ export KPUBDATA_DATAGO_API_KEY="your-api-key"
 
 # HuggingFace API 토큰 (https://huggingface.co/settings/tokens 에서 발급)
 export HF_TOKEN="hf_..."
+
+# Kaggle API 인증 (https://www.kaggle.com/settings → API → Create New Token)
+export KAGGLE_USERNAME="your-username"
+export KAGGLE_KEY="your-api-key"
 ```
 
 설정 후 반영:
@@ -37,6 +41,8 @@ export HF_TOKEN="hf_..."
 ```bash
 source ~/.zshrc
 ```
+
+> **Kaggle 대체 인증 방법**: `~/.kaggle/kaggle.json` 파일에 `{"username": "...", "key": "..."}` 형태로 저장해도 됩니다. 환경변수가 우선합니다.
 
 ### 2. HuggingFace 토큰 발급
 
@@ -57,41 +63,62 @@ org 단위로 데이터셋을 관리하려면:
 1. https://huggingface.co/organizations/new 에서 org 생성
 2. 토큰 발급 시 해당 org에 대한 write 권한 부여
 
-### 4. 의존성 설치
+### 4. Kaggle API 토큰 발급
+
+1. https://www.kaggle.com/settings 접속
+2. **API** 섹션에서 **Create New Token** 클릭
+3. 다운로드된 `kaggle.json`에서 `username`과 `key`를 환경변수에 설정
+4. 주의: 새 토큰을 발급하면 이전 토큰은 **즉시 폐기**됨
+
+> Kaggle은 organization을 지원하지 않습니다. 모든 데이터셋은 **개인 계정** 소속입니다.
+
+### 5. 의존성 설치
 
 ```bash
 cd kpubdata-builder
 uv sync --extra publish
 ```
 
-`publish` extra에는 `polars`와 `huggingface-hub`가 포함됩니다.
+`publish` extra에는 `polars`, `huggingface-hub`, `kaggle`이 포함됩니다.
 
 ---
 
 ## 사용법
 
-### 기본 실행 (fetch + transform + upload)
+### 기본 실행 (HuggingFace + Kaggle 모두 업로드)
 
 ```bash
-uv run python scripts/publish_to_hf.py scripts/configs/korean_apartment_trades.yaml
+uv run python scripts/publish_to_hf.py scripts/configs/seoul_apartment_trades.yaml
+```
+
+### HuggingFace만 업로드
+
+```bash
+uv run python scripts/publish_to_hf.py scripts/configs/seoul_apartment_trades.yaml --target hf
+```
+
+### Kaggle만 업로드
+
+```bash
+uv run python scripts/publish_to_hf.py scripts/configs/seoul_apartment_trades.yaml --target kaggle
 ```
 
 ### 로컬에서만 파일 생성 (업로드 안 함)
 
 ```bash
-uv run python scripts/publish_to_hf.py scripts/configs/korean_apartment_trades.yaml --local-only
+uv run python scripts/publish_to_hf.py scripts/configs/seoul_apartment_trades.yaml --local-only
 ```
 
 ### 드라이런 (업로드 시뮬레이션)
 
 ```bash
-uv run python scripts/publish_to_hf.py scripts/configs/korean_apartment_trades.yaml --dry-run
+uv run python scripts/publish_to_hf.py scripts/configs/seoul_apartment_trades.yaml --dry-run
 ```
 
 ### 디버그 로깅
 
 ```bash
-uv run python scripts/publish_to_hf.py scripts/configs/korean_apartment_trades.yaml -v
+uv run python scripts/publish_to_hf.py scripts/configs/seoul_apartment_trades.yaml -v
 ```
 
 ### CLI 옵션 요약
@@ -99,7 +126,8 @@ uv run python scripts/publish_to_hf.py scripts/configs/korean_apartment_trades.y
 | 옵션 | 설명 |
 | :--- | :--- |
 | `config` (필수) | YAML config 파일 경로 |
-| `--dry-run` | HF 업로드를 건너뛰고 로컬 파일만 생성 (업로드 시뮬레이션 로그 출력) |
+| `--target` | 업로드 대상: `hf` (HuggingFace), `kaggle`, `all` (기본값: `all`) |
+| `--dry-run` | 업로드를 건너뛰고 로컬 파일만 생성 (업로드 시뮬레이션 로그 출력) |
 | `--local-only` | 로컬 파일 생성까지만 실행 (업로드 로직 자체를 건너뜀) |
 | `--verbose`, `-v` | DEBUG 레벨 로깅 활성화 |
 
@@ -192,14 +220,16 @@ filters:
 
 ```yaml
 output:
-  hf_repo: "kpubdata/korean-apartment-trades"
+  hf_repo: "kpubdata/seoul-apartment-trades"
+  kaggle_slug: "yschoe/seoul-apartment-trades"
   parquet_filename: "data/train.parquet"
-  staging_dir: "./staging/korean-apartment-trades"
+  staging_dir: "./staging/seoul-apartment-trades"
 ```
 
 | 필드 | 타입 | 필수 | 설명 |
 | :--- | :--- | :--- | :--- |
 | `hf_repo` | str | ✅ | HuggingFace 레포 ID (`org/dataset-name`) |
+| `kaggle_slug` | str | | Kaggle 데이터셋 슬러그 (`username/dataset-name`). 없으면 Kaggle 업로드 건너뜀 |
 | `parquet_filename` | str | ✅ | staging 내 parquet 파일 경로 |
 | `staging_dir` | str | ✅ | 로컬 staging 디렉토리 (스크립트 실행 위치 기준 상대경로) |
 
@@ -252,7 +282,9 @@ generate_dataset_card()       → Export            HF Dataset Card (README.md) 
   ├── _build_sample_table()                       샘플 데이터 테이블
   └── _build_stats_section()                      수치 컬럼 통계
 upload_to_hf()                → Publish           whitelist 기반 HF Hub 업로드
-main()                        → CLI               argparse 기반 진입점
+upload_to_kaggle()            → Publish           dataset-metadata.json 생성 + Kaggle API 업로드
+  └── _map_kaggle_license()                       HF→Kaggle 라이선스 매핑
+main()                        → CLI               argparse 기반 진입점 (--target hf|kaggle|all)
 ```
 
 ### 업로드 보안
@@ -336,6 +368,23 @@ uv sync --extra publish
 - 원본 데이터에 빈 문자열, `"-"`, `"N/A"` 등이 포함되어 있을 수 있습니다 → `int`/`float` 타입은 자동으로 null-safe 처리됩니다
 - 콤마가 포함된 숫자 필드는 `int_comma` 타입을 사용하세요
 
+### Kaggle 업로드 401 에러
+
+- `KAGGLE_USERNAME`과 `KAGGLE_KEY` 환경변수 확인
+- 또는 `~/.kaggle/kaggle.json` 파일 존재 여부 확인
+- Kaggle 토큰을 재발급하면 **이전 토큰이 즉시 폐기**됨. 새 토큰으로 환경변수/파일 모두 갱신 필요
+
+### Kaggle `dataset_view` AttributeError
+
+- kaggle SDK 1.6+ 에서 `dataset_view()` 메서드가 제거됨
+- 스크립트는 `dataset_list(mine=True, search=slug)` 방식으로 데이터셋 존재 여부를 판별
+
+### Kaggle organization 미지원
+
+- Kaggle은 HuggingFace와 달리 organization 계정을 지원하지 않음
+- 모든 데이터셋은 개인 계정 소속 (`username/dataset-name`)
+- `kaggle_slug`은 `hf_repo`와 다른 namespace를 가질 수 있음
+
 ---
 
 ## Builder 모듈 분해 가이드
@@ -349,6 +398,7 @@ uv sync --extra publish
 | `write_parquet()` | Gold stage | `src/kpubdata_builder/stages/gold/` |
 | `generate_dataset_card()` | HF Layout Exporter | `src/kpubdata_builder/exporters/` |
 | `upload_to_hf()` | HF Publisher | `src/kpubdata_builder/publishers/` |
+| `upload_to_kaggle()` | Kaggle Publisher | `src/kpubdata_builder/publishers/` |
 | Config YAML | BuildSpec model | `src/kpubdata_builder/spec.py` |
 
 참고 이슈: #50, #8, #9, #10, #28, #37, #40

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ docs = [
 ]
 parquet = ["pyarrow>=15,<18"]
 huggingface = ["huggingface-hub>=0.23,<1"]
-publish = ["polars>=1.0,<2", "huggingface-hub>=0.23,<1", "xmltodict>=0.13,<1"]
+publish = ["polars>=1.0,<2", "huggingface-hub>=0.23,<1", "xmltodict>=0.13,<1", "kaggle>=1.6,<2"]
 dev = [
   "build>=1.2,<2",
   "mypy>=1.10,<2",

--- a/scripts/configs/seoul_apartment_trades.yaml
+++ b/scripts/configs/seoul_apartment_trades.yaml
@@ -3064,6 +3064,7 @@ transform:
 
 output:
   hf_repo: "kpubdata/seoul-apartment-trades"
+  kaggle_slug: "yschoe/seoul-apartment-trades"
   parquet_filename: "data/train.parquet"
   # Local staging directory (relative to script working dir)
   staging_dir: "./staging/seoul-apartment-trades"

--- a/scripts/pipeline/publish.py
+++ b/scripts/pipeline/publish.py
@@ -1,11 +1,13 @@
-"""Upload packaged dataset to HuggingFace Hub."""
+"""Upload packaged dataset to HuggingFace Hub and/or Kaggle."""
 
 from __future__ import annotations
 
 import logging
 import shutil
 import sys
+import json
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger("publish_to_hf.publish")
 
@@ -55,3 +57,118 @@ def upload_to_hf(staging_dir: Path, hf_repo: str, *, dry_run: bool = False) -> N
     )
     shutil.rmtree(upload_dir)
     logger.info("Uploaded to https://huggingface.co/datasets/%s", hf_repo)
+
+
+def upload_to_kaggle(staging_dir: Path, config: dict[str, Any], *, dry_run: bool = False) -> None:
+    """Upload staged dataset files to Kaggle.
+
+    Args:
+        staging_dir: Directory containing data/*.parquet.
+        config: Full pipeline config (needs output.kaggle_slug and card info).
+        dry_run: If True, skip actual upload.
+    """
+    output_cfg = config["output"]
+    kaggle_slug = output_cfg.get("kaggle_slug")
+    if not kaggle_slug:
+        logger.error("No kaggle_slug in output config. Skipping Kaggle upload.")
+        return
+
+    card = config["card"]
+
+    try:
+        from kaggle.api.kaggle_api_extended import KaggleApi
+    except ImportError:
+        logger.error("kaggle not installed. Install with: pip install 'kpubdata-builder[publish]'")
+        sys.exit(1)
+
+    upload_dir = staging_dir / ".kaggle_upload"
+    if upload_dir.exists():
+        shutil.rmtree(upload_dir)
+    upload_dir.mkdir(parents=True)
+
+    data_dir = staging_dir / "data"
+    if data_dir.exists():
+        for parquet_file in data_dir.glob("*.parquet"):
+            shutil.copy2(parquet_file, upload_dir / parquet_file.name)
+
+    description = card.get("description", "").strip()
+    attribution = card.get("attribution", "").strip()
+    if attribution:
+        description = f"{description}\n\n{attribution}"
+
+    license_name = _map_kaggle_license(card.get("license", "cc-by-4.0"))
+
+    metadata: dict[str, Any] = {
+        "title": card["title"],
+        "id": kaggle_slug,
+        "licenses": [{"name": license_name}],
+    }
+
+    subtitle = card.get("subtitle", "")
+    if not subtitle:
+        subtitle = description.split("\n")[0][:80].strip()
+    if 20 <= len(subtitle) <= 80:
+        metadata["subtitle"] = subtitle
+
+    if description:
+        metadata["description"] = description
+
+    tags = card.get("tags", [])
+    if tags:
+        metadata["keywords"] = tags
+
+    metadata_path = upload_dir / "dataset-metadata.json"
+    metadata_path.write_text(json.dumps(metadata, indent=2, ensure_ascii=False), encoding="utf-8")
+    logger.info("Wrote Kaggle metadata: %s", metadata_path)
+
+    if dry_run:
+        logger.info("[DRY RUN] Would upload %s to Kaggle as %s", upload_dir, kaggle_slug)
+        shutil.rmtree(upload_dir)
+        return
+
+    api = KaggleApi()
+    api.authenticate()
+
+    try:
+        results = api.dataset_list(mine=True, search=kaggle_slug.split("/")[-1])
+        dataset_exists = any(str(d) == kaggle_slug for d in results)
+    except Exception:
+        dataset_exists = False
+
+    if dataset_exists:
+        api.dataset_create_version(
+            folder=str(upload_dir),
+            version_notes="Updated dataset",
+            quiet=False,
+            convert_to_csv=False,
+            delete_old_versions=False,
+            dir_mode="skip",
+        )
+        logger.info("Updated Kaggle dataset: https://www.kaggle.com/datasets/%s", kaggle_slug)
+    else:
+        api.dataset_create_new(
+            folder=str(upload_dir),
+            public=True,
+            quiet=False,
+            convert_to_csv=False,
+            dir_mode="skip",
+        )
+        logger.info("Created Kaggle dataset: https://www.kaggle.com/datasets/%s", kaggle_slug)
+
+    shutil.rmtree(upload_dir)
+
+
+def _map_kaggle_license(hf_license: str) -> str:
+    """Map HuggingFace license string to Kaggle license name."""
+    mapping = {
+        "cc-by-4.0": "CC-BY-4.0",
+        "cc0-1.0": "CC0-1.0",
+        "cc-by-sa-4.0": "CC-BY-SA-4.0",
+        "cc-by-nc-4.0": "CC-BY-NC-4.0",
+        "cc-by-nc-sa-4.0": "CC-BY-NC-SA-4.0",
+        "apache-2.0": "apache-2.0",
+        "mit": "other",
+        "odc-by": "ODC-BY-1.0",
+        "odbl": "ODbL-1.0",
+    }
+    return mapping.get(hf_license.lower(), "other")

--- a/scripts/publish_to_hf.py
+++ b/scripts/publish_to_hf.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Publish kpubdata dataset to HuggingFace Hub.
+"""Publish kpubdata dataset to HuggingFace Hub and/or Kaggle.
 
 This is the CLI entrypoint. All logic lives in the pipeline/ package.
 """
@@ -15,7 +15,7 @@ from typing import Any
 import yaml
 from pipeline.fetch import fetch_records
 from pipeline.package import generate_dataset_card, write_parquet
-from pipeline.publish import upload_to_hf
+from pipeline.publish import upload_to_hf, upload_to_kaggle
 from pipeline.transform import transform_records, validate_schema
 
 logger = logging.getLogger("publish_to_hf")
@@ -33,9 +33,17 @@ def load_config(config_path: str) -> dict[str, Any]:
 
 def main(argv: list[str] | None = None) -> None:
     """Main entrypoint for the publish pipeline."""
-    parser = argparse.ArgumentParser(description="Publish kpubdata dataset to HuggingFace Hub")
+    parser = argparse.ArgumentParser(
+        description="Publish kpubdata dataset to HuggingFace and/or Kaggle"
+    )
     parser.add_argument("config", help="Path to YAML config file")
-    parser.add_argument("--dry-run", action="store_true", help="Skip HF upload, generate locally")
+    parser.add_argument(
+        "--target",
+        choices=["hf", "kaggle", "all"],
+        default="all",
+        help="Upload target: hf (HuggingFace), kaggle, or all (default: all)",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Skip upload, generate locally")
     parser.add_argument("--local-only", action="store_true", help="Only generate local files")
     parser.add_argument("--resume", action="store_true", help="Resume from last checkpoint")
     parser.add_argument("--verbose", "-v", action="store_true", help="Enable debug logging")
@@ -75,7 +83,11 @@ def main(argv: list[str] | None = None) -> None:
         logger.info("Local-only mode. Files at: %s", staging_dir)
         return
 
-    upload_to_hf(staging_dir, output_cfg["hf_repo"], dry_run=args.dry_run)
+    target = args.target
+    if target in ("hf", "all"):
+        upload_to_hf(staging_dir, output_cfg["hf_repo"], dry_run=args.dry_run)
+    if target in ("kaggle", "all") and output_cfg.get("kaggle_slug"):
+        upload_to_kaggle(staging_dir, config, dry_run=args.dry_run)
 
     # Clean up checkpoint on successful completion
     if checkpoint_dir.exists():

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,18 @@ wheels = [
 ]
 
 [[package]]
+name = "bleach"
+version = "6.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/18/3c8523962314be6bf4c8989c79ad9531c825210dd13a8669f6b84336e8bd/bleach-6.3.0.tar.gz", hash = "sha256:6f3b91b1c0a02bb9a78b5a454c92506aa0fdf197e1d5e114d2e00c6f64306d22", size = 203533, upload-time = "2025-10-27T17:57:39.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl", hash = "sha256:fe10ec77c93ddf3d13a73b035abaac7a9f5e436513864ccdad516693213c65d6", size = 164437, upload-time = "2025-10-27T17:57:37.538Z" },
+]
+
+[[package]]
 name = "build"
 version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -426,6 +438,70 @@ wheels = [
 ]
 
 [[package]]
+name = "kaggle"
+version = "1.7.4.5"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "bleach", marker = "python_full_version < '3.11'" },
+    { name = "certifi", marker = "python_full_version < '3.11'" },
+    { name = "charset-normalizer", marker = "python_full_version < '3.11'" },
+    { name = "idna", marker = "python_full_version < '3.11'" },
+    { name = "protobuf", marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "python-slugify", marker = "python_full_version < '3.11'" },
+    { name = "requests", marker = "python_full_version < '3.11'" },
+    { name = "setuptools", marker = "python_full_version < '3.11'" },
+    { name = "six", marker = "python_full_version < '3.11'" },
+    { name = "text-unidecode", marker = "python_full_version < '3.11'" },
+    { name = "tqdm", marker = "python_full_version < '3.11'" },
+    { name = "urllib3", marker = "python_full_version < '3.11'" },
+    { name = "webencodings", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/02/b0c189a46531ea2b2691ae277508d2c80e5fd3d757083283c5cc27800ca8/kaggle-1.7.4.5.tar.gz", hash = "sha256:1d9821bd6a6a1470741c76d26495a18475b5a7bfe0c80b19191254b2735d41dd", size = 336100, upload-time = "2025-05-08T21:17:20.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/83/7f29c7abe0d5dc769dad7da993382c3e4239ad63e1dd58414d129e0a4da2/kaggle-1.7.4.5-py3-none-any.whl", hash = "sha256:9732afb1c073f14acc7e49dfab98456f887d10b735bcd6348bc1340e92393882", size = 181238, upload-time = "2025-05-08T21:17:18.245Z" },
+]
+
+[[package]]
+name = "kaggle"
+version = "1.8.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+]
+dependencies = [
+    { name = "bleach", marker = "python_full_version >= '3.11'" },
+    { name = "kagglesdk", marker = "python_full_version >= '3.11'" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "protobuf", marker = "python_full_version >= '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "python-slugify", marker = "python_full_version >= '3.11'" },
+    { name = "requests", marker = "python_full_version >= '3.11'" },
+    { name = "tqdm", marker = "python_full_version >= '3.11'" },
+    { name = "urllib3", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/fe/3c097d1155ce3e4e743ff34fed0338c99b50e95b3464b801de653aeea871/kaggle-1.8.4.tar.gz", hash = "sha256:d71137f98312581726047cadceb28992c53ef905fe38c6dd9d6d3bfc4e43c982", size = 134878, upload-time = "2026-02-05T15:40:43.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/18/d0bc2485953a4c02caf5049f894b930e7cb11b35128a78af896b5a2d1d61/kaggle-1.8.4-py3-none-any.whl", hash = "sha256:b9cb6da6e99ce8ef22f8e84e75da2c82f814c2e548bfa07f3db220c9aeeaa8ba", size = 75470, upload-time = "2026-02-05T15:40:42.642Z" },
+]
+
+[[package]]
+name = "kagglesdk"
+version = "0.1.21"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf", marker = "python_full_version >= '3.11'" },
+    { name = "requests", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/a9/b7c061fa7b37880193af31ed6963a4752ee71cc4efa7f9337f96792dd6e1/kagglesdk-0.1.21.tar.gz", hash = "sha256:3a85c189bbf3ad9add563b77118e8c3982dfc03cfd4d39897db28bc56c61cf1a", size = 160519, upload-time = "2026-04-24T16:45:52.558Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/5f/5634273da33299123f6bb3bfbf4e9ed002568b0ca41f925d8fab6d94e3e9/kagglesdk-0.1.21-py3-none-any.whl", hash = "sha256:e8bafe345165ad6058df71b4817a312fd9e21060b9deb3ba2894619185e5fbc8", size = 212679, upload-time = "2026-04-24T16:45:51.223Z" },
+]
+
+[[package]]
 name = "kpubdata"
 version = "0.4.0"
 source = { editable = "../kpubdata" }
@@ -477,7 +553,10 @@ parquet = [
 ]
 publish = [
     { name = "huggingface-hub" },
+    { name = "kaggle", version = "1.7.4.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "kaggle", version = "1.8.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "polars" },
+    { name = "xmltodict" },
 ]
 
 [package.metadata]
@@ -485,6 +564,7 @@ requires-dist = [
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.2,<2" },
     { name = "huggingface-hub", marker = "extra == 'huggingface'", specifier = ">=0.23,<1" },
     { name = "huggingface-hub", marker = "extra == 'publish'", specifier = ">=0.23,<1" },
+    { name = "kaggle", marker = "extra == 'publish'", specifier = ">=1.6,<2" },
     { name = "kpubdata", editable = "../kpubdata" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10,<2" },
     { name = "polars", marker = "extra == 'publish'", specifier = ">=1.0,<2" },
@@ -494,6 +574,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0,<7" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5,<1" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
+    { name = "xmltodict", marker = "extra == 'publish'", specifier = ">=0.13,<1" },
 ]
 provides-extras = ["parquet", "huggingface", "publish", "dev"]
 
@@ -852,6 +933,21 @@ wheels = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "7.34.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/6b/a0e95cad1ad7cc3f2c6821fcab91671bd5b78bd42afb357bb4765f29bc41/protobuf-7.34.1.tar.gz", hash = "sha256:9ce42245e704cc5027be797c1db1eb93184d44d1cdd71811fb2d9b25ad541280", size = 454708, upload-time = "2026-03-20T17:34:47.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/11/3325d41e6ee15bf1125654301211247b042563bcc898784351252549a8ad/protobuf-7.34.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8b2cc79c4d8f62b293ad9b11ec3aebce9af481fa73e64556969f7345ebf9fc7", size = 429247, upload-time = "2026-03-20T17:34:37.024Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/9d/aa69df2724ff63efa6f72307b483ce0827f4347cc6d6df24b59e26659fef/protobuf-7.34.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b", size = 325753, upload-time = "2026-03-20T17:34:38.751Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e8/d174c91fd48e50101943f042b09af9029064810b734e4160bbe282fa1caa/protobuf-7.34.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:403b093a6e28a960372b44e5eb081775c9b056e816a8029c61231743d63f881a", size = 340198, upload-time = "2026-03-20T17:34:39.871Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4", size = 324267, upload-time = "2026-03-20T17:34:41.1Z" },
+    { url = "https://files.pythonhosted.org/packages/85/29/64de04a0ac142fb685fd09999bc3d337943fb386f3a0ec57f92fd8203f97/protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a", size = 426628, upload-time = "2026-03-20T17:34:42.536Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/87/cb5e585192a22b8bd457df5a2c16a75ea0db9674c3a0a39fc9347d84e075/protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c", size = 437901, upload-time = "2026-03-20T17:34:44.112Z" },
+    { url = "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11", size = 170715, upload-time = "2026-03-20T17:34:45.384Z" },
+]
+
+[[package]]
 name = "pyarrow"
 version = "17.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -931,6 +1027,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/74/67/00efc8d11b630c56f15f4ad9c7f9223f1e5ec275aaae3fa9118c6a223ad2/pytest-cov-5.0.0.tar.gz", hash = "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857", size = 63042, upload-time = "2024-03-24T20:16:34.856Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/3a/af5b4fa5961d9a1e6237b530eb87dd04aea6eb83da09d2a4073d81b54ccf/pytest_cov-5.0.0-py3-none-any.whl", hash = "sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652", size = 21990, upload-time = "2024-03-24T20:16:32.444Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
 ]
 
 [[package]]
@@ -1038,6 +1158,33 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1128,6 +1275,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
+]
+
+[[package]]
+name = "xmltodict"
+version = "0.15.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/7a/42f705c672e77dc3ce85a6823bb289055323aac30de7c4b9eca1e28b2c17/xmltodict-0.15.1.tar.gz", hash = "sha256:3d8d49127f3ce6979d40a36dbcad96f8bab106d232d24b49efdd4bd21716983c", size = 62984, upload-time = "2025-09-08T18:33:19.349Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/4e/001c53a22f6bd5f383f49915a53e40f0cab2d3f1884d968f3ae14be367b7/xmltodict-0.15.1-py2.py3-none-any.whl", hash = "sha256:dcd84b52f30a15be5ac4c9099a0cb234df8758624b035411e329c5c1e7a49089", size = 11260, upload-time = "2025-09-08T18:33:17.87Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `publish_to_hf.py`에 Kaggle 업로드 기능 추가 (`upload_to_kaggle()`, `_map_kaggle_license()`)
- `--target hf|kaggle|all` CLI 옵션으로 업로드 대상 선택 가능 (기본값: `all`)
- `output.kaggle_slug` config 필드로 Kaggle 네임스페이스 독립 관리

## Changes

### 스크립트 (`scripts/publish_to_hf.py`)
- `upload_to_kaggle()`: `dataset-metadata.json` 자동 생성 + Kaggle API 호출
- `_map_kaggle_license()`: HF 소문자 라이선스 → Kaggle 대문자 자동 변환
- 데이터셋 존재 여부 자동 판별 (신규 생성 vs 버전 업데이트)
- `dataset_list` 사용 (`dataset_view`는 kaggle SDK 1.6+에서 제거됨)

### Config (`scripts/configs/seoul_apartment_trades.yaml`)
- `kaggle_slug: "yschoe/seoul-apartment-trades"` 추가

### 의존성 (`pyproject.toml`)
- `publish` extra에 `kaggle>=1.6,<2` 추가

### 문서
- `docs/publishing.md`: Kaggle 인증, `--target` CLI, `kaggle_slug` 스키마, 트러블슈팅 추가
- `docs/lessons-learned.md`: §7~9 Kaggle 시행착오 추가 (dataset_view 버그, 401 에러, org 미지원)
- `docs/hf-publishing-standards.md`: §10 Kaggle 퍼블리싱 섹션 추가

## 검증

- ✅ HuggingFace 업로드 성공: https://huggingface.co/datasets/kpubdata/seoul-apartment-trades
- ✅ Kaggle 업로드 성공: https://www.kaggle.com/datasets/yschoe/seoul-apartment-trades