### PR TITLE
fix(tabular): expand DtypeSpec and add cast audit mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ Thumbs.db
 .env
 .env.local
 .github/workflows/ci.yml
+staging/

--- a/src/kpubdata_builder/tabular/__init__.py
+++ b/src/kpubdata_builder/tabular/__init__.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
-from .polars_helpers import cast_columns, records_to_dataframe, validate_required_columns
+from .polars_helpers import (
+    CastReport,
+    CastResult,
+    cast_columns,
+    records_to_dataframe,
+    validate_required_columns,
+)
 
 __all__ = [
+    "CastReport",
+    "CastResult",
     "cast_columns",
     "records_to_dataframe",
     "validate_required_columns",

--- a/src/kpubdata_builder/tabular/polars_helpers.py
+++ b/src/kpubdata_builder/tabular/polars_helpers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
+from typing import Literal, overload
 
 import polars as pl
 
@@ -31,7 +32,7 @@ _NAMED_DTYPES: Mapping[str, pl.DataType] = {
 
 @dataclass(frozen=True)
 class CastReport:
-    """Report of null values introduced during casting."""
+    """Per-column count of null values introduced by strict=False casting."""
 
     column: str
     nulls_before: int
@@ -44,13 +45,13 @@ class CastReport:
 
 @dataclass(frozen=True)
 class CastResult:
-    """Result of cast_columns with optional audit information."""
+    """Result of cast_columns(audit=True) with null-introduction tracking."""
 
     df: pl.DataFrame
     reports: tuple[CastReport, ...] = field(default_factory=tuple)
 
     @property
-    def has_data_loss(self) -> bool:
+    def has_nulls_introduced(self) -> bool:
         return any(r.nulls_introduced > 0 for r in self.reports)
 
 
@@ -69,6 +70,24 @@ def validate_required_columns(
         missing = ", ".join(missing_columns)
         raise ValueError(f"Missing required columns: {missing}")
     return df
+
+
+@overload
+def cast_columns(
+    df: pl.DataFrame,
+    dtypes: Mapping[str, DtypeSpec],
+    *,
+    audit: Literal[False] = ...,
+) -> pl.DataFrame: ...
+
+
+@overload
+def cast_columns(
+    df: pl.DataFrame,
+    dtypes: Mapping[str, DtypeSpec],
+    *,
+    audit: Literal[True],
+) -> CastResult: ...
 
 
 def cast_columns(

--- a/src/kpubdata_builder/tabular/polars_helpers.py
+++ b/src/kpubdata_builder/tabular/polars_helpers.py
@@ -3,29 +3,55 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
 
 import polars as pl
 
 from ..spec import JsonValue
 
-DtypeSpec = str | type[pl.DataType]
+DtypeSpec = str | pl.DataType | type[pl.DataType]
 
 _TRUE_TOKENS = {"1", "t", "true", "y", "yes"}
 _FALSE_TOKENS = {"0", "f", "false", "n", "no"}
 
-_NAMED_DTYPES: Mapping[str, type[pl.DataType]] = {
-    "bool": pl.Boolean,
-    "boolean": pl.Boolean,
-    "date": pl.Date,
-    "datetime": pl.Datetime,
-    "float": pl.Float64,
-    "float64": pl.Float64,
-    "int": pl.Int64,
-    "int64": pl.Int64,
-    "str": pl.Utf8,
-    "string": pl.Utf8,
-    "utf8": pl.Utf8,
+_NAMED_DTYPES: Mapping[str, pl.DataType] = {
+    "bool": pl.Boolean(),
+    "boolean": pl.Boolean(),
+    "date": pl.Date(),
+    "datetime": pl.Datetime(),
+    "float": pl.Float64(),
+    "float64": pl.Float64(),
+    "int": pl.Int64(),
+    "int64": pl.Int64(),
+    "str": pl.Utf8(),
+    "string": pl.Utf8(),
+    "utf8": pl.Utf8(),
 }
+
+
+@dataclass(frozen=True)
+class CastReport:
+    """Report of null values introduced during casting."""
+
+    column: str
+    nulls_before: int
+    nulls_after: int
+
+    @property
+    def nulls_introduced(self) -> int:
+        return self.nulls_after - self.nulls_before
+
+
+@dataclass(frozen=True)
+class CastResult:
+    """Result of cast_columns with optional audit information."""
+
+    df: pl.DataFrame
+    reports: tuple[CastReport, ...] = field(default_factory=tuple)
+
+    @property
+    def has_data_loss(self) -> bool:
+        return any(r.nulls_introduced > 0 for r in self.reports)
 
 
 def records_to_dataframe(records: Sequence[dict[str, JsonValue]]) -> pl.DataFrame:
@@ -48,31 +74,66 @@ def validate_required_columns(
 def cast_columns(
     df: pl.DataFrame,
     dtypes: Mapping[str, DtypeSpec],
-) -> pl.DataFrame:
-    """Cast DataFrame columns according to a column-to-dtype mapping."""
+    *,
+    audit: bool = False,
+) -> pl.DataFrame | CastResult:
+    """Cast DataFrame columns according to a column-to-dtype mapping.
+
+    When audit=True, returns a CastResult with per-column null reports.
+    When audit=False (default), returns the DataFrame directly.
+    """
+    reports: list[CastReport] = []
     expressions: list[pl.Expr] = []
+
     for column, dtype in dtypes.items():
         if column not in df.columns:
-            raise ValueError(f"Cannot cast missing column: {column}")
+            raise ValueError(
+                f"Cannot cast missing column: {column!r}. Available columns: {df.columns}"
+            )
         resolved_dtype = _resolve_dtype(dtype)
-        if resolved_dtype == pl.Boolean:
+        if isinstance(resolved_dtype, pl.Boolean):
             expressions.append(_cast_boolean(column))
         else:
             expressions.append(pl.col(column).cast(resolved_dtype, strict=False).alias(column))
 
     if not expressions:
+        if audit:
+            return CastResult(df=df, reports=())
         return df
-    return df.with_columns(expressions)
+
+    if audit:
+        nulls_before = {col: df[col].null_count() for col in dtypes if col in df.columns}
+
+    result_df = df.with_columns(expressions)
+
+    if audit:
+        for column in dtypes:
+            if column in df.columns:
+                report = CastReport(
+                    column=column,
+                    nulls_before=nulls_before[column],
+                    nulls_after=result_df[column].null_count(),
+                )
+                if report.nulls_introduced > 0:
+                    reports.append(report)
+        return CastResult(df=result_df, reports=tuple(reports))
+
+    return result_df
 
 
-def _resolve_dtype(dtype: DtypeSpec) -> type[pl.DataType]:
+def _resolve_dtype(dtype: DtypeSpec) -> pl.DataType:
     if isinstance(dtype, str):
         normalized = dtype.strip().lower()
         try:
             return _NAMED_DTYPES[normalized]
         except KeyError as exc:
-            raise ValueError(f"Unsupported dtype: {dtype}") from exc
-    return dtype
+            supported = ", ".join(sorted(_NAMED_DTYPES.keys()))
+            raise ValueError(f"Unsupported dtype: {dtype!r}. Supported: {supported}") from exc
+    if isinstance(dtype, pl.DataType):
+        return dtype
+    if isinstance(dtype, type) and issubclass(dtype, pl.DataType):
+        return dtype()
+    raise TypeError(f"Invalid dtype spec: {dtype!r}")
 
 
 def _cast_boolean(column: str) -> pl.Expr:

--- a/tests/unit/test_tabular_helpers.py
+++ b/tests/unit/test_tabular_helpers.py
@@ -87,11 +87,11 @@ def test_cast_columns_accepts_polars_dtypes() -> None:
     assert casted.to_dicts() == [{"id": "1", "amount": 1000}]
 
 
-def test_cast_columns_accepts_polars_dtype_class() -> None:
-    """type[pl.DataType] (e.g. pl.Int64 without ()) should also work."""
+def test_cast_columns_accepts_polars_dtype_instance() -> None:
+    """pl.Int64() (instantiated DataType) should work."""
     df = records_to_dataframe(({"id": "1", "amount": "1000"},))
 
-    casted = cast_columns(df, {"amount": pl.Int64})
+    casted = cast_columns(df, {"amount": pl.Int64()})
 
     assert isinstance(casted, pl.DataFrame)
     assert casted.schema["amount"] == pl.Int64
@@ -133,7 +133,7 @@ def test_cast_columns_audit_returns_cast_result() -> None:
 
     assert isinstance(result, CastResult)
     assert result.df.schema["amount"] == pl.Int64
-    assert result.has_data_loss is False
+    assert result.has_nulls_introduced is False
     assert result.reports == ()
 
 
@@ -149,7 +149,7 @@ def test_cast_columns_audit_detects_data_loss() -> None:
     result = cast_columns(df, {"amount": "int"}, audit=True)
 
     assert isinstance(result, CastResult)
-    assert result.has_data_loss is True
+    assert result.has_nulls_introduced is True
     assert len(result.reports) == 1
     report = result.reports[0]
     assert report.column == "amount"

--- a/tests/unit/test_tabular_helpers.py
+++ b/tests/unit/test_tabular_helpers.py
@@ -5,6 +5,8 @@ import pytest
 
 from kpubdata_builder.spec import JsonValue
 from kpubdata_builder.tabular import (
+    CastReport,
+    CastResult,
     cast_columns,
     records_to_dataframe,
     validate_required_columns,
@@ -63,6 +65,7 @@ def test_cast_columns_casts_named_dtypes_without_changing_original_dataframe() -
         },
     )
 
+    assert isinstance(casted, pl.DataFrame)
     assert casted.schema["id"] == pl.Utf8
     assert casted.schema["amount"] == pl.Int64
     assert casted.schema["ratio"] == pl.Float64
@@ -79,19 +82,92 @@ def test_cast_columns_accepts_polars_dtypes() -> None:
 
     casted = cast_columns(df, {"amount": pl.Int64})
 
+    assert isinstance(casted, pl.DataFrame)
     assert casted.schema["amount"] == pl.Int64
     assert casted.to_dicts() == [{"id": "1", "amount": 1000}]
+
+
+def test_cast_columns_accepts_polars_dtype_class() -> None:
+    """type[pl.DataType] (e.g. pl.Int64 without ()) should also work."""
+    df = records_to_dataframe(({"id": "1", "amount": "1000"},))
+
+    casted = cast_columns(df, {"amount": pl.Int64})
+
+    assert isinstance(casted, pl.DataFrame)
+    assert casted.schema["amount"] == pl.Int64
+
+
+def test_cast_columns_accepts_parameterized_dtype_instance() -> None:
+    """Parameterized dtype instances like pl.Datetime('ms') should work."""
+    df = records_to_dataframe(({"ts": "2025-01-01 00:00:00"},))
+
+    casted = cast_columns(df, {"ts": pl.Datetime("ms")})
+
+    assert isinstance(casted, pl.DataFrame)
+    assert casted.schema["ts"] == pl.Datetime("ms")
 
 
 def test_cast_columns_raises_for_missing_column() -> None:
     df = records_to_dataframe(({"id": "1"},))
 
-    with pytest.raises(ValueError, match="Cannot cast missing column: amount"):
+    with pytest.raises(ValueError, match="Cannot cast missing column"):
         cast_columns(df, {"amount": "int"})
 
 
 def test_cast_columns_raises_for_unknown_dtype() -> None:
     df = records_to_dataframe(({"id": "1"},))
 
-    with pytest.raises(ValueError, match="Unsupported dtype: money"):
+    with pytest.raises(ValueError, match="Unsupported dtype"):
         cast_columns(df, {"id": "money"})
+
+
+def test_cast_columns_audit_returns_cast_result() -> None:
+    df = records_to_dataframe(
+        (
+            {"amount": "1000"},
+            {"amount": "2000"},
+        )
+    )
+
+    result = cast_columns(df, {"amount": "int"}, audit=True)
+
+    assert isinstance(result, CastResult)
+    assert result.df.schema["amount"] == pl.Int64
+    assert result.has_data_loss is False
+    assert result.reports == ()
+
+
+def test_cast_columns_audit_detects_data_loss() -> None:
+    df = records_to_dataframe(
+        (
+            {"amount": "1000"},
+            {"amount": "bad"},
+            {"amount": "3000"},
+        )
+    )
+
+    result = cast_columns(df, {"amount": "int"}, audit=True)
+
+    assert isinstance(result, CastResult)
+    assert result.has_data_loss is True
+    assert len(result.reports) == 1
+    report = result.reports[0]
+    assert report.column == "amount"
+    assert report.nulls_before == 0
+    assert report.nulls_after == 1
+    assert report.nulls_introduced == 1
+
+
+def test_cast_columns_audit_empty_dtypes() -> None:
+    df = records_to_dataframe(({"id": "1"},))
+
+    result = cast_columns(df, {}, audit=True)
+
+    assert isinstance(result, CastResult)
+    assert result.df is df
+    assert result.reports == ()
+
+
+def test_cast_report_nulls_introduced() -> None:
+    report = CastReport(column="x", nulls_before=1, nulls_after=3)
+    assert report.nulls_introduced == 2


### PR DESCRIPTION
## Summary

- `DtypeSpec`을 `str | pl.DataType | type[pl.DataType]`로 확장하여 parameterized dtype 인스턴스 (예: `pl.Datetime("ms")`) 지원
- `CastReport` / `CastResult` dataclass 추가: cast 시 null 도입 여부 추적
- `cast_columns(audit=True)` 옵션 추가: per-column data loss 감지
- 에러 메시지 개선: available columns, supported dtypes 포함

Closes #78