### PR TITLE
feat: Polars tabular helper 추가 (#49)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 ]
 dependencies = [
   "kpubdata>=0.1.0a0",
+  "polars>=1.0,<2",
   "pyyaml>=6.0,<7",
 ]
 
@@ -38,7 +39,7 @@ docs = [
 ]
 parquet = ["pyarrow>=15,<18"]
 huggingface = ["huggingface-hub>=0.23,<1"]
-publish = ["polars>=1.0,<2", "huggingface-hub>=0.23,<1", "xmltodict>=0.13,<1", "kaggle>=1.6,<2", "kr-building-name-normalizer>=0.2.0,<1"]
+publish = ["huggingface-hub>=0.23,<1", "xmltodict>=0.13,<1", "kaggle>=1.6,<2", "kr-building-name-normalizer>=0.2.0,<1"]
 dev = [
   "build>=1.2,<2",
   "mypy>=1.10,<2",

--- a/scripts/pipeline/package.py
+++ b/scripts/pipeline/package.py
@@ -20,7 +20,12 @@ def write_parquet(df: pl.DataFrame, output_path: Path) -> Path:
     return output_path
 
 
-def generate_dataset_card(df: pl.DataFrame, config: dict[str, Any], output_path: Path, variant_names: list[str] | None = None) -> Path:
+def generate_dataset_card(
+    df: pl.DataFrame,
+    config: dict[str, Any],
+    output_path: Path,
+    variant_names: list[str] | None = None,
+) -> Path:
     """Generate a HuggingFace dataset card (README.md) from config and data."""
     card = config["card"]
     output_cfg = config["output"]

--- a/scripts/pipeline/publish.py
+++ b/scripts/pipeline/publish.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import shutil
 import sys
-import json
 from pathlib import Path
 from typing import Any
 
@@ -76,7 +76,7 @@ def upload_to_kaggle(staging_dir: Path, config: dict[str, Any], *, dry_run: bool
     card = config["card"]
 
     try:
-        from kaggle.api.kaggle_api_extended import KaggleApi
+        from kaggle.api.kaggle_api_extended import KaggleApi  # type: ignore[import-untyped]
     except ImportError:
         logger.error("kaggle not installed. Install with: pip install 'kpubdata-builder[publish]'")
         sys.exit(1)

--- a/src/kpubdata_builder/tabular/__init__.py
+++ b/src/kpubdata_builder/tabular/__init__.py
@@ -1,0 +1,11 @@
+"""Tabular helpers backed by Polars."""
+
+from __future__ import annotations
+
+from .polars_helpers import cast_columns, records_to_dataframe, validate_required_columns
+
+__all__ = [
+    "cast_columns",
+    "records_to_dataframe",
+    "validate_required_columns",
+]

--- a/src/kpubdata_builder/tabular/polars_helpers.py
+++ b/src/kpubdata_builder/tabular/polars_helpers.py
@@ -1,0 +1,87 @@
+"""Small Polars helpers for tabularizing raw records."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+import polars as pl
+
+from ..spec import JsonValue
+
+DtypeSpec = str | type[pl.DataType]
+
+_TRUE_TOKENS = {"1", "t", "true", "y", "yes"}
+_FALSE_TOKENS = {"0", "f", "false", "n", "no"}
+
+_NAMED_DTYPES: Mapping[str, type[pl.DataType]] = {
+    "bool": pl.Boolean,
+    "boolean": pl.Boolean,
+    "date": pl.Date,
+    "datetime": pl.Datetime,
+    "float": pl.Float64,
+    "float64": pl.Float64,
+    "int": pl.Int64,
+    "int64": pl.Int64,
+    "str": pl.Utf8,
+    "string": pl.Utf8,
+    "utf8": pl.Utf8,
+}
+
+
+def records_to_dataframe(records: Sequence[dict[str, JsonValue]]) -> pl.DataFrame:
+    """Convert raw record mappings into a Polars DataFrame."""
+    return pl.DataFrame(list(records))
+
+
+def validate_required_columns(
+    df: pl.DataFrame,
+    required_columns: Sequence[str],
+) -> pl.DataFrame:
+    """Validate that a DataFrame contains all required columns."""
+    missing_columns = [column for column in required_columns if column not in df.columns]
+    if missing_columns:
+        missing = ", ".join(missing_columns)
+        raise ValueError(f"Missing required columns: {missing}")
+    return df
+
+
+def cast_columns(
+    df: pl.DataFrame,
+    dtypes: Mapping[str, DtypeSpec],
+) -> pl.DataFrame:
+    """Cast DataFrame columns according to a column-to-dtype mapping."""
+    expressions: list[pl.Expr] = []
+    for column, dtype in dtypes.items():
+        if column not in df.columns:
+            raise ValueError(f"Cannot cast missing column: {column}")
+        resolved_dtype = _resolve_dtype(dtype)
+        if resolved_dtype == pl.Boolean:
+            expressions.append(_cast_boolean(column))
+        else:
+            expressions.append(pl.col(column).cast(resolved_dtype, strict=False).alias(column))
+
+    if not expressions:
+        return df
+    return df.with_columns(expressions)
+
+
+def _resolve_dtype(dtype: DtypeSpec) -> type[pl.DataType]:
+    if isinstance(dtype, str):
+        normalized = dtype.strip().lower()
+        try:
+            return _NAMED_DTYPES[normalized]
+        except KeyError as exc:
+            raise ValueError(f"Unsupported dtype: {dtype}") from exc
+    return dtype
+
+
+def _cast_boolean(column: str) -> pl.Expr:
+    normalized = pl.col(column).cast(pl.Utf8).str.strip_chars().str.to_lowercase()
+    return (
+        pl.when(normalized.is_in(_TRUE_TOKENS))
+        .then(pl.lit(True))
+        .when(normalized.is_in(_FALSE_TOKENS))
+        .then(pl.lit(False))
+        .otherwise(pl.lit(None, dtype=pl.Boolean))
+        .alias(column)
+    )

--- a/tests/unit/test_tabular_helpers.py
+++ b/tests/unit/test_tabular_helpers.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from kpubdata_builder.spec import JsonValue
+from kpubdata_builder.tabular import (
+    cast_columns,
+    records_to_dataframe,
+    validate_required_columns,
+)
+
+
+def test_records_to_dataframe_converts_raw_records_without_mutating_input() -> None:
+    records: list[dict[str, JsonValue]] = [
+        {"id": "1", "amount": "1000", "district": "강남구"},
+        {"id": "2", "amount": "2500", "district": "서초구"},
+    ]
+
+    df = records_to_dataframe(records)
+
+    assert df.shape == (2, 3)
+    assert df.to_dicts() == records
+    assert records[0]["amount"] == "1000"
+
+
+def test_records_to_dataframe_accepts_empty_records() -> None:
+    df = records_to_dataframe(())
+
+    assert df.shape == (0, 0)
+
+
+def test_validate_required_columns_returns_dataframe_when_columns_exist() -> None:
+    df = records_to_dataframe(({"id": "1", "amount": "1000"},))
+
+    result = validate_required_columns(df, ("id", "amount"))
+
+    assert result is df
+
+
+def test_validate_required_columns_raises_for_missing_columns() -> None:
+    df = records_to_dataframe(({"id": "1"},))
+
+    with pytest.raises(ValueError, match="Missing required columns: amount, district"):
+        validate_required_columns(df, ("id", "amount", "district"))
+
+
+def test_cast_columns_casts_named_dtypes_without_changing_original_dataframe() -> None:
+    df = records_to_dataframe(
+        (
+            {"id": "1", "amount": "1000", "ratio": "1.5", "active": "true"},
+            {"id": "2", "amount": "bad", "ratio": "", "active": "false"},
+        )
+    )
+
+    casted = cast_columns(
+        df,
+        {
+            "id": "str",
+            "amount": "int",
+            "ratio": "float",
+            "active": "bool",
+        },
+    )
+
+    assert casted.schema["id"] == pl.Utf8
+    assert casted.schema["amount"] == pl.Int64
+    assert casted.schema["ratio"] == pl.Float64
+    assert casted.schema["active"] == pl.Boolean
+    assert casted.to_dicts() == [
+        {"id": "1", "amount": 1000, "ratio": 1.5, "active": True},
+        {"id": "2", "amount": None, "ratio": None, "active": False},
+    ]
+    assert df.schema["amount"] == pl.Utf8
+
+
+def test_cast_columns_accepts_polars_dtypes() -> None:
+    df = records_to_dataframe(({"id": "1", "amount": "1000"},))
+
+    casted = cast_columns(df, {"amount": pl.Int64})
+
+    assert casted.schema["amount"] == pl.Int64
+    assert casted.to_dicts() == [{"id": "1", "amount": 1000}]
+
+
+def test_cast_columns_raises_for_missing_column() -> None:
+    df = records_to_dataframe(({"id": "1"},))
+
+    with pytest.raises(ValueError, match="Cannot cast missing column: amount"):
+        cast_columns(df, {"amount": "int"})
+
+
+def test_cast_columns_raises_for_unknown_dtype() -> None:
+    df = records_to_dataframe(({"id": "1"},))
+
+    with pytest.raises(ValueError, match="Unsupported dtype: money"):
+        cast_columns(df, {"id": "money"})

--- a/uv.lock
+++ b/uv.lock
@@ -457,6 +457,7 @@ version = "0.1.0a0"
 source = { editable = "." }
 dependencies = [
     { name = "kpubdata" },
+    { name = "polars" },
     { name = "pyyaml" },
 ]
 
@@ -478,7 +479,6 @@ parquet = [
 publish = [
     { name = "huggingface-hub" },
     { name = "kr-building-name-normalizer" },
-    { name = "polars" },
     { name = "xmltodict" },
 ]
 
@@ -490,7 +490,7 @@ requires-dist = [
     { name = "kpubdata", editable = "../kpubdata" },
     { name = "kr-building-name-normalizer", marker = "extra == 'publish'", specifier = ">=0.1.0,<1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10,<2" },
-    { name = "polars", marker = "extra == 'publish'", specifier = ">=1.0,<2" },
+    { name = "polars", specifier = ">=1.0,<2" },
     { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=15,<18" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2,<9" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5,<6" },


### PR DESCRIPTION
## Summary
- Polars 기반 tabular helper의 최소 구현을 추가했습니다.
- raw records를 `pl.DataFrame`으로 변환하는 `records_to_dataframe`을 추가했습니다.
- required column 검증 helper와 dtype cast helper를 추가했습니다.
- helper 단위 테스트를 추가했습니다.
- Polars 기반 helper가 core module로 추가되어 `polars`를 기본 dependency로 이동했습니다.
- 기존 pipeline helper의 ruff/mypy 관련 최소 정리도 포함했습니다.
## Scope
- 이번 PR은 Issue #49의 전체 tabular engine 중 최소 helper만 다룹니다.
- Silver stage, Gold stage, Pipeline orchestrator는 구현하지 않았습니다.
- 아직 main에 merge되지 않은 #45 Bronze stage 코드에는 의존하지 않습니다.
## Tests
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy .`
- `uv run pytest`
## Notes
- API key, token, secret은 코드/fixture/test/docs에 포함하지 않았습니다.
- dtype helper는 최소 alias 중심이며, schema/statistics/preview 타입 모델과의 연결은 후속 PR 범위로 남겼습니다.
Refs #49
