### PR TITLE
feat(spec): reject empty sources/exports at parse time and expand tests

### DIFF
--- a/src/kpubdata_builder/spec.py
+++ b/src/kpubdata_builder/spec.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TypeAlias
+from typing import TypeAlias, cast
 
 import yaml
 
@@ -147,7 +147,7 @@ def load_spec(path: Path) -> BuildSpec:
         SpecLoadError: 파일 읽기, YAML 파싱, 최상위 구조 검증 실패 시.
     """
     try:
-        raw_data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        raw_data = cast(object, yaml.safe_load(path.read_text(encoding="utf-8")))
     except (FileNotFoundError, OSError, yaml.YAMLError) as exc:
         raise SpecLoadError(f"Failed to load build spec from {path}: {exc}") from exc
 
@@ -156,7 +156,7 @@ def load_spec(path: Path) -> BuildSpec:
             f"Failed to parse build spec from {path}: top-level YAML must be a mapping"
         )
 
-    return parse_spec(raw_data)
+    return parse_spec(cast(dict[str, object], raw_data))
 
 
 def _require_string(data: dict[str, object], key: str, *, prefix: str = "") -> str:
@@ -189,27 +189,39 @@ def _parse_string_list(value: object, *, field_name: str) -> tuple[str, ...]:
     """문자열 목록 필드를 불변 튜플로 변환한다."""
     if not isinstance(value, list):
         raise TypeError(f"{field_name} must be a list")
-    if not all(isinstance(item, str) for item in value):
+
+    items = cast(list[object], value)
+    if not all(isinstance(item, str) for item in items):
         raise TypeError(f"{field_name} entries must be strings")
-    return tuple(value)
+    return tuple(cast(str, item) for item in items)
 
 
 def _parse_string_dict(value: object, *, field_name: str) -> dict[str, str]:
     """문자열 키/값 매핑을 검증하고 새 dict로 복사한다."""
     if not isinstance(value, dict):
         raise TypeError(f"{field_name} must be a mapping")
-    if not all(isinstance(key, str) and isinstance(item, str) for key, item in value.items()):
-        raise TypeError(f"{field_name} entries must be string pairs")
-    return dict(value)
+
+    raw_mapping = cast(dict[object, object], value)
+    parsed: dict[str, str] = {}
+    for key, item in raw_mapping.items():
+        if not isinstance(key, str) or not isinstance(item, str):
+            raise TypeError(f"{field_name} entries must be string pairs")
+        parsed[key] = item
+    return parsed
 
 
 def _parse_json_mapping(value: object, *, field_name: str) -> dict[str, JsonValue]:
     """JSON 호환 값만 담는 매핑 필드를 검증한다."""
     if not isinstance(value, dict):
         raise TypeError(f"{field_name} must be a mapping")
-    if not all(isinstance(key, str) for key in value):
-        raise TypeError(f"{field_name} keys must be strings")
-    return {key: item for key, item in value.items()}
+
+    raw_mapping = cast(dict[object, JsonValue], value)
+    parsed: dict[str, JsonValue] = {}
+    for key, item in raw_mapping.items():
+        if not isinstance(key, str):
+            raise TypeError(f"{field_name} keys must be strings")
+        parsed[key] = item
+    return parsed
 
 
 def _parse_sources(value: object) -> tuple[SourceRef, ...]:
@@ -219,8 +231,9 @@ def _parse_sources(value: object) -> tuple[SourceRef, ...]:
     if not value:
         raise ValueError("sources must not be empty")
 
+    items = cast(list[object], value)
     parsed_sources: list[SourceRef] = []
-    for index, item in enumerate(value):
+    for index, item in enumerate(items):
         prefix = f"sources[{index}]"
         mapping = _ensure_mapping(item, field_name=prefix)
         provider = _require_string(mapping, "provider", prefix=prefix)
@@ -253,8 +266,9 @@ def _parse_exports(value: object) -> tuple[ExportTarget, ...]:
     if not value:
         raise ValueError("exports must not be empty")
 
+    items = cast(list[object], value)
     parsed_exports: list[ExportTarget] = []
-    for index, item in enumerate(value):
+    for index, item in enumerate(items):
         prefix = f"exports[{index}]"
         mapping = _ensure_mapping(item, field_name=prefix)
         kind = _require_string(mapping, "kind", prefix=prefix)
@@ -270,9 +284,14 @@ def _ensure_mapping(value: object, *, field_name: str) -> dict[str, object]:
     """문자열 키를 가진 매핑인지 확인하고 복사본을 반환한다."""
     if not isinstance(value, dict):
         raise TypeError(f"{field_name} must be a mapping")
-    if not all(isinstance(key, str) for key in value):
-        raise TypeError(f"{field_name} keys must be strings")
-    return {key: item for key, item in value.items()}
+
+    raw_mapping = cast(dict[object, object], value)
+    parsed: dict[str, object] = {}
+    for key, item in raw_mapping.items():
+        if not isinstance(key, str):
+            raise TypeError(f"{field_name} keys must be strings")
+        parsed[key] = item
+    return parsed
 
 
 __all__ = [

--- a/src/kpubdata_builder/spec.py
+++ b/src/kpubdata_builder/spec.py
@@ -117,8 +117,8 @@ def parse_spec(data: dict[str, object]) -> BuildSpec:
         transforms = _parse_string_list(data.get("transforms", []), field_name="transforms")
         metadata = _parse_string_dict(data.get("metadata", {}), field_name="metadata")
         publish = _parse_bool(data.get("publish", False), field_name="publish")
-        sources = _parse_sources(data.get("sources", []))
-        exports = _parse_exports(data.get("exports", []))
+        sources = _parse_sources(_require_present(data, "sources"))
+        exports = _parse_exports(_require_present(data, "exports"))
     except (KeyError, TypeError, ValueError) as exc:
         raise SpecLoadError(f"Failed to parse build spec: {exc}") from exc
 
@@ -159,12 +159,23 @@ def load_spec(path: Path) -> BuildSpec:
     return parse_spec(raw_data)
 
 
-def _require_string(data: dict[str, object], key: str) -> str:
+def _require_string(data: dict[str, object], key: str, *, prefix: str = "") -> str:
     """필수 문자열 필드를 추출한다."""
+    label = f"{prefix}.{key}" if prefix else key
+    if key not in data:
+        raise KeyError(f"{label} is required")
     value = data[key]
     if not isinstance(value, str):
-        raise TypeError(f"{key} must be a string")
+        raise TypeError(f"{label} must be a string")
+    if not value:
+        raise ValueError(f"{label} must not be empty")
     return value
+
+
+def _require_present(data: dict[str, object], key: str) -> object:
+    if key not in data:
+        raise KeyError(f"{key} is required")
+    return data[key]
 
 
 def _parse_bool(value: object, *, field_name: str) -> bool:
@@ -205,12 +216,15 @@ def _parse_sources(value: object) -> tuple[SourceRef, ...]:
     """sources 배열을 SourceRef 튜플로 변환한다."""
     if not isinstance(value, list):
         raise TypeError("sources must be a list")
+    if not value:
+        raise ValueError("sources must not be empty")
 
     parsed_sources: list[SourceRef] = []
     for index, item in enumerate(value):
-        mapping = _ensure_mapping(item, field_name=f"sources[{index}]")
-        provider = _require_string(mapping, "provider")
-        dataset = _require_string(mapping, "dataset")
+        prefix = f"sources[{index}]"
+        mapping = _ensure_mapping(item, field_name=prefix)
+        provider = _require_string(mapping, "provider", prefix=prefix)
+        dataset = _require_string(mapping, "dataset", prefix=prefix)
         params = _parse_json_mapping(
             mapping.get("params", {}), field_name=f"sources[{index}].params"
         )
@@ -236,12 +250,15 @@ def _parse_exports(value: object) -> tuple[ExportTarget, ...]:
     """exports 배열을 ExportTarget 튜플로 변환한다."""
     if not isinstance(value, list):
         raise TypeError("exports must be a list")
+    if not value:
+        raise ValueError("exports must not be empty")
 
     parsed_exports: list[ExportTarget] = []
     for index, item in enumerate(value):
-        mapping = _ensure_mapping(item, field_name=f"exports[{index}]")
-        kind = _require_string(mapping, "kind")
-        output_path = _require_string(mapping, "output_path")
+        prefix = f"exports[{index}]"
+        mapping = _ensure_mapping(item, field_name=prefix)
+        kind = _require_string(mapping, "kind", prefix=prefix)
+        output_path = _require_string(mapping, "output_path", prefix=prefix)
         options = _parse_json_mapping(
             mapping.get("options", {}), field_name=f"exports[{index}].options"
         )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -120,8 +120,8 @@ def test_validate_fails_for_invalid_spec(
     captured = capsys.readouterr()
 
     assert exit_code == 1
-    assert "spec validation failed" in captured.err
-    assert "at least one source is required" in captured.err
+    assert "failed to load spec" in captured.err
+    assert "sources" in captured.err
 
 
 def test_preview_is_reserved(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -86,7 +86,7 @@ def test_validate_succeeds_for_valid_spec(
 ) -> None:
     # 유효한 YAML 명세는 validate 명령에서 성공해야 한다.
     spec_path = tmp_path / "spec.yaml"
-    spec_path.write_text(VALID_SPEC_YAML, encoding="utf-8")
+    _ = spec_path.write_text(VALID_SPEC_YAML, encoding="utf-8")
 
     exit_code = main(["validate", str(spec_path)])
     captured = capsys.readouterr()
@@ -114,7 +114,7 @@ def test_validate_fails_for_invalid_spec(
 ) -> None:
     # YAML 문법은 맞아도 필수 필드 검증에 실패하면 오류가 출력되는지 확인한다.
     spec_path = tmp_path / "spec.yaml"
-    spec_path.write_text(INVALID_SPEC_YAML_NO_SOURCES, encoding="utf-8")
+    _ = spec_path.write_text(INVALID_SPEC_YAML_NO_SOURCES, encoding="utf-8")
 
     exit_code = main(["validate", str(spec_path)])
     captured = capsys.readouterr()
@@ -169,7 +169,7 @@ def test_validate_fails_for_malformed_yaml(
 ) -> None:
     # YAML 문법 자체가 깨진 경우 로드 실패로 처리되는지 확인한다.
     spec_path = tmp_path / "bad.yaml"
-    spec_path.write_text("{{{{not: valid: yaml: [", encoding="utf-8")
+    _ = spec_path.write_text("{{{{not: valid: yaml: [", encoding="utf-8")
 
     exit_code = main(["validate", str(spec_path)])
     captured = capsys.readouterr()

--- a/tests/unit/test_spec.py
+++ b/tests/unit/test_spec.py
@@ -1,8 +1,27 @@
-"""BuildSpec 관련 데이터 클래스의 최소 생성 동작을 검증한다."""
-
 from __future__ import annotations
 
-from kpubdata_builder.spec import BuildSpec, ExportTarget, SourceRef
+from pathlib import Path
+
+import pytest
+
+from kpubdata_builder.errors import SpecLoadError
+from kpubdata_builder.spec import (
+    BuildSpec,
+    ExportTarget,
+    SourceRef,
+    load_spec,
+    parse_spec,
+)
+
+
+def _valid_payload() -> dict[str, object]:
+    return {
+        "dataset_id": "dataset.sample",
+        "title": "Sample Dataset",
+        "description": "Sample description",
+        "sources": [{"provider": "datago", "dataset": "air_quality"}],
+        "exports": [{"kind": "jsonl", "output_path": "out/data.jsonl"}],
+    }
 
 
 def test_build_spec_instantiation() -> None:
@@ -17,3 +36,207 @@ def test_build_spec_instantiation() -> None:
     )
 
     assert spec.dataset_id == "dataset.sample"
+    assert spec.transforms == ()
+    assert spec.metadata == {}
+    assert spec.publish is False
+
+
+def test_parse_spec_converts_nested_to_typed_objects() -> None:
+    """Top-level lists become tuples of SourceRef / ExportTarget."""
+    spec = parse_spec(_valid_payload())
+
+    assert isinstance(spec, BuildSpec)
+    assert isinstance(spec.sources, tuple)
+    assert isinstance(spec.exports, tuple)
+    assert isinstance(spec.sources[0], SourceRef)
+    assert isinstance(spec.exports[0], ExportTarget)
+    assert spec.sources[0].provider == "datago"
+    assert spec.sources[0].dataset == "air_quality"
+    assert spec.exports[0].kind == "jsonl"
+    assert spec.exports[0].output_path == "out/data.jsonl"
+
+
+def test_parse_spec_applies_optional_defaults() -> None:
+    """transforms/metadata/publish default when omitted from YAML."""
+    spec = parse_spec(_valid_payload())
+
+    assert spec.transforms == ()
+    assert spec.metadata == {}
+    assert spec.publish is False
+    assert spec.sources[0].params == {}
+    assert spec.sources[0].normalization_mode == "canonical"
+    assert spec.sources[0].alias == ""
+    assert spec.exports[0].options == {}
+
+
+def test_parse_spec_preserves_provided_optionals() -> None:
+    """Provided optional fields are carried through unchanged."""
+    payload = _valid_payload()
+    payload["transforms"] = ["normalize", "dedupe"]
+    payload["metadata"] = {"owner": "kpubdata"}
+    payload["publish"] = True
+    sources = payload["sources"]
+    assert isinstance(sources, list)
+    sources[0]["params"] = {"year": 2024}
+    sources[0]["normalization_mode"] = "raw"
+    sources[0]["alias"] = "aq"
+    exports = payload["exports"]
+    assert isinstance(exports, list)
+    exports[0]["options"] = {"compression": "gzip"}
+
+    spec = parse_spec(payload)
+
+    assert spec.transforms == ("normalize", "dedupe")
+    assert spec.metadata == {"owner": "kpubdata"}
+    assert spec.publish is True
+    assert spec.sources[0].params == {"year": 2024}
+    assert spec.sources[0].normalization_mode == "raw"
+    assert spec.sources[0].alias == "aq"
+    assert spec.exports[0].options == {"compression": "gzip"}
+
+
+@pytest.mark.parametrize("missing", ["dataset_id", "title", "description"])
+def test_parse_spec_rejects_missing_required_top_level_field(missing: str) -> None:
+    """Missing dataset_id/title/description raises with the field name in the message."""
+    payload = _valid_payload()
+    del payload[missing]
+
+    with pytest.raises(SpecLoadError, match=missing):
+        parse_spec(payload)
+
+
+@pytest.mark.parametrize("empty_field", ["dataset_id", "title", "description"])
+def test_parse_spec_rejects_empty_required_top_level_field(empty_field: str) -> None:
+    """Empty strings are rejected for required identifying fields."""
+    payload = _valid_payload()
+    payload[empty_field] = ""
+
+    with pytest.raises(SpecLoadError, match=empty_field):
+        parse_spec(payload)
+
+
+def test_parse_spec_rejects_missing_sources() -> None:
+    payload = _valid_payload()
+    del payload["sources"]
+
+    with pytest.raises(SpecLoadError, match="sources"):
+        parse_spec(payload)
+
+
+def test_parse_spec_rejects_empty_sources() -> None:
+    payload = _valid_payload()
+    payload["sources"] = []
+
+    with pytest.raises(SpecLoadError, match="sources"):
+        parse_spec(payload)
+
+
+def test_parse_spec_rejects_missing_exports() -> None:
+    payload = _valid_payload()
+    del payload["exports"]
+
+    with pytest.raises(SpecLoadError, match="exports"):
+        parse_spec(payload)
+
+
+def test_parse_spec_rejects_empty_exports() -> None:
+    payload = _valid_payload()
+    payload["exports"] = []
+
+    with pytest.raises(SpecLoadError, match="exports"):
+        parse_spec(payload)
+
+
+@pytest.mark.parametrize("missing", ["provider", "dataset"])
+def test_parse_spec_rejects_source_missing_required_field(missing: str) -> None:
+    """Each source must declare provider and dataset; message includes index + field."""
+    payload = _valid_payload()
+    sources = payload["sources"]
+    assert isinstance(sources, list)
+    del sources[0][missing]
+
+    with pytest.raises(SpecLoadError, match=rf"sources\[0\]\.{missing}"):
+        parse_spec(payload)
+
+
+@pytest.mark.parametrize("missing", ["kind", "output_path"])
+def test_parse_spec_rejects_export_missing_required_field(missing: str) -> None:
+    """Each export must declare kind and output_path; message includes index + field."""
+    payload = _valid_payload()
+    exports = payload["exports"]
+    assert isinstance(exports, list)
+    del exports[0][missing]
+
+    with pytest.raises(SpecLoadError, match=rf"exports\[0\]\.{missing}"):
+        parse_spec(payload)
+
+
+def test_load_spec_round_trips_from_yaml(tmp_path: Path) -> None:
+    """A full YAML document parses into the expected BuildSpec."""
+    spec_path = tmp_path / "spec.yaml"
+    spec_path.write_text(
+        """
+dataset_id: dataset.sample
+title: Sample Dataset
+description: Sample description
+transforms:
+  - normalize
+metadata:
+  owner: kpubdata
+publish: true
+sources:
+  - provider: datago
+    dataset: air_quality
+    params:
+      year: 2024
+exports:
+  - kind: jsonl
+    output_path: out/data.jsonl
+    options:
+      compression: gzip
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    spec = load_spec(spec_path)
+
+    assert spec.dataset_id == "dataset.sample"
+    assert spec.transforms == ("normalize",)
+    assert spec.metadata == {"owner": "kpubdata"}
+    assert spec.publish is True
+    assert spec.sources[0].params == {"year": 2024}
+    assert spec.exports[0].options == {"compression": "gzip"}
+
+
+def test_load_spec_rejects_empty_yaml(tmp_path: Path) -> None:
+    spec_path = tmp_path / "spec.yaml"
+    spec_path.write_text("", encoding="utf-8")
+
+    with pytest.raises(SpecLoadError):
+        load_spec(spec_path)
+
+
+def test_build_spec_from_yaml_classmethod(tmp_path: Path) -> None:
+    """BuildSpec.from_yaml mirrors load_spec for ergonomic call sites."""
+    spec_path = tmp_path / "spec.yaml"
+    spec_path.write_text(
+        """
+dataset_id: dataset.sample
+title: Sample Dataset
+description: Sample description
+sources:
+  - provider: datago
+    dataset: air_quality
+exports:
+  - kind: jsonl
+    output_path: out/data.jsonl
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    spec = BuildSpec.from_yaml(spec_path)
+
+    assert spec.dataset_id == "dataset.sample"
+    assert spec.sources[0].provider == "datago"

--- a/tests/unit/test_spec.py
+++ b/tests/unit/test_spec.py
@@ -102,7 +102,7 @@ def test_parse_spec_rejects_missing_required_top_level_field(missing: str) -> No
     del payload[missing]
 
     with pytest.raises(SpecLoadError, match=missing):
-        parse_spec(payload)
+        _ = parse_spec(payload)
 
 
 @pytest.mark.parametrize("empty_field", ["dataset_id", "title", "description"])
@@ -112,7 +112,7 @@ def test_parse_spec_rejects_empty_required_top_level_field(empty_field: str) -> 
     payload[empty_field] = ""
 
     with pytest.raises(SpecLoadError, match=empty_field):
-        parse_spec(payload)
+        _ = parse_spec(payload)
 
 
 def test_parse_spec_rejects_missing_sources() -> None:
@@ -120,7 +120,7 @@ def test_parse_spec_rejects_missing_sources() -> None:
     del payload["sources"]
 
     with pytest.raises(SpecLoadError, match="sources"):
-        parse_spec(payload)
+        _ = parse_spec(payload)
 
 
 def test_parse_spec_rejects_empty_sources() -> None:
@@ -128,7 +128,7 @@ def test_parse_spec_rejects_empty_sources() -> None:
     payload["sources"] = []
 
     with pytest.raises(SpecLoadError, match="sources"):
-        parse_spec(payload)
+        _ = parse_spec(payload)
 
 
 def test_parse_spec_rejects_missing_exports() -> None:
@@ -136,7 +136,7 @@ def test_parse_spec_rejects_missing_exports() -> None:
     del payload["exports"]
 
     with pytest.raises(SpecLoadError, match="exports"):
-        parse_spec(payload)
+        _ = parse_spec(payload)
 
 
 def test_parse_spec_rejects_empty_exports() -> None:
@@ -144,7 +144,7 @@ def test_parse_spec_rejects_empty_exports() -> None:
     payload["exports"] = []
 
     with pytest.raises(SpecLoadError, match="exports"):
-        parse_spec(payload)
+        _ = parse_spec(payload)
 
 
 @pytest.mark.parametrize("missing", ["provider", "dataset"])
@@ -156,7 +156,7 @@ def test_parse_spec_rejects_source_missing_required_field(missing: str) -> None:
     del sources[0][missing]
 
     with pytest.raises(SpecLoadError, match=rf"sources\[0\]\.{missing}"):
-        parse_spec(payload)
+        _ = parse_spec(payload)
 
 
 @pytest.mark.parametrize("missing", ["kind", "output_path"])
@@ -168,13 +168,13 @@ def test_parse_spec_rejects_export_missing_required_field(missing: str) -> None:
     del exports[0][missing]
 
     with pytest.raises(SpecLoadError, match=rf"exports\[0\]\.{missing}"):
-        parse_spec(payload)
+        _ = parse_spec(payload)
 
 
 def test_load_spec_round_trips_from_yaml(tmp_path: Path) -> None:
     """A full YAML document parses into the expected BuildSpec."""
     spec_path = tmp_path / "spec.yaml"
-    spec_path.write_text(
+    _ = spec_path.write_text(
         """
 dataset_id: dataset.sample
 title: Sample Dataset
@@ -211,16 +211,16 @@ exports:
 
 def test_load_spec_rejects_empty_yaml(tmp_path: Path) -> None:
     spec_path = tmp_path / "spec.yaml"
-    spec_path.write_text("", encoding="utf-8")
+    _ = spec_path.write_text("", encoding="utf-8")
 
     with pytest.raises(SpecLoadError):
-        load_spec(spec_path)
+        _ = load_spec(spec_path)
 
 
 def test_build_spec_from_yaml_classmethod(tmp_path: Path) -> None:
     """BuildSpec.from_yaml mirrors load_spec for ergonomic call sites."""
     spec_path = tmp_path / "spec.yaml"
-    spec_path.write_text(
+    _ = spec_path.write_text(
         """
 dataset_id: dataset.sample
 title: Sample Dataset


### PR DESCRIPTION
Closes #1

- spec.py: require sources/exports keys; raise SpecLoadError when missing or empty so invalid recipes are rejected before validation runs.
- spec.py: include the field path (e.g. sources[0].provider) in the error message and reject empty required strings.
- tests: cover required-field, default-value, nested-type, and load-time error cases for parse_spec/load_spec/BuildSpec.from_yaml.
- tests/cli: update the empty-sources case to match the new parse-time failure path.