### PR TITLE
feat(cli): build 명령 — spec → Medallion 파이프라인 실행 연결 (#4)

### DIFF
--- a/src/kpubdata_builder/cli.py
+++ b/src/kpubdata_builder/cli.py
@@ -1,7 +1,7 @@
 """kpubdata-builder용 명령줄 진입점.
 
-이 모듈은 argparse 기반 CLI를 구성하고, 현재 지원되는 validate 명령과
-향후 예약된 preview/build 명령의 진입점을 제공한다.
+이 모듈은 argparse 기반 CLI를 구성하고, validate/build 명령과 향후 예약된
+preview 명령의 진입점을 제공한다.
 
 주요 함수:
     - build_parser: 하위 명령을 포함한 ArgumentParser 구성
@@ -18,11 +18,11 @@ from pathlib import Path
 from typing import cast
 
 from . import __version__
-from .build import execute_build
-from .errors import BuildError, SpecLoadError, ValidationError
-from .executor import SourceClient
+from .errors import SpecLoadError, ValidationError
+from .pipeline import run_build
 from .spec import load_spec
 from .spec.validator import validate_spec
+from .stages.bronze.build import SourceClient
 
 _RESERVED_COMMANDS: frozenset[str] = frozenset({"preview"})
 
@@ -67,16 +67,32 @@ def build_parser() -> argparse.ArgumentParser:
 
     build_cmd = subparsers.add_parser(
         "build",
-        help="Execute a BuildSpec to produce artifacts.",
+        help="Execute a BuildSpec through the Medallion pipeline.",
     )
     build_cmd.add_argument("spec", help="Path to the BuildSpec YAML file.")
     build_cmd.add_argument(
         "--output-dir",
-        default="./dist",
-        help="Directory where artifacts and manifest are written (default: ./dist).",
+        default="build",
+        help="Run workspace root directory (default: build).",
+    )
+    build_cmd.add_argument(
+        "--run-id",
+        default=None,
+        help="Run identifier (default: generated timestamp).",
     )
 
     return parser
+
+
+def _create_client() -> SourceClient:
+    """kpubdata 클라이언트를 환경설정으로 생성한다.
+
+    테스트에서 monkeypatch로 대체할 수 있도록 별도 함수로 분리한다. 실제
+    네트워크 호출은 build 실행(run_build) 시점에만 발생한다.
+    """
+    from kpubdata import Client
+
+    return cast(SourceClient, Client.from_env())
 
 
 def _run_validate(spec_path: str) -> int:
@@ -106,21 +122,17 @@ def _run_validate(spec_path: str) -> int:
     return 0
 
 
-def _make_default_client() -> SourceClient:
-    """Create the default kpubdata client. Isolated for test injection.
+def _run_build(spec_path: str, *, output_dir: str, run_id: str | None) -> int:
+    """BuildSpec을 로드·검증한 뒤 Medallion 파이프라인을 실행한다.
 
-    kpubdata's concrete ``Client`` satisfies the ``SourceClient`` Protocol at
-    runtime (duck typing), but mypy cannot confirm structural compatibility
-    across the package boundary: ``Client.dataset`` returns kpubdata's concrete
-    ``Dataset`` rather than our minimal ``SourceDataset`` Protocol. This single,
-    explicit cast localizes that boundary instead of suppressing it line-by-line.
+    매개변수:
+        spec_path: 빌드할 BuildSpec YAML 경로.
+        output_dir: 실행 워크스페이스 루트.
+        run_id: 실행 식별자. None이면 타임스탬프로 생성.
+
+    반환값:
+        int: 모든 소스 성공 시 0, 로드/검증/빌드 실패 시 1.
     """
-    from kpubdata import Client
-
-    return cast(SourceClient, Client.from_env())
-
-
-def _run_build(spec_path: str, output_dir: str) -> int:
     try:
         spec = load_spec(Path(spec_path))
         validate_spec(spec)
@@ -133,18 +145,21 @@ def _run_build(spec_path: str, output_dir: str) -> int:
             print(f"  - {problem}", file=sys.stderr)
         return 1
 
-    try:
-        client = _make_default_client()
-        result = execute_build(spec, client, output_dir=Path(output_dir))
-    except BuildError as exc:
-        print(f"error: build failed: {exc}", file=sys.stderr)
-        return 1
+    client = _create_client()
+    result = run_build(spec, client=client, output_root=Path(output_dir), run_id=run_id)
 
-    print(f"built spec: {spec.dataset_id}")
-    print("artifacts:")
-    for path in result.artifact_paths:
-        print(f"  - {path}")
+    print(f"build: {spec.dataset_id} (run {result.context.run_id})")
+    for outcome in result.outcomes:
+        stages = ", ".join(outcome.stages_completed) or "-"
+        print(f"  - {outcome.source_key}: {outcome.status} [{stages}]")
     print(f"manifest: {result.manifest_path}")
+
+    if result.status != "ok":
+        print("error: build failed for one or more sources", file=sys.stderr)
+        for outcome in result.outcomes:
+            if outcome.status == "failed":
+                print(f"  - {outcome.source_key}: {outcome.error}", file=sys.stderr)
+        return 1
     return 0
 
 
@@ -158,8 +173,7 @@ def _run_reserved(command: str) -> int:
         int: 항상 1.
     """
     print(
-        f"error: '{command}' is not implemented yet "
-        "(pipeline orchestrator pending — see issue #43)",
+        f"error: '{command}' is not implemented yet (preview command pending — see issue #3)",
         file=sys.stderr,
     )
     return 1
@@ -183,11 +197,9 @@ def dispatch(args: argparse.Namespace) -> int:
     if command == "validate":
         return _run_validate(args.spec)
     if command == "build":
-        return _run_build(args.spec, args.output_dir)
+        return _run_build(args.spec, output_dir=args.output_dir, run_id=args.run_id)
     if command in _RESERVED_COMMANDS:
         return _run_reserved(command)
-    # 일반적인 CLI 경로로는 도달할 수 없지만(argparse가 알 수 없는 하위 명령을 거부함),
-    # 프로그래밍 방식 호출자를 위한 방어적 대체 경로로 유지한다.
     return 2
 
 

--- a/tests/unit/test_cli_build.py
+++ b/tests/unit/test_cli_build.py
@@ -1,0 +1,123 @@
+"""CLI `build` 명령(#4): spec → run_build 연결과 종료 코드/출력 검증."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from pathlib import Path
+
+import pytest
+
+from kpubdata_builder import cli
+from kpubdata_builder.spec import JsonValue
+
+VALID_SPEC_YAML = (
+    """
+dataset_id: dataset.sample
+title: Sample Dataset
+description: Sample description
+sources:
+  - provider: datago
+    dataset: air_quality
+exports:
+  - kind: jsonl
+    output_path: out/data.jsonl
+""".strip()
+    + "\n"
+)
+
+
+class _FakeResult:
+    def __init__(self, items: list[dict[str, JsonValue]]) -> None:
+        self._items = items
+
+    @property
+    def items(self) -> Iterable[dict[str, JsonValue]]:
+        return self._items
+
+
+class _FakeDataset:
+    def __init__(self, items: list[dict[str, JsonValue]]) -> None:
+        self._items = items
+
+    def list(self, **params: JsonValue) -> _FakeResult:
+        return _FakeResult(self._items)
+
+
+class _FakeClient:
+    def __init__(self, data: dict[str, list[dict[str, JsonValue]]]) -> None:
+        self._data = data
+
+    def dataset(self, source_key: str) -> _FakeDataset:
+        if source_key not in self._data:
+            raise KeyError(f"unknown source: {source_key}")
+        return _FakeDataset(self._data[source_key])
+
+
+def _write_spec(tmp_path: Path) -> Path:
+    spec_path = tmp_path / "spec.yaml"
+    _ = spec_path.write_text(VALID_SPEC_YAML, encoding="utf-8")
+    return spec_path
+
+
+def test_build_runs_pipeline_and_reports(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    spec_path = _write_spec(tmp_path)
+    out_dir = tmp_path / "out"
+    client = _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}, {"id": "2", "v": 20}]})
+    monkeypatch.setattr(cli, "_create_client", lambda: client)
+
+    exit_code = cli.main(
+        ["build", str(spec_path), "--output-dir", str(out_dir), "--run-id", "run1"]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert (out_dir / "run1" / "manifest.json").exists()
+    manifest = json.loads((out_dir / "run1" / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["build_id"] == "run1"
+    assert "run1" in captured.out
+    assert captured.err == ""
+
+
+def test_build_reports_failure_with_exit_one(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    spec_path = _write_spec(tmp_path)
+    out_dir = tmp_path / "out"
+    # 소스 키가 없는 클라이언트 → bronze fetch 실패
+    client = _FakeClient({"datago.other": [{"id": "1"}]})
+    monkeypatch.setattr(cli, "_create_client", lambda: client)
+
+    exit_code = cli.main(
+        ["build", str(spec_path), "--output-dir", str(out_dir), "--run-id", "run1"]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert captured.err
+    # 실패해도 manifest는 남는다
+    assert (out_dir / "run1" / "manifest.json").exists()
+
+
+def test_build_requires_spec_argument(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = cli.main(["build"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert captured.err
+
+
+def test_build_reports_spec_load_error(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    missing = tmp_path / "missing.yaml"
+
+    exit_code = cli.main(["build", str(missing)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "failed to load spec" in captured.err


### PR DESCRIPTION
## 개요
issue #4 — CLI `build` 명령을 #48 orchestrator(`run_build`)에 연결하여 spec → Bronze→Silver→Gold→manifest 전체 빌드를 실행합니다.

> ⚠️ **#91→#92→#93→#94→#95 위에 스택된 PR입니다.** 선행 PR들을 순서대로 머지한 뒤 rebase하면 `feat(cli)…(#4)` 커밋만 남습니다.

## 핵심: 어댑터 불필요
조사 결과 `kpubdata.Client`가 bronze `SourceClient` 프로토콜을 **구조적으로 그대로 충족**합니다:
- `Client.dataset(dataset_id).list(**params).items` ≡ `SourceClient.dataset(key).list(**params).items`
- kpubdata `dataset_id` 형식이 **`provider.dataset`** (`catalog.resolve`의 `_split_dataset_id`) → orchestrator의 `source_key = f"{provider}.{dataset}"`와 일치

따라서 별도 어댑터 없이 `Client.from_env()`를 그대로 주입합니다.

## 변경 사항 (`cli.py`)
- `build` 하위 명령 **실구현** (reserved에서 제거)
  - `spec` 필수 인자 + `--output-dir`(기본 `build`) + `--run-id`(기본 타임스탬프)
  - `_create_client()`: `Client.from_env()` — **테스트 monkeypatch 지점**, 실제 네트워크는 `run_build` 시점에만 발생
  - `_run_build()`: load → validate → `run_build` → 요약 출력(소스별 상태/manifest 경로), 실패 시 exit 1
- `preview`는 여전히 reserved (#3에서 구현)

## 테스트 (TDD)
- 신규 `tests/unit/test_cli_build.py` 4건 **선작성(red)** 후 구현(green) — fake client로 전체 파이프라인/실패 exit 1/spec 필수/로드 오류 검증
- 기존 `test_cli` build-reserved 테스트 갱신

## 품질 게이트
- ✅ `pytest tests/unit` — **133 passed**
- ✅ `mypy src` — no issues (47 files)
- ✅ `ruff check .` / `ruff format --check .` — clean

Closes #4