### PR TITLE
feat: Harden publish pipeline — retry/backoff, checkpoint, module split

### DIFF
--- a/scripts/pipeline/__init__.py
+++ b/scripts/pipeline/__init__.py
@@ -1,0 +1,15 @@
+"""Pipeline modules for kpubdata HuggingFace publishing."""
+
+from pipeline.fetch import fetch_records
+from pipeline.package import generate_dataset_card, write_parquet
+from pipeline.publish import upload_to_hf
+from pipeline.transform import transform_records, validate_schema
+
+__all__ = [
+    "fetch_records",
+    "transform_records",
+    "validate_schema",
+    "write_parquet",
+    "generate_dataset_card",
+    "upload_to_hf",
+]

--- a/scripts/pipeline/fetch.py
+++ b/scripts/pipeline/fetch.py
@@ -1,0 +1,150 @@
+"""Fetch records from public data APIs with retry/backoff and checkpoint support."""
+
+from __future__ import annotations
+
+import json
+import logging
+import random
+import time
+from pathlib import Path
+from typing import Any
+
+from kpubdata import Client
+
+logger = logging.getLogger("publish_to_hf.fetch")
+
+# Default retry configuration
+MAX_RETRIES = 5
+BASE_DELAY = 2.0  # seconds
+MAX_DELAY = 120.0  # seconds
+
+
+class FetchError(Exception):
+    """Raised when fetch fails after all retries."""
+
+
+def fetch_records(
+    config: dict[str, Any],
+    *,
+    checkpoint_dir: Path | None = None,
+    resume: bool = False,
+) -> list[dict[str, Any]]:
+    """Fetch all records from the configured source.
+
+    Args:
+        config: Pipeline configuration dict.
+        checkpoint_dir: Directory to store fetch checkpoints. If None, no checkpointing.
+        resume: If True and checkpoint exists, resume from last successful fetch.
+
+    Returns:
+        List of raw record dicts.
+    """
+    source = config["source"]
+    client = Client.from_env()
+    ds = client.dataset(f"{source['provider']}.{source['dataset']}")
+
+    all_records: list[dict[str, Any]] = []
+    use_list_all = source.get("list_all", False)
+    fetch_params_list: list[dict[str, Any]] = source["fetch_params"]
+    total = len(fetch_params_list)
+
+    # Determine resume point
+    start_index = 0
+    checkpoint_file = _checkpoint_path(checkpoint_dir) if checkpoint_dir else None
+
+    if resume and checkpoint_file and checkpoint_file.exists():
+        checkpoint_data = json.loads(checkpoint_file.read_text(encoding="utf-8"))
+        start_index = checkpoint_data.get("next_index", 0)
+        all_records = checkpoint_data.get("records", [])
+        logger.info(
+            "Resuming from checkpoint: index %d/%d (%d records cached)",
+            start_index,
+            total,
+            len(all_records),
+        )
+
+    for i in range(start_index, total):
+        params = fetch_params_list[i]
+        logger.info("Fetching param set %d/%d: %s", i + 1, total, params)
+
+        records = _fetch_with_retry(ds, params, use_list_all=use_list_all)
+        all_records.extend(records)
+
+        # Save checkpoint after each successful fetch
+        if checkpoint_file:
+            _save_checkpoint(checkpoint_file, next_index=i + 1, records=all_records)
+
+    logger.info("Fetched %d total records", len(all_records))
+    return all_records
+
+
+def _fetch_with_retry(
+    ds: Any,
+    params: dict[str, Any],
+    *,
+    use_list_all: bool = False,
+    max_retries: int = MAX_RETRIES,
+    base_delay: float = BASE_DELAY,
+) -> list[dict[str, Any]]:
+    """Fetch a single param set with exponential backoff on failure."""
+    records: list[dict[str, Any]] = []
+
+    for attempt in range(max_retries + 1):
+        try:
+            if use_list_all:
+                for batch in ds.list_all(**params):
+                    records.extend(batch.items)
+            else:
+                result = ds.list(**params)
+                records.extend(result.items)
+            return records
+        except Exception as exc:
+            error_msg = str(exc).lower()
+            is_retryable = any(
+                token in error_msg
+                for token in (
+                    "429",
+                    "too many requests",
+                    "500",
+                    "502",
+                    "503",
+                    "504",
+                    "timeout",
+                    "connection",
+                )
+            )
+
+            if not is_retryable or attempt == max_retries:
+                if attempt == max_retries:
+                    raise FetchError(
+                        f"Failed after {max_retries} retries for params {params}: {exc}"
+                    ) from exc
+                raise
+
+            delay = min(base_delay * (2**attempt) + random.uniform(0, 1), MAX_DELAY)
+            logger.warning(
+                "Retryable error (attempt %d/%d), waiting %.1fs: %s",
+                attempt + 1,
+                max_retries,
+                delay,
+                exc,
+            )
+            records.clear()
+            time.sleep(delay)
+
+    return records  # unreachable, but satisfies type checker
+
+
+def _checkpoint_path(checkpoint_dir: Path) -> Path:
+    """Get the checkpoint file path."""
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    return checkpoint_dir / "fetch_checkpoint.json"
+
+
+def _save_checkpoint(path: Path, *, next_index: int, records: list[dict[str, Any]]) -> None:
+    """Save fetch progress to a checkpoint file."""
+    data = {"next_index": next_index, "records": records}
+    # Write atomically via temp file
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+    tmp.rename(path)

