### PR TITLE
feat: Preview command

### DIFF
--- a/src/kpubdata_builder/__init__.py
+++ b/src/kpubdata_builder/__init__.py
@@ -13,6 +13,7 @@ from .errors import (
     ValidationError,
 )
 from .manifest import BuildManifest, manifest_writer
+from .preview import PreviewResult, preview_build
 from .spec import BuildSpec, ExportTarget, SourceRef
 from .validator import validate_spec
 
@@ -27,11 +28,13 @@ __all__ = [
     "ExportError",
     "ManifestError",
     "ExportTarget",
+    "PreviewResult",
     "SourceRef",
     "SpecLoadError",
     "ValidationError",
     "AssemblyError",
     "__version__",
     "manifest_writer",
+    "preview_build",
     "validate_spec",
 ]

--- a/src/kpubdata_builder/cli.py
+++ b/src/kpubdata_builder/cli.py
@@ -3,16 +3,18 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from collections.abc import Sequence
 from pathlib import Path
 
 from . import __version__
 from .errors import SpecLoadError, ValidationError
-from .spec import load_spec
+from .preview import PreviewResult, preview_build
+from .spec import BuildSpec, load_spec
 from .validator import validate_spec
 
-_RESERVED_COMMANDS: frozenset[str] = frozenset({"preview", "build"})
+_RESERVED_COMMANDS: frozenset[str] = frozenset({"build"})
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -36,9 +38,9 @@ def build_parser() -> argparse.ArgumentParser:
 
     preview_cmd = subparsers.add_parser(
         "preview",
-        help="Preview a BuildSpec execution (reserved; not implemented yet).",
+        help="Preview a build's schema and sample records without writing artifacts.",
     )
