### PR TITLE
feat(gold): Gold 단계 — export-ready 패키지 + persist (#47)

### DIFF
--- a/src/kpubdata_builder/stages/bronze/persist.py
+++ b/src/kpubdata_builder/stages/bronze/persist.py
@@ -55,7 +55,8 @@ def persist_bronze_artifact(
     output_root: Path,
     run_id: str,
 ) -> BronzePersistResult:
-    """원시 레코드와 메타데이터를 build/{run_id}/bronze/{source_key}/{artifact_id} 아래에 기록한다.
+    """원시 레코드와 메타데이터를 output_root/{run_id}/bronze/{source_key}/{artifact_id}
+    아래에 기록한다.
 
     run_id 또는 source_key에 안전하지 않은 경로 문자가 포함되면 ValueError를 발생시킨다.
     """

--- a/src/kpubdata_builder/stages/gold/__init__.py
+++ b/src/kpubdata_builder/stages/gold/__init__.py
@@ -1,9 +1,24 @@
-"""Gold 단계 패키지 (Medallion 재구성 골격).
+"""Gold 단계 패키지 (#47).
 
 Silver 정제 테이블을 export-ready 패키지(GoldPackage)로 만드는 Gold 단계
-구현이 이 패키지에 들어온다 (issue #47).
+구현을 노출한다.
+
+주요 구성:
+    - GoldPackage / ExportPlan: 산출물·내보내기 계획 모델
+    - build_gold_package: SilverDataset → GoldPackage
+    - persist_gold_package: Gold 산출물 영속화
 """
 
 from __future__ import annotations
 
-__all__: list[str] = []
+from .build import build_gold_package
+from .models import ExportPlan, GoldPackage
+from .persist import GoldPersistResult, persist_gold_package
+
+__all__ = [
+    "ExportPlan",
+    "GoldPackage",
+    "GoldPersistResult",
+    "build_gold_package",
+    "persist_gold_package",
+]

--- a/src/kpubdata_builder/stages/gold/build.py
+++ b/src/kpubdata_builder/stages/gold/build.py
@@ -1,0 +1,43 @@
+"""Gold 단계 오케스트레이션 (#47).
+
+SilverDataset을 받아 export-ready GoldPackage로 변환한다. 현재는 Silver 테이블을
+그대로 패키징하고 내보내기 계획을 부착한다. split 분할은 v0.2(#38)에서 도입한다.
+
+주요 함수:
+    - build_gold_package: SilverDataset → GoldPackage
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+from ...spec import ExportTarget
+from ..silver.models import SilverDataset
+from .models import ExportPlan, GoldPackage
+
+
+def build_gold_package(
+    silver: SilverDataset,
+    *,
+    dataset_name: str,
+    exports: Sequence[ExportTarget] = (),
+    metadata: Mapping[str, str] | None = None,
+) -> GoldPackage:
+    """Silver 데이터셋을 export-ready Gold 패키지로 변환한다.
+
+    매개변수:
+        silver: 원천 Silver 데이터셋.
+        dataset_name: 데이터셋 이름.
+        exports: 내보내기 대상 목록.
+        metadata: 패키지에 실을 임의 메타데이터.
+
+    반환값:
+        GoldPackage: 최종 테이블과 내보내기 계획.
+    """
+    return GoldPackage(
+        dataset_name=dataset_name,
+        table=silver.table,
+        export_plan=ExportPlan(targets=tuple(exports)),
+        source_silver=silver.source_bronze,
+        metadata=dict(metadata or {}),
+    )

--- a/src/kpubdata_builder/stages/gold/models.py
+++ b/src/kpubdata_builder/stages/gold/models.py
@@ -1,0 +1,48 @@
+"""Gold 단계 산출물 모델 (#47).
+
+Silver 정제 테이블을 export-ready 패키지로 표현한다. Gold는 내부 stage
+모델이므로 table에 Polars 타입을 노출한다. export 대상은 spec.ExportTarget을
+재사용한다. split 지원(SplitSet)은 v0.2(#38)에서 도입한다.
+
+주요 구성:
+    - ExportPlan: 어떤 형식으로 어디에 내보낼지에 대한 계획
+    - GoldPackage: Gold 단계 산출물
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import polars as pl
+
+from ...spec import ExportTarget
+
+
+@dataclass(frozen=True)
+class ExportPlan:
+    """Gold 패키지의 내보내기 계획.
+
+    속성:
+        targets: 적용할 내보내기 대상 목록 (spec.ExportTarget 재사용).
+    """
+
+    targets: tuple[ExportTarget, ...] = ()
+
+
+@dataclass(frozen=True)
+class GoldPackage:
+    """export 준비가 끝난 최종 데이터셋 패키지.
+
+    속성:
+        dataset_name: 데이터셋 이름 (출력 디렉터리 세그먼트로도 사용).
+        table: export용 최종 Polars 테이블.
+        export_plan: 내보내기 계획.
+        source_silver: 원천 SilverDataset의 source 참조.
+        metadata: 패키지에 실을 임의 메타데이터.
+    """
+
+    dataset_name: str
+    table: pl.DataFrame
+    export_plan: ExportPlan
+    source_silver: str
+    metadata: dict[str, str] = field(default_factory=dict)

--- a/src/kpubdata_builder/stages/gold/persist.py
+++ b/src/kpubdata_builder/stages/gold/persist.py
@@ -1,0 +1,121 @@
+"""Gold 단계 산출물을 실행 워크스페이스에 저장한다 (#47).
+
+GoldPackage를 build/{run_id}/gold/{dataset_name}/ 아래에 저장한다. 테이블은
+parquet으로, 패키지 메타데이터는 결정적 JSON으로 기록한다.
+
+주요 구성:
+    - GoldPersistResult: 저장 경로 결과 객체
+    - persist_gold_package: Gold 산출물 파일 기록 함수
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+from ...spec import JsonValue
+from .models import GoldPackage
+
+_SAFE_PATH_SEGMENT = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
+
+
+@dataclass(frozen=True)
+class GoldPersistResult:
+    """Gold 산출물을 위해 기록된 파일시스템 경로.
+
+    속성:
+        gold_dir: 산출물이 저장된 Gold 디렉터리.
+        table_path: 최종 테이블 parquet 파일 경로.
+        package_path: 패키지 메타데이터 JSON 경로.
+    """
+
+    gold_dir: Path
+    table_path: Path
+    package_path: Path
+
+
+def _validate_path_segment(value: str, *, field_name: str) -> None:
+    """워크스페이스를 벗어날 수 있는 경로 세그먼트를 거부한다."""
+    if not value:
+        raise ValueError(f"{field_name} must not be empty")
+    if value != value.strip():
+        raise ValueError(f"{field_name} must not have leading/trailing whitespace")
+    if not _SAFE_PATH_SEGMENT.match(value):
+        raise ValueError(
+            f"{field_name} contains unsafe characters: {value!r}. "
+            "Only alphanumeric, dot, hyphen, and underscore are allowed."
+        )
+
+
+def _package_metadata(package: GoldPackage) -> dict[str, JsonValue]:
+    """GoldPackage의 JSON 직렬화 가능한 메타데이터를 구성한다."""
+    return {
+        "dataset_name": package.dataset_name,
+        "source_silver": package.source_silver,
+        "row_count": package.table.height,
+        "columns": cast(list[JsonValue], list(package.table.columns)),
+        "metadata": dict(package.metadata),
+        "export_plan": {
+            "targets": [
+                {
+                    "kind": target.kind,
+                    "output_path": target.output_path,
+                    "options": target.options,
+                }
+                for target in package.export_plan.targets
+            ],
+        },
+    }
+
+
+def persist_gold_package(
+    package: GoldPackage,
+    *,
+    output_root: Path,
+    run_id: str,
+) -> GoldPersistResult:
+    """Gold 산출물을 build/{run_id}/gold/{dataset_name}/ 아래에 기록한다.
+
+    run_id 또는 dataset_name에 안전하지 않은 경로 문자가 포함되면 ValueError를
+    발생시킨다.
+
+    매개변수:
+        package: 저장할 Gold 패키지.
+        output_root: 실행 워크스페이스 루트.
+        run_id: 빌드 실행 식별자.
+
+    반환값:
+        GoldPersistResult: 기록된 파일 경로 모음.
+    """
+    _validate_path_segment(run_id, field_name="run_id")
+    _validate_path_segment(package.dataset_name, field_name="dataset_name")
+
+    gold_dir = output_root / run_id / "gold" / package.dataset_name
+
+    # 최종 포함 여부 검사: 해석된 경로는 반드시 output_root 아래에 있어야 한다.
+    resolved_root = output_root.resolve()
+    resolved_gold = gold_dir.resolve()
+    if not str(resolved_gold).startswith(str(resolved_root)):
+        raise ValueError(
+            f"Resolved gold directory {resolved_gold} escapes output_root {resolved_root}"
+        )
+
+    gold_dir.mkdir(parents=True, exist_ok=True)
+
+    table_path = gold_dir / "table.parquet"
+    package_path = gold_dir / "package.json"
+
+    package.table.write_parquet(table_path)
+    package_path.write_text(
+        json.dumps(_package_metadata(package), ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    return GoldPersistResult(
+        gold_dir=gold_dir,
+        table_path=table_path,
+        package_path=package_path,
+    )

--- a/src/kpubdata_builder/stages/gold/persist.py
+++ b/src/kpubdata_builder/stages/gold/persist.py
@@ -11,15 +11,13 @@ parquet으로, 패키지 메타데이터는 결정적 JSON으로 기록한다.
 from __future__ import annotations
 
 import json
-import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
 
 from ...spec import JsonValue
+from .._path_safety import ensure_within, validate_path_segment
 from .models import GoldPackage
-
-_SAFE_PATH_SEGMENT = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
 
 
 @dataclass(frozen=True)
@@ -35,19 +33,6 @@ class GoldPersistResult:
     gold_dir: Path
     table_path: Path
     package_path: Path
-
-
-def _validate_path_segment(value: str, *, field_name: str) -> None:
-    """워크스페이스를 벗어날 수 있는 경로 세그먼트를 거부한다."""
-    if not value:
-        raise ValueError(f"{field_name} must not be empty")
-    if value != value.strip():
-        raise ValueError(f"{field_name} must not have leading/trailing whitespace")
-    if not _SAFE_PATH_SEGMENT.match(value):
-        raise ValueError(
-            f"{field_name} contains unsafe characters: {value!r}. "
-            "Only alphanumeric, dot, hyphen, and underscore are allowed."
-        )
 
 
 def _package_metadata(package: GoldPackage) -> dict[str, JsonValue]:
@@ -90,18 +75,11 @@ def persist_gold_package(
     반환값:
         GoldPersistResult: 기록된 파일 경로 모음.
     """
-    _validate_path_segment(run_id, field_name="run_id")
-    _validate_path_segment(package.dataset_name, field_name="dataset_name")
+    validate_path_segment(run_id, field_name="run_id")
+    validate_path_segment(package.dataset_name, field_name="dataset_name")
 
     gold_dir = output_root / run_id / "gold" / package.dataset_name
-
-    # 최종 포함 여부 검사: 해석된 경로는 반드시 output_root 아래에 있어야 한다.
-    resolved_root = output_root.resolve()
-    resolved_gold = gold_dir.resolve()
-    if not str(resolved_gold).startswith(str(resolved_root)):
-        raise ValueError(
-            f"Resolved gold directory {resolved_gold} escapes output_root {resolved_root}"
-        )
+    ensure_within(output_root, gold_dir, label="gold directory")
 
     gold_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/kpubdata_builder/stages/gold/persist.py
+++ b/src/kpubdata_builder/stages/gold/persist.py
@@ -1,6 +1,6 @@
 """Gold 단계 산출물을 실행 워크스페이스에 저장한다 (#47).
 
-GoldPackage를 build/{run_id}/gold/{dataset_name}/ 아래에 저장한다. 테이블은
+GoldPackage를 output_root/{run_id}/gold/{dataset_name}/ 아래에 저장한다. 테이블은
 parquet으로, 패키지 메타데이터는 결정적 JSON으로 기록한다.
 
 주요 구성:
@@ -62,7 +62,7 @@ def persist_gold_package(
     output_root: Path,
     run_id: str,
 ) -> GoldPersistResult:
-    """Gold 산출물을 build/{run_id}/gold/{dataset_name}/ 아래에 기록한다.
+    """Gold 산출물을 output_root/{run_id}/gold/{dataset_name}/ 아래에 기록한다.
 
     run_id 또는 dataset_name에 안전하지 않은 경로 문자가 포함되면 ValueError를
     발생시킨다.

--- a/src/kpubdata_builder/stages/silver/persist.py
+++ b/src/kpubdata_builder/stages/silver/persist.py
@@ -1,6 +1,6 @@
 """Silver 단계 산출물을 실행 워크스페이스에 저장한다 (#46).
 
-SilverDataset을 build/{run_id}/silver/{source_key}/ 아래에 저장한다. 테이블은
+SilverDataset을 output_root/{run_id}/silver/{source_key}/ 아래에 저장한다. 테이블은
 parquet으로, 스키마/통계/미리보기/검증 정보는 결정적 JSON으로 기록한다.
 
 주요 구성:
@@ -66,7 +66,7 @@ def persist_silver_dataset(
     output_root: Path,
     run_id: str,
 ) -> SilverPersistResult:
-    """Silver 산출물을 build/{run_id}/silver/{source_key}/ 아래에 기록한다.
+    """Silver 산출물을 output_root/{run_id}/silver/{source_key}/ 아래에 기록한다.
 
     run_id 또는 source_key에 안전하지 않은 경로 문자가 포함되면 ValueError를
     발생시킨다.

--- a/tests/unit/test_gold.py
+++ b/tests/unit/test_gold.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import cast
 
 import polars as pl
 import pytest
@@ -18,9 +21,11 @@ from kpubdata_builder.stages.gold import (
 from kpubdata_builder.stages.silver import SilverDataset, build_silver_dataset
 
 
-def _silver(records: tuple[dict[str, JsonValue], ...]) -> SilverDataset:
+def _silver(records: tuple[Mapping[str, JsonValue], ...]) -> SilverDataset:
     bronze = BronzeArtifact(
-        source_key="datago.apt_trade", raw_records=records, fetched_at=utc_now()
+        source_key="datago.apt_trade",
+        raw_records=tuple(dict(record) for record in records),
+        fetched_at=utc_now(),
     )
     return build_silver_dataset(bronze)
 
@@ -46,7 +51,7 @@ class TestBuildGoldPackage:
 
 
 class TestPersistGoldPackage:
-    def test_writes_parquet_and_package_json(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    def test_writes_parquet_and_package_json(self, tmp_path: Path) -> None:
         silver = _silver(({"id": "1", "amount": 1000}, {"id": "2", "amount": 2500}))
         package = build_gold_package(
             silver,
@@ -60,14 +65,18 @@ class TestPersistGoldPackage:
         assert result.package_path.exists()
         assert pl.read_parquet(result.table_path).to_dicts() == package.table.to_dicts()
 
-        meta = json.loads(result.package_path.read_text(encoding="utf-8"))
+        meta = cast(
+            dict[str, JsonValue], json.loads(result.package_path.read_text(encoding="utf-8"))
+        )
         assert meta["dataset_name"] == "apt_trade"
         assert meta["row_count"] == 2
-        assert meta["export_plan"]["targets"][0]["kind"] == "jsonl"
+        export_plan = cast(dict[str, JsonValue], meta["export_plan"])
+        targets = cast(list[dict[str, JsonValue]], export_plan["targets"])
+        assert targets[0]["kind"] == "jsonl"
         assert meta["source_silver"] == "datago.apt_trade"
 
-    def test_rejects_unsafe_dataset_name(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    def test_rejects_unsafe_dataset_name(self, tmp_path: Path) -> None:
         package = build_gold_package(_silver(({"id": "1"},)), dataset_name="../escape")
 
         with pytest.raises(ValueError, match="dataset_name"):
-            persist_gold_package(package, output_root=tmp_path, run_id="run1")
+            _ = persist_gold_package(package, output_root=tmp_path, run_id="run1")

--- a/tests/unit/test_gold.py
+++ b/tests/unit/test_gold.py
@@ -80,3 +80,9 @@ class TestPersistGoldPackage:
 
         with pytest.raises(ValueError, match="dataset_name"):
             _ = persist_gold_package(package, output_root=tmp_path, run_id="run1")
+
+    def test_rejects_unsafe_run_id(self, tmp_path: Path) -> None:
+        package = build_gold_package(_silver(({"id": "1"},)), dataset_name="apt_trade")
+
+        with pytest.raises(ValueError, match="run_id"):
+            _ = persist_gold_package(package, output_root=tmp_path, run_id="../escape")

--- a/tests/unit/test_gold.py
+++ b/tests/unit/test_gold.py
@@ -1,0 +1,73 @@
+"""Gold 단계(#47): SilverDataset → export-ready GoldPackage + persist 검증."""
+
+from __future__ import annotations
+
+import json
+
+import polars as pl
+import pytest
+
+from kpubdata_builder.spec import ExportTarget, JsonValue
+from kpubdata_builder.stages.bronze.models import BronzeArtifact, utc_now
+from kpubdata_builder.stages.gold import (
+    ExportPlan,
+    GoldPackage,
+    build_gold_package,
+    persist_gold_package,
+)
+from kpubdata_builder.stages.silver import SilverDataset, build_silver_dataset
+
+
+def _silver(records: tuple[dict[str, JsonValue], ...]) -> SilverDataset:
+    bronze = BronzeArtifact(
+        source_key="datago.apt_trade", raw_records=records, fetched_at=utc_now()
+    )
+    return build_silver_dataset(bronze)
+
+
+class TestBuildGoldPackage:
+    def test_packages_silver_table_with_export_plan(self) -> None:
+        silver = _silver(({"id": "1", "amount": 1000}, {"id": "2", "amount": 2500}))
+        exports = (ExportTarget(kind="jsonl", output_path="data.jsonl"),)
+
+        package = build_gold_package(silver, dataset_name="apt_trade", exports=exports)
+
+        assert isinstance(package, GoldPackage)
+        assert package.dataset_name == "apt_trade"
+        assert package.table.to_dicts() == silver.table.to_dicts()
+        assert isinstance(package.export_plan, ExportPlan)
+        assert package.export_plan.targets == exports
+        assert package.source_silver == "datago.apt_trade"
+
+    def test_empty_export_plan_when_no_targets(self) -> None:
+        package = build_gold_package(_silver(({"id": "1"},)), dataset_name="d")
+
+        assert package.export_plan.targets == ()
+
+
+class TestPersistGoldPackage:
+    def test_writes_parquet_and_package_json(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        silver = _silver(({"id": "1", "amount": 1000}, {"id": "2", "amount": 2500}))
+        package = build_gold_package(
+            silver,
+            dataset_name="apt_trade",
+            exports=(ExportTarget(kind="jsonl", output_path="data.jsonl"),),
+        )
+
+        result = persist_gold_package(package, output_root=tmp_path, run_id="run1")
+
+        assert result.table_path.exists()
+        assert result.package_path.exists()
+        assert pl.read_parquet(result.table_path).to_dicts() == package.table.to_dicts()
+
+        meta = json.loads(result.package_path.read_text(encoding="utf-8"))
+        assert meta["dataset_name"] == "apt_trade"
+        assert meta["row_count"] == 2
+        assert meta["export_plan"]["targets"][0]["kind"] == "jsonl"
+        assert meta["source_silver"] == "datago.apt_trade"
+
+    def test_rejects_unsafe_dataset_name(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        package = build_gold_package(_silver(({"id": "1"},)), dataset_name="../escape")
+
+        with pytest.raises(ValueError, match="dataset_name"):
+            persist_gold_package(package, output_root=tmp_path, run_id="run1")


### PR DESCRIPTION
## 개요
issue #47 — Silver 정제 테이블을 export-ready **GoldPackage**로 만드는 Gold 단계를 구현합니다.

> ⚠️ **#91(#44) ← #92(#49) ← #93(#46) 위에 스택된 PR입니다.** diff에 선행 PR 커밋이 함께 보입니다. **#91 → #92 → #93 순으로 머지** 후 rebase하면 `feat(gold)…(#47)` 커밋만 남습니다. 리뷰는 해당 #47 커밋만 보시면 됩니다.

## 변경 사항 (`stages/gold/`)
- `models.py` — `GoldPackage`, `ExportPlan`
  - export 대상은 **`spec.ExportTarget` 재사용**
  - Gold도 내부 stage 모델이라 `table: pl.DataFrame` 노출
- `build.py` — `SilverDataset → GoldPackage` (테이블 패키징 + 내보내기 계획 부착)
- `persist.py` — `build/{run_id}/gold/{dataset_name}/` 에 `table.parquet` + `package.json` 기록 (경로 세그먼트 검증 + output_root escape 차단)

## 설계 메모
- **split 분할(`SplitSet`)은 v0.2(#38)로 연기** — 이슈 본문의 `split_set` 슬롯은 이번 PR에서 제외하고, 분할 지원 도입 시 추가합니다.
- `package.json`에 dataset_name / source_silver / row_count / columns / export_plan / metadata를 결정적 JSON으로 기록.

## 테스트 (TDD)
- 신규 `tests/unit/test_gold.py` 4건 **선작성(red)** 후 구현(green)
- 패키징 결과, 빈 export_plan, persist parquet round-trip + package.json, 안전하지 않은 dataset_name 거부

## 품질 게이트
- ✅ `pytest tests/unit` — **114 passed**
- ✅ `mypy src` — no issues (43 files)
- ✅ `ruff check .` / `ruff format --check .` — clean

Closes #47