--- a/scripts/pipeline/package.py
+++ b/scripts/pipeline/package.py
@@ -1,0 +1,154 @@
+"""Package transformed data into Parquet files and dataset cards."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+
+logger = logging.getLogger("publish_to_hf.package")
+
+
+def write_parquet(df: pl.DataFrame, output_path: Path) -> Path:
+    """Write DataFrame to Parquet file."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    df.write_parquet(output_path)
+    size_mb = output_path.stat().st_size / (1024 * 1024)
+    logger.info("Wrote parquet: %s (%.2f MB, %d rows)", output_path, size_mb, df.height)
+    return output_path
+
+
+def generate_dataset_card(df: pl.DataFrame, config: dict[str, Any], output_path: Path) -> Path:
+    """Generate a HuggingFace dataset card (README.md) from config and data."""
+    card = config["card"]
+    output_cfg = config["output"]
+
+    features_table = _build_features_table(card.get("features", []))
+    sample_table = _build_sample_table(df, max_rows=5)
+    stats_section = _build_stats_section(df)
+
+    tags_yaml = "\n".join(f"- {t}" for t in card.get("tags", []))
+    languages_yaml = "\n".join(f"- {lang}" for lang in card.get("language", ["ko"]))
+    task_categories = card.get("task_categories", [])
+    task_categories_yaml = "\n".join(f"- {t}" for t in task_categories)
+    task_categories_block = f"task_categories:\n{task_categories_yaml}\n" if task_categories else ""
+    hf_repo = output_cfg["hf_repo"]
+    source_url = config["source"].get("source_url", "https://www.data.go.kr")
+    attribution = card.get("attribution", "")
+    attribution_block = f"\n{attribution}\n" if attribution else ""
+
+    content = f"""---
+license: {card.get("license", "cc-by-4.0")}
+language:
+{languages_yaml}
+tags:
+{tags_yaml}
+size_categories:
+- {_size_category(df.height)}
+{task_categories_block}---
+
+# {card["title"]}
+
+{card["description"]}
+
+## Dataset Summary
+
+- **Records**: {df.height:,}
+- **Features**: {df.width}
+- **Source**: [data.go.kr]({source_url})
+- **HuggingFace Repo**: [{hf_repo}](https://huggingface.co/datasets/{hf_repo})
+
+{stats_section}
+
+## Features
+
+{features_table}
+
+## Sample Data
+
+{sample_table}
+
+## Usage
+
+```python
+from datasets import load_dataset
+
+ds = load_dataset("{hf_repo}")
+df = ds["train"].to_pandas()
+print(df.head())
+```
+
+## Source
+
+This dataset was generated using [kpubdata](https://github.com/yeongseon/kpubdata)
+from public data APIs on data.go.kr.
+{attribution_block}"""
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(content, encoding="utf-8")
+    logger.info("Wrote dataset card: %s", output_path)
+    return output_path
+
+
+def _build_features_table(features: list[dict[str, str]]) -> str:
+    if not features:
+        return ""
+    lines = ["| Feature | Description |", "| :--- | :--- |"]
+    for f in features:
+        escaped_desc = f["description"].replace("|", "\\|")
+        lines.append(f"| `{f['name']}` | {escaped_desc} |")
+    return "\n".join(lines)
+
+
+def _build_sample_table(df: pl.DataFrame, max_rows: int = 5) -> str:
+    sample = df.head(max_rows)
+    header = "| " + " | ".join(sample.columns) + " |"
+    separator = "| " + " | ".join("---" for _ in sample.columns) + " |"
+    rows: list[str] = []
+    for row in sample.iter_rows(named=True):
+        cells = " | ".join(str(v).replace("|", "\\|") for v in row.values())
+        rows.append(f"| {cells} |")
+    return "\n".join([header, separator, *rows])
+
+
+def _build_stats_section(df: pl.DataFrame) -> str:
+    numeric_cols = [
+        col for col, dtype in zip(df.columns, df.dtypes, strict=True) if dtype.is_numeric()
+    ]
+    if not numeric_cols:
+        return ""
+
+    lines = [
+        "## Statistics",
+        "",
+        "| Feature | Mean | Std | Min | Max |",
+        "| :--- | ---: | ---: | ---: | ---: |",
+    ]
+    for col in numeric_cols:
+        series = df[col].drop_nulls()
+        if series.is_empty():
+            continue
+        mean_val = series.mean()
+        std_val = series.std()
+        mean = float(str(mean_val)) if mean_val is not None else 0.0
+        std = float(str(std_val)) if std_val is not None else 0.0
+        min_val = str(series.min())
+        max_val = str(series.max())
+        lines.append(f"| `{col}` | {mean:,.2f} | {std:,.2f} | {min_val} | {max_val} |")
+    return "\n".join(lines)
+
+
+def _size_category(n: int) -> str:
+    if n < 1_000:
+        return "n<1K"
+    if n < 10_000:
+        return "1K<n<10K"
+    if n < 100_000:
+        return "10K<n<100K"
+    if n < 1_000_000:
+        return "100K<n<1M"
+    if n < 10_000_000:
+        return "1M<n<10M"
+    return "n>10M"

