### PR TITLE
fix(cli): reserved commands UX and missing tests

### DIFF
--- a/src/kpubdata_builder/cli.py
+++ b/src/kpubdata_builder/cli.py
@@ -38,13 +38,13 @@ def build_parser() -> argparse.ArgumentParser:
         "preview",
         help="Preview a BuildSpec execution (reserved; not implemented yet).",
     )
-    preview_cmd.add_argument("spec", help="Path to the BuildSpec YAML file.")
+    preview_cmd.add_argument("spec", nargs="?", help="Path to the BuildSpec YAML file.")
 
     build_cmd = subparsers.add_parser(
         "build",
         help="Execute a BuildSpec to produce artifacts (reserved; not implemented yet).",
     )
-    build_cmd.add_argument("spec", help="Path to the BuildSpec YAML file.")
+    build_cmd.add_argument("spec", nargs="?", help="Path to the BuildSpec YAML file.")
 
     return parser
 
@@ -80,7 +80,8 @@ def dispatch(args: argparse.Namespace) -> int:
         return _run_validate(args.spec)
     if command in _RESERVED_COMMANDS:
         return _run_reserved(command)
-    print(f"error: unknown command: {command!r}", file=sys.stderr)
+    # Unreachable via normal CLI (argparse rejects unknown subcommands),
+    # but kept as a defensive fallback for programmatic callers.
     return 2
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -125,6 +125,15 @@ def test_preview_is_reserved(capsys: pytest.CaptureFixture[str]) -> None:
     assert "not implemented" in captured.err
 
 
+def test_preview_without_spec_is_reserved(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main(["preview"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "preview" in captured.err
+    assert "not implemented" in captured.err
+
+
 def test_build_is_reserved(capsys: pytest.CaptureFixture[str]) -> None:
     exit_code = main(["build", "any.yaml"])
     captured = capsys.readouterr()
@@ -132,3 +141,25 @@ def test_build_is_reserved(capsys: pytest.CaptureFixture[str]) -> None:
     assert exit_code == 1
     assert "build" in captured.err
     assert "not implemented" in captured.err
+
+
+def test_build_without_spec_is_reserved(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main(["build"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "build" in captured.err
+    assert "not implemented" in captured.err
+
+
+def test_validate_fails_for_malformed_yaml(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    spec_path = tmp_path / "bad.yaml"
+    spec_path.write_text("{{{{not: valid: yaml: [", encoding="utf-8")
+
+    exit_code = main(["validate", str(spec_path)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "failed to load spec" in captured.err


### PR DESCRIPTION
## Summary

Follow-up to PR #82 (CLI entrypoint).

- Make `spec` argument optional for `preview`/`build` so they correctly show "not implemented" instead of argparse's "missing argument" error
- Add tests: `preview`/`build` without spec arg, malformed YAML parse error
- Clean up unreachable `dispatch()` branch with explanatory comment