-    preview_cmd.add_argument("spec", nargs="?", help="Path to the BuildSpec YAML file.")
+    preview_cmd.add_argument("spec", help="Path to the BuildSpec YAML file.")
 
     build_cmd = subparsers.add_parser(
         "build",
@@ -65,6 +67,33 @@ def _run_validate(spec_path: str) -> int:
     return 0
 
 
+def _print_preview(spec: BuildSpec, preview: PreviewResult) -> None:
+    print(f"preview: {spec.dataset_id}")
+    print(f"schema: {', '.join(preview.schema) if preview.schema else '(empty)'}")
+    shown = len(preview.sample_records)
+    print(f"records ({shown} of {preview.total_records} shown):")
+    for record in preview.sample_records:
+        print(f"  {json.dumps(record, ensure_ascii=False, sort_keys=True)}")
+    for warning in preview.warnings:
+        print(f"warning: {warning}")
+
+
+def _run_preview(spec_path: str) -> int:
+    try:
+        spec = load_spec(Path(spec_path))
+        preview = preview_build(spec)
+    except SpecLoadError as exc:
+        print(f"error: failed to load spec: {exc}", file=sys.stderr)
+        return 1
+    except ValidationError as exc:
+        print("error: spec validation failed:", file=sys.stderr)
+        for problem in exc.problems:
+            print(f"  - {problem}", file=sys.stderr)
+        return 1
+    _print_preview(spec, preview)
+    return 0
+
+
 def _run_reserved(command: str) -> int:
     print(
         f"error: '{command}' is not implemented yet "
@@ -78,6 +107,8 @@ def dispatch(args: argparse.Namespace) -> int:
     command = args.command
     if command == "validate":
         return _run_validate(args.spec)
+    if command == "preview":
+        return _run_preview(args.spec)
     if command in _RESERVED_COMMANDS:
         return _run_reserved(command)
     # Unreachable via normal CLI (argparse rejects unknown subcommands),

--- a/src/kpubdata_builder/preview.py
+++ b/src/kpubdata_builder/preview.py
@@ -1,0 +1,80 @@
+"""Preview service: inspect a build's schema and sample records without exporting.
+
+A preview is a "taste test" of a build — it runs validation and source execution
+and surfaces the resulting schema plus a small sample of records, but never writes
+any artifact files (README.md, .jsonl, .parquet, ...).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .artifact import ArtifactDataset
+from .executor import source_executor
+from .spec import BuildSpec, JsonValue
+
+DEFAULT_PREVIEW_LIMIT = 5
+
+
+@dataclass(frozen=True)
+class PreviewResult:
+    """Schema and a small record sample for inspecting a build before running it."""
+
+    schema: tuple[str, ...] = ()
+    sample_records: tuple[dict[str, JsonValue], ...] = ()
+    total_records: int = 0
+    provenance: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+
+def _derive_schema(artifact: ArtifactDataset) -> tuple[str, ...]:
+    """Field names from the artifact schema, falling back to first-seen record keys."""
+    if artifact.schema:
+        return tuple(artifact.schema)
+    seen: dict[str, None] = {}
+    for record in artifact.records:
+        for key in record:
+            seen.setdefault(key, None)
+    return tuple(seen)
+
+
+def build_preview_result(
+    artifact: ArtifactDataset, *, limit: int = DEFAULT_PREVIEW_LIMIT
+) -> PreviewResult:
+    """Derive a preview (schema + first ``limit`` records) from an assembled artifact.
+
+    ``total_records`` always reflects the full record count regardless of ``limit``.
+    """
+    if limit < 0:
+        raise ValueError("limit must be non-negative")
+    return PreviewResult(
+        schema=_derive_schema(artifact),
+        sample_records=artifact.records[:limit],
+        total_records=len(artifact.records),
+        provenance=artifact.provenance,
+    )
+
+
+def preview_build(spec: BuildSpec, *, limit: int = DEFAULT_PREVIEW_LIMIT) -> PreviewResult:
+    """Validate a spec, execute its sources, and return a preview without exporting.
+
+    Validation is performed by :func:`source_executor`; an invalid spec raises
+    ``ValidationError``. No artifact files are written.
+    """
+    execution = source_executor(spec)
+    result = build_preview_result(execution.artifact, limit=limit)
+    return PreviewResult(
+        schema=result.schema,
+        sample_records=result.sample_records,
+        total_records=result.total_records,
+        provenance=result.provenance,
+        warnings=execution.warnings,
+    )
+
+
+__all__ = [
+    "DEFAULT_PREVIEW_LIMIT",
+    "PreviewResult",
+    "build_preview_result",
+    "preview_build",
+]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -116,22 +116,51 @@ def test_validate_fails_for_invalid_spec(
     assert "at least one source is required" in captured.err
 
 
-def test_preview_is_reserved(capsys: pytest.CaptureFixture[str]) -> None:
-    exit_code = main(["preview", "any.yaml"])
+def test_preview_succeeds_for_valid_spec(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    spec_path = tmp_path / "spec.yaml"
+    spec_path.write_text(VALID_SPEC_YAML, encoding="utf-8")
+
+    exit_code = main(["preview", str(spec_path)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "preview: dataset.sample" in captured.out
+    assert "schema:" in captured.out
+    assert "records (" in captured.out
+    assert captured.err == ""
+
+
+def test_preview_writes_no_artifact_files(tmp_path: Path) -> None:
+    spec_path = tmp_path / "spec.yaml"
+    spec_path.write_text(VALID_SPEC_YAML, encoding="utf-8")
+
+    main(["preview", str(spec_path)])
+
+    # The spec declares out/data.jsonl; preview must not create it.
+    assert not (tmp_path / "out").exists()
+    assert list(tmp_path.iterdir()) == [spec_path]
+
+
+def test_preview_fails_for_invalid_spec(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    spec_path = tmp_path / "spec.yaml"
+    spec_path.write_text(INVALID_SPEC_YAML_NO_SOURCES, encoding="utf-8")
+
+    exit_code = main(["preview", str(spec_path)])
     captured = capsys.readouterr()
 
     assert exit_code == 1
-    assert "preview" in captured.err
-    assert "not implemented" in captured.err
+    assert "spec validation failed" in captured.err
+    assert "at least one source is required" in captured.err
 
 
-def test_preview_without_spec_is_reserved(capsys: pytest.CaptureFixture[str]) -> None:
+def test_preview_without_spec_errors(capsys: pytest.CaptureFixture[str]) -> None:
     exit_code = main(["preview"])
     captured = capsys.readouterr()
 
-    assert exit_code == 1
-    assert "preview" in captured.err
-    assert "not implemented" in captured.err
+    assert exit_code == 2
+    assert captured.err
 
 
 def test_build_is_reserved(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/unit/test_preview.py
+++ b/tests/unit/test_preview.py
@@ -1,0 +1,83 @@
+"""Tests for the preview service (schema + sample records, no exports)."""
+
+from __future__ import annotations
+
+import pytest
+
+from kpubdata_builder import ValidationError
+from kpubdata_builder.artifact import ArtifactDataset
+from kpubdata_builder.preview import (
+    DEFAULT_PREVIEW_LIMIT,
+    PreviewResult,
+    build_preview_result,
+    preview_build,
+)
+from kpubdata_builder.spec import BuildSpec, ExportTarget, SourceRef
+
+_DEFAULT_SOURCES = (SourceRef(provider="datago", dataset="apt"),)
+
+
+def _spec(sources: tuple[SourceRef, ...] = _DEFAULT_SOURCES) -> BuildSpec:
+    return BuildSpec(
+        dataset_id="dataset.sample",
+        title="Sample Dataset",
+        description="Sample description",
+        sources=sources,
+        exports=(ExportTarget(kind="jsonl", output_path="out/data.jsonl"),),
+    )
+
+
+def test_build_preview_result_caps_samples_but_keeps_total() -> None:
+    records = tuple({"id": str(i)} for i in range(12))
+    artifact = ArtifactDataset(records=records)
+
+    result = build_preview_result(artifact, limit=5)
+
+    assert len(result.sample_records) == 5
+    assert result.sample_records[0] == {"id": "0"}
+    assert result.total_records == 12
+
+
+def test_build_preview_result_default_limit_is_five() -> None:
+    records = tuple({"id": str(i)} for i in range(10))
+    result = build_preview_result(ArtifactDataset(records=records))
+
+    assert DEFAULT_PREVIEW_LIMIT == 5
+    assert len(result.sample_records) == 5
+
+
+def test_build_preview_result_derives_schema_from_record_keys() -> None:
+    artifact = ArtifactDataset(records=({"id": "1", "name": "a"}, {"id": "2", "amount": 3}))
+
+    result = build_preview_result(artifact)
+
+    assert result.schema == ("id", "name", "amount")
+
+
+def test_build_preview_result_prefers_explicit_schema() -> None:
+    artifact = ArtifactDataset(
+        records=({"id": "1"},),
+        schema={"id": "str", "amount": "int"},
+    )
+
+    result = build_preview_result(artifact)
+
+    assert result.schema == ("id", "amount")
+
+
+def test_build_preview_result_rejects_negative_limit() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        build_preview_result(ArtifactDataset(), limit=-1)
+
+
+def test_preview_build_returns_preview_result_for_valid_spec() -> None:
+    result = preview_build(_spec())
+
+    assert isinstance(result, PreviewResult)
+    assert result.total_records == 0
+    assert result.sample_records == ()
+
+
+def test_preview_build_raises_on_invalid_spec() -> None:
+    with pytest.raises(ValidationError):
+        preview_build(_spec(sources=()))


### PR DESCRIPTION
…ports

Adds a preview_build() service and wires the previously-reserved `preview` CLI command to it:

- preview.py: PreviewResult model, build_preview_result() (pure derivation with a default 5-record cap and schema from artifact.schema or record keys), and preview_build() which validates + executes sources without exporting
- cli.py: drop "preview" from reserved commands, require a spec arg, add _run_preview/_print_preview, route in dispatch
- __init__.py: export preview_build and PreviewResult
- tests: replace preview-reserved CLI tests with implemented-command tests (incl. assertion that no artifact files are written) and add test_preview.py

Closes #3