--- a/scripts/pipeline/publish.py
+++ b/scripts/pipeline/publish.py
@@ -1,0 +1,57 @@
+"""Upload packaged dataset to HuggingFace Hub."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import sys
+from pathlib import Path
+
+logger = logging.getLogger("publish_to_hf.publish")
+
+
+def upload_to_hf(staging_dir: Path, hf_repo: str, *, dry_run: bool = False) -> None:
+    """Upload staged dataset files to HuggingFace Hub.
+
+    Args:
+        staging_dir: Directory containing README.md and data/*.parquet.
+        hf_repo: HuggingFace repo ID (e.g. 'kpubdata/seoul-apartment-trades').
+        dry_run: If True, skip actual upload.
+    """
+    if dry_run:
+        logger.info("[DRY RUN] Would upload %s to %s", staging_dir, hf_repo)
+        return
+
+    try:
+        from huggingface_hub import HfApi
+    except ImportError:
+        logger.error(
+            "huggingface_hub not installed. Install with: pip install 'kpubdata-builder[publish]'"
+        )
+        sys.exit(1)
+
+    upload_dir = staging_dir / ".hf_upload"
+    if upload_dir.exists():
+        shutil.rmtree(upload_dir)
+    upload_dir.mkdir(parents=True)
+
+    readme = staging_dir / "README.md"
+    if readme.exists():
+        shutil.copy2(readme, upload_dir / "README.md")
+
+    data_dir = staging_dir / "data"
+    if data_dir.exists():
+        dest_data = upload_dir / "data"
+        dest_data.mkdir()
+        for parquet_file in data_dir.glob("*.parquet"):
+            shutil.copy2(parquet_file, dest_data / parquet_file.name)
+
+    api = HfApi()
+    api.create_repo(repo_id=hf_repo, repo_type="dataset", exist_ok=True)
+    api.upload_folder(
+        folder_path=str(upload_dir),
+        repo_id=hf_repo,
+        repo_type="dataset",
+    )
+    shutil.rmtree(upload_dir)
+    logger.info("Uploaded to https://huggingface.co/datasets/%s", hf_repo)

--- a/scripts/pipeline/transform.py
+++ b/scripts/pipeline/transform.py
@@ -1,0 +1,181 @@
+"""Transform raw records into a validated Polars DataFrame."""
+
+from __future__ import annotations
+
+import logging
+import re
+import sys
+from typing import Any
+
+import polars as pl
+
+logger = logging.getLogger("publish_to_hf.transform")
+
+_FILTER_RE = re.compile(r"(\w+)\s*(>=|<=|!=|==|>|<)\s*(.+)")
+_NULL_TOKENS = {"", "-", "N/A", "null", "None"}
+
+
+def transform_records(records: list[dict[str, Any]], config: dict[str, Any]) -> pl.DataFrame:
+    """Transform raw records into a typed Polars DataFrame based on config."""
+    transform = config["transform"]
+    column_mapping: dict[str, str] = transform["column_mapping"]
+    dtypes: dict[str, str] = transform.get("dtypes", {})
+
+    mapped: list[dict[str, Any]] = []
+    for record in records:
+        row: dict[str, Any] = {}
+        for raw_key, clean_key in column_mapping.items():
+            val = record.get(raw_key)
+            row[clean_key] = str(val) if val is not None else None
+        mapped.append(row)
+
+    # Force all columns to Utf8 to avoid mixed-type inference errors
+    schema = {clean: pl.Utf8 for clean in column_mapping.values()}
+    df = pl.DataFrame(mapped, schema=schema)
+    logger.info("Raw DataFrame: %d rows x %d cols", df.height, df.width)
+
+    for col, dtype_str in dtypes.items():
+        if col not in df.columns:
+            continue
+        df = _cast_column(df, col, dtype_str)
+
+    for derived in transform.get("derived", []):
+        df = _add_derived_column(df, derived)
+
+    pre_filter_count = df.height
+    for filter_expr in transform.get("filters", []):
+        df = _apply_filter(df, filter_expr)
+    if df.height != pre_filter_count:
+        logger.info("Filtered: %d -> %d rows", pre_filter_count, df.height)
+
+    logger.info("Transformed DataFrame: %d rows x %d cols", df.height, df.width)
+    return df
+
+
+def validate_schema(df: pl.DataFrame, config: dict[str, Any]) -> None:
+    """Validate that the DataFrame schema matches the config exactly.
+
+    Fails if:
+    - DataFrame has columns not declared in column_mapping + derived
+    - Config declares columns missing from DataFrame
+    - Any non-allowlisted column is 100% null
+    """
+    transform = config["transform"]
+    column_mapping = transform["column_mapping"]
+    derived = [d["name"] for d in transform.get("derived", [])]
+    expected_cols = set(column_mapping.values()) | set(derived)
+    actual_cols = set(df.columns)
+
+    undeclared = actual_cols - expected_cols
+    if undeclared:
+        logger.error("Schema validation FAILED: undeclared columns in output: %s", undeclared)
+        sys.exit(1)
+
+    missing = expected_cols - actual_cols
+    if missing:
+        logger.error("Schema validation FAILED: declared columns missing from output: %s", missing)
+        sys.exit(1)
+
+    # Check for 100% null columns (warn, don't fail — some fields are legitimately sparse)
+    for col in df.columns:
+        if df[col].null_count() == df.height:
+            logger.warning("Column '%s' is 100%% null in this dataset", col)
+
+    logger.info("Schema validation passed: %d columns match config", len(actual_cols))
+
+
+def _apply_filter(df: pl.DataFrame, expr_str: str) -> pl.DataFrame:
+    """Apply a simple comparison filter: 'col >= value', 'col != value', etc."""
+    match = _FILTER_RE.match(expr_str.strip())
+    if not match:
+        logger.warning("Cannot parse filter expression: %s", expr_str)
+        return df
+
+    col, op, val_str = match.group(1), match.group(2), match.group(3).strip()
+
+    if col not in df.columns:
+        logger.warning("Filter references unknown column '%s', skipping", col)
+        return df
+
+    try:
+        val: int | float = int(val_str)
+    except ValueError:
+        val = float(val_str)
+
+    ops = {
+        ">": pl.col(col) > val,
+        "<": pl.col(col) < val,
+        ">=": pl.col(col) >= val,
+        "<=": pl.col(col) <= val,
+        "==": pl.col(col) == val,
+        "!=": pl.col(col) != val,
+    }
+    return df.filter(ops[op])
+
+
+def _nullify_tokens(col: str) -> pl.Expr:
+    return (
+        pl.when(pl.col(col).cast(pl.Utf8).str.strip_chars().is_in(list(_NULL_TOKENS)))
+        .then(pl.lit(None, dtype=pl.Utf8))
+        .otherwise(pl.col(col).cast(pl.Utf8).str.strip_chars())
+        .alias(col)
+    )
+
+
+def _cast_column(df: pl.DataFrame, col: str, dtype_str: str) -> pl.DataFrame:
+    if dtype_str == "int_comma":
+        return df.with_columns(
+            pl.col(col)
+            .cast(pl.Utf8)
+            .str.replace_all(",", "")
+            .str.strip_chars()
+            .cast(pl.Int64, strict=False)
+            .alias(col)
+        )
+    if dtype_str == "int":
+        df = df.with_columns(_nullify_tokens(col))
+        return df.with_columns(pl.col(col).cast(pl.Int64, strict=False).alias(col))
+    if dtype_str == "float":
+        df = df.with_columns(_nullify_tokens(col))
+        return df.with_columns(pl.col(col).cast(pl.Float64, strict=False).alias(col))
+    if dtype_str == "str":
+        return df.with_columns(pl.col(col).cast(pl.Utf8).alias(col))
+    logger.warning("Unknown dtype '%s' for column '%s', skipping cast", dtype_str, col)
+    return df
+
+
+def _add_derived_column(df: pl.DataFrame, derived: dict[str, Any]) -> pl.DataFrame:
+    name = derived["name"]
+    expr = derived["expr"]
+    dtype_str = derived.get("dtype", "str")
+
+    if expr.startswith("concat_date("):
+        inner = expr[len("concat_date(") : -1]
+        col_refs = [p.strip() for p in inner.split(",")]
+        if len(col_refs) == 3:
+            year_col, month_col, day_col = col_refs
+            polars_expr = (
+                pl.col(year_col).cast(pl.Utf8)
+                + pl.lit("-")
+                + pl.col(month_col).cast(pl.Utf8).str.zfill(2)
+                + pl.lit("-")
+                + pl.col(day_col).cast(pl.Utf8).str.zfill(2)
+            ).alias(name)
+            df = df.with_columns(polars_expr)
+        else:
+            logger.warning("concat_date requires exactly 3 columns, got %d", len(col_refs))
+            return df
+    elif expr.startswith("format("):
+        inner = expr[len("format(") : -1]
+        parts = [p.strip() for p in inner.split(",")]
+        fmt_str = parts[0].strip("'\"")
+        col_refs = [p.strip() for p in parts[1:]]
+        polars_expr = pl.format(fmt_str, *[pl.col(c) for c in col_refs]).alias(name)
+        df = df.with_columns(polars_expr)
+    else:
+        logger.warning("Unsupported derived expression: %s", expr)
+        return df
+
+    if dtype_str != "str":
+        df = _cast_column(df, name, dtype_str)
+    return df

--- a/scripts/publish_to_hf.py
+++ b/scripts/publish_to_hf.py
@@ -1,24 +1,28 @@
 #!/usr/bin/env python3
+"""Publish kpubdata dataset to HuggingFace Hub.
+
+This is the CLI entrypoint. All logic lives in the pipeline/ package.
+"""
+
 from __future__ import annotations
 
 import argparse
 import logging
-import re
-import shutil
 import sys
 from pathlib import Path
 from typing import Any
 
-import polars as pl
 import yaml
-from kpubdata import Client
+from pipeline.fetch import fetch_records
+from pipeline.package import generate_dataset_card, write_parquet
+from pipeline.publish import upload_to_hf
+from pipeline.transform import transform_records, validate_schema
 
 logger = logging.getLogger("publish_to_hf")
 
-_FILTER_RE = re.compile(r"(\w+)\s*(>=|<=|!=|==|>|<)\s*(.+)")
-
 
 def load_config(config_path: str) -> dict[str, Any]:
+    """Load and validate YAML config file."""
     with open(config_path, encoding="utf-8") as f:
         data: dict[str, Any] = yaml.safe_load(f)
         if not isinstance(data, dict):
@@ -27,381 +31,13 @@ def load_config(config_path: str) -> dict[str, Any]:
         return data
 
 
-def fetch_records(config: dict[str, Any]) -> list[dict[str, Any]]:
-    source = config["source"]
-    client = Client.from_env()
-    ds = client.dataset(f"{source['provider']}.{source['dataset']}")
-
-    all_records: list[dict[str, Any]] = []
-    use_list_all = source.get("list_all", False)
-
-    for i, params in enumerate(source["fetch_params"]):
-        logger.info("Fetching param set %d/%d: %s", i + 1, len(source["fetch_params"]), params)
-
-        if use_list_all:
-            for batch in ds.list_all(**params):
-                all_records.extend(batch.items)
-        else:
-            result = ds.list(**params)
-            all_records.extend(result.items)
-
-    logger.info("Fetched %d total records", len(all_records))
-    return all_records
-
-
-def transform_records(records: list[dict[str, Any]], config: dict[str, Any]) -> pl.DataFrame:
-    transform = config["transform"]
-    column_mapping: dict[str, str] = transform["column_mapping"]
-    dtypes: dict[str, str] = transform.get("dtypes", {})
-
-    mapped: list[dict[str, Any]] = []
-    for record in records:
-        row: dict[str, Any] = {}
-        for raw_key, clean_key in column_mapping.items():
-            val = record.get(raw_key)
-            row[clean_key] = str(val) if val is not None else None
-        mapped.append(row)
-
-    # Force all columns to Utf8 to avoid mixed-type inference errors
-    schema = {clean: pl.Utf8 for clean in column_mapping.values()}
-    df = pl.DataFrame(mapped, schema=schema)
-    logger.info("Raw DataFrame: %d rows x %d cols", df.height, df.width)
-
-    for col, dtype_str in dtypes.items():
-        if col not in df.columns:
-            continue
-        df = _cast_column(df, col, dtype_str)
-
-    for derived in transform.get("derived", []):
-        df = _add_derived_column(df, derived)
-
-    pre_filter_count = df.height
-    for filter_expr in transform.get("filters", []):
-        df = _apply_filter(df, filter_expr)
-    if df.height != pre_filter_count:
-        logger.info("Filtered: %d -> %d rows", pre_filter_count, df.height)
-
-    logger.info("Transformed DataFrame: %d rows x %d cols", df.height, df.width)
-    return df
-
-
-def validate_schema(df: pl.DataFrame, config: dict[str, Any]) -> None:
-    """Validate that the DataFrame schema matches the config exactly.
-
-    Fails if:
-    - DataFrame has columns not declared in column_mapping + derived
-    - Config declares columns missing from DataFrame
-    - Any non-allowlisted column is 100% null
-    """
-    transform = config["transform"]
-    column_mapping = transform["column_mapping"]
-    derived = [d["name"] for d in transform.get("derived", [])]
-    expected_cols = set(column_mapping.values()) | set(derived)
-    actual_cols = set(df.columns)
-
-    undeclared = actual_cols - expected_cols
-    if undeclared:
-        logger.error("Schema validation FAILED: undeclared columns in output: %s", undeclared)
-        sys.exit(1)
-
-    missing = expected_cols - actual_cols
-    if missing:
-        logger.error("Schema validation FAILED: declared columns missing from output: %s", missing)
-        sys.exit(1)
-
-    # Check for 100% null columns (warn, don't fail — some fields are legitimately sparse)
-    for col in df.columns:
-        if df[col].null_count() == df.height:
-            logger.warning("Column '%s' is 100%% null in this dataset", col)
-
-    logger.info("Schema validation passed: %d columns match config", len(actual_cols))
-
-def _apply_filter(df: pl.DataFrame, expr_str: str) -> pl.DataFrame:
-    """Apply a simple comparison filter: 'col >= value', 'col != value', etc."""
-    match = _FILTER_RE.match(expr_str.strip())
-    if not match:
-        logger.warning("Cannot parse filter expression: %s", expr_str)
-        return df
-
-    col, op, val_str = match.group(1), match.group(2), match.group(3).strip()
-
-    if col not in df.columns:
-        logger.warning("Filter references unknown column '%s', skipping", col)
-        return df
-
-    try:
-        val: int | float = int(val_str)
-    except ValueError:
-        val = float(val_str)
-
-    ops = {
-        ">": pl.col(col) > val,
-        "<": pl.col(col) < val,
-        ">=": pl.col(col) >= val,
-        "<=": pl.col(col) <= val,
-        "==": pl.col(col) == val,
-        "!=": pl.col(col) != val,
-    }
-    return df.filter(ops[op])
-
-
-_NULL_TOKENS = {"", "-", "N/A", "null", "None"}
-
-
-def _nullify_tokens(col: str) -> pl.Expr:
-    return (
-        pl.when(pl.col(col).cast(pl.Utf8).str.strip_chars().is_in(list(_NULL_TOKENS)))
-        .then(pl.lit(None, dtype=pl.Utf8))
-        .otherwise(pl.col(col).cast(pl.Utf8).str.strip_chars())
-        .alias(col)
-    )
-
-
-def _cast_column(df: pl.DataFrame, col: str, dtype_str: str) -> pl.DataFrame:
-    if dtype_str == "int_comma":
-        return df.with_columns(
-            pl.col(col)
-            .cast(pl.Utf8)
-            .str.replace_all(",", "")
-            .str.strip_chars()
-            .cast(pl.Int64, strict=False)
-            .alias(col)
-        )
-    if dtype_str == "int":
-        df = df.with_columns(_nullify_tokens(col))
-        return df.with_columns(pl.col(col).cast(pl.Int64, strict=False).alias(col))
-    if dtype_str == "float":
-        df = df.with_columns(_nullify_tokens(col))
-        return df.with_columns(pl.col(col).cast(pl.Float64, strict=False).alias(col))
-    if dtype_str == "str":
-        return df.with_columns(pl.col(col).cast(pl.Utf8).alias(col))
-    logger.warning("Unknown dtype '%s' for column '%s', skipping cast", dtype_str, col)
-    return df
-
-
-def _add_derived_column(df: pl.DataFrame, derived: dict[str, Any]) -> pl.DataFrame:
-    name = derived["name"]
-    expr = derived["expr"]
-    dtype_str = derived.get("dtype", "str")
-
-    if expr.startswith("concat_date("):
-        inner = expr[len("concat_date(") : -1]
-        col_refs = [p.strip() for p in inner.split(",")]
-        if len(col_refs) == 3:
-            year_col, month_col, day_col = col_refs
-            polars_expr = (
-                pl.col(year_col).cast(pl.Utf8)
-                + pl.lit("-")
-                + pl.col(month_col).cast(pl.Utf8).str.zfill(2)
-                + pl.lit("-")
-                + pl.col(day_col).cast(pl.Utf8).str.zfill(2)
-            ).alias(name)
-            df = df.with_columns(polars_expr)
-        else:
-            logger.warning("concat_date requires exactly 3 columns, got %d", len(col_refs))
-            return df
-    elif expr.startswith("format("):
-        inner = expr[len("format(") : -1]
-        parts = [p.strip() for p in inner.split(",")]
-        fmt_str = parts[0].strip("'\"")
-        col_refs = [p.strip() for p in parts[1:]]
-        polars_expr = pl.format(fmt_str, *[pl.col(c) for c in col_refs]).alias(name)
-        df = df.with_columns(polars_expr)
-    else:
-        logger.warning("Unsupported derived expression: %s", expr)
-        return df
-
-    if dtype_str != "str":
-        df = _cast_column(df, name, dtype_str)
-    return df
-
-
-def write_parquet(df: pl.DataFrame, output_path: Path) -> Path:
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    df.write_parquet(output_path)
-    size_mb = output_path.stat().st_size / (1024 * 1024)
-    logger.info("Wrote parquet: %s (%.2f MB, %d rows)", output_path, size_mb, df.height)
-    return output_path
-
-
-def generate_dataset_card(df: pl.DataFrame, config: dict[str, Any], output_path: Path) -> Path:
-    card = config["card"]
-    output_cfg = config["output"]
-
-    features_table = _build_features_table(card.get("features", []))
-    sample_table = _build_sample_table(df, max_rows=5)
-    stats_section = _build_stats_section(df)
-
-    tags_yaml = "\n".join(f"- {t}" for t in card.get("tags", []))
-    languages_yaml = "\n".join(f"- {lang}" for lang in card.get("language", ["ko"]))
-    task_categories = card.get("task_categories", [])
-    task_categories_yaml = "\n".join(f"- {t}" for t in task_categories)
-    task_categories_block = f"task_categories:\n{task_categories_yaml}\n" if task_categories else ""
-    hf_repo = output_cfg["hf_repo"]
-    source_url = config["source"].get("source_url", "https://www.data.go.kr")
-    attribution = card.get("attribution", "")
-    attribution_block = f"\n{attribution}\n" if attribution else ""
-
-    content = f"""---
-license: {card.get("license", "cc-by-4.0")}
-language:
-{languages_yaml}
-tags:
-{tags_yaml}
-size_categories:
-- {_size_category(df.height)}
-{task_categories_block}---
-
-# {card["title"]}
-
-{card["description"]}
-
-## Dataset Summary
-
-- **Records**: {df.height:,}
-- **Features**: {df.width}
-- **Source**: [data.go.kr]({source_url})
-- **HuggingFace Repo**: [{hf_repo}](https://huggingface.co/datasets/{hf_repo})
-
-{stats_section}
-
-## Features
-
-{features_table}
-
-## Sample Data
-
-{sample_table}
-
-## Usage
-
-```python
-from datasets import load_dataset
-
-ds = load_dataset("{hf_repo}")
-df = ds["train"].to_pandas()
-print(df.head())
-```
-
-## Source
-
-This dataset was generated using [kpubdata](https://github.com/yeongseon/kpubdata)
-from public data APIs on data.go.kr.
-{attribution_block}"""
-
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(content, encoding="utf-8")
-    logger.info("Wrote dataset card: %s", output_path)
-    return output_path
-
-
-def _build_features_table(features: list[dict[str, str]]) -> str:
-    if not features:
-        return ""
-    lines = ["| Feature | Description |", "| :--- | :--- |"]
-    for f in features:
-        escaped_desc = f["description"].replace("|", "\\|")
-        lines.append(f"| `{f['name']}` | {escaped_desc} |")
-    return "\n".join(lines)
-
-
-def _build_sample_table(df: pl.DataFrame, max_rows: int = 5) -> str:
-    sample = df.head(max_rows)
-    header = "| " + " | ".join(sample.columns) + " |"
-    separator = "| " + " | ".join("---" for _ in sample.columns) + " |"
-    rows: list[str] = []
-    for row in sample.iter_rows(named=True):
-        cells = " | ".join(str(v).replace("|", "\\|") for v in row.values())
-        rows.append(f"| {cells} |")
-    return "\n".join([header, separator, *rows])
-
-
-def _build_stats_section(df: pl.DataFrame) -> str:
-    numeric_cols = [
-        col for col, dtype in zip(df.columns, df.dtypes, strict=True) if dtype.is_numeric()
-    ]
-    if not numeric_cols:
-        return ""
-
-    lines = [
-        "## Statistics",
-        "",
-        "| Feature | Mean | Std | Min | Max |",
-        "| :--- | ---: | ---: | ---: | ---: |",
-    ]
-    for col in numeric_cols:
-        series = df[col].drop_nulls()
-        if series.is_empty():
-            continue
-        mean_val = series.mean()
-        std_val = series.std()
-        mean = float(str(mean_val)) if mean_val is not None else 0.0
-        std = float(str(std_val)) if std_val is not None else 0.0
-        min_val = str(series.min())
-        max_val = str(series.max())
-        lines.append(f"| `{col}` | {mean:,.2f} | {std:,.2f} | {min_val} | {max_val} |")
-    return "\n".join(lines)
-
-
-def _size_category(n: int) -> str:
-    if n < 1_000:
-        return "n<1K"
-    if n < 10_000:
-        return "1K<n<10K"
-    if n < 100_000:
-        return "10K<n<100K"
-    if n < 1_000_000:
-        return "100K<n<1M"
-    if n < 10_000_000:
-        return "1M<n<10M"
-    return "n>10M"
-
-
-def upload_to_hf(staging_dir: Path, hf_repo: str, *, dry_run: bool = False) -> None:
-    if dry_run:
-        logger.info("[DRY RUN] Would upload %s to %s", staging_dir, hf_repo)
-        return
-
-    try:
-        from huggingface_hub import HfApi
-    except ImportError:
-        logger.error(
-            "huggingface_hub not installed. Install with: pip install 'kpubdata-builder[publish]'"
-        )
-        sys.exit(1)
-
-    upload_dir = staging_dir / ".hf_upload"
-    if upload_dir.exists():
-        shutil.rmtree(upload_dir)
-    upload_dir.mkdir(parents=True)
-
-    readme = staging_dir / "README.md"
-    if readme.exists():
-        shutil.copy2(readme, upload_dir / "README.md")
-
-    data_dir = staging_dir / "data"
-    if data_dir.exists():
-        dest_data = upload_dir / "data"
-        dest_data.mkdir()
-        for parquet_file in data_dir.glob("*.parquet"):
-            shutil.copy2(parquet_file, dest_data / parquet_file.name)
-
-    api = HfApi()
-    api.create_repo(repo_id=hf_repo, repo_type="dataset", exist_ok=True)
-    api.upload_folder(
-        folder_path=str(upload_dir),
-        repo_id=hf_repo,
-        repo_type="dataset",
-    )
-    shutil.rmtree(upload_dir)
-    logger.info("Uploaded to https://huggingface.co/datasets/%s", hf_repo)
-
-
 def main(argv: list[str] | None = None) -> None:
+    """Main entrypoint for the publish pipeline."""
     parser = argparse.ArgumentParser(description="Publish kpubdata dataset to HuggingFace Hub")
     parser.add_argument("config", help="Path to YAML config file")
     parser.add_argument("--dry-run", action="store_true", help="Skip HF upload, generate locally")
     parser.add_argument("--local-only", action="store_true", help="Only generate local files")
+    parser.add_argument("--resume", action="store_true", help="Resume from last checkpoint")
     parser.add_argument("--verbose", "-v", action="store_true", help="Enable debug logging")
     args = parser.parse_args(argv)
 
@@ -414,7 +50,10 @@ def main(argv: list[str] | None = None) -> None:
     output_cfg = config["output"]
     staging_dir = Path(output_cfg["staging_dir"])
 
-    records = fetch_records(config)
+    # Checkpoint directory lives alongside staging
+    checkpoint_dir = staging_dir / ".checkpoints"
+
+    records = fetch_records(config, checkpoint_dir=checkpoint_dir, resume=args.resume)
     if not records:
         logger.error("No records fetched. Check API key and fetch_params.")
         sys.exit(1)
@@ -437,6 +76,13 @@ def main(argv: list[str] | None = None) -> None:
         return
 
     upload_to_hf(staging_dir, output_cfg["hf_repo"], dry_run=args.dry_run)
+
+    # Clean up checkpoint on successful completion
+    if checkpoint_dir.exists():
+        import shutil
+
+        shutil.rmtree(checkpoint_dir)
+        logger.info("Cleaned up checkpoints after successful publish")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Split monolithic `publish_to_hf.py` (443 lines) into `scripts/pipeline/` package with 4 focused modules
- Added exponential backoff with jitter for 429/5xx errors (max 5 retries)
- Added checkpoint/resume: `--resume` flag continues from last successful fetch after crashes
- Backward-compatible CLI interface preserved

## Modules

| Module | Responsibility |
|--------|---------------|
| `fetch.py` | Data collection with retry/backoff + checkpoint |
| `transform.py` | Polars transformation + schema validation |
| `package.py` | Parquet writing + dataset card generation |
| `publish.py` | HuggingFace Hub upload |

Closes #59