### PR TITLE
feat: Bronze snapshot/provenance 구현 (#45)

### DIFF
--- a/scripts/pipeline/package.py
+++ b/scripts/pipeline/package.py
@@ -20,7 +20,12 @@ def write_parquet(df: pl.DataFrame, output_path: Path) -> Path:
     return output_path
 
 
-def generate_dataset_card(df: pl.DataFrame, config: dict[str, Any], output_path: Path, variant_names: list[str] | None = None) -> Path:
+def generate_dataset_card(
+    df: pl.DataFrame,
+    config: dict[str, Any],
+    output_path: Path,
+    variant_names: list[str] | None = None,
+) -> Path:
     """Generate a HuggingFace dataset card (README.md) from config and data."""
     card = config["card"]
     output_cfg = config["output"]

--- a/scripts/pipeline/publish.py
+++ b/scripts/pipeline/publish.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import shutil
 import sys
-import json
 from pathlib import Path
 from typing import Any
 
@@ -76,7 +76,7 @@ def upload_to_kaggle(staging_dir: Path, config: dict[str, Any], *, dry_run: bool
     card = config["card"]
 
     try:
-        from kaggle.api.kaggle_api_extended import KaggleApi
+        from kaggle.api.kaggle_api_extended import KaggleApi  # type: ignore[import-untyped]
     except ImportError:
         logger.error("kaggle not installed. Install with: pip install 'kpubdata-builder[publish]'")
         sys.exit(1)

--- a/src/kpubdata_builder/stages/__init__.py
+++ b/src/kpubdata_builder/stages/__init__.py
@@ -1,0 +1,5 @@
+"""Medallion stage implementations."""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/kpubdata_builder/stages/bronze/__init__.py
+++ b/src/kpubdata_builder/stages/bronze/__init__.py
@@ -1,0 +1,15 @@
+"""Bronze stage public API."""
+
+from __future__ import annotations
+
+from .build import build_bronze_artifact
+from .models import BronzeArtifact, ProvenanceEvent
+from .persist import BronzePersistResult, persist_bronze_artifact
+
+__all__ = [
+    "BronzeArtifact",
+    "BronzePersistResult",
+    "ProvenanceEvent",
+    "build_bronze_artifact",
+    "persist_bronze_artifact",
+]

--- a/src/kpubdata_builder/stages/bronze/build.py
+++ b/src/kpubdata_builder/stages/bronze/build.py
@@ -1,0 +1,62 @@
+"""Bronze stage source fetch helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import datetime
+from typing import Protocol
+
+from ...spec import JsonValue
+from .models import BronzeArtifact, ProvenanceEvent, require_timezone_aware, utc_now
+
+
+class DatasetResult(Protocol):
+    """Minimal result shape returned by compatible kpubdata datasets."""
+
+    @property
+    def items(self) -> Iterable[dict[str, JsonValue]]:
+        """Return fetched records."""
+
+
+class SourceDataset(Protocol):
+    """Minimal dataset shape used by the Bronze stage."""
+
+    def list(self, **params: JsonValue) -> DatasetResult:
+        """Fetch records for one parameter set."""
+
+
+class SourceClient(Protocol):
+    """Minimal client shape used by the Bronze stage."""
+
+    def dataset(self, source_key: str) -> SourceDataset:
+        """Return a dataset object for a source key."""
+
+
+def build_bronze_artifact(
+    client: SourceClient,
+    *,
+    source_key: str,
+    fetch_params: dict[str, JsonValue] | None = None,
+    fetched_at: datetime | None = None,
+) -> BronzeArtifact:
+    """Fetch raw records from a compatible client and return a Bronze artifact."""
+    resolved_params = dict(fetch_params or {})
+    resolved_fetched_at = fetched_at or utc_now()
+    require_timezone_aware(resolved_fetched_at, field_name="fetched_at")
+
+    dataset = client.dataset(source_key)
+    result = dataset.list(**resolved_params)
+    raw_records = tuple(result.items)
+    provenance = ProvenanceEvent(
+        source_key=source_key,
+        fetch_params=resolved_params,
+        fetched_at=resolved_fetched_at,
+    )
+
+    return BronzeArtifact(
+        source_key=source_key,
+        raw_records=raw_records,
+        fetch_params=resolved_params,
+        fetched_at=resolved_fetched_at,
+        provenance=provenance,
+    )

--- a/src/kpubdata_builder/stages/bronze/models.py
+++ b/src/kpubdata_builder/stages/bronze/models.py
@@ -1,0 +1,51 @@
+"""Bronze stage artifact and provenance models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+from ...spec import JsonValue
+
+
+def utc_now() -> datetime:
+    """Return a timezone-aware UTC timestamp."""
+    return datetime.now(tz=timezone.utc)
+
+
+def require_timezone_aware(value: datetime, *, field_name: str) -> None:
+    """Validate that a datetime includes timezone information."""
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field_name} must be timezone-aware")
+
+
+@dataclass(frozen=True)
+class ProvenanceEvent:
+    """Record where and when a Bronze source fetch happened."""
+
+    source_key: str
+    fetch_params: dict[str, JsonValue] = field(default_factory=dict)
+    fetched_at: datetime = field(default_factory=utc_now)
+    operation: str = "fetch"
+
+    def __post_init__(self) -> None:
+        require_timezone_aware(self.fetched_at, field_name="fetched_at")
+
+
+@dataclass(frozen=True)
+class BronzeArtifact:
+    """Raw source records captured by the Bronze stage."""
+
+    source_key: str
+    raw_records: tuple[dict[str, JsonValue], ...]
+    fetch_params: dict[str, JsonValue] = field(default_factory=dict)
+    fetched_at: datetime = field(default_factory=utc_now)
+    provenance: ProvenanceEvent | None = None
+
+    def __post_init__(self) -> None:
+        require_timezone_aware(self.fetched_at, field_name="fetched_at")
+
+    @property
+    def record_count(self) -> int:
+        """Return the number of preserved raw records."""
+        return len(self.raw_records)

--- a/src/kpubdata_builder/stages/bronze/persist.py
+++ b/src/kpubdata_builder/stages/bronze/persist.py
@@ -1,0 +1,88 @@
+"""Persist Bronze stage artifacts to a run workspace."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from ...spec import JsonValue
+from .models import BronzeArtifact, ProvenanceEvent
+
+
+@dataclass(frozen=True)
+class BronzePersistResult:
+    """Filesystem paths written for a Bronze artifact."""
+
+    bronze_dir: Path
+    records_path: Path
+    metadata_path: Path
+
+
+def persist_bronze_artifact(
+    artifact: BronzeArtifact,
+    *,
+    output_root: Path,
+    run_id: str,
+) -> BronzePersistResult:
+    """Write raw records and metadata under build/{run_id}/bronze."""
+    bronze_dir = output_root / run_id / "bronze"
+    records_path = bronze_dir / "raw_records.jsonl"
+    metadata_path = bronze_dir / "metadata.json"
+    bronze_dir.mkdir(parents=True, exist_ok=True)
+
+    records_content = "".join(
+        f"{json.dumps(record, ensure_ascii=False, sort_keys=True)}\n"
+        for record in artifact.raw_records
+    )
+    records_path.write_text(records_content, encoding="utf-8")
+
+    metadata = _metadata_for_artifact(
+        artifact,
+        records_path=records_path,
+        metadata_path=metadata_path,
+    )
+    metadata_path.write_text(
+        json.dumps(metadata, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    return BronzePersistResult(
+        bronze_dir=bronze_dir,
+        records_path=records_path,
+        metadata_path=metadata_path,
+    )
+
+
+def _metadata_for_artifact(
+    artifact: BronzeArtifact,
+    *,
+    records_path: Path,
+    metadata_path: Path,
+) -> dict[str, JsonValue]:
+    provenance = artifact.provenance
+    return {
+        "source_key": artifact.source_key,
+        "fetch_params": artifact.fetch_params,
+        "fetched_at": _format_datetime(artifact.fetched_at),
+        "provenance": _provenance_to_dict(provenance) if provenance else None,
+        "record_count": artifact.record_count,
+        "artifact_paths": {
+            "records": str(records_path),
+            "metadata": str(metadata_path),
+        },
+    }
+
+
+def _provenance_to_dict(provenance: ProvenanceEvent) -> dict[str, JsonValue]:
+    return {
+        "operation": provenance.operation,
+        "source_key": provenance.source_key,
+        "fetch_params": provenance.fetch_params,
+        "fetched_at": _format_datetime(provenance.fetched_at),
+    }
+
+
+def _format_datetime(value: datetime) -> str:
+    return value.isoformat()

--- a/tests/unit/test_bronze.py
+++ b/tests/unit/test_bronze.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from kpubdata_builder.spec import JsonValue
+from kpubdata_builder.stages.bronze import (
+    BronzeArtifact,
+    ProvenanceEvent,
+    build_bronze_artifact,
+    persist_bronze_artifact,
+)
+from kpubdata_builder.stages.bronze.build import DatasetResult, SourceDataset
+
+
+@dataclass(frozen=True)
+class FakeResult:
+    items: list[dict[str, JsonValue]]
+
+
+class FakeDataset:
+    def __init__(self, records: list[dict[str, JsonValue]]) -> None:
+        self.records = records
+        self.seen_params: dict[str, JsonValue] | None = None
+
+    def list(self, **params: JsonValue) -> DatasetResult:
+        self.seen_params = dict(params)
+        return FakeResult(items=self.records)
+
+
+class FakeClient:
+    def __init__(self, dataset: FakeDataset) -> None:
+        self.dataset_instance = dataset
+        self.seen_source_key = ""
+
+    def dataset(self, source_key: str) -> SourceDataset:
+        self.seen_source_key = source_key
+        return self.dataset_instance
+
+
+def test_bronze_models_preserve_record_count_and_timezone() -> None:
+    fetched_at = datetime(2026, 5, 8, 12, 0, tzinfo=timezone.utc)
+    provenance = ProvenanceEvent(
+        source_key="datago.apt_trade",
+        fetch_params={"page": 1},
+        fetched_at=fetched_at,
+    )
+    artifact = BronzeArtifact(
+        source_key="datago.apt_trade",
+        raw_records=({"id": "1"}, {"id": "2"}),
+        fetch_params={"page": 1},
+        fetched_at=fetched_at,
+        provenance=provenance,
+    )
+
+    assert artifact.record_count == 2
+    assert artifact.fetched_at.tzinfo is not None
+    assert artifact.provenance == provenance
+
+
+def test_bronze_models_reject_naive_fetched_at() -> None:
+    naive = datetime(2026, 5, 8, 12, 0)
+
+    with pytest.raises(ValueError, match="timezone-aware"):
+        ProvenanceEvent(source_key="datago.apt_trade", fetched_at=naive)
+
+    with pytest.raises(ValueError, match="timezone-aware"):
+        BronzeArtifact(source_key="datago.apt_trade", raw_records=(), fetched_at=naive)
+
+
+def test_build_bronze_artifact_fetches_raw_records_without_transforming() -> None:
+    fetched_at = datetime(2026, 5, 8, 12, 0, tzinfo=timezone.utc)
+    records: list[dict[str, JsonValue]] = [
+        {"id": "1", "name": "강남구", "amount": 100, "nested": {"b": 2, "a": 1}},
+        {"id": "2", "name": "서초구", "amount": None, "tags": ["raw", "bronze"]},
+    ]
+    dataset = FakeDataset(records)
+    client = FakeClient(dataset)
+
+    artifact = build_bronze_artifact(
+        client,
+        source_key="datago.apt_trade",
+        fetch_params={"lawd_cd": "11680", "deal_ymd": "202501"},
+        fetched_at=fetched_at,
+    )
+
+    assert client.seen_source_key == "datago.apt_trade"
+    assert dataset.seen_params == {"lawd_cd": "11680", "deal_ymd": "202501"}
+    assert artifact.source_key == "datago.apt_trade"
+    assert artifact.fetch_params == {"lawd_cd": "11680", "deal_ymd": "202501"}
+    assert artifact.fetched_at == fetched_at
+    assert artifact.raw_records == tuple(records)
+    assert artifact.raw_records[0] is records[0]
+    assert artifact.record_count == 2
+    assert artifact.provenance == ProvenanceEvent(
+        source_key="datago.apt_trade",
+        fetch_params={"lawd_cd": "11680", "deal_ymd": "202501"},
+        fetched_at=fetched_at,
+    )
+
+
+def test_persist_bronze_artifact_writes_jsonl_and_metadata(tmp_path: Path) -> None:
+    fetched_at = datetime(2026, 5, 8, 12, 0, tzinfo=timezone.utc)
+    artifact = BronzeArtifact(
+        source_key="datago.apt_trade",
+        raw_records=(
+            {"id": "1", "name": "강남구", "nested": {"b": 2, "a": 1}},
+            {"id": "2", "name": "서초구", "amount": None},
+        ),
+        fetch_params={"lawd_cd": "11680"},
+        fetched_at=fetched_at,
+        provenance=ProvenanceEvent(
+            source_key="datago.apt_trade",
+            fetch_params={"lawd_cd": "11680"},
+            fetched_at=fetched_at,
+        ),
+    )
+
+    result = persist_bronze_artifact(artifact, output_root=tmp_path / "build", run_id="run-1")
+
+    assert result.bronze_dir == tmp_path / "build" / "run-1" / "bronze"
+    assert result.records_path == result.bronze_dir / "raw_records.jsonl"
+    assert result.metadata_path == result.bronze_dir / "metadata.json"
+
+    jsonl_records = [
+        json.loads(line) for line in result.records_path.read_text(encoding="utf-8").splitlines()
+    ]
+    metadata = json.loads(result.metadata_path.read_text(encoding="utf-8"))
+
+    assert jsonl_records == list(artifact.raw_records)
+    assert metadata["source_key"] == "datago.apt_trade"
+    assert metadata["fetch_params"] == {"lawd_cd": "11680"}
+    assert metadata["fetched_at"] == "2026-05-08T12:00:00+00:00"
+    assert metadata["record_count"] == 2
+    assert metadata["artifact_paths"] == {
+        "records": str(result.records_path),
+        "metadata": str(result.metadata_path),
+    }
+    assert metadata["provenance"] == {
+        "operation": "fetch",
+        "source_key": "datago.apt_trade",
+        "fetch_params": {"lawd_cd": "11680"},
+        "fetched_at": "2026-05-08T12:00:00+00:00",
+    }


### PR DESCRIPTION
## Summary
- Bronze stage 최소 구현으로 `BronzeArtifact`, `ProvenanceEvent` 모델을 추가했습니다.
- compatible kpubdata client를 통해 source dataset을 fetch하고 raw records를 그대로 보존하는 `build_bronze_artifact`를 추가했습니다.
- `build/{run_id}/bronze/` 아래에 `raw_records.jsonl`과 `metadata.json`을 저장하는 persist 함수를 추가했습니다.
- fake client/dataset/records 기반 단위 테스트로 raw 보존, provenance, metadata, record_count를 검증했습니다.
- 기존 pipeline helper의 ruff/mypy 관련 최소 정리도 포함했습니다.
## Scope
- 전체 pipeline orchestrator, Silver, Gold, Export, Manifest 구현은 포함하지 않았습니다.
- 실제 외부 API 호출 테스트는 포함하지 않았습니다.
- 현재 Bronze fetch는 compatible client의 `client.dataset(source_key).list(**params).items` 형태를 기준으로 합니다.
## Tests
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy .`
- `uv run pytest`
## Notes
- API key, token, secret은 코드/fixture/test/docs에 포함하지 않았습니다.
- Issue #45의 모델/build/persist/unit test 요구사항은 대부분 충족하지만, maintainer 판단을 위해 기본적으로 `Refs #45`로 연결합니다.
Refs #45
