### PR TITLE
feat: ko/en dataset variants with romanized English config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ docs = [
 ]
 parquet = ["pyarrow>=15,<18"]
 huggingface = ["huggingface-hub>=0.23,<1"]
-publish = ["polars>=1.0,<2", "huggingface-hub>=0.23,<1", "xmltodict>=0.13,<1", "kaggle>=1.6,<2"]
+
+publish = ["polars>=1.0,<2", "huggingface-hub>=0.23,<1", "xmltodict>=0.13,<1", "kaggle>=1.6,<2", "kr-building-name-normalizer>=0.1.0,<1"]
 dev = [
   "build>=1.2,<2",
   "mypy>=1.10,<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,7 @@ docs = [
 ]
 parquet = ["pyarrow>=15,<18"]
 huggingface = ["huggingface-hub>=0.23,<1"]
-
-publish = ["polars>=1.0,<2", "huggingface-hub>=0.23,<1", "xmltodict>=0.13,<1", "kaggle>=1.6,<2", "kr-building-name-normalizer>=0.1.0,<1"]
+publish = ["polars>=1.0,<2", "huggingface-hub>=0.23,<1", "xmltodict>=0.13,<1", "kaggle>=1.6,<2", "kr-building-name-normalizer>=0.2.0,<1"]
 dev = [
   "build>=1.2,<2",
   "mypy>=1.10,<2",

--- a/scripts/configs/seoul_apartment_trades.yaml
+++ b/scripts/configs/seoul_apartment_trades.yaml
@@ -3062,10 +3062,35 @@ transform:
   filters:
     - "deal_amount_10k_krw > 0"
 
+# Dataset variants for multi-language HuggingFace configs.
+# Each variant produces a separate parquet under data/<variant>/train.parquet.
+variants:
+  en:
+    # English variant: romanize Korean text columns using kr-building-name-normalizer
+    romanize_columns:
+      - apartment_name
+      - neighborhood
+  ko:
+    # Korean variant: rename English column names to Korean
+    column_rename:
+      district_code: 구코드
+      neighborhood: 동
+      apartment_name: 아파트명
+      exclusive_area_m2: 전용면적_m2
+      floor: 층
+      build_year: 건축년도
+      deal_year: 거래년도
+      deal_month: 거래월
+      deal_day: 거래일
+      deal_amount_10k_krw: 거래금액_만원
+      lot_number: 지번
+      deal_date: 거래일자
+      registration_date: 등기일자
+      apartment_seq: 아파트일련번호
+
 output:
   hf_repo: "kpubdata/seoul-apartment-trades"
   kaggle_slug: "yschoe/seoul-apartment-trades"
-  parquet_filename: "data/train.parquet"
   # Local staging directory (relative to script working dir)
   staging_dir: "./staging/seoul-apartment-trades"
 

--- a/scripts/pipeline/package.py
+++ b/scripts/pipeline/package.py
@@ -20,7 +20,7 @@ def write_parquet(df: pl.DataFrame, output_path: Path) -> Path:
     return output_path
 
 
-def generate_dataset_card(df: pl.DataFrame, config: dict[str, Any], output_path: Path) -> Path:
+def generate_dataset_card(df: pl.DataFrame, config: dict[str, Any], output_path: Path, variant_names: list[str] | None = None) -> Path:
     """Generate a HuggingFace dataset card (README.md) from config and data."""
     card = config["card"]
     output_cfg = config["output"]
@@ -39,6 +39,16 @@ def generate_dataset_card(df: pl.DataFrame, config: dict[str, Any], output_path:
     attribution = card.get("attribution", "")
     attribution_block = f"\n{attribution}\n" if attribution else ""
 
+    configs_block = ""
+    if variant_names and len(variant_names) > 1:
+        configs_lines = ["configs:"]
+        for vname in variant_names:
+            configs_lines.append(f"- config_name: {vname}")
+            configs_lines.append(f"  data_files: data/{vname}/train.parquet")
+        default_config = "en" if "en" in variant_names else variant_names[0]
+        configs_lines.append(f"default_config_name: {default_config}")
+        configs_block = "\n".join(configs_lines) + "\n"
+
     content = f"""---
 license: {card.get("license", "cc-by-4.0")}
 language:
@@ -47,7 +57,7 @@ tags:
 {tags_yaml}
 size_categories:
 - {_size_category(df.height)}
-{task_categories_block}---
+{task_categories_block}{configs_block}---
 
 # {card["title"]}
 

--- a/scripts/pipeline/transform.py
+++ b/scripts/pipeline/transform.py
@@ -179,3 +179,37 @@ def _add_derived_column(df: pl.DataFrame, derived: dict[str, Any]) -> pl.DataFra
     if dtype_str != "str":
         df = _cast_column(df, name, dtype_str)
     return df
+
+
+def build_variant_dataframes(df: pl.DataFrame, config: dict[str, Any]) -> dict[str, pl.DataFrame]:
+    """Build dataset variants (e.g. ko/en) based on config.
+
+    If no variants configured, returns {"default": df}.
+    """
+    variants_cfg: dict[str, Any] = config.get("variants", {})
+    if not variants_cfg:
+        return {"default": df}
+
+    result: dict[str, pl.DataFrame] = {}
+    for name, opts in variants_cfg.items():
+        variant_df = df.clone()
+
+        romanize_cols = opts.get("romanize_columns", [])
+        if romanize_cols:
+            from kr_building_normalizer import romanize
+
+            for col in romanize_cols:
+                if col in variant_df.columns:
+                    variant_df = variant_df.with_columns(
+                        pl.col(col).map_elements(romanize, return_dtype=pl.Utf8).alias(col)
+                    )
+
+        col_rename = opts.get("column_rename", {})
+        if col_rename:
+            rename_map = {k: v for k, v in col_rename.items() if k in variant_df.columns}
+            variant_df = variant_df.rename(rename_map)
+
+        result[name] = variant_df
+        logger.info("Variant '%s': %d rows x %d cols", name, variant_df.height, variant_df.width)
+
+    return result

--- a/scripts/publish_to_hf.py
+++ b/scripts/publish_to_hf.py
@@ -16,7 +16,7 @@ import yaml
 from pipeline.fetch import fetch_records
 from pipeline.package import generate_dataset_card, write_parquet
 from pipeline.publish import upload_to_hf, upload_to_kaggle
-from pipeline.transform import transform_records, validate_schema
+from pipeline.transform import build_variant_dataframes, transform_records, validate_schema
 
 logger = logging.getLogger("publish_to_hf")
 
@@ -73,11 +73,22 @@ def main(argv: list[str] | None = None) -> None:
 
     validate_schema(df, config)
 
-    parquet_path = staging_dir / output_cfg["parquet_filename"]
-    write_parquet(df, parquet_path)
+    # Build variants (ko/en etc.) or single default
+    variants = build_variant_dataframes(df, config)
+    variant_names = sorted(variants.keys())
+
+    if len(variants) == 1 and "default" in variants:
+        parquet_path = staging_dir / "data" / "train.parquet"
+        write_parquet(df, parquet_path)
+        variant_names_for_card: list[str] | None = None
+    else:
+        for vname, vdf in variants.items():
+            parquet_path = staging_dir / "data" / vname / "train.parquet"
+            write_parquet(vdf, parquet_path)
+        variant_names_for_card = variant_names
 
     card_path = staging_dir / "README.md"
-    generate_dataset_card(df, config, card_path)
+    generate_dataset_card(df, config, card_path, variant_names=variant_names_for_card)
 
     if args.local_only:
         logger.info("Local-only mode. Files at: %s", staging_dir)

--- a/uv.lock
+++ b/uv.lock
@@ -21,18 +21,6 @@ wheels = [
 ]
 
 [[package]]
-name = "bleach"
-version = "6.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "webencodings" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/07/18/3c8523962314be6bf4c8989c79ad9531c825210dd13a8669f6b84336e8bd/bleach-6.3.0.tar.gz", hash = "sha256:6f3b91b1c0a02bb9a78b5a454c92506aa0fdf197e1d5e114d2e00c6f64306d22", size = 203533, upload-time = "2025-10-27T17:57:39.211Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl", hash = "sha256:fe10ec77c93ddf3d13a73b035abaac7a9f5e436513864ccdad516693213c65d6", size = 164437, upload-time = "2025-10-27T17:57:37.538Z" },
-]
-
-[[package]]
 name = "build"
 version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -438,70 +426,6 @@ wheels = [
 ]
 
 [[package]]
-name = "kaggle"
-version = "1.7.4.5"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11'",
-]
-dependencies = [
-    { name = "bleach", marker = "python_full_version < '3.11'" },
-    { name = "certifi", marker = "python_full_version < '3.11'" },
-    { name = "charset-normalizer", marker = "python_full_version < '3.11'" },
-    { name = "idna", marker = "python_full_version < '3.11'" },
-    { name = "protobuf", marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
-    { name = "python-slugify", marker = "python_full_version < '3.11'" },
-    { name = "requests", marker = "python_full_version < '3.11'" },
-    { name = "setuptools", marker = "python_full_version < '3.11'" },
-    { name = "six", marker = "python_full_version < '3.11'" },
-    { name = "text-unidecode", marker = "python_full_version < '3.11'" },
-    { name = "tqdm", marker = "python_full_version < '3.11'" },
-    { name = "urllib3", marker = "python_full_version < '3.11'" },
-    { name = "webencodings", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/02/b0c189a46531ea2b2691ae277508d2c80e5fd3d757083283c5cc27800ca8/kaggle-1.7.4.5.tar.gz", hash = "sha256:1d9821bd6a6a1470741c76d26495a18475b5a7bfe0c80b19191254b2735d41dd", size = 336100, upload-time = "2025-05-08T21:17:20.081Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/83/7f29c7abe0d5dc769dad7da993382c3e4239ad63e1dd58414d129e0a4da2/kaggle-1.7.4.5-py3-none-any.whl", hash = "sha256:9732afb1c073f14acc7e49dfab98456f887d10b735bcd6348bc1340e92393882", size = 181238, upload-time = "2025-05-08T21:17:18.245Z" },
-]
-
-[[package]]
-name = "kaggle"
-version = "1.8.4"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.11'",
-]
-dependencies = [
-    { name = "bleach", marker = "python_full_version >= '3.11'" },
-    { name = "kagglesdk", marker = "python_full_version >= '3.11'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "protobuf", marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
-    { name = "python-slugify", marker = "python_full_version >= '3.11'" },
-    { name = "requests", marker = "python_full_version >= '3.11'" },
-    { name = "tqdm", marker = "python_full_version >= '3.11'" },
-    { name = "urllib3", marker = "python_full_version >= '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/fe/3c097d1155ce3e4e743ff34fed0338c99b50e95b3464b801de653aeea871/kaggle-1.8.4.tar.gz", hash = "sha256:d71137f98312581726047cadceb28992c53ef905fe38c6dd9d6d3bfc4e43c982", size = 134878, upload-time = "2026-02-05T15:40:43.769Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/18/d0bc2485953a4c02caf5049f894b930e7cb11b35128a78af896b5a2d1d61/kaggle-1.8.4-py3-none-any.whl", hash = "sha256:b9cb6da6e99ce8ef22f8e84e75da2c82f814c2e548bfa07f3db220c9aeeaa8ba", size = 75470, upload-time = "2026-02-05T15:40:42.642Z" },
-]
-
-[[package]]
-name = "kagglesdk"
-version = "0.1.21"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "protobuf", marker = "python_full_version >= '3.11'" },
-    { name = "requests", marker = "python_full_version >= '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/a9/b7c061fa7b37880193af31ed6963a4752ee71cc4efa7f9337f96792dd6e1/kagglesdk-0.1.21.tar.gz", hash = "sha256:3a85c189bbf3ad9add563b77118e8c3982dfc03cfd4d39897db28bc56c61cf1a", size = 160519, upload-time = "2026-04-24T16:45:52.558Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/5f/5634273da33299123f6bb3bfbf4e9ed002568b0ca41f925d8fab6d94e3e9/kagglesdk-0.1.21-py3-none-any.whl", hash = "sha256:e8bafe345165ad6058df71b4817a312fd9e21060b9deb3ba2894619185e5fbc8", size = 212679, upload-time = "2026-04-24T16:45:51.223Z" },
-]
-
-[[package]]
 name = "kpubdata"
 version = "0.4.0"
 source = { editable = "../kpubdata" }
@@ -553,8 +477,7 @@ parquet = [
 ]
 publish = [
     { name = "huggingface-hub" },
-    { name = "kaggle", version = "1.7.4.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "kaggle", version = "1.8.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "kr-building-name-normalizer" },
     { name = "polars" },
     { name = "xmltodict" },
 ]
@@ -564,8 +487,8 @@ requires-dist = [
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.2,<2" },
     { name = "huggingface-hub", marker = "extra == 'huggingface'", specifier = ">=0.23,<1" },
     { name = "huggingface-hub", marker = "extra == 'publish'", specifier = ">=0.23,<1" },
-    { name = "kaggle", marker = "extra == 'publish'", specifier = ">=1.6,<2" },
     { name = "kpubdata", editable = "../kpubdata" },
+    { name = "kr-building-name-normalizer", marker = "extra == 'publish'", specifier = ">=0.1.0,<1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10,<2" },
     { name = "polars", marker = "extra == 'publish'", specifier = ">=1.0,<2" },
     { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=15,<18" },
@@ -577,6 +500,15 @@ requires-dist = [
     { name = "xmltodict", marker = "extra == 'publish'", specifier = ">=0.13,<1" },
 ]
 provides-extras = ["parquet", "huggingface", "publish", "dev"]
+
+[[package]]
+name = "kr-building-name-normalizer"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/41/826e5cb315bac718d90f49ff82e06918089c556f8a0fc32f244542c3826e/kr_building_name_normalizer-0.1.0.tar.gz", hash = "sha256:4b8c9e81aa2fee7a6aaa2449286da973dc680f42e2988dc0fc0a933c884fdcad", size = 40405, upload-time = "2026-04-27T13:20:37.14Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/d4/20aecd8c3adb9db2819c991782bfdd4330da93168fd99c38cdd255a0a690/kr_building_name_normalizer-0.1.0-py3-none-any.whl", hash = "sha256:69a1790cf80ac3d9942c7ade322bf762f8325e724d532fc9f98f11f690920e06", size = 13583, upload-time = "2026-04-27T13:20:35.895Z" },
+]
 
 [[package]]
 name = "librt"
@@ -933,21 +865,6 @@ wheels = [
 ]
 
 [[package]]
-name = "protobuf"
-version = "7.34.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6b/6b/a0e95cad1ad7cc3f2c6821fcab91671bd5b78bd42afb357bb4765f29bc41/protobuf-7.34.1.tar.gz", hash = "sha256:9ce42245e704cc5027be797c1db1eb93184d44d1cdd71811fb2d9b25ad541280", size = 454708, upload-time = "2026-03-20T17:34:47.036Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/11/3325d41e6ee15bf1125654301211247b042563bcc898784351252549a8ad/protobuf-7.34.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8b2cc79c4d8f62b293ad9b11ec3aebce9af481fa73e64556969f7345ebf9fc7", size = 429247, upload-time = "2026-03-20T17:34:37.024Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/9d/aa69df2724ff63efa6f72307b483ce0827f4347cc6d6df24b59e26659fef/protobuf-7.34.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b", size = 325753, upload-time = "2026-03-20T17:34:38.751Z" },
-    { url = "https://files.pythonhosted.org/packages/92/e8/d174c91fd48e50101943f042b09af9029064810b734e4160bbe282fa1caa/protobuf-7.34.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:403b093a6e28a960372b44e5eb081775c9b056e816a8029c61231743d63f881a", size = 340198, upload-time = "2026-03-20T17:34:39.871Z" },
-    { url = "https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4", size = 324267, upload-time = "2026-03-20T17:34:41.1Z" },
-    { url = "https://files.pythonhosted.org/packages/85/29/64de04a0ac142fb685fd09999bc3d337943fb386f3a0ec57f92fd8203f97/protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a", size = 426628, upload-time = "2026-03-20T17:34:42.536Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/87/cb5e585192a22b8bd457df5a2c16a75ea0db9674c3a0a39fc9347d84e075/protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c", size = 437901, upload-time = "2026-03-20T17:34:44.112Z" },
-    { url = "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11", size = 170715, upload-time = "2026-03-20T17:34:45.384Z" },
-]
-
-[[package]]
 name = "pyarrow"
 version = "17.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1027,30 +944,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/74/67/00efc8d11b630c56f15f4ad9c7f9223f1e5ec275aaae3fa9118c6a223ad2/pytest-cov-5.0.0.tar.gz", hash = "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857", size = 63042, upload-time = "2024-03-24T20:16:34.856Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/3a/af5b4fa5961d9a1e6237b530eb87dd04aea6eb83da09d2a4073d81b54ccf/pytest_cov-5.0.0-py3-none-any.whl", hash = "sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652", size = 21990, upload-time = "2024-03-24T20:16:32.444Z" },
-]
-
-[[package]]
-name = "python-dateutil"
-version = "2.9.0.post0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
-]
-
-[[package]]
-name = "python-slugify"
-version = "8.0.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "text-unidecode" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
 ]
 
 [[package]]
@@ -1158,33 +1051,6 @@ wheels = [
 ]
 
 [[package]]
-name = "setuptools"
-version = "82.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
-]
-
-[[package]]
-name = "six"
-version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
-]
-
-[[package]]
-name = "text-unidecode"
-version = "1.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
-]
-
-[[package]]
 name = "tomli"
 version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1275,15 +1141,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
-]
-
-[[package]]
-name = "webencodings"
-version = "0.5.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `kr-building-name-normalizer`를 `publish` extra에 추가하고, `publish_to_hf.py`에 ko/en variant 생성 로직을 구현
- **en config** (default): `apartment_name`, `neighborhood` 컬럼을 `kr-building-name-normalizer`로 로마자 변환
- **ko config**: 영어 컬럼명을 한국어로 치환 (district_code→구코드 등), 원본 한국어 텍스트 유지

## Changes

| File | Description |
|------|-------------|
| `pyproject.toml` | `kr-building-name-normalizer>=0.1.0` 추가 (publish extra) |
| `scripts/configs/seoul_apartment_trades.yaml` | `variants` 섹션 추가 (en: romanize, ko: column rename), language에 en 추가 |
| `scripts/publish_to_hf.py` | `build_variant_dataframes()` 추가, dataset card에 HF multi-config YAML 생성, variant별 parquet 출력 |
| `uv.lock` | 자동 업데이트 |

## HuggingFace 구조

```
data/
├── en/train.parquet   # romanized English (default config)
└── ko/train.parquet   # Korean column names + original text
```

README YAML front-matter에 `configs:` / `default_config_name: en` 추가.

## 사용법

```python
ds_en = load_dataset("kpubdata/seoul-apartment-trades", "en")  # default
ds_ko = load_dataset("kpubdata/seoul-apartment-trades", "ko")
```

## Notes

- 기존 8개 테스트 collection error는 main에서도 동일 (ModuleNotFoundError, pre-existing)
- ruff check / format 통과