### PR TITLE
feat: Silver stage 구현 — tabularize + validate + summarize

### DIFF
--- a/src/kpubdata_builder/stages/silver/__init__.py
+++ b/src/kpubdata_builder/stages/silver/__init__.py
@@ -1,0 +1,35 @@
+"""Silver stage public API."""
+
+from __future__ import annotations
+
+from .build import build_silver_dataset
+from .models import (
+    ColumnInfo,
+    PreviewSlice,
+    SchemaSummary,
+    SilverDataset,
+    TableStatistics,
+    ValidationResult,
+)
+from .normalize import normalize_table
+from .persist import SilverPersistResult, persist_silver_dataset
+from .preview import build_preview
+from .summarize import summarize_schema, summarize_statistics
+from .validate import validate_table
+
+__all__ = [
+    "ColumnInfo",
+    "PreviewSlice",
+    "SchemaSummary",
+    "SilverDataset",
+    "SilverPersistResult",
+    "TableStatistics",
+    "ValidationResult",
+    "build_preview",
+    "build_silver_dataset",
+    "normalize_table",
+    "persist_silver_dataset",
+    "summarize_schema",
+    "summarize_statistics",
+    "validate_table",
+]

--- a/src/kpubdata_builder/stages/silver/build.py
+++ b/src/kpubdata_builder/stages/silver/build.py
@@ -1,0 +1,42 @@
+"""Silver stage orchestration: BronzeArtifact -> SilverDataset."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from ...tabular.polars_helpers import records_to_dataframe
+from ..bronze.models import BronzeArtifact
+from .models import SilverDataset
+from .normalize import normalize_table
+from .preview import DEFAULT_PREVIEW_ROWS, build_preview
+from .summarize import summarize_schema, summarize_statistics
+from .validate import validate_table
+
+
+def build_silver_dataset(
+    artifact: BronzeArtifact,
+    *,
+    transforms: Sequence[str] = (),
+    preview_limit: int = DEFAULT_PREVIEW_ROWS,
+) -> SilverDataset:
+    """Tabularize a Bronze artifact and produce a validated Silver dataset.
+
+    Steps: records -> DataFrame -> spec-declared normalization -> schema and
+    statistics summaries -> preview slice -> structural validation.
+    """
+    table = records_to_dataframe(artifact.raw_records)
+    table = normalize_table(table, transforms)
+
+    schema_summary = summarize_schema(table)
+    statistics = summarize_statistics(table)
+    preview = build_preview(table, limit=preview_limit)
+    validation_result = validate_table(table)
+
+    return SilverDataset(
+        table=table,
+        schema_summary=schema_summary,
+        statistics=statistics,
+        preview=preview,
+        validation_result=validation_result,
+        source_bronze=artifact.source_key,
+    )

--- a/src/kpubdata_builder/stages/silver/models.py
+++ b/src/kpubdata_builder/stages/silver/models.py
@@ -34,6 +34,12 @@ class TableStatistics:
     null_counts: dict[str, int] = field(default_factory=dict)
     duplicate_rate: float = 0.0
 
+    def __post_init__(self) -> None:
+        # frozen=True only blocks attribute reassignment; the mapping itself
+        # stays mutable. Store a defensive copy so a caller mutating the dict
+        # they passed in cannot alter this otherwise-immutable value.
+        object.__setattr__(self, "null_counts", dict(self.null_counts))
+
 
 @dataclass(frozen=True)
 class PreviewSlice:
@@ -58,7 +64,12 @@ class ValidationResult:
 
 @dataclass(frozen=True)
 class SilverDataset:
-    """Tabularized, validated dataset produced by the Silver stage."""
+    """Tabularized, validated dataset produced by the Silver stage.
+
+    ``frozen=True`` here is shallow: ``table`` is held by reference. A Polars
+    ``DataFrame`` is treated as immutable by convention (its operations return
+    new frames), so this is safe in practice but is not deep immutability.
+    """
 
     table: pl.DataFrame
     schema_summary: SchemaSummary

--- a/src/kpubdata_builder/stages/silver/models.py
+++ b/src/kpubdata_builder/stages/silver/models.py
@@ -15,7 +15,7 @@ class ColumnInfo:
 
     name: str
     dtype: str
-    nullable: bool
+    has_nulls: bool
     unique_count: int
 
 

--- a/src/kpubdata_builder/stages/silver/models.py
+++ b/src/kpubdata_builder/stages/silver/models.py
@@ -1,0 +1,68 @@
+"""Silver stage models: tabularized dataset with schema, stats, and preview."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import polars as pl
+
+from ...spec import JsonValue
+
+
+@dataclass(frozen=True)
+class ColumnInfo:
+    """Schema information for a single column."""
+
+    name: str
+    dtype: str
+    nullable: bool
+    unique_count: int
+
+
+@dataclass(frozen=True)
+class SchemaSummary:
+    """Column-level schema description of a Silver table."""
+
+    columns: tuple[ColumnInfo, ...] = ()
+
+
+@dataclass(frozen=True)
+class TableStatistics:
+    """Aggregate statistics for a Silver table."""
+
+    row_count: int
+    null_counts: dict[str, int] = field(default_factory=dict)
+    duplicate_rate: float = 0.0
+
+
+@dataclass(frozen=True)
+class PreviewSlice:
+    """A small sample of rows for previewing a Silver table."""
+
+    rows: tuple[dict[str, JsonValue], ...] = ()
+    total_rows: int = 0
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    """Outcome of validating a Silver table against expectations."""
+
+    errors: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+    @property
+    def ok(self) -> bool:
+        """True when validation produced no errors."""
+        return not self.errors
+
+
+@dataclass(frozen=True)
+class SilverDataset:
+    """Tabularized, validated dataset produced by the Silver stage."""
+
+    table: pl.DataFrame
+    schema_summary: SchemaSummary
+    statistics: TableStatistics
+    preview: PreviewSlice
+    validation_result: ValidationResult
+    source_bronze: str

