### PR TITLE
feat(cli): preview 명령 — 스키마+샘플 미리보기 (파일 미기록) (#3)

### DIFF
--- a/src/kpubdata_builder/cli.py
+++ b/src/kpubdata_builder/cli.py
@@ -192,19 +192,33 @@ def _run_preview(spec_path: str, *, limit: int) -> int:
             print(f"  - {problem}", file=sys.stderr)
         return 1
 
-    client = _create_client()
-    result = preview_build(spec, client=client, limit=limit)
+    try:
+        client = _create_client()
+        result = preview_build(spec, client=client, limit=limit)
+    except ValueError as exc:
+        # limit < 1 같은 사용자 입력 오류.
+        print(f"error: invalid preview input: {exc}", file=sys.stderr)
+        return 1
 
     print(f"preview: {spec.dataset_id}")
+    failed_sources: list[str] = []
     for source in result.previews:
         if source.status != "ok":
-            print(f"  - {source.source_key}: failed ({source.error})")
+            failed_sources.append(source.source_key)
             continue
         columns = ", ".join(f"{c.name} ({c.dtype})" for c in source.schema.columns)
         print(f"  - {source.source_key}: {columns}")
         print(f"    sample ({len(source.preview.rows)} of {source.preview.total_rows} rows):")
         for row in source.preview.rows:
             print(f"      {row}")
+
+    if failed_sources:
+        # 소스 fetch 실패는 stderr + exit 1 — CI/자동화가 성공으로 오판하지 않도록.
+        print("error: preview failed for one or more sources", file=sys.stderr)
+        for source in result.previews:
+            if source.status != "ok":
+                print(f"  - {source.source_key}: {source.error}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/src/kpubdata_builder/cli.py
+++ b/src/kpubdata_builder/cli.py
@@ -1,7 +1,7 @@
 """kpubdata-builder용 명령줄 진입점.
 
-이 모듈은 argparse 기반 CLI를 구성하고, validate/build 명령과 향후 예약된
-preview 명령의 진입점을 제공한다.
+이 모듈은 argparse 기반 CLI를 구성하고, validate/preview/build 명령의 진입점을
+제공한다.
 
 주요 함수:
     - build_parser: 하위 명령을 포함한 ArgumentParser 구성
@@ -19,12 +19,11 @@ from typing import cast
 
 from . import __version__
 from .errors import SpecLoadError, ValidationError
-from .pipeline import run_build
+from .pipeline import preview_build, run_build
 from .spec import load_spec
 from .spec.validator import validate_spec
 from .stages.bronze.build import SourceClient
-
-_RESERVED_COMMANDS: frozenset[str] = frozenset({"preview"})
+from .tabular import DEFAULT_PREVIEW_LIMIT
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -61,9 +60,15 @@ def build_parser() -> argparse.ArgumentParser:
 
     preview_cmd = subparsers.add_parser(
         "preview",
-        help="Preview a BuildSpec execution (reserved; not implemented yet).",
+        help="Preview a BuildSpec: schema and sample rows without writing artifacts.",
     )
-    preview_cmd.add_argument("spec", nargs="?", help="Path to the BuildSpec YAML file.")
+    preview_cmd.add_argument("spec", help="Path to the BuildSpec YAML file.")
+    preview_cmd.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_PREVIEW_LIMIT,
+        help=f"Maximum sample rows per source (default: {DEFAULT_PREVIEW_LIMIT}).",
+    )
 
     build_cmd = subparsers.add_parser(
         "build",
@@ -163,20 +168,44 @@ def _run_build(spec_path: str, *, output_dir: str, run_id: str | None) -> int:
     return 0
 
 
-def _run_reserved(command: str) -> int:
-    """예약된 미구현 명령에 대한 공통 오류 메시지를 출력한다.
+def _run_preview(spec_path: str, *, limit: int) -> int:
+    """BuildSpec을 로드·검증한 뒤 각 소스의 스키마와 샘플만 출력한다.
+
+    실제 아티팩트 파일은 만들지 않는다.
 
     매개변수:
-        command: 사용자가 요청한 하위 명령 이름.
+        spec_path: 미리볼 BuildSpec YAML 경로.
+        limit: 소스별 샘플 최대 행 수.
 
     반환값:
-        int: 항상 1.
+        int: 성공 시 0, 로드/검증 실패 시 1.
     """
-    print(
-        f"error: '{command}' is not implemented yet (preview command pending — see issue #3)",
-        file=sys.stderr,
-    )
-    return 1
+    try:
+        spec = load_spec(Path(spec_path))
+        validate_spec(spec)
+    except SpecLoadError as exc:
+        print(f"error: failed to load spec: {exc}", file=sys.stderr)
+        return 1
+    except ValidationError as exc:
+        print("error: spec validation failed:", file=sys.stderr)
+        for problem in exc.problems:
+            print(f"  - {problem}", file=sys.stderr)
+        return 1
+
+    client = _create_client()
+    result = preview_build(spec, client=client, limit=limit)
+
+    print(f"preview: {spec.dataset_id}")
+    for source in result.previews:
+        if source.status != "ok":
+            print(f"  - {source.source_key}: failed ({source.error})")
+            continue
+        columns = ", ".join(f"{c.name} ({c.dtype})" for c in source.schema.columns)
+        print(f"  - {source.source_key}: {columns}")
+        print(f"    sample ({len(source.preview.rows)} of {source.preview.total_rows} rows):")
+        for row in source.preview.rows:
+            print(f"      {row}")
+    return 0
 
 
 def dispatch(args: argparse.Namespace) -> int:
@@ -196,10 +225,12 @@ def dispatch(args: argparse.Namespace) -> int:
     command = args.command
     if command == "validate":
         return _run_validate(args.spec)
+    if command == "preview":
+        return _run_preview(args.spec, limit=args.limit)
     if command == "build":
         return _run_build(args.spec, output_dir=args.output_dir, run_id=args.run_id)
-    if command in _RESERVED_COMMANDS:
-        return _run_reserved(command)
+    # 일반적인 CLI 경로로는 도달할 수 없지만(argparse가 알 수 없는 하위 명령을 거부함),
+    # 프로그래밍 방식 호출자를 위한 방어적 대체 경로로 유지한다.
     return 2
 
 

--- a/src/kpubdata_builder/pipeline/__init__.py
+++ b/src/kpubdata_builder/pipeline/__init__.py
@@ -7,16 +7,22 @@ Bronze → Silver → Gold → (Export) → Manifest 흐름을 묶는 orchestrat
     - BuildContext: 단일 실행 컨텍스트
     - run_build: 파이프라인 진입점
     - BuildResult / SourceBuildOutcome: 실행 결과 모델
+    - preview_build: 파일 미기록 미리보기 진입점
+    - PreviewResult / SourcePreview: 미리보기 결과 모델
 """
 
 from __future__ import annotations
 
 from .context import BuildContext
 from .orchestrator import BuildResult, SourceBuildOutcome, run_build
+from .preview import PreviewResult, SourcePreview, preview_build
 
 __all__ = [
     "BuildContext",
     "BuildResult",
+    "PreviewResult",
     "SourceBuildOutcome",
+    "SourcePreview",
+    "preview_build",
     "run_build",
 ]

--- a/src/kpubdata_builder/pipeline/preview.py
+++ b/src/kpubdata_builder/pipeline/preview.py
@@ -50,9 +50,14 @@ class PreviewResult:
     previews: tuple[SourcePreview, ...]
 
 
-def _source_key(source: SourceRef) -> str:
-    """소스 식별자를 alias 우선으로 결정한다."""
-    return source.alias if source.alias else f"{source.provider}.{source.dataset}"
+def _fetch_key(source: SourceRef) -> str:
+    """kpubdata Client.dataset()에 전달할 정규 fetch 키 (provider.dataset)."""
+    return f"{source.provider}.{source.dataset}"
+
+
+def _output_key(source: SourceRef) -> str:
+    """미리보기 결과 표면에 노출할 키 — alias가 있으면 alias."""
+    return source.alias if source.alias else _fetch_key(source)
 
 
 def _preview_source(
@@ -62,19 +67,23 @@ def _preview_source(
     limit: int,
 ) -> SourcePreview:
     """한 소스를 fetch → Silver(메모리)로 만들어 스키마/샘플만 추출한다."""
-    key = _source_key(source)
+    # fetch_key는 항상 provider.dataset (kpubdata.Client 계약). 표면 키는 alias 우선.
+    fetch_key = _fetch_key(source)
+    out_key = _output_key(source)
     try:
-        bronze = build_bronze_artifact(client, source_key=key, fetch_params=dict(source.params))
+        bronze = build_bronze_artifact(
+            client, source_key=fetch_key, fetch_params=dict(source.params)
+        )
         silver = build_silver_dataset(bronze, preview_limit=limit)
         return SourcePreview(
-            source_key=key,
+            source_key=out_key,
             status="ok",
             schema=silver.schema,
             preview=silver.preview,
         )
     except Exception as exc:  # 미리보기 실패를 결과로 변환
         return SourcePreview(
-            source_key=key,
+            source_key=out_key,
             status="failed",
             schema=SchemaInfo(),
             preview=PreviewSlice(rows=(), total_rows=0),
@@ -97,6 +106,11 @@ def preview_build(
 
     반환값:
         PreviewResult: 소스별 스키마/샘플.
+
+    예외:
+        ValueError: limit이 1보다 작은 경우.
     """
+    if limit < 1:
+        raise ValueError(f"limit must be >= 1, got {limit}")
     previews = tuple(_preview_source(source, client=client, limit=limit) for source in spec.sources)
     return PreviewResult(previews=previews)

--- a/src/kpubdata_builder/pipeline/preview.py
+++ b/src/kpubdata_builder/pipeline/preview.py
@@ -1,0 +1,102 @@
+"""빌드 미리보기 (#3).
+
+실제 빌드를 전부 돌리기 전에 각 소스의 스키마와 샘플 몇 행만 보여준다. Bronze
+fetch 후 Silver를 메모리에서 구성하되 **어떤 산출물 파일도 기록하지 않는다**
+(persist 호출 없음). build의 축소판이다.
+
+주요 구성:
+    - SourcePreview: 소스별 미리보기 결과
+    - PreviewResult: 전체 미리보기 결과
+    - preview_build: 미리보기 진입점
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..spec import BuildSpec, SourceRef
+from ..stages.bronze.build import SourceClient, build_bronze_artifact
+from ..stages.silver.build import build_silver_dataset
+from ..tabular import DEFAULT_PREVIEW_LIMIT, PreviewSlice, SchemaInfo
+
+
+@dataclass(frozen=True)
+class SourcePreview:
+    """단일 소스의 미리보기 결과.
+
+    속성:
+        source_key: 소스 식별자.
+        status: "ok" 또는 "failed".
+        schema: 추론된 스키마 요약 (실패 시 빈 SchemaInfo).
+        preview: 상위 N행 미리보기 (실패 시 빈 PreviewSlice).
+        error: 실패 시 오류 메시지.
+    """
+
+    source_key: str
+    status: str
+    schema: SchemaInfo
+    preview: PreviewSlice
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class PreviewResult:
+    """전체 미리보기 결과.
+
+    속성:
+        previews: 소스별 미리보기 결과.
+    """
+
+    previews: tuple[SourcePreview, ...]
+
+
+def _source_key(source: SourceRef) -> str:
+    """소스 식별자를 alias 우선으로 결정한다."""
+    return source.alias if source.alias else f"{source.provider}.{source.dataset}"
+
+
+def _preview_source(
+    source: SourceRef,
+    *,
+    client: SourceClient,
+    limit: int,
+) -> SourcePreview:
+    """한 소스를 fetch → Silver(메모리)로 만들어 스키마/샘플만 추출한다."""
+    key = _source_key(source)
+    try:
+        bronze = build_bronze_artifact(client, source_key=key, fetch_params=dict(source.params))
+        silver = build_silver_dataset(bronze, preview_limit=limit)
+        return SourcePreview(
+            source_key=key,
+            status="ok",
+            schema=silver.schema,
+            preview=silver.preview,
+        )
+    except Exception as exc:  # 미리보기 실패를 결과로 변환
+        return SourcePreview(
+            source_key=key,
+            status="failed",
+            schema=SchemaInfo(),
+            preview=PreviewSlice(rows=(), total_rows=0),
+            error=str(exc),
+        )
+
+
+def preview_build(
+    spec: BuildSpec,
+    *,
+    client: SourceClient,
+    limit: int = DEFAULT_PREVIEW_LIMIT,
+) -> PreviewResult:
+    """각 소스의 스키마와 샘플 행을 산출한다 (파일 미기록).
+
+    매개변수:
+        spec: 미리볼 빌드 명세.
+        client: Bronze fetch에 사용할 kpubdata 호환 클라이언트.
+        limit: 미리보기에 포함할 최대 행 수.
+
+    반환값:
+        PreviewResult: 소스별 스키마/샘플.
+    """
+    previews = tuple(_preview_source(source, client=client, limit=limit) for source in spec.sources)
+    return PreviewResult(previews=previews)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -124,26 +124,6 @@ def test_validate_fails_for_invalid_spec(
     assert "sources" in captured.err
 
 
-def test_preview_is_reserved(capsys: pytest.CaptureFixture[str]) -> None:
-    # 예약 명령 preview가 미구현 오류로 차단되는지 검증한다.
-    exit_code = main(["preview", "any.yaml"])
-    captured = capsys.readouterr()
-
-    assert exit_code == 1
-    assert "preview" in captured.err
-    assert "not implemented" in captured.err
-
-
-def test_preview_without_spec_is_reserved(capsys: pytest.CaptureFixture[str]) -> None:
-    # preview 인자 생략 시에도 예약 명령 오류 경로를 유지하는지 확인한다.
-    exit_code = main(["preview"])
-    captured = capsys.readouterr()
-
-    assert exit_code == 1
-    assert "preview" in captured.err
-    assert "not implemented" in captured.err
-
-
 def test_validate_fails_for_malformed_yaml(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/unit/test_cli_preview.py
+++ b/tests/unit/test_cli_preview.py
@@ -94,3 +94,40 @@ def test_preview_reports_spec_load_error(
 
     assert exit_code == 1
     assert "failed to load spec" in captured.err
+
+
+def test_preview_exits_one_when_source_fetch_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """소스 fetch 실패 시 CLI는 exit 1 + stderr 메시지로 알린다 (자동화 오판 방지)."""
+    spec_path = _write_spec(tmp_path)
+    # 소스 키가 없는 클라이언트 → bronze fetch 실패
+    client = _FakeClient({"datago.other": [{"id": "1"}]})
+    monkeypatch.setattr(cli, "_create_client", lambda: client)
+
+    exit_code = cli.main(["preview", str(spec_path)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "preview failed" in captured.err
+    assert "datago.air_quality" in captured.err
+
+
+def test_preview_rejects_non_positive_limit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """음수/0 limit은 Polars head()의 신기한 동작에 위임하지 않고 명시적으로 거부."""
+    spec_path = _write_spec(tmp_path)
+    client = _FakeClient({"datago.air_quality": [{"id": "1"}]})
+    monkeypatch.setattr(cli, "_create_client", lambda: client)
+
+    exit_code = cli.main(["preview", str(spec_path), "--limit", "0"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "invalid preview input" in captured.err
+    assert "limit" in captured.err

--- a/tests/unit/test_cli_preview.py
+++ b/tests/unit/test_cli_preview.py
@@ -1,0 +1,96 @@
+"""CLI `preview` 명령(#3): 스키마+샘플 출력, 아티팩트 파일 미생성 검증."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+import pytest
+
+from kpubdata_builder import cli
+from kpubdata_builder.spec import JsonValue
+
+VALID_SPEC_YAML = (
+    """
+dataset_id: dataset.sample
+title: Sample Dataset
+description: Sample description
+sources:
+  - provider: datago
+    dataset: air_quality
+exports:
+  - kind: jsonl
+    output_path: out/data.jsonl
+""".strip()
+    + "\n"
+)
+
+
+class _FakeResult:
+    def __init__(self, items: list[dict[str, JsonValue]]) -> None:
+        self._items = items
+
+    @property
+    def items(self) -> Iterable[dict[str, JsonValue]]:
+        return self._items
+
+
+class _FakeDataset:
+    def __init__(self, items: list[dict[str, JsonValue]]) -> None:
+        self._items = items
+
+    def list(self, **params: JsonValue) -> _FakeResult:
+        return _FakeResult(self._items)
+
+
+class _FakeClient:
+    def __init__(self, data: dict[str, list[dict[str, JsonValue]]]) -> None:
+        self._data = data
+
+    def dataset(self, source_key: str) -> _FakeDataset:
+        if source_key not in self._data:
+            raise KeyError(f"unknown source: {source_key}")
+        return _FakeDataset(self._data[source_key])
+
+
+def _write_spec(tmp_path: Path) -> Path:
+    spec_path = tmp_path / "spec.yaml"
+    _ = spec_path.write_text(VALID_SPEC_YAML, encoding="utf-8")
+    return spec_path
+
+
+def test_preview_prints_schema_and_sample(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    spec_path = _write_spec(tmp_path)
+    client = _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}, {"id": "2", "v": 20}]})
+    monkeypatch.setattr(cli, "_create_client", lambda: client)
+
+    exit_code = cli.main(["preview", str(spec_path), "--limit", "1"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "datago.air_quality" in captured.out
+    assert "id" in captured.out and "v" in captured.out
+    # 미리보기는 어떤 아티팩트 파일도 만들지 않는다 (spec.yaml만 존재)
+    assert list(tmp_path.iterdir()) == [spec_path]
+
+
+def test_preview_requires_spec_argument(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = cli.main(["preview"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert captured.err
+
+
+def test_preview_reports_spec_load_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    exit_code = cli.main(["preview", str(tmp_path / "missing.yaml")])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "failed to load spec" in captured.err

--- a/tests/unit/test_preview.py
+++ b/tests/unit/test_preview.py
@@ -1,0 +1,85 @@
+"""Preview(#3): preview_build가 스키마+샘플만 만들고 파일은 쓰지 않는지 검증."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from kpubdata_builder.pipeline import PreviewResult, preview_build
+from kpubdata_builder.spec import BuildSpec, ExportTarget, JsonValue, SourceRef
+from kpubdata_builder.tabular import PreviewSlice, SchemaInfo
+
+
+class _FakeResult:
+    def __init__(self, items: list[dict[str, JsonValue]]) -> None:
+        self._items = items
+
+    @property
+    def items(self) -> Iterable[dict[str, JsonValue]]:
+        return self._items
+
+
+class _FakeDataset:
+    def __init__(self, items: list[dict[str, JsonValue]]) -> None:
+        self._items = items
+
+    def list(self, **params: JsonValue) -> _FakeResult:
+        return _FakeResult(self._items)
+
+
+class _FakeClient:
+    def __init__(self, data: dict[str, list[dict[str, JsonValue]]]) -> None:
+        self._data = data
+
+    def dataset(self, source_key: str) -> _FakeDataset:
+        if source_key not in self._data:
+            raise KeyError(f"unknown source: {source_key}")
+        return _FakeDataset(self._data[source_key])
+
+
+def _spec(*sources: SourceRef) -> BuildSpec:
+    return BuildSpec(
+        dataset_id="apt_trade",
+        title="Apartment Trades",
+        description="seoul apartment trades",
+        sources=tuple(sources),
+        exports=(ExportTarget(kind="jsonl", output_path="data.jsonl"),),
+    )
+
+
+def test_preview_build_returns_schema_and_sample() -> None:
+    spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
+    client = _FakeClient({"datago.apt_trade": [{"id": str(i), "v": i} for i in range(10)]})
+
+    result = preview_build(spec, client=client, limit=3)
+
+    assert isinstance(result, PreviewResult)
+    assert len(result.previews) == 1
+    preview = result.previews[0]
+    assert preview.source_key == "datago.apt_trade"
+    assert preview.status == "ok"
+    assert isinstance(preview.schema, SchemaInfo)
+    assert [c.name for c in preview.schema.columns] == ["id", "v"]
+    assert isinstance(preview.preview, PreviewSlice)
+    assert preview.preview.total_rows == 10
+    assert len(preview.preview.rows) == 3
+
+
+def test_preview_build_writes_no_files(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
+    client = _FakeClient({"datago.apt_trade": [{"id": "1"}]})
+
+    # preview_build은 output_root를 받지 않으므로 어떤 파일도 만들지 않는다.
+    preview_build(spec, client=client, limit=5)
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_preview_build_records_failure_for_missing_source() -> None:
+    spec = _spec(SourceRef(provider="datago", dataset="missing"))
+    client = _FakeClient({"datago.apt_trade": [{"id": "1"}]})
+
+    result = preview_build(spec, client=client)
+
+    preview = result.previews[0]
+    assert preview.status == "failed"
+    assert preview.error is not None

--- a/tests/unit/test_preview.py
+++ b/tests/unit/test_preview.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
+import pytest
+
 from kpubdata_builder.pipeline import PreviewResult, preview_build
 from kpubdata_builder.spec import BuildSpec, ExportTarget, JsonValue, SourceRef
 from kpubdata_builder.tabular import PreviewSlice, SchemaInfo
@@ -83,3 +85,23 @@ def test_preview_build_records_failure_for_missing_source() -> None:
     preview = result.previews[0]
     assert preview.status == "failed"
     assert preview.error is not None
+
+
+def test_preview_build_fetches_by_provider_dataset_and_reports_alias() -> None:
+    """alias가 있어도 fetch는 provider.dataset 키로, 표면 키는 alias로 (#98 review와 동일 회귀)."""
+    spec = _spec(SourceRef(provider="datago", dataset="apt_trade", alias="trades"))
+    client = _FakeClient({"datago.apt_trade": [{"id": "1"}]})
+
+    result = preview_build(spec, client=client, limit=1)
+
+    preview = result.previews[0]
+    assert preview.status == "ok"
+    assert preview.source_key == "trades"
+
+
+def test_preview_build_rejects_non_positive_limit() -> None:
+    spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
+    client = _FakeClient({"datago.apt_trade": [{"id": "1"}]})
+
+    with pytest.raises(ValueError, match="limit"):
+        preview_build(spec, client=client, limit=0)


### PR DESCRIPTION
## 개요
issue #3 — 실제 빌드 전에 각 소스의 **스키마와 샘플 행만** 보여주는 `preview` 명령을 구현합니다. build의 축소판으로 **어떤 아티팩트 파일도 만들지 않습니다**.

> ⚠️ **#91→#92→#93→#94→#95→#98(#4) 위에 스택된 PR입니다.** 선행 PR들을 순서대로 머지 후 rebase하면 `feat(cli)…(#3)` 커밋만 남습니다.

## 변경 사항
- **`pipeline/preview.py`** — `preview_build(spec, *, client, limit) → PreviewResult`
  - 소스별 `SourcePreview`(schema / preview / status / error)
  - fetch → Silver를 **메모리에서** 구성하고 `silver.schema` + `silver.preview`만 추출
  - `output_root`를 받지 않으므로 **구조적으로 파일을 만들 수 없음** (persist 미호출)
- **`cli.py`** — `preview` 하위 명령 실구현
  - `spec` 필수 + `--limit`(기본 `DEFAULT_PREVIEW_LIMIT=5`)
  - 스키마(필드/타입) + 샘플 행 출력
  - `_run_reserved`/`_RESERVED_COMMANDS` 제거 — validate/preview/build 모두 구현 완료

## 설계 메모
- "fetch a portion"은 현재 fetch 후 상위 N행 미리보기로 구현(전량 fetch). kpubdata fetch 단계 행 제한은 후속.
- preview가 파일을 만들지 않음을 테스트로 잠금(`tmp_path`에 spec.yaml 외 생성물 없음).

## 테스트 (TDD)
- 신규 `tests/unit/test_preview.py` 3건 + `test_cli_preview.py` 3건 **선작성(red)** 후 구현(green)
- schema/sample 반환, 파일 미생성, 실패 기록, CLI 출력/spec 필수/로드 오류
- 기존 `test_cli` preview-reserved 테스트 갱신

## 품질 게이트
- ✅ `pytest tests/unit` — **137 passed**
- ✅ `mypy src` — no issues (48 files)
- ✅ `ruff check .` / `ruff format --check .` — clean

Closes #3