### PR TITLE
feat: build 커맨드와 source 실행 연결 

### DIFF
--- a/src/kpubdata_builder/build.py
+++ b/src/kpubdata_builder/build.py
@@ -1,0 +1,84 @@
+"""Build orchestration: connect source execution, assembly, export, and manifest."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .assembler import assemble_artifact
+from .errors import ExportError
+from .executor import SourceClient, execute_sources
+from .exporters import EXPORTER_REGISTRY
+from .exporters.base import BaseExporter
+from .manifest import BuildManifest, manifest_writer
+from .spec import BuildSpec
+from .spec.validator import validate_spec
+
+MANIFEST_FILENAME = "manifest.json"
+
+
+@dataclass(frozen=True)
+class BuildResult:
+    """Outcome of a build run: produced files and manifest location."""
+
+    artifact_paths: tuple[Path, ...]
+    manifest_path: Path
+    warnings: tuple[str, ...] = ()
+
+
+def execute_build(
+    spec: BuildSpec,
+    client: SourceClient,
+    *,
+    output_dir: Path,
+    exporters: Mapping[str, BaseExporter] = EXPORTER_REGISTRY,
+    build_id: str | None = None,
+) -> BuildResult:
+    """Run the full build pipeline for a validated spec.
+
+    Steps: validate -> fetch sources -> assemble -> export -> write manifest.
+    The client is injected so tests can supply a fake without network access.
+    A manifest is always written, recording inputs, outputs, and warnings.
+    """
+    validate_spec(spec)
+
+    resolved_build_id = build_id or uuid.uuid4().hex[:12]
+    started_at = datetime.now(tz=timezone.utc)
+
+    records_by_source = execute_sources(spec, client)
+    assembly = assemble_artifact(spec, records_by_source)
+    artifact = assembly.artifact
+
+    artifact_paths: list[Path] = []
+    for target in spec.exports:
+        exporter = exporters.get(target.kind)
+        if exporter is None:
+            supported = ", ".join(sorted(exporters)) or "(none)"
+            raise ExportError(f"Unsupported export kind: {target.kind!r}. Supported: {supported}")
+        result = exporter.export(artifact, target, output_dir)
+        artifact_paths.append(result.output_path)
+
+    finished_at = datetime.now(tz=timezone.utc)
+    manifest_path = output_dir / MANIFEST_FILENAME
+    manifest = BuildManifest(
+        build_id=resolved_build_id,
+        started_at=started_at,
+        finished_at=finished_at,
+        inputs=tuple(f"{s.provider}.{s.dataset}" for s in spec.sources),
+        outputs=tuple(str(p) for p in artifact_paths),
+        warnings=assembly.warnings,
+        row_counts={"records": len(artifact.records)},
+    )
+    manifest_writer(manifest, manifest_path)
+
+    return BuildResult(
+        artifact_paths=tuple(artifact_paths),
+        manifest_path=manifest_path,
+        warnings=assembly.warnings,
+    )
+
+
+__all__ = ["BuildResult", "execute_build", "MANIFEST_FILENAME"]

--- a/src/kpubdata_builder/cli.py
+++ b/src/kpubdata_builder/cli.py
@@ -17,11 +17,13 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from . import __version__
-from .errors import SpecLoadError, ValidationError
+from .build import execute_build
+from .errors import BuildError, SpecLoadError, ValidationError
+from .executor import SourceClient
 from .spec import load_spec
 from .spec.validator import validate_spec
 
-_RESERVED_COMMANDS: frozenset[str] = frozenset({"preview", "build"})
+_RESERVED_COMMANDS: frozenset[str] = frozenset({"preview"})
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -64,9 +66,14 @@ def build_parser() -> argparse.ArgumentParser:
 
     build_cmd = subparsers.add_parser(
         "build",
-        help="Execute a BuildSpec to produce artifacts (reserved; not implemented yet).",
+        help="Execute a BuildSpec to produce artifacts.",
     )
-    build_cmd.add_argument("spec", nargs="?", help="Path to the BuildSpec YAML file.")
+    build_cmd.add_argument("spec", help="Path to the BuildSpec YAML file.")
+    build_cmd.add_argument(
+        "--output-dir",
+        default="./dist",
+        help="Directory where artifacts and manifest are written (default: ./dist).",
+    )
 
     return parser
 
@@ -95,6 +102,41 @@ def _run_validate(spec_path: str) -> int:
             print(f"  - {problem}", file=sys.stderr)
         return 1
     print(f"spec is valid: {spec.dataset_id}")
+    return 0
+
+
+def _make_default_client() -> SourceClient:
+    """Create the default kpubdata client. Isolated for test injection."""
+    from kpubdata import Client
+
+    return Client.from_env()    # type: ignore[return-value]
+
+
+def _run_build(spec_path: str, output_dir: str) -> int:
+    try:
+        spec = load_spec(Path(spec_path))
+        validate_spec(spec)
+    except SpecLoadError as exc:
+        print(f"error: failed to load spec: {exc}", file=sys.stderr)
+        return 1
+    except ValidationError as exc:
+        print("error: spec validation failed:", file=sys.stderr)
+        for problem in exc.problems:
+            print(f"  - {problem}", file=sys.stderr)
+        return 1
+
+    try:
+        client = _make_default_client()
+        result = execute_build(spec, client, output_dir=Path(output_dir))
+    except BuildError as exc:
+        print(f"error: build failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"built spec: {spec.dataset_id}")
+    print("artifacts:")
+    for path in result.artifact_paths:
+        print(f"  - {path}")
+    print(f"manifest: {result.manifest_path}")
     return 0
 
 
@@ -132,6 +174,8 @@ def dispatch(args: argparse.Namespace) -> int:
     command = args.command
     if command == "validate":
         return _run_validate(args.spec)
+    if command == "build":
+        return _run_build(args.spec, args.output_dir)
     if command in _RESERVED_COMMANDS:
         return _run_reserved(command)
     # 일반적인 CLI 경로로는 도달할 수 없지만(argparse가 알 수 없는 하위 명령을 거부함),

--- a/src/kpubdata_builder/executor.py
+++ b/src/kpubdata_builder/executor.py
@@ -10,11 +10,13 @@ BuildSpec 검증과 최소 provenance 구성을 수행하는 실행 스텁을 �
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
+from typing import Protocol
 
 from .artifact import ArtifactDataset
 from .errors import ExecutionError, ValidationError
-from .spec import BuildSpec
+from .spec import BuildSpec, JsonValue, SourceRef
 from .spec.validator import validate_spec
 
 
@@ -64,8 +66,58 @@ def source_executor(spec: BuildSpec) -> ExecutionResult:
         raise ExecutionError(
             f"Failed to execute sources for dataset {spec.dataset_id}: {exc}"
         ) from exc
-
     return ExecutionResult(artifact=artifact)
 
 
-__all__ = ["ExecutionResult", "source_executor"]
+class DatasetResult(Protocol):
+    """Minimal result shape returned by a kpubdata dataset query."""
+
+    @property
+    def items(self) -> Iterable[dict[str, JsonValue]]:
+        """Return fetched records."""
+
+
+class SourceDataset(Protocol):
+    """Minimal dataset shape used to fetch source records."""
+
+    def list(self, **params: JsonValue) -> DatasetResult:
+        """Fetch records for one parameter set."""
+
+
+class SourceClient(Protocol):
+    """Minimal client shape used to resolve source datasets."""
+
+    def dataset(self, dataset_id: str) -> SourceDataset:
+        """Return a dataset object for a dataset_id."""
+
+
+def _source_key(source: SourceRef) -> str:
+    """Key a source by its alias when present, else provider.dataset."""
+    return source.alias if source.alias else f"{source.provider}.{source.dataset}"
+
+
+def execute_sources(
+    spec: BuildSpec,
+    client: SourceClient,
+) -> dict[str, Sequence[dict[str, JsonValue]]]:
+    """Fetch records for every declared source via a kpubdata-compatible client.
+
+    Returns a mapping of source key (alias or provider.dataset) to its records,
+    suitable for ``assemble_artifact``. The client is injected so tests can
+    supply a fake without hitting the network.
+    """
+    records_by_source: dict[str, Sequence[dict[str, JsonValue]]] = {}
+    for source in spec.sources:
+        key = _source_key(source)
+        try:
+            dataset = client.dataset(f"{source.provider}.{source.dataset}")
+            result = dataset.list(**source.params)
+            records_by_source[key] = list(result.items)
+        except Exception as exc:
+            raise ExecutionError(
+                f"Failed to fetch source {key} for dataset {spec.dataset_id}: {exc}"
+            ) from exc
+    return records_by_source
+
+
+__all__ = ["ExecutionResult", "execute_sources", "source_executor"]

--- a/tests/unit/test_build_flow.py
+++ b/tests/unit/test_build_flow.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kpubdata_builder.errors import ValidationError
+from kpubdata_builder.executor import execute_sources
+from kpubdata_builder.spec import BuildSpec, ExportTarget, SourceRef
+
+
+class FakeResult:
+    def __init__(self, items: list[dict[str, object]]) -> None:
+        self.items = items
+
+
+class FakeDataset:
+    def __init__(self, records: list[dict[str, object]]) -> None:
+        self._records = records
+        self.seen_params: dict[str, object] | None = None
+
+    def list(self, **params: object) -> FakeResult:
+        self.seen_params = dict(params)
+        return FakeResult(self._records)
+
+
+class FakeClient:
+    def __init__(self, records: list[dict[str, object]]) -> None:
+        self._records = records
+        self.seen_keys: list[str] = []
+
+    def dataset(self, source_key: str) -> FakeDataset:
+        self.seen_keys.append(source_key)
+        return FakeDataset(self._records)
+
+
+def _spec(kind: str = "jsonl") -> BuildSpec:
+    return BuildSpec(
+        dataset_id="test.dataset",
+        title="Test",
+        description="desc",
+        sources=(SourceRef(provider="datago", dataset="air_quality"),),
+        exports=(ExportTarget(kind=kind, output_path="data.jsonl"),),
+        metadata={"owner": "team-data"},
+    )
+
+
+def test_execute_sources_collects_records_by_key() -> None:
+    client = FakeClient([{"id": "1"}, {"id": "2"}])
+    result = execute_sources(_spec(), client)
+    assert result == {"datago.air_quality": [{"id": "1"}, {"id": "2"}]}
+    assert client.seen_keys == ["datago.air_quality"]
+
+
+def test_execute_sources_uses_alias_as_key() -> None:
+    spec = BuildSpec(
+        dataset_id="test.dataset",
+        title="Test",
+        description="desc",
+        sources=(SourceRef(provider="datago", dataset="air_quality", alias="air"),),
+        exports=(ExportTarget(kind="jsonl", output_path="data.jsonl"),),
+    )
+    client = FakeClient([{"id": "1"}])
+    result = execute_sources(spec, client)
+    assert "air" in result
+    assert client.seen_keys == ["datago.air_quality"]
+
+
+def test_execute_build_runs_full_pipeline(tmp_path: Path) -> None:
+    from kpubdata_builder.build import execute_build
+
+    client = FakeClient([{"id": "1", "name": "강남구"}, {"id": "2", "name": "서초구"}])
+    result = execute_build(_spec(), client, output_dir=tmp_path)
+
+    assert len(result.artifact_paths) == 1
+    artifact = result.artifact_paths[0]
+    assert artifact.exists()
+    lines = artifact.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0])["name"] == "강남구"
+
+    assert result.manifest_path.exists()
+    manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    assert manifest["inputs"] == ["datago.air_quality"]
+    assert manifest["row_counts"] == {"records": 2}
+    assert manifest["outputs"] == [str(artifact)]
+
+
+def test_execute_build_rejects_unsupported_export_kind(tmp_path: Path) -> None:
+    from kpubdata_builder.build import execute_build
+
+    client = FakeClient([{"id": "1"}])
+    with pytest.raises(ValidationError):
+        execute_build(_spec(kind="xml"), client, output_dir=tmp_path)
+
+
+def test_cli_build_command_end_to_end(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import kpubdata_builder.cli as cli
+
+    monkeypatch.setattr(cli, "_make_default_client", lambda: FakeClient([{"id": "1"}]))
+
+    spec_path = tmp_path / "spec.yaml"
+    spec_path.write_text(
+        "dataset_id: test.ds\n"
+        "title: Test\n"
+        "description: desc\n"
+        "sources:\n"
+        "  - provider: datago\n"
+        "    dataset: air_quality\n"
+        "exports:\n"
+        "  - kind: jsonl\n"
+        "    output_path: data.jsonl\n",
+        encoding="utf-8",
+    )
+    code = cli.main(["build", str(spec_path), "--output-dir", str(tmp_path)])
+    assert code == 0
+    assert (tmp_path / "data.jsonl").exists()
+    assert (tmp_path / "manifest.json").exists()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -144,26 +144,6 @@ def test_preview_without_spec_is_reserved(capsys: pytest.CaptureFixture[str]) ->
     assert "not implemented" in captured.err
 
 
-def test_build_is_reserved(capsys: pytest.CaptureFixture[str]) -> None:
-    # 예약 명령 build가 미구현 오류를 반환하는지 검증한다.
-    exit_code = main(["build", "any.yaml"])
-    captured = capsys.readouterr()
-
-    assert exit_code == 1
-    assert "build" in captured.err
-    assert "not implemented" in captured.err
-
-
-def test_build_without_spec_is_reserved(capsys: pytest.CaptureFixture[str]) -> None:
-    # build 인자가 없어도 예약 명령 오류 메시지를 유지해야 한다.
-    exit_code = main(["build"])
-    captured = capsys.readouterr()
-
-    assert exit_code == 1
-    assert "build" in captured.err
-    assert "not implemented" in captured.err
-
-
 def test_validate_fails_for_malformed_yaml(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
Closes #4

## 개요

`kpubdata`로 실제 데이터를 fetch하고, artifact로 조립하고, exporter를 돌리고, manifest까지 남기는 전체 `build` 흐름을 연결합니다.

## 구현

- `executor.py`: `execute_sources()` 추가 — 주입 가능한 클라이언트(Protocol 기반)로 source별 records를 수집해 `records_by_source`를 만듭니다. 기존 `source_executor`는 건드리지 않아 기존 테스트 3개를 그대로 유지합니다.
- `build.py` (신규): `execute_build()` — validate → fetch → assemble → export → manifest를 잇는 중앙 오케스트레이션. exporter는 기존 `EXPORTER_REGISTRY`를 재사용합니다.
- `cli.py`: `build` 커맨드 구현(기존 reserved 해제), `--output-dir` 옵션 추가. 실제 클라이언트 생성은 `_make_default_client()`로 격리해 테스트에서 monkeypatch 가능하게 했습니다.
- `tests/unit/test_build_flow.py` (신규): execute_sources / execute_build / CLI build를 monkeypatch 기반으로 검증(네트워크 미사용) — 5개 테스트.
- `tests/unit/test_cli.py`: build가 구현되어 더 이상 reserved가 아니므로, 낡은 build-reserved 테스트 2개를 제거(동작은 test_build_flow.py가 커버).

## 설계 노트

- **클라이언트 주입**: 이슈 권고대로 네트워크 호출을 작은 함수로 격리하고 Protocol로 추상화해, 테스트에서 실제 API를 때리지 않고 `FakeClient`로 전 구간을 검증합니다.
- **에러 처리 범위**: stdlib 예외를 `BuildError` 계층으로 감싸고, 성공 빌드는 manifest를 항상 생성합니다. 다만 "실패한 빌드도 manifest 생성", `SourceExecutionError` 등 세분화된 에러 계층, manifest `status` 필드는 `docs/error_handling.md`의 향후 설계에 해당하며, 현재 코드 상태(errors.py, validator.py)와 정합을 맞추기 위해 이 PR 범위에서 제외했습니다. 별도 이슈로 다루는 것을 제안합니다.
- **mypy `type: ignore` 1건**: `_make_default_client`가 실제 `kpubdata.Client`를 반환하는데, Client는 런타임에 `SourceClient` Protocol을 만족하나 `Dataset.list(**kwargs: object)` 시그니처 차이로 mypy 정적 매칭이 실패합니다. Protocol 추상화(테스트 용이성)를 유지하기 위해 해당 한 줄에만 `# type: ignore[return-value]`를 사용했고, 동작은 테스트로 검증됩니다.

## 완료 조건

- [x] `uv run pytest tests/unit` 통과
- [x] `uv run mypy src` 에러 없음
- [x] `uv run ruff check .` 경고 없음
- [x] `kpubdata-builder build <spec.yaml>` 동작
- [x] source 실행 → 조립 → export → manifest 흐름 연결