### PR TITLE
feat: CLI entrypoint 기본 구조 추가 (#43)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ dependencies = [
   "pyyaml>=6.0,<7",
 ]
 
+[project.scripts]
+kpubdata-builder = "kpubdata_builder.cli:main"
+
 [project.optional-dependencies]
 docs = [
   "mkdocs-material>=9,<10",

--- a/src/kpubdata_builder/cli.py
+++ b/src/kpubdata_builder/cli.py
@@ -1,0 +1,104 @@
+"""Command-line entrypoint for kpubdata-builder."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+from . import __version__
+from .errors import SpecLoadError, ValidationError
+from .spec import load_spec
+from .validator import validate_spec
+
+_RESERVED_COMMANDS: frozenset[str] = frozenset({"preview", "build"})
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="kpubdata-builder",
+        description="KPubData Builder command-line interface.",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", metavar="command")
+
+    validate_cmd = subparsers.add_parser(
+        "validate",
+        help="Validate a BuildSpec YAML file.",
+    )
+    validate_cmd.add_argument("spec", help="Path to the BuildSpec YAML file.")
+
+    preview_cmd = subparsers.add_parser(
+        "preview",
+        help="Preview a BuildSpec execution (reserved; not implemented yet).",
+    )
+    preview_cmd.add_argument("spec", help="Path to the BuildSpec YAML file.")
+
+    build_cmd = subparsers.add_parser(
+        "build",
+        help="Execute a BuildSpec to produce artifacts (reserved; not implemented yet).",
+    )
+    build_cmd.add_argument("spec", help="Path to the BuildSpec YAML file.")
+
+    return parser
+
+
+def _run_validate(spec_path: str) -> int:
+    try:
+        spec = load_spec(Path(spec_path))
+        validate_spec(spec)
+    except SpecLoadError as exc:
+        print(f"error: failed to load spec: {exc}", file=sys.stderr)
+        return 1
+    except ValidationError as exc:
+        print("error: spec validation failed:", file=sys.stderr)
+        for problem in exc.problems:
+            print(f"  - {problem}", file=sys.stderr)
+        return 1
+    print(f"spec is valid: {spec.dataset_id}")
+    return 0
+
+
+def _run_reserved(command: str) -> int:
+    print(
+        f"error: '{command}' is not implemented yet "
+        "(pipeline orchestrator pending — see issue #43)",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def dispatch(args: argparse.Namespace) -> int:
+    command = args.command
+    if command == "validate":
+        return _run_validate(args.spec)
+    if command in _RESERVED_COMMANDS:
+        return _run_reserved(command)
+    print(f"error: unknown command: {command!r}", file=sys.stderr)
+    return 2
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    try:
+        args = parser.parse_args(list(argv) if argv is not None else None)
+    except SystemExit as exc:
+        code = exc.code
+        if code is None:
+            return 0
+        if isinstance(code, int):
+            return code
+        return 2
+    if args.command is None:
+        parser.print_help(sys.stderr)
+        return 2
+    return dispatch(args)
+
+
+__all__ = ["build_parser", "dispatch", "main"]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,134 @@
+"""Tests for the kpubdata-builder command-line entrypoint."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kpubdata_builder import __version__
+from kpubdata_builder.cli import build_parser, main
+
+VALID_SPEC_YAML = (
+    """
+dataset_id: dataset.sample
+title: Sample Dataset
+description: Sample description
+sources:
+  - provider: datago
+    dataset: air_quality
+exports:
+  - kind: jsonl
+    output_path: out/data.jsonl
+""".strip()
+    + "\n"
+)
+
+INVALID_SPEC_YAML_NO_SOURCES = (
+    """
+dataset_id: dataset.sample
+title: Sample Dataset
+description: Sample description
+sources: []
+exports:
+  - kind: jsonl
+    output_path: out/data.jsonl
+""".strip()
+    + "\n"
+)
+
+
+def test_build_parser_uses_program_name() -> None:
+    parser = build_parser()
+    assert parser.prog == "kpubdata-builder"
+
+
+def test_help_returns_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main(["--help"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "kpubdata-builder" in captured.out
+    assert "validate" in captured.out
+
+
+def test_version_returns_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main(["--version"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert __version__ in captured.out
+
+
+def test_no_subcommand_returns_two(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main([])
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "kpubdata-builder" in captured.err
+
+
+def test_unknown_command_returns_two(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main(["does-not-exist"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert captured.err
+
+
+def test_validate_succeeds_for_valid_spec(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    spec_path = tmp_path / "spec.yaml"
+    spec_path.write_text(VALID_SPEC_YAML, encoding="utf-8")
+
+    exit_code = main(["validate", str(spec_path)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "dataset.sample" in captured.out
+    assert captured.err == ""
+
+
+def test_validate_fails_for_missing_file(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    missing = tmp_path / "missing.yaml"
+
+    exit_code = main(["validate", str(missing)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "failed to load spec" in captured.err
+
+
+def test_validate_fails_for_invalid_spec(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    spec_path = tmp_path / "spec.yaml"
+    spec_path.write_text(INVALID_SPEC_YAML_NO_SOURCES, encoding="utf-8")
+
+    exit_code = main(["validate", str(spec_path)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "spec validation failed" in captured.err
+    assert "at least one source is required" in captured.err
+
+
+def test_preview_is_reserved(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main(["preview", "any.yaml"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "preview" in captured.err
+    assert "not implemented" in captured.err
+
+
+def test_build_is_reserved(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main(["build", "any.yaml"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "build" in captured.err
+    assert "not implemented" in captured.err


### PR DESCRIPTION
## 개요

`kpubdata-builder` console script entrypoint와 argparse 기반 CLI 골격을 추가합니다.
이번 PR은 CLI surface와 `validate` 동작 구현까지만 다루고, Bronze/Silver/Gold/orchestrator 본체 구현은 포함하지 않습니다.

## 변경 사항

- `src/kpubdata_builder/cli.py` 신규 추가
  - `build_parser()`: top-level parser + `validate`/`preview`/`build` 서브파서 정의
  - `dispatch(args)`: 서브커맨드별 분기 처리
  - `main(argv)`: `SystemExit`를 잡아 int exit code로 반환
  - `validate <spec>`: 현재 main의 `load_spec` + `validate_spec`을 사용한 실제 검증 동작
  - `preview`, `build`: pipeline orchestrator 부재로 reserved 처리
- `pyproject.toml`에 console script 등록
  - `kpubdata-builder = "kpubdata_builder.cli:main"`
- `tests/unit/test_cli.py` 신규 추가

## CLI 동작

| 입력 | exit code | 출력 |
| :--- | :--- | :--- |
| `--help` | 0 | stdout에 도움말 |
| `--version` | 0 | stdout에 버전 문자열 |
| 서브커맨드 미지정 | 2 | stderr에 도움말 |
| `validate <valid-spec>` | 0 | stdout에 `spec is valid: <dataset_id>` |
| `validate <missing-or-invalid>` | 1 | stderr에 실패 메시지 |
| `preview <spec>` / `build <spec>` | 1 | stderr에 `not implemented` |

## 범위 외

- Bronze/Silver/Gold stage 실제 실행
- pipeline orchestrator 구현
- `preview`/`build`의 실제 동작
- 외부 API 호출 / fetch 로직
- `publish` extras dependency 정상화

## 검증

로컬에서 일반 `uv run`은 현재 main의 `publish` extra 의존성 해결 단계에서 실패합니다.
`kr-building-name-normalizer` 패키지를 registry에서 찾지 못하는 기존 문제이며, 이번 PR 변경과는 무관합니다.

대신 `uv run --no-sync`로 변경 파일과 전체 스위트를 검증했습니다.

- `uv run --no-sync ruff check .`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync mypy .`
- `uv run --no-sync pytest` — `51 passed`

## 체크리스트

- [x] BuildSpec / Manifest / stage 책임 경계를 침범하지 않음
- [x] Bronze/Silver/Gold 코드 무변경
- [x] `# type: ignore` 추가 없음
- [x] API key/token/secret 미포함
- [x] unrelated dependency/lockfile 변경 없음

Refs #43
