### PR TITLE
fix: Bronze storage layout with source_key scoping and run_id validation (#77)

### DIFF
--- a/src/kpubdata_builder/stages/bronze/persist.py
+++ b/src/kpubdata_builder/stages/bronze/persist.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
+import re
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
 from ...spec import JsonValue
 from .models import BronzeArtifact, ProvenanceEvent
+
+_SAFE_PATH_SEGMENT = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
 
 
 @dataclass(frozen=True)
@@ -20,16 +24,58 @@ class BronzePersistResult:
     metadata_path: Path
 
 
+def _validate_path_segment(value: str, *, field_name: str) -> None:
+    """Reject path segments that could escape the workspace."""
+    if not value:
+        raise ValueError(f"{field_name} must not be empty")
+    if value != value.strip():
+        raise ValueError(f"{field_name} must not have leading/trailing whitespace")
+    if not _SAFE_PATH_SEGMENT.match(value):
+        raise ValueError(
+            f"{field_name} contains unsafe characters: {value!r}. "
+            "Only alphanumeric, dot, hyphen, and underscore are allowed."
+        )
+
+
+def _artifact_id(artifact: BronzeArtifact) -> str:
+    """Generate a short deterministic ID from source_key + fetch_params."""
+    key_material = json.dumps(
+        {"source_key": artifact.source_key, "fetch_params": artifact.fetch_params},
+        sort_keys=True,
+    )
+    return hashlib.sha256(key_material.encode()).hexdigest()[:12]
+
+
 def persist_bronze_artifact(
     artifact: BronzeArtifact,
     *,
     output_root: Path,
     run_id: str,
 ) -> BronzePersistResult:
-    """Write raw records and metadata under build/{run_id}/bronze."""
-    bronze_dir = output_root / run_id / "bronze"
+    """Write raw records and metadata under build/{run_id}/bronze/{source_key}/{artifact_id}.
+
+    Raises ValueError if run_id or source_key contain unsafe path characters.
+    """
+    _validate_path_segment(run_id, field_name="run_id")
+
+    # Sanitize source_key for filesystem (e.g. "datago.apt_trade" → "datago.apt_trade")
+    source_key_segment = artifact.source_key.replace("/", "_")
+    _validate_path_segment(source_key_segment, field_name="source_key")
+
+    artifact_id = _artifact_id(artifact)
+
+    bronze_dir = output_root / run_id / "bronze" / source_key_segment / artifact_id
     records_path = bronze_dir / "raw_records.jsonl"
     metadata_path = bronze_dir / "metadata.json"
+
+    # Final containment check: resolved path must be under output_root
+    resolved_root = output_root.resolve()
+    resolved_bronze = bronze_dir.resolve()
+    if not str(resolved_bronze).startswith(str(resolved_root)):
+        raise ValueError(
+            f"Resolved bronze directory {resolved_bronze} escapes output_root {resolved_root}"
+        )
+
     bronze_dir.mkdir(parents=True, exist_ok=True)
 
     records_content = "".join(

--- a/tests/unit/test_bronze.py
+++ b/tests/unit/test_bronze.py
@@ -122,7 +122,9 @@ def test_persist_bronze_artifact_writes_jsonl_and_metadata(tmp_path: Path) -> No
 
     result = persist_bronze_artifact(artifact, output_root=tmp_path / "build", run_id="run-1")
 
-    assert result.bronze_dir == tmp_path / "build" / "run-1" / "bronze"
+    assert "run-1" in str(result.bronze_dir)
+    assert "bronze" in str(result.bronze_dir)
+    assert "datago.apt_trade" in str(result.bronze_dir)
     assert result.records_path == result.bronze_dir / "raw_records.jsonl"
     assert result.metadata_path == result.bronze_dir / "metadata.json"
 
@@ -146,3 +148,44 @@ def test_persist_bronze_artifact_writes_jsonl_and_metadata(tmp_path: Path) -> No
         "fetch_params": {"lawd_cd": "11680"},
         "fetched_at": "2026-05-08T12:00:00+00:00",
     }
+
+
+def test_persist_bronze_artifact_separates_different_params(tmp_path: Path) -> None:
+    fetched_at = datetime(2026, 5, 8, 12, 0, tzinfo=timezone.utc)
+    artifact_a = BronzeArtifact(
+        source_key="datago.apt_trade",
+        raw_records=({"id": "1"},),
+        fetch_params={"lawd_cd": "11680"},
+        fetched_at=fetched_at,
+    )
+    artifact_b = BronzeArtifact(
+        source_key="datago.apt_trade",
+        raw_records=({"id": "2"},),
+        fetch_params={"lawd_cd": "11650"},
+        fetched_at=fetched_at,
+    )
+
+    result_a = persist_bronze_artifact(artifact_a, output_root=tmp_path, run_id="run-1")
+    result_b = persist_bronze_artifact(artifact_b, output_root=tmp_path, run_id="run-1")
+
+    assert result_a.bronze_dir != result_b.bronze_dir
+    assert result_a.records_path.read_text(encoding="utf-8").strip() == '{"id": "1"}'
+    assert result_b.records_path.read_text(encoding="utf-8").strip() == '{"id": "2"}'
+
+
+def test_persist_bronze_artifact_rejects_unsafe_run_id(tmp_path: Path) -> None:
+    fetched_at = datetime(2026, 5, 8, 12, 0, tzinfo=timezone.utc)
+    artifact = BronzeArtifact(
+        source_key="datago.apt_trade",
+        raw_records=(),
+        fetched_at=fetched_at,
+    )
+
+    with pytest.raises(ValueError, match="unsafe characters"):
+        persist_bronze_artifact(artifact, output_root=tmp_path, run_id="../escape")
+
+    with pytest.raises(ValueError, match="unsafe characters"):
+        persist_bronze_artifact(artifact, output_root=tmp_path, run_id="/absolute")
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        persist_bronze_artifact(artifact, output_root=tmp_path, run_id="")


### PR DESCRIPTION
## Summary
- Persist path 변경: `build/{run_id}/bronze/` → `build/{run_id}/bronze/{source_key}/{artifact_id}/`
- 같은 run에서 다른 source/params 사용 시 덮어쓰기 방지
- `run_id` / `source_key` path traversal 방어 (regex + resolve containment check)
- deterministic `artifact_id` = sha256(source_key + fetch_params)[:12]

## Tests
- 기존 persist 테스트 업데이트
- 다른 params → 다른 디렉토리 테스트 추가
- unsafe run_id (`../`, `/absolute`, empty) rejection 테스트 추가
- `uv run ruff check .` ✅
- `uv run mypy src/kpubdata_builder/stages/bronze/persist.py` ✅
- `uv run pytest tests/unit/test_bronze.py` — 6 passed ✅

Fixes #77