--- a/src/kpubdata_builder/stages/silver/normalize.py
+++ b/src/kpubdata_builder/stages/silver/normalize.py
@@ -1,0 +1,29 @@
+"""Silver stage normalization: apply only spec-declared transforms.
+
+Per the Silver stage principle, the Builder must not invent its own notion
+of "clean" data. Normalization applies only transforms explicitly declared
+in the BuildSpec. Anything not declared is left untouched.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import polars as pl
+
+
+def normalize_table(table: pl.DataFrame, transforms: Sequence[str] = ()) -> pl.DataFrame:
+    """Apply spec-declared transforms to a table.
+
+    With no declared transforms (the common case), the table is returned
+    unchanged. Declared transforms that the Builder does not yet support
+    raise an error rather than being silently ignored, to keep behavior
+    deterministic and avoid implying transforms ran when they did not.
+    """
+    if not transforms:
+        return table
+    unsupported = ", ".join(repr(t) for t in transforms)
+    raise ValueError(
+        f"Unsupported transforms declared in spec: {unsupported}. "
+        "The Silver stage does not yet implement declarative transforms."
+    )

--- a/src/kpubdata_builder/stages/silver/persist.py
+++ b/src/kpubdata_builder/stages/silver/persist.py
@@ -1,0 +1,88 @@
+"""Persist Silver stage datasets to a run workspace."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from ...spec import JsonValue
+from .models import SilverDataset
+
+_SAFE_PATH_SEGMENT = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
+
+
+@dataclass(frozen=True)
+class SilverPersistResult:
+    """Filesystem paths written for a Silver dataset."""
+
+    silver_dir: Path
+    table_path: Path
+    schema_path: Path
+    stats_path: Path
+    preview_path: Path
+
+
+def _validate_path_segment(value: str, *, field_name: str) -> None:
+    """Reject path segments that could escape the workspace."""
+    if not value:
+        raise ValueError(f"{field_name} must not be empty")
+    if value != value.strip():
+        raise ValueError(f"{field_name} must not have leading/trailing whitespace")
+    if not _SAFE_PATH_SEGMENT.match(value):
+        raise ValueError(
+            f"{field_name} contains unsafe characters: {value!r}. "
+            "Only alphanumeric, dot, hyphen, and underscore are allowed."
+        )
+
+
+def _write_json(path: Path, payload: dict[str, JsonValue]) -> None:
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def persist_silver_dataset(
+    dataset: SilverDataset,
+    *,
+    output_root: Path,
+    run_id: str,
+) -> SilverPersistResult:
+    """Write the table (parquet) and schema/stats/preview (json) under
+    build/{run_id}/silver/{source_bronze}.
+
+    Raises ValueError if run_id or source_bronze contain unsafe path characters.
+    """
+    _validate_path_segment(run_id, field_name="run_id")
+    source_segment = dataset.source_bronze.replace("/", "_")
+    _validate_path_segment(source_segment, field_name="source_bronze")
+
+    silver_dir = output_root / run_id / "silver" / source_segment
+    table_path = silver_dir / "table.parquet"
+    schema_path = silver_dir / "schema.json"
+    stats_path = silver_dir / "stats.json"
+    preview_path = silver_dir / "preview.json"
+
+    resolved_root = output_root.resolve()
+    resolved_silver = silver_dir.resolve()
+    if not str(resolved_silver).startswith(str(resolved_root)):
+        raise ValueError(
+            f"Resolved silver directory {resolved_silver} escapes output_root {resolved_root}"
+        )
+
+    silver_dir.mkdir(parents=True, exist_ok=True)
+
+    dataset.table.write_parquet(table_path)
+    _write_json(schema_path, asdict(dataset.schema_summary))
+    _write_json(stats_path, asdict(dataset.statistics))
+    _write_json(preview_path, asdict(dataset.preview))
+
+    return SilverPersistResult(
+        silver_dir=silver_dir,
+        table_path=table_path,
+        schema_path=schema_path,
+        stats_path=stats_path,
+        preview_path=preview_path,
+    )

--- a/src/kpubdata_builder/stages/silver/persist.py
+++ b/src/kpubdata_builder/stages/silver/persist.py
@@ -56,8 +56,8 @@ def persist_silver_dataset(
     Raises ValueError if run_id or source_bronze contain unsafe path characters.
     """
     _validate_path_segment(run_id, field_name="run_id")
-    source_segment = dataset.source_bronze.replace("/", "_")
-    _validate_path_segment(source_segment, field_name="source_bronze")
+    _validate_path_segment(dataset.source_bronze, field_name="source_bronze")
+    source_segment = dataset.source_bronze
 
     silver_dir = output_root / run_id / "silver" / source_segment
     table_path = silver_dir / "table.parquet"

--- a/src/kpubdata_builder/stages/silver/preview.py
+++ b/src/kpubdata_builder/stages/silver/preview.py
@@ -16,7 +16,7 @@ DEFAULT_PREVIEW_ROWS = 10
 def _to_json_safe(value: object) -> JsonValue:
     """Convert a Polars-deserialized value to a JSON-serializable Python type."""
     if value is None or isinstance(value, (bool, int, float, str)):
-        return value  # type: ignore[return-value]
+        return value
     if isinstance(value, (datetime.datetime, datetime.date)):
         return value.isoformat()
     if isinstance(value, datetime.timedelta):

--- a/src/kpubdata_builder/stages/silver/preview.py
+++ b/src/kpubdata_builder/stages/silver/preview.py
@@ -2,12 +2,34 @@
 
 from __future__ import annotations
 
+import datetime
+from decimal import Decimal
+
 import polars as pl
 
 from ...spec import JsonValue
 from .models import PreviewSlice
 
 DEFAULT_PREVIEW_ROWS = 10
+
+
+def _to_json_safe(value: object) -> JsonValue:
+    """Convert a Polars-deserialized value to a JSON-serializable Python type."""
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value  # type: ignore[return-value]
+    if isinstance(value, (datetime.datetime, datetime.date)):
+        return value.isoformat()
+    if isinstance(value, datetime.timedelta):
+        return value.total_seconds()
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, bytes):
+        return value.hex()
+    return str(value)
+
+
+def _convert_row(row: dict[str, object]) -> dict[str, JsonValue]:
+    return {k: _to_json_safe(v) for k, v in row.items()}
 
 
 def build_preview(table: pl.DataFrame, *, limit: int = DEFAULT_PREVIEW_ROWS) -> PreviewSlice:
@@ -17,7 +39,9 @@ def build_preview(table: pl.DataFrame, *, limit: int = DEFAULT_PREVIEW_ROWS) -> 
     """
     if limit < 0:
         raise ValueError("limit must be non-negative")
-    head_rows: list[dict[str, JsonValue]] = table.head(limit).to_dicts()
+    head_rows: list[dict[str, JsonValue]] = [
+        _convert_row(row) for row in table.head(limit).to_dicts()
+    ]
     return PreviewSlice(
         rows=tuple(head_rows),
         total_rows=table.height,

--- a/src/kpubdata_builder/stages/silver/preview.py
+++ b/src/kpubdata_builder/stages/silver/preview.py
@@ -1,0 +1,24 @@
+"""Silver stage preview: a small row sample for inspection."""
+
+from __future__ import annotations
+
+import polars as pl
+
+from ...spec import JsonValue
+from .models import PreviewSlice
+
+DEFAULT_PREVIEW_ROWS = 10
+
+
+def build_preview(table: pl.DataFrame, *, limit: int = DEFAULT_PREVIEW_ROWS) -> PreviewSlice:
+    """Return the first ``limit`` rows as a preview slice.
+
+    The full row count is preserved in ``total_rows`` regardless of ``limit``.
+    """
+    if limit < 0:
+        raise ValueError("limit must be non-negative")
+    head_rows: list[dict[str, JsonValue]] = table.head(limit).to_dicts()
+    return PreviewSlice(
+        rows=tuple(head_rows),
+        total_rows=table.height,
+    )

--- a/src/kpubdata_builder/stages/silver/summarize.py
+++ b/src/kpubdata_builder/stages/silver/summarize.py
@@ -16,7 +16,7 @@ def summarize_schema(table: pl.DataFrame) -> SchemaSummary:
             ColumnInfo(
                 name=name,
                 dtype=str(series.dtype),
-                nullable=series.null_count() > 0,
+                has_nulls=series.null_count() > 0,
                 unique_count=series.n_unique(),
             )
         )

--- a/src/kpubdata_builder/stages/silver/summarize.py
+++ b/src/kpubdata_builder/stages/silver/summarize.py
@@ -1,0 +1,43 @@
+"""Silver stage summarization: schema description and table statistics."""
+
+from __future__ import annotations
+
+import polars as pl
+
+from .models import ColumnInfo, SchemaSummary, TableStatistics
+
+
+def summarize_schema(table: pl.DataFrame) -> SchemaSummary:
+    """Describe each column's dtype, nullability, and unique value count."""
+    columns: list[ColumnInfo] = []
+    for name in table.columns:
+        series = table[name]
+        columns.append(
+            ColumnInfo(
+                name=name,
+                dtype=str(series.dtype),
+                nullable=series.null_count() > 0,
+                unique_count=series.n_unique(),
+            )
+        )
+    return SchemaSummary(columns=tuple(columns))
+
+
+def summarize_statistics(table: pl.DataFrame) -> TableStatistics:
+    """Compute row count, per-column null counts, and duplicate row rate."""
+    row_count = table.height
+    null_counts = {name: int(table[name].null_count()) for name in table.columns}
+    duplicate_rate = _duplicate_rate(table, row_count)
+    return TableStatistics(
+        row_count=row_count,
+        null_counts=null_counts,
+        duplicate_rate=duplicate_rate,
+    )
+
+
+def _duplicate_rate(table: pl.DataFrame, row_count: int) -> float:
+    """Fraction of rows that are duplicates of an earlier row (0.0 when empty)."""
+    if row_count == 0:
+        return 0.0
+    unique_rows = table.unique().height
+    return (row_count - unique_rows) / row_count

--- a/src/kpubdata_builder/stages/silver/validate.py
+++ b/src/kpubdata_builder/stages/silver/validate.py
@@ -13,6 +13,11 @@ def validate_table(table: pl.DataFrame) -> ValidationResult:
     Only reports informational warnings; it does not impose data-quality
     opinions, per the Silver stage principle that the Builder must not
     define what "clean" data means.
+
+    Empty-table policy: a table with no rows and/or no columns is a VALID
+    Silver output. Emptiness yields warnings, never errors, so an empty
+    upstream source does not fail the build; deciding whether emptiness is
+    acceptable is left to downstream stages.
     """
     warnings: list[str] = []
     if table.width == 0:

--- a/src/kpubdata_builder/stages/silver/validate.py
+++ b/src/kpubdata_builder/stages/silver/validate.py
@@ -1,0 +1,22 @@
+"""Silver stage validation: structural checks producing a ValidationResult."""
+
+from __future__ import annotations
+
+import polars as pl
+
+from .models import ValidationResult
+
+
+def validate_table(table: pl.DataFrame) -> ValidationResult:
+    """Run conservative structural checks on a tabularized Silver table.
+
+    Only reports informational warnings; it does not impose data-quality
+    opinions, per the Silver stage principle that the Builder must not
+    define what "clean" data means.
+    """
+    warnings: list[str] = []
+    if table.width == 0:
+        warnings.append("table has no columns")
+    if table.height == 0:
+        warnings.append("table has no rows")
+    return ValidationResult(errors=(), warnings=tuple(warnings))

--- a/tests/unit/test_silver.py
+++ b/tests/unit/test_silver.py
@@ -35,8 +35,8 @@ def test_summarize_schema_reports_dtype_nullable_and_unique() -> None:
     schema = summarize_schema(df)
     by_name = {c.name: c for c in schema.columns}
     assert by_name["name"].unique_count == 2
-    assert by_name["name"].nullable is False
-    assert by_name["amount"].nullable is True
+    assert by_name["name"].has_nulls is False
+    assert by_name["amount"].has_nulls is True
 
 
 def test_summarize_statistics_counts_rows_nulls_and_duplicates() -> None:
@@ -112,3 +112,14 @@ def test_persist_silver_dataset_rejects_unsafe_run_id(tmp_path: Path) -> None:
         persist_silver_dataset(silver, output_root=tmp_path, run_id="../escape")
     with pytest.raises(ValueError, match="must not be empty"):
         persist_silver_dataset(silver, output_root=tmp_path, run_id="")
+
+
+def test_persist_silver_dataset_rejects_source_bronze_with_slash(tmp_path: Path) -> None:
+    artifact = BronzeArtifact(
+        source_key="a/b",
+        raw_records=({"id": "1"},),
+        fetched_at=datetime(2026, 5, 8, tzinfo=timezone.utc),
+    )
+    silver = build_silver_dataset(artifact)
+    with pytest.raises(ValueError, match="unsafe characters"):
+        persist_silver_dataset(silver, output_root=tmp_path, run_id="run-1")

--- a/tests/unit/test_silver.py
+++ b/tests/unit/test_silver.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from kpubdata_builder.spec import JsonValue
+from kpubdata_builder.stages.bronze.models import BronzeArtifact
+from kpubdata_builder.stages.silver import (
+    build_silver_dataset,
+    persist_silver_dataset,
+)
+from kpubdata_builder.stages.silver.normalize import normalize_table
+from kpubdata_builder.stages.silver.preview import build_preview
+from kpubdata_builder.stages.silver.summarize import (
+    summarize_schema,
+    summarize_statistics,
+)
+from kpubdata_builder.stages.silver.validate import validate_table
+
+
+def _bronze(records: tuple[dict[str, JsonValue], ...]) -> BronzeArtifact:
+    return BronzeArtifact(
+        source_key="datago.apt_trade",
+        raw_records=records,
+        fetched_at=datetime(2026, 5, 8, tzinfo=timezone.utc),
+    )
+
+
+def test_summarize_schema_reports_dtype_nullable_and_unique() -> None:
+    df = pl.DataFrame({"name": ["강남구", "서초구", "서초구"], "amount": [100, None, 200]})
+    schema = summarize_schema(df)
+    by_name = {c.name: c for c in schema.columns}
+    assert by_name["name"].unique_count == 2
+    assert by_name["name"].nullable is False
+    assert by_name["amount"].nullable is True
+
+
+def test_summarize_statistics_counts_rows_nulls_and_duplicates() -> None:
+    df = pl.DataFrame({"id": ["1", "2", "2"], "amount": [10, 20, 20]})
+    stats = summarize_statistics(df)
+    assert stats.row_count == 3
+    assert stats.null_counts == {"id": 0, "amount": 0}
+    assert stats.duplicate_rate == pytest.approx(1 / 3)
+
+
+def test_build_preview_limits_rows_but_keeps_total() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3, 4, 5]})
+    preview = build_preview(df, limit=2)
+    assert len(preview.rows) == 2
+    assert preview.total_rows == 5
+
+
+def test_validate_table_warns_on_empty_without_error() -> None:
+    result = validate_table(pl.DataFrame({"a": []}))
+    assert result.ok is True
+    assert "table has no rows" in result.warnings
+
+
+def test_normalize_table_passthrough_without_transforms() -> None:
+    df = pl.DataFrame({"a": [1, 2]})
+    assert normalize_table(df) is df
+
+
+def test_normalize_table_rejects_unsupported_transforms() -> None:
+    df = pl.DataFrame({"a": [1, 2]})
+    with pytest.raises(ValueError, match="Unsupported transforms"):
+        normalize_table(df, ["filter:x"])
+
+
+def test_build_silver_dataset_orchestrates_all_parts() -> None:
+    artifact = _bronze(
+        (
+            {"id": "1", "name": "강남구", "amount": 100},
+            {"id": "2", "name": "서초구", "amount": 200},
+        )
+    )
+    silver = build_silver_dataset(artifact)
+    assert silver.source_bronze == "datago.apt_trade"
+    assert silver.statistics.row_count == 2
+    assert {c.name for c in silver.schema_summary.columns} == {"id", "name", "amount"}
+    assert silver.preview.total_rows == 2
+    assert silver.validation_result.ok is True
+
+
+def test_persist_silver_dataset_writes_parquet_and_json(tmp_path: Path) -> None:
+    artifact = _bronze(({"id": "1", "name": "강남구"}, {"id": "2", "name": "서초구"}))
+    silver = build_silver_dataset(artifact)
+    result = persist_silver_dataset(silver, output_root=tmp_path / "build", run_id="run-1")
+
+    assert "run-1" in str(result.silver_dir)
+    assert "silver" in str(result.silver_dir)
+    assert result.table_path.exists()
+    assert result.schema_path.exists()
+    assert result.stats_path.exists()
+    assert result.preview_path.exists()
+
+    reloaded = pl.read_parquet(result.table_path)
+    assert reloaded.height == 2
+    assert reloaded["name"].to_list() == ["강남구", "서초구"]
+
+    stats = json.loads(result.stats_path.read_text(encoding="utf-8"))
+    assert stats["row_count"] == 2
+
+
+def test_persist_silver_dataset_rejects_unsafe_run_id(tmp_path: Path) -> None:
+    silver = build_silver_dataset(_bronze(({"id": "1"},)))
+    with pytest.raises(ValueError, match="unsafe characters"):
+        persist_silver_dataset(silver, output_root=tmp_path, run_id="../escape")
+    with pytest.raises(ValueError, match="must not be empty"):
+        persist_silver_dataset(silver, output_root=tmp_path, run_id="")

--- a/tests/unit/test_silver.py
+++ b/tests/unit/test_silver.py
@@ -13,6 +13,7 @@ from kpubdata_builder.stages.silver import (
     build_silver_dataset,
     persist_silver_dataset,
 )
+from kpubdata_builder.stages.silver.models import TableStatistics
 from kpubdata_builder.stages.silver.normalize import normalize_table
 from kpubdata_builder.stages.silver.preview import build_preview
 from kpubdata_builder.stages.silver.summarize import (
@@ -45,6 +46,13 @@ def test_summarize_statistics_counts_rows_nulls_and_duplicates() -> None:
     assert stats.row_count == 3
     assert stats.null_counts == {"id": 0, "amount": 0}
     assert stats.duplicate_rate == pytest.approx(1 / 3)
+
+
+def test_table_statistics_defends_against_external_mutation() -> None:
+    source = {"id": 0}
+    stats = TableStatistics(row_count=1, null_counts=source)
+    source["id"] = 999  # mutating the original must not affect the frozen value
+    assert stats.null_counts == {"id": 0}
 
 
 def test_build_preview_limits_rows_but_keeps_total() -> None:


### PR DESCRIPTION
close #46 

## 개요

Bronze artifact를 받아 Polars 테이블로 변환하고, 스키마 요약·통계·미리보기·검증을 수행하는 Silver stage를 구현합니다.

## 구현

- `stages/silver/models.py`: SilverDataset, SchemaSummary, ColumnInfo, TableStatistics, PreviewSlice, ValidationResult
- `stages/silver/summarize.py`: 스키마 요약 + 통계(row_count, null_counts, duplicate_rate)
- `stages/silver/preview.py`: 첫 N행 미리보기 슬라이스
- `stages/silver/validate.py`: 보수적 구조 검증 (빈 테이블 등은 경고만, error 미생성)
- `stages/silver/normalize.py`: spec 선언 transform만 적용, 미지원 transform은 명시적 실패
- `stages/silver/build.py`: BronzeArtifact → SilverDataset 오케스트레이션
- `stages/silver/persist.py`: `build/{run_id}/silver/`에 parquet + schema/stats/preview json 저장
- `tests/unit/test_silver.py`: 단위 테스트 9개

## 설계 노트

- 원칙 준수: Silver normalization은 spec에 선언된 규칙만 적용하며, Builder가 임의로 "깨끗한 데이터"를 정의하지 않습니다. 현재 spec의 transforms가 단순 문자열 리스트이므로, 선언이 없으면 패스스루하고 미지원 transform은 조용히 무시하지 않고 명확히 실패시킵니다 (AGENTS.md "fail early and clearly").
- 기존 `tabular/polars_helpers.records_to_dataframe`를 재사용했습니다. 이슈 작업항목의 `convert.py`/`polars_engine.py`를 새로 만드는 대신 기존 함수를 활용해 중복을 피했습니다. 별도 파일이 필요하다면 의견 주세요.
- 모델은 Bronze stage 컨벤션(frozen dataclass, tuple 필드)을, persist는 Bronze persist의 경로 안전성 패턴을 따랐습니다.