### PR TITLE
feat(pipeline): Medallion 오케스트레이터 — Bronze→Silver→Gold + manifest (#48)

### DIFF
--- a/src/kpubdata_builder/pipeline/__init__.py
+++ b/src/kpubdata_builder/pipeline/__init__.py
@@ -1,10 +1,22 @@
-"""파이프라인 오케스트레이션 패키지 (Medallion 재구성 골격).
+"""파이프라인 오케스트레이션 패키지 (#48).
 
-Bronze → Silver → Gold → Export → Manifest 흐름을 묶는 orchestrator와
-BuildContext가 이 패키지에 들어온다 (issue #48). 현재는 디렉터리 구조로
-Medallion 파이프라인의 진입점 위치를 드러내기 위한 골격이다.
+Bronze → Silver → Gold → (Export) → Manifest 흐름을 묶는 orchestrator와 실행
+컨텍스트를 노출한다. Export 단계 연결은 stage-aware exporter(#28/v0.2)에서 추가한다.
+
+주요 구성:
+    - BuildContext: 단일 실행 컨텍스트
+    - run_build: 파이프라인 진입점
+    - BuildResult / SourceBuildOutcome: 실행 결과 모델
 """
 
 from __future__ import annotations
 
-__all__: list[str] = []
+from .context import BuildContext
+from .orchestrator import BuildResult, SourceBuildOutcome, run_build
+
+__all__ = [
+    "BuildContext",
+    "BuildResult",
+    "SourceBuildOutcome",
+    "run_build",
+]

--- a/src/kpubdata_builder/pipeline/context.py
+++ b/src/kpubdata_builder/pipeline/context.py
@@ -1,0 +1,80 @@
+"""빌드 실행 컨텍스트 (#48).
+
+하나의 빌드 실행을 식별하는 run_id, 출력 워크스페이스 루트, 대상 BuildSpec,
+실행 시작 시각을 한데 묶는다.
+
+주요 구성:
+    - BuildContext: 단일 실행 컨텍스트
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ..spec import BuildSpec
+
+_SAFE_RUN_ID = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
+
+
+def _utc_now() -> datetime:
+    """시간대 정보가 있는 UTC 현재 시각을 반환한다."""
+    return datetime.now(tz=timezone.utc)
+
+
+def _validate_run_id(run_id: str) -> None:
+    """워크스페이스를 벗어날 수 있는 run_id를 거부한다.
+
+    예외:
+        ValueError: 비어 있거나 허용되지 않은 문자가 포함된 경우.
+    """
+    if not run_id or run_id != run_id.strip() or not _SAFE_RUN_ID.match(run_id):
+        raise ValueError(
+            f"run_id contains unsafe characters: {run_id!r}. "
+            "Only alphanumeric, dot, hyphen, and underscore are allowed."
+        )
+
+
+@dataclass(frozen=True)
+class BuildContext:
+    """단일 빌드 실행에 대한 컨텍스트.
+
+    속성:
+        run_id: 실행 식별자 (출력 디렉터리 세그먼트로 사용).
+        output_root: 실행 워크스페이스 루트.
+        spec: 실행 대상 빌드 명세.
+        started_at: 실행 시작 시각 (timezone-aware).
+    """
+
+    run_id: str
+    output_root: Path
+    spec: BuildSpec
+    started_at: datetime
+
+    @classmethod
+    def create(
+        cls,
+        spec: BuildSpec,
+        *,
+        output_root: Path,
+        run_id: str | None = None,
+        started_at: datetime | None = None,
+    ) -> BuildContext:
+        """run_id를 검증/생성하여 BuildContext를 만든다.
+
+        run_id를 생략하면 시작 시각 기반의 결정적 타임스탬프를 사용한다.
+
+        예외:
+            ValueError: run_id에 안전하지 않은 문자가 포함된 경우.
+        """
+        started = started_at or _utc_now()
+        resolved_run_id = run_id or started.strftime("%Y%m%dT%H%M%S%fZ")
+        _validate_run_id(resolved_run_id)
+        return cls(
+            run_id=resolved_run_id,
+            output_root=output_root,
+            spec=spec,
+            started_at=started,
+        )

--- a/src/kpubdata_builder/pipeline/orchestrator.py
+++ b/src/kpubdata_builder/pipeline/orchestrator.py
@@ -1,0 +1,177 @@
+"""Medallion 파이프라인 오케스트레이터 (#48).
+
+BuildSpec의 각 소스를 Bronze → Silver → Gold 순서로 실행하고, 각 단계 산출물을
+실행 워크스페이스에 저장한 뒤 빌드 매니페스트를 기록한다.
+
+부분 성공 정책(BUILD_STATE.md): 소스 중 하나라도 실패하면 전체 상태는 failed로
+기록하되, 성공한 소스의 산출물과 실패 정보를 매니페스트에 함께 남긴다.
+
+Export 단계 연결은 stage-aware exporter 도입(#28/v0.2) 시점으로 연기한다.
+
+주요 구성:
+    - SourceBuildOutcome: 소스별 실행 결과
+    - BuildResult: 전체 실행 결과
+    - run_build: 파이프라인 진입점
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..manifest import BuildManifest, manifest_writer
+from ..spec import BuildSpec, SourceRef
+from ..stages.bronze.build import SourceClient, build_bronze_artifact
+from ..stages.bronze.models import utc_now
+from ..stages.bronze.persist import persist_bronze_artifact
+from ..stages.gold.build import build_gold_package
+from ..stages.gold.persist import persist_gold_package
+from ..stages.silver.build import build_silver_dataset
+from ..stages.silver.persist import persist_silver_dataset
+from .context import BuildContext
+
+
+@dataclass(frozen=True)
+class SourceBuildOutcome:
+    """단일 소스에 대한 파이프라인 실행 결과.
+
+    속성:
+        source_key: 소스 식별자.
+        status: "ok" 또는 "failed".
+        stages_completed: 성공적으로 끝난 단계 이름 순서 (bronze/silver/gold).
+        error: 실패 시 오류 메시지.
+    """
+
+    source_key: str
+    status: str
+    stages_completed: tuple[str, ...] = ()
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class BuildResult:
+    """전체 빌드 실행 결과.
+
+    속성:
+        context: 실행 컨텍스트.
+        status: 전체 상태 ("ok" 또는 "failed").
+        outcomes: 소스별 실행 결과.
+        manifest_path: 기록된 빌드 매니페스트 경로.
+    """
+
+    context: BuildContext
+    status: str
+    outcomes: tuple[SourceBuildOutcome, ...]
+    manifest_path: Path
+
+
+def _source_key(source: SourceRef) -> str:
+    """소스 식별자를 alias 우선으로 결정한다."""
+    return source.alias if source.alias else f"{source.provider}.{source.dataset}"
+
+
+def _run_source_pipeline(
+    source: SourceRef,
+    *,
+    client: SourceClient,
+    context: BuildContext,
+    outputs: list[str],
+    row_counts: dict[str, int],
+) -> SourceBuildOutcome:
+    """한 소스를 Bronze → Silver → Gold로 실행하고 산출물을 저장한다."""
+    key = _source_key(source)
+    completed: list[str] = []
+    try:
+        bronze = build_bronze_artifact(client, source_key=key, fetch_params=dict(source.params))
+        bronze_paths = persist_bronze_artifact(
+            bronze, output_root=context.output_root, run_id=context.run_id
+        )
+        completed.append("bronze")
+        outputs.extend([str(bronze_paths.records_path), str(bronze_paths.metadata_path)])
+
+        silver = build_silver_dataset(bronze)
+        silver_paths = persist_silver_dataset(
+            silver, output_root=context.output_root, run_id=context.run_id
+        )
+        completed.append("silver")
+        outputs.append(str(silver_paths.table_path))
+
+        gold = build_gold_package(silver, dataset_name=key, exports=context.spec.exports)
+        gold_paths = persist_gold_package(
+            gold, output_root=context.output_root, run_id=context.run_id
+        )
+        completed.append("gold")
+        outputs.append(str(gold_paths.table_path))
+
+        row_counts[key] = silver.statistics.row_count
+        return SourceBuildOutcome(source_key=key, status="ok", stages_completed=tuple(completed))
+    except Exception as exc:  # stage 실패를 결과로 변환하여 매니페스트에 기록
+        return SourceBuildOutcome(
+            source_key=key,
+            status="failed",
+            stages_completed=tuple(completed),
+            error=str(exc),
+        )
+
+
+def run_build(
+    spec: BuildSpec,
+    *,
+    client: SourceClient,
+    output_root: Path,
+    run_id: str | None = None,
+) -> BuildResult:
+    """BuildSpec을 Medallion 파이프라인으로 실행한다.
+
+    매개변수:
+        spec: 실행할 빌드 명세.
+        client: Bronze fetch에 사용할 kpubdata 호환 클라이언트.
+        output_root: 실행 워크스페이스 루트.
+        run_id: 실행 식별자. 생략 시 타임스탬프 기반으로 생성.
+
+    반환값:
+        BuildResult: 전체 상태, 소스별 결과, 매니페스트 경로.
+
+    예외:
+        ValueError: run_id에 안전하지 않은 문자가 포함된 경우.
+    """
+    context = BuildContext.create(spec, output_root=output_root, run_id=run_id)
+
+    outputs: list[str] = []
+    row_counts: dict[str, int] = {}
+    outcomes = tuple(
+        _run_source_pipeline(
+            source,
+            client=client,
+            context=context,
+            outputs=outputs,
+            row_counts=row_counts,
+        )
+        for source in spec.sources
+    )
+
+    errors = tuple(
+        f"{outcome.source_key}: {outcome.error}"
+        for outcome in outcomes
+        if outcome.status == "failed" and outcome.error is not None
+    )
+    status = "ok" if not errors else "failed"
+
+    manifest = BuildManifest(
+        build_id=context.run_id,
+        started_at=context.started_at,
+        finished_at=utc_now(),
+        inputs=tuple(_source_key(source) for source in spec.sources),
+        outputs=tuple(outputs),
+        errors=errors,
+        row_counts=row_counts,
+    )
+    manifest_path = context.output_root / context.run_id / "manifest.json"
+    manifest_writer(manifest, manifest_path)
+
+    return BuildResult(
+        context=context,
+        status=status,
+        outcomes=outcomes,
+        manifest_path=manifest_path,
+    )

--- a/src/kpubdata_builder/pipeline/orchestrator.py
+++ b/src/kpubdata_builder/pipeline/orchestrator.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from ..manifest import BuildManifest, manifest_writer
 from ..spec import BuildSpec, SourceRef
 from ..stages.bronze.build import SourceClient, build_bronze_artifact
+from ..stages.bronze.models import BronzeArtifact
 from ..stages.bronze.models import utc_now
 from ..stages.bronze.persist import persist_bronze_artifact
 from ..stages.gold.build import build_gold_package
@@ -65,9 +66,30 @@ class BuildResult:
     manifest_path: Path
 
 
-def _source_key(source: SourceRef) -> str:
-    """소스 식별자를 alias 우선으로 결정한다."""
-    return source.alias if source.alias else f"{source.provider}.{source.dataset}"
+def _fetch_source_key(source: SourceRef) -> str:
+    """Bronze fetch에 사용할 실제 provider.dataset 키를 반환한다."""
+    return f"{source.provider}.{source.dataset}"
+
+
+def _output_source_key(source: SourceRef) -> str:
+    """워크스페이스/결과 기록에 사용할 사용자 노출 키를 반환한다."""
+    return source.alias if source.alias else _fetch_source_key(source)
+
+
+def _retag_bronze_artifact(artifact: BronzeArtifact, *, output_key: str) -> BronzeArtifact:
+    """fetch provenance는 유지하고 산출물 경로용 source_key만 교체한다."""
+    return BronzeArtifact(
+        source_key=output_key,
+        raw_records=artifact.raw_records,
+        fetch_params=artifact.fetch_params,
+        fetched_at=artifact.fetched_at,
+        provenance=artifact.provenance,
+    )
+
+
+def _record_output_paths(outputs: list[str], *paths: Path) -> None:
+    """생성된 산출물 경로를 manifest outputs에 모두 기록한다."""
+    outputs.extend(str(path) for path in paths)
 
 
 def _run_source_pipeline(
@@ -79,35 +101,48 @@ def _run_source_pipeline(
     row_counts: dict[str, int],
 ) -> SourceBuildOutcome:
     """한 소스를 Bronze → Silver → Gold로 실행하고 산출물을 저장한다."""
-    key = _source_key(source)
+    fetch_key = _fetch_source_key(source)
+    output_key = _output_source_key(source)
     completed: list[str] = []
     try:
-        bronze = build_bronze_artifact(client, source_key=key, fetch_params=dict(source.params))
+        bronze = build_bronze_artifact(
+            client, source_key=fetch_key, fetch_params=dict(source.params)
+        )
+        bronze = _retag_bronze_artifact(bronze, output_key=output_key)
         bronze_paths = persist_bronze_artifact(
             bronze, output_root=context.output_root, run_id=context.run_id
         )
         completed.append("bronze")
-        outputs.extend([str(bronze_paths.records_path), str(bronze_paths.metadata_path)])
+        _record_output_paths(outputs, bronze_paths.records_path, bronze_paths.metadata_path)
 
         silver = build_silver_dataset(bronze)
         silver_paths = persist_silver_dataset(
             silver, output_root=context.output_root, run_id=context.run_id
         )
         completed.append("silver")
-        outputs.append(str(silver_paths.table_path))
+        _record_output_paths(
+            outputs,
+            silver_paths.table_path,
+            silver_paths.schema_path,
+            silver_paths.stats_path,
+            silver_paths.preview_path,
+            silver_paths.validation_path,
+        )
 
-        gold = build_gold_package(silver, dataset_name=key, exports=context.spec.exports)
+        gold = build_gold_package(silver, dataset_name=output_key, exports=context.spec.exports)
         gold_paths = persist_gold_package(
             gold, output_root=context.output_root, run_id=context.run_id
         )
         completed.append("gold")
-        outputs.append(str(gold_paths.table_path))
+        _record_output_paths(outputs, gold_paths.table_path, gold_paths.package_path)
 
-        row_counts[key] = silver.statistics.row_count
-        return SourceBuildOutcome(source_key=key, status="ok", stages_completed=tuple(completed))
+        row_counts[output_key] = silver.statistics.row_count
+        return SourceBuildOutcome(
+            source_key=output_key, status="ok", stages_completed=tuple(completed)
+        )
     except Exception as exc:  # stage 실패를 결과로 변환하여 매니페스트에 기록
         return SourceBuildOutcome(
-            source_key=key,
+            source_key=output_key,
             status="failed",
             stages_completed=tuple(completed),
             error=str(exc),
@@ -161,7 +196,7 @@ def run_build(
         build_id=context.run_id,
         started_at=context.started_at,
         finished_at=utc_now(),
-        inputs=tuple(_source_key(source) for source in spec.sources),
+        inputs=tuple(_output_source_key(source) for source in spec.sources),
         outputs=tuple(outputs),
         errors=errors,
         row_counts=row_counts,

--- a/src/kpubdata_builder/pipeline/orchestrator.py
+++ b/src/kpubdata_builder/pipeline/orchestrator.py
@@ -22,8 +22,7 @@ from pathlib import Path
 from ..manifest import BuildManifest, manifest_writer
 from ..spec import BuildSpec, SourceRef
 from ..stages.bronze.build import SourceClient, build_bronze_artifact
-from ..stages.bronze.models import BronzeArtifact
-from ..stages.bronze.models import utc_now
+from ..stages.bronze.models import BronzeArtifact, utc_now
 from ..stages.bronze.persist import persist_bronze_artifact
 from ..stages.gold.build import build_gold_package
 from ..stages.gold.persist import persist_gold_package

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -4,17 +4,20 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterable
+from pathlib import Path
+from typing import cast
 
 import polars as pl
 import pytest
 
+import kpubdata_builder.pipeline.orchestrator as orchestrator
 from kpubdata_builder.pipeline import BuildContext, BuildResult, run_build
 from kpubdata_builder.spec import BuildSpec, ExportTarget, JsonValue, SourceRef
 
 
 class _FakeResult:
     def __init__(self, items: list[dict[str, JsonValue]]) -> None:
-        self._items = items
+        self._items: list[dict[str, JsonValue]] = items
 
     @property
     def items(self) -> Iterable[dict[str, JsonValue]]:
@@ -23,9 +26,9 @@ class _FakeResult:
 
 class _FakeDataset:
     def __init__(self, items: list[dict[str, JsonValue]]) -> None:
-        self._items = items
+        self._items: list[dict[str, JsonValue]] = items
 
-    def list(self, **params: JsonValue) -> _FakeResult:
+    def list(self, **_params: JsonValue) -> _FakeResult:
         return _FakeResult(self._items)
 
 
@@ -33,7 +36,7 @@ class _FakeClient:
     """source_key → 레코드 매핑을 돌려주는 테스트용 클라이언트."""
 
     def __init__(self, data: dict[str, list[dict[str, JsonValue]]]) -> None:
-        self._data = data
+        self._data: dict[str, list[dict[str, JsonValue]]] = data
 
     def dataset(self, source_key: str) -> _FakeDataset:
         if source_key not in self._data:
@@ -51,7 +54,7 @@ def _spec(*sources: SourceRef) -> BuildSpec:
     )
 
 
-def test_build_context_create_validates_and_defaults_run_id(tmp_path) -> None:  # type: ignore[no-untyped-def]
+def test_build_context_create_validates_and_defaults_run_id(tmp_path: Path) -> None:
     spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
 
     ctx = BuildContext.create(spec, output_root=tmp_path)
@@ -61,7 +64,7 @@ def test_build_context_create_validates_and_defaults_run_id(tmp_path) -> None:  
     assert ctx.spec is spec
 
 
-def test_run_build_executes_full_pipeline_and_writes_workspace(tmp_path) -> None:  # type: ignore[no-untyped-def]
+def test_run_build_executes_full_pipeline_and_writes_workspace(tmp_path: Path) -> None:
     spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
     client = _FakeClient(
         {"datago.apt_trade": [{"id": "1", "amount": 1000}, {"id": "2", "amount": 2500}]}
@@ -85,9 +88,18 @@ def test_run_build_executes_full_pipeline_and_writes_workspace(tmp_path) -> None
 
     # manifest 기록
     assert result.manifest_path.exists()
-    manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    manifest = cast(
+        dict[str, JsonValue], json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    )
     assert manifest["build_id"] == "run1"
-    assert "datago.apt_trade" in manifest["inputs"]
+    inputs = cast(list[str], manifest["inputs"])
+    assert "datago.apt_trade" in inputs
+    outputs = cast(list[str], manifest["outputs"])
+    assert str(run_dir / "silver" / "datago.apt_trade" / "schema.json") in outputs
+    assert str(run_dir / "silver" / "datago.apt_trade" / "stats.json") in outputs
+    assert str(run_dir / "silver" / "datago.apt_trade" / "preview.json") in outputs
+    assert str(run_dir / "silver" / "datago.apt_trade" / "validation.json") in outputs
+    assert str(run_dir / "gold" / "datago.apt_trade" / "package.json") in outputs
 
     # gold parquet 산출
     gold_parquet = run_dir / "gold" / "datago.apt_trade" / "table.parquet"
@@ -98,17 +110,18 @@ def test_run_build_executes_full_pipeline_and_writes_workspace(tmp_path) -> None
     ]
 
 
-def test_run_build_uses_alias_as_source_key(tmp_path) -> None:  # type: ignore[no-untyped-def]
+def test_run_build_uses_alias_as_source_key(tmp_path: Path) -> None:
     spec = _spec(SourceRef(provider="datago", dataset="apt_trade", alias="trades"))
-    client = _FakeClient({"trades": [{"id": "1"}]})
+    client = _FakeClient({"datago.apt_trade": [{"id": "1"}]})
 
     result = run_build(spec, client=client, output_root=tmp_path, run_id="run1")
 
     assert result.status == "ok"
     assert result.outcomes[0].source_key == "trades"
+    assert (tmp_path / "run1" / "gold" / "trades" / "table.parquet").exists()
 
 
-def test_run_build_records_failure_when_source_missing(tmp_path) -> None:  # type: ignore[no-untyped-def]
+def test_run_build_records_failure_when_source_missing(tmp_path: Path) -> None:
     spec = _spec(SourceRef(provider="datago", dataset="missing"))
     client = _FakeClient({"datago.apt_trade": [{"id": "1"}]})
 
@@ -122,13 +135,42 @@ def test_run_build_records_failure_when_source_missing(tmp_path) -> None:  # typ
 
     # 실패해도 manifest는 남는다
     assert result.manifest_path.exists()
-    manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    manifest = cast(
+        dict[str, JsonValue], json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    )
     assert manifest["errors"]
 
 
-def test_run_build_rejects_unsafe_run_id(tmp_path) -> None:  # type: ignore[no-untyped-def]
+def test_run_build_preserves_partial_artifacts_when_later_stage_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
+    client = _FakeClient({"datago.apt_trade": [{"id": "1"}, {"id": "2"}]})
+
+    def _fail_gold(*_args: object, **_kwargs: object) -> object:
+        raise RuntimeError("gold failed")
+
+    monkeypatch.setattr(orchestrator, "build_gold_package", _fail_gold)
+
+    result = run_build(spec, client=client, output_root=tmp_path, run_id="run1")
+
+    assert result.status == "failed"
+    assert result.outcomes[0].stages_completed == ("bronze", "silver")
+    assert (tmp_path / "run1" / "bronze" / "datago.apt_trade").is_dir()
+    assert (tmp_path / "run1" / "silver" / "datago.apt_trade" / "table.parquet").exists()
+    assert not (tmp_path / "run1" / "gold" / "datago.apt_trade").exists()
+
+    manifest = cast(
+        dict[str, JsonValue], json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    )
+    outputs = cast(list[str], manifest["outputs"])
+    assert str(tmp_path / "run1" / "silver" / "datago.apt_trade" / "preview.json") in outputs
+    assert str(tmp_path / "run1" / "gold" / "datago.apt_trade" / "table.parquet") not in outputs
+
+
+def test_run_build_rejects_unsafe_run_id(tmp_path: Path) -> None:
     spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
     client = _FakeClient({"datago.apt_trade": [{"id": "1"}]})
 
     with pytest.raises(ValueError, match="run_id"):
-        run_build(spec, client=client, output_root=tmp_path, run_id="../escape")
+        _ = run_build(spec, client=client, output_root=tmp_path, run_id="../escape")

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -1,0 +1,134 @@
+"""Pipeline orchestrator(#48): Bronze→Silver→Gold 실행·워크스페이스·manifest 검증."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+
+import polars as pl
+import pytest
+
+from kpubdata_builder.pipeline import BuildContext, BuildResult, run_build
+from kpubdata_builder.spec import BuildSpec, ExportTarget, JsonValue, SourceRef
+
+
+class _FakeResult:
+    def __init__(self, items: list[dict[str, JsonValue]]) -> None:
+        self._items = items
+
+    @property
+    def items(self) -> Iterable[dict[str, JsonValue]]:
+        return self._items
+
+
+class _FakeDataset:
+    def __init__(self, items: list[dict[str, JsonValue]]) -> None:
+        self._items = items
+
+    def list(self, **params: JsonValue) -> _FakeResult:
+        return _FakeResult(self._items)
+
+
+class _FakeClient:
+    """source_key → 레코드 매핑을 돌려주는 테스트용 클라이언트."""
+
+    def __init__(self, data: dict[str, list[dict[str, JsonValue]]]) -> None:
+        self._data = data
+
+    def dataset(self, source_key: str) -> _FakeDataset:
+        if source_key not in self._data:
+            raise KeyError(f"unknown source: {source_key}")
+        return _FakeDataset(self._data[source_key])
+
+
+def _spec(*sources: SourceRef) -> BuildSpec:
+    return BuildSpec(
+        dataset_id="apt_trade",
+        title="Apartment Trades",
+        description="seoul apartment trades",
+        sources=tuple(sources),
+        exports=(ExportTarget(kind="jsonl", output_path="data.jsonl"),),
+    )
+
+
+def test_build_context_create_validates_and_defaults_run_id(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
+
+    ctx = BuildContext.create(spec, output_root=tmp_path)
+
+    assert ctx.run_id  # 비어 있지 않은 기본 run_id
+    assert ctx.output_root == tmp_path
+    assert ctx.spec is spec
+
+
+def test_run_build_executes_full_pipeline_and_writes_workspace(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
+    client = _FakeClient(
+        {"datago.apt_trade": [{"id": "1", "amount": 1000}, {"id": "2", "amount": 2500}]}
+    )
+
+    result = run_build(spec, client=client, output_root=tmp_path, run_id="run1")
+
+    assert isinstance(result, BuildResult)
+    assert result.status == "ok"
+    assert len(result.outcomes) == 1
+    outcome = result.outcomes[0]
+    assert outcome.source_key == "datago.apt_trade"
+    assert outcome.status == "ok"
+    assert outcome.stages_completed == ("bronze", "silver", "gold")
+
+    # run workspace 디렉터리 구조
+    run_dir = tmp_path / "run1"
+    assert (run_dir / "bronze").is_dir()
+    assert (run_dir / "silver").is_dir()
+    assert (run_dir / "gold").is_dir()
+
+    # manifest 기록
+    assert result.manifest_path.exists()
+    manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    assert manifest["build_id"] == "run1"
+    assert "datago.apt_trade" in manifest["inputs"]
+
+    # gold parquet 산출
+    gold_parquet = run_dir / "gold" / "datago.apt_trade" / "table.parquet"
+    assert gold_parquet.exists()
+    assert pl.read_parquet(gold_parquet).to_dicts() == [
+        {"id": "1", "amount": 1000},
+        {"id": "2", "amount": 2500},
+    ]
+
+
+def test_run_build_uses_alias_as_source_key(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    spec = _spec(SourceRef(provider="datago", dataset="apt_trade", alias="trades"))
+    client = _FakeClient({"trades": [{"id": "1"}]})
+
+    result = run_build(spec, client=client, output_root=tmp_path, run_id="run1")
+
+    assert result.status == "ok"
+    assert result.outcomes[0].source_key == "trades"
+
+
+def test_run_build_records_failure_when_source_missing(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    spec = _spec(SourceRef(provider="datago", dataset="missing"))
+    client = _FakeClient({"datago.apt_trade": [{"id": "1"}]})
+
+    result = run_build(spec, client=client, output_root=tmp_path, run_id="run1")
+
+    assert result.status == "failed"
+    outcome = result.outcomes[0]
+    assert outcome.status == "failed"
+    assert outcome.error is not None
+    assert "bronze" not in outcome.stages_completed
+
+    # 실패해도 manifest는 남는다
+    assert result.manifest_path.exists()
+    manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    assert manifest["errors"]
+
+
+def test_run_build_rejects_unsafe_run_id(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
+    client = _FakeClient({"datago.apt_trade": [{"id": "1"}]})
+
+    with pytest.raises(ValueError, match="run_id"):
+        run_build(spec, client=client, output_root=tmp_path, run_id="../escape")


### PR DESCRIPTION
## 개요
issue #48 — `BuildSpec`의 각 소스를 **Bronze → Silver → Gold** 순서로 실행하고, run workspace에 산출물을 저장한 뒤 빌드 매니페스트를 기록하는 **파이프라인 오케스트레이터**를 구현합니다.

> ⚠️ **#91 ← #92 ← #93 ← #94 위에 스택된 PR입니다.** diff에 선행 PR 커밋이 함께 보입니다. **#91 → #92 → #93 → #94 순으로 머지** 후 rebase하면 `feat(pipeline)…(#48)` 커밋만 남습니다.

## 변경 사항 (`pipeline/`)
- `context.py` — `BuildContext` (run_id 검증/생성, output_root, spec, started_at). run_id 생략 시 타임스탬프 기반 생성.
- `orchestrator.py`
  - `run_build(spec, *, client, output_root, run_id) → BuildResult`
  - 소스별 Bronze→Silver→Gold 실행 + 단계별 persist
  - `SourceBuildOutcome`으로 단계 성공/실패 기록
  - **부분 성공 정책**(BUILD_STATE.md): 소스 중 하나라도 실패하면 전체 `failed`로 기록하되 성공 산출물·실패 정보를 매니페스트에 함께 남김
  - `BuildManifest`를 `build/{run_id}/manifest.json`에 기록 (실패해도 남김)
- run workspace: `build/{run_id}/{bronze,silver,gold}/`

## 설계 메모
- **Export 단계 연결은 연기** — 현 exporter는 레거시 `ArtifactDataset`을 소비하므로 `GoldPackage`와 직접 연결하지 않습니다. stage-aware exporter(#28 / v0.2 #8·#9)에서 연결합니다. (이번 PR은 Bronze→Silver→Gold→Manifest까지)
- Bronze fetch는 `stages.bronze.build.SourceClient` Protocol을 받아 테스트에서 fake client로 주입 가능.
- gold `dataset_name`은 소스 식별자(alias 우선)를 사용 — 다중 소스 산출물 충돌 방지. 멀티소스 데이터셋 identity 정교화는 후속.

## 테스트 (TDD)
- 신규 `tests/unit/test_pipeline.py` 5건 **선작성(red)** 후 구현(green)
- 전체 흐름 + 워크스페이스/매니페스트/parquet, alias source_key, 소스 누락 실패 기록, 안전하지 않은 run_id 거부

## 품질 게이트
- ✅ `pytest tests/unit` — **119 passed**
- ✅ `mypy src` — no issues (45 files)
- ✅ `ruff check .` / `ruff format --check .` — clean

Closes #48