### PR TITLE
refactor(publishers): Exporter/Publisher 경계 구체화 + LocalPublisher (#28)

### DIFF
--- a/src/kpubdata_builder/errors.py
+++ b/src/kpubdata_builder/errors.py
@@ -52,12 +52,17 @@ class ManifestError(BuildError):
     """매니페스트 직렬화 또는 디스크 기록이 실패했음을 나타낸다."""
 
 
+class PublishError(BuildError):
+    """산출물 게시(복사/업로드/등록)가 실패했음을 나타낸다."""
+
+
 __all__ = [
     "AssemblyError",
     "BuildError",
     "ExecutionError",
     "ExportError",
     "ManifestError",
+    "PublishError",
     "SpecLoadError",
     "ValidationError",
 ]

--- a/src/kpubdata_builder/publishers/__init__.py
+++ b/src/kpubdata_builder/publishers/__init__.py
@@ -1,13 +1,28 @@
-"""원격 산출물 게시 연동을 위한 게시 도구 레지스트리.
+"""산출물 게시 도구 레지스트리 (#28).
 
-현재는 구체 구현이 없지만, 향후 HuggingFace나 GitHub 같은 원격 대상에
-게시할 구현체를 이 레지스트리로 연결할 예정이다.
+Exporter가 생성한 파일을 외부/로컬 destination에 등록·업로드하는 publisher를
+kind 문자열로 찾을 수 있게 한다. HuggingFace/GitHub 등 원격 대상은 후속
+이슈에서 추가한다.
+
+주요 구성:
+    - PublishResult: 게시 결과 메타데이터
+    - BasePublisher: publisher 추상 기반 클래스
+    - LocalPublisher: 로컬 레지스트리 등록 publisher
+    - PUBLISHER_REGISTRY: name -> publisher 인스턴스 매핑
 """
 
 from __future__ import annotations
 
-from .base import BasePublisher
+from .base import BasePublisher, PublishResult
+from .local import LocalPublisher
 
-PUBLISHER_REGISTRY: dict[str, BasePublisher] = {}
+PUBLISHER_REGISTRY: dict[str, BasePublisher] = {
+    "local": LocalPublisher(),
+}
 
-__all__ = ["BasePublisher", "PUBLISHER_REGISTRY"]
+__all__ = [
+    "PUBLISHER_REGISTRY",
+    "BasePublisher",
+    "LocalPublisher",
+    "PublishResult",
+]

--- a/src/kpubdata_builder/publishers/base.py
+++ b/src/kpubdata_builder/publishers/base.py
@@ -1,19 +1,47 @@
-"""원격 산출물 게시를 위한 기본 게시 도구 계약.
+"""원격/로컬 산출물 게시를 위한 기본 게시 도구 계약 (#28).
 
-이 모듈은 빌드가 생성한 파일 묶음을 외부 대상에 전송하는 publisher 구현이
-따라야 할 최소 인터페이스를 정의한다.
+Exporter / Publisher 책임 경계:
+    - Exporter: 파일 또는 구조를 **생성**한다 (kpubdata_builder.exporters).
+    - Publisher: 생성된 산출물을 외부/로컬 destination에 **업로드/등록**한다.
+
+이 모듈은 publisher 구현이 따라야 할 최소 인터페이스와, 게시 결과를 보고하는
+PublishResult 값 객체를 정의한다.
+
+주요 구성:
+    - PublishResult: 게시 결과 메타데이터
+    - BasePublisher: publisher 추상 기반 클래스
 """
 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from pathlib import Path
+
+
+@dataclass(frozen=True)
+class PublishResult:
+    """게시 결과 메타데이터.
+
+    속성:
+        publisher: 게시를 수행한 publisher 식별자.
+        reference: 게시 위치 참조 (로컬 경로, URL, 레지스트리 ID 등).
+        artifact_count: 게시된 산출물 개수.
+        status: 게시 상태 ("ok" 등).
+    """
+
+    publisher: str
+    reference: str
+    artifact_count: int
+    status: str = "ok"
 
 
 class BasePublisher(ABC):
     """게시 백엔드를 위한 추상 인터페이스.
 
-    구현체는 name 식별자와 publish 메서드를 제공해야 한다.
+    구현체는 name 식별자와 publish 메서드를 제공해야 한다. publish는 파일을
+    생성하지 않으며(그것은 Exporter의 책임), 이미 생성된 산출물 경로를 받아
+    destination에 등록/업로드하고 PublishResult를 반환한다.
     """
 
     @property
@@ -22,9 +50,16 @@ class BasePublisher(ABC):
         """게시 도구 식별자를 반환한다."""
 
     @abstractmethod
-    def publish(self, artifact_paths: tuple[Path, ...]) -> None:
-        """생성된 산출물 경로를 설정된 대상에 게시한다.
+    def publish(self, artifact_paths: tuple[Path, ...], *, destination: str) -> PublishResult:
+        """생성된 산출물 경로를 지정한 destination에 게시한다.
 
         매개변수:
             artifact_paths: 게시 대상 파일 경로 튜플.
+            destination: 게시 대상 식별자 (로컬 경로, 원격 repo id 등).
+
+        반환값:
+            PublishResult: 게시 결과 메타데이터.
         """
+
+
+__all__ = ["BasePublisher", "PublishResult"]

--- a/src/kpubdata_builder/publishers/local.py
+++ b/src/kpubdata_builder/publishers/local.py
@@ -1,0 +1,47 @@
+"""로컬 파일시스템 게시 도구 (#28).
+
+생성된 산출물 파일을 로컬 레지스트리 디렉터리로 복사하여 등록한다. 원격
+업로드 없이 Exporter/Publisher 경계를 검증할 수 있는 가장 단순한 publisher다.
+
+주요 구성:
+    - LocalPublisher: 로컬 디렉터리 등록 publisher
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from .base import BasePublisher, PublishResult
+
+
+class LocalPublisher(BasePublisher):
+    """산출물을 로컬 레지스트리 디렉터리로 복사·등록하는 publisher."""
+
+    @property
+    def name(self) -> str:
+        """게시 도구 식별자."""
+        return "local"
+
+    def publish(self, artifact_paths: tuple[Path, ...], *, destination: str) -> PublishResult:
+        """산출물 파일을 destination 디렉터리로 복사하고 결과를 반환한다.
+
+        매개변수:
+            artifact_paths: 복사할 산출물 파일 경로.
+            destination: 대상 로컬 디렉터리 경로.
+
+        반환값:
+            PublishResult: 게시 위치와 개수.
+        """
+        dest_dir = Path(destination)
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        for path in artifact_paths:
+            _ = shutil.copy2(path, dest_dir / path.name)
+        return PublishResult(
+            publisher=self.name,
+            reference=str(dest_dir),
+            artifact_count=len(artifact_paths),
+        )
+
+
+__all__ = ["LocalPublisher"]

--- a/src/kpubdata_builder/publishers/local.py
+++ b/src/kpubdata_builder/publishers/local.py
@@ -12,11 +12,20 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 
+from ..errors import PublishError
 from .base import BasePublisher, PublishResult
 
 
 class LocalPublisher(BasePublisher):
-    """산출물을 로컬 레지스트리 디렉터리로 복사·등록하는 publisher."""
+    """산출물을 로컬 레지스트리 디렉터리로 복사·등록하는 publisher.
+
+    실패 정책:
+        - 디렉터리 artifact는 명시적으로 거부한다(`PublishError`). 디렉터리 레이아웃
+          게시는 별도 publisher의 책임이며, 여기서 무음 복사 형태로 지원하지 않는다.
+        - 서로 다른 경로지만 basename이 충돌하는 artifact는 거부한다 — 데이터 손실을
+          막기 위한 명시적 실패를 선택한다.
+        - copy 자체가 실패하면 `OSError`를 `PublishError`로 감싸 전파한다.
+    """
 
     @property
     def name(self) -> str:
@@ -32,11 +41,36 @@ class LocalPublisher(BasePublisher):
 
         반환값:
             PublishResult: 게시 위치와 개수.
+
+        예외:
+            PublishError: 디렉터리 artifact / basename 충돌 / 복사 I/O 실패.
         """
+        # 디렉터리 거부: shutil.copy2는 디렉터리를 다루지 못하므로 사전에 명확한 에러를 던진다.
+        directories = [p for p in artifact_paths if p.is_dir()]
+        if directories:
+            offenders = ", ".join(str(p) for p in directories)
+            raise PublishError(
+                f"directory artifacts are not supported by LocalPublisher: {offenders}"
+            )
+
+        # basename 충돌 거부: flat copy 정책에서 같은 이름이면 한쪽이 묻히므로 명시적으로 실패.
+        names: dict[str, Path] = {}
+        for path in artifact_paths:
+            existing = names.get(path.name)
+            if existing is not None and existing != path:
+                raise PublishError(
+                    f"duplicate artifact basename {path.name!r}: "
+                    f"{existing} and {path} cannot share the destination directory"
+                )
+            names[path.name] = path
+
         dest_dir = Path(destination)
         dest_dir.mkdir(parents=True, exist_ok=True)
         for path in artifact_paths:
-            _ = shutil.copy2(path, dest_dir / path.name)
+            try:
+                _ = shutil.copy2(path, dest_dir / path.name)
+            except OSError as exc:
+                raise PublishError(f"failed to copy {path} → {dest_dir}: {exc}") from exc
         return PublishResult(
             publisher=self.name,
             reference=str(dest_dir),

--- a/tests/unit/test_publishers.py
+++ b/tests/unit/test_publishers.py
@@ -1,0 +1,53 @@
+"""Publisher 경계(#28): PublishResult 계약과 LocalPublisher 등록 동작 검증."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kpubdata_builder.publishers import (
+    PUBLISHER_REGISTRY,
+    BasePublisher,
+    LocalPublisher,
+    PublishResult,
+)
+
+
+def _make_artifacts(tmp_path: Path) -> tuple[Path, ...]:
+    a = tmp_path / "a.jsonl"
+    b = tmp_path / "b.md"
+    _ = a.write_text("{}\n", encoding="utf-8")
+    _ = b.write_text("# title\n", encoding="utf-8")
+    return (a, b)
+
+
+class TestLocalPublisher:
+    def test_is_a_base_publisher_named_local(self) -> None:
+        publisher = LocalPublisher()
+        assert isinstance(publisher, BasePublisher)
+        assert publisher.name == "local"
+
+    def test_copies_artifacts_into_destination_and_reports(self, tmp_path: Path) -> None:
+        artifacts = _make_artifacts(tmp_path)
+        destination = tmp_path / "registry" / "dataset-v1"
+
+        result = LocalPublisher().publish(artifacts, destination=str(destination))
+
+        assert isinstance(result, PublishResult)
+        assert result.publisher == "local"
+        assert result.status == "ok"
+        assert result.artifact_count == 2
+        assert (destination / "a.jsonl").exists()
+        assert (destination / "b.md").exists()
+        assert result.reference == str(destination)
+
+    def test_registered_in_publisher_registry(self) -> None:
+        assert "local" in PUBLISHER_REGISTRY
+        assert isinstance(PUBLISHER_REGISTRY["local"], LocalPublisher)
+
+
+def test_publish_result_is_immutable() -> None:
+    result = PublishResult(publisher="local", reference="/tmp/x", artifact_count=1)
+    with pytest.raises(AttributeError):
+        result.publisher = "other"  # type: ignore[misc]

--- a/tests/unit/test_publishers.py
+++ b/tests/unit/test_publishers.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from kpubdata_builder.errors import PublishError
 from kpubdata_builder.publishers import (
     PUBLISHER_REGISTRY,
     BasePublisher,
@@ -51,3 +52,42 @@ def test_publish_result_is_immutable() -> None:
     result = PublishResult(publisher="local", reference="/tmp/x", artifact_count=1)
     with pytest.raises(AttributeError):
         result.publisher = "other"  # type: ignore[misc]
+
+
+class TestLocalPublisherFailurePolicy:
+    def test_rejects_duplicate_basenames(self, tmp_path: Path) -> None:
+        # 서로 다른 디렉터리의 동일 이름 파일 두 개는 flat copy에서 한쪽을 덮어쓰므로 거부.
+        d1 = tmp_path / "a"
+        d2 = tmp_path / "b"
+        d1.mkdir()
+        d2.mkdir()
+        f1 = d1 / "data.jsonl"
+        f2 = d2 / "data.jsonl"
+        _ = f1.write_text("{}\n", encoding="utf-8")
+        _ = f2.write_text("{}\n", encoding="utf-8")
+
+        with pytest.raises(PublishError, match="duplicate artifact basename"):
+            LocalPublisher().publish((f1, f2), destination=str(tmp_path / "registry"))
+
+    def test_rejects_directory_artifacts(self, tmp_path: Path) -> None:
+        # 디렉터리는 shutil.copy2가 다룰 수 없으므로 명시적으로 거부.
+        dir_artifact = tmp_path / "hf_layout"
+        dir_artifact.mkdir()
+
+        with pytest.raises(PublishError, match="directory artifacts"):
+            LocalPublisher().publish((dir_artifact,), destination=str(tmp_path / "registry"))
+
+    def test_wraps_copy_failures_in_publish_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # shutil.copy2가 OSError를 던지면 PublishError로 감싸 전파해야 한다.
+        artifact = tmp_path / "data.jsonl"
+        _ = artifact.write_text("{}\n", encoding="utf-8")
+
+        def _boom(src: object, dst: object) -> None:
+            raise PermissionError("read-only filesystem")
+
+        monkeypatch.setattr("kpubdata_builder.publishers.local.shutil.copy2", _boom)
+
+        with pytest.raises(PublishError, match="failed to copy"):
+            LocalPublisher().publish((artifact,), destination=str(tmp_path / "registry"))


### PR DESCRIPTION
## 개요
issue #28 — export(파일 생성)와 publish(등록/업로드) 책임 경계를 계약으로 명확히 하고, 첫 구체 publisher로 경계를 시연합니다.

> ⚠️ 스택 PR (…#98(#4)→#99(#3) 위). 선행 PR 순서대로 머지 후 rebase하면 이 커밋만 남습니다.

## 경계 정의
| 계층 | 책임 |
|---|---|
| **Exporter** (`exporters/`) | 파일/구조 **생성** (`export()→ExportResult`) |
| **Publisher** (`publishers/`) | 생성된 산출물을 destination에 **등록/업로드** (`publish()→PublishResult`) |

## 변경 사항 (`publishers/`)
- `base.py`: **`PublishResult`** 모델 추가, `BasePublisher.publish`가 `PublishResult` 반환(기존 `None`) + `destination` 인자 + 경계 문서화
- `local.py`: **`LocalPublisher`** — 산출물을 로컬 레지스트리 디렉터리로 복사·등록 (원격 의존성 없음, 권장 구조의 `local_registry`)
- `PUBLISHER_REGISTRY = {"local": LocalPublisher()}` (기존 빈 레지스트리 채움)

## 범위 메모
- manifest의 publish 결과 기록 + 파이프라인 publish 연결은 **stage-aware exporter(Export 단계) 연결과 함께 후속**에서 다룹니다. 본 PR은 경계 계약 + 첫 publisher 확립에 집중합니다.
- HuggingFace/GitHub publisher는 후속 이슈(#10 등).

## 테스트 (TDD)
- 신규 `tests/unit/test_publishers.py` 4건 **선작성(red)** 후 구현(green) — LocalPublisher 복사/결과, 레지스트리 등록, PublishResult 불변성

## 품질 게이트
- ✅ `pytest tests/unit` — **141 passed**
- ✅ `mypy src` — no issues (49 files)
- ✅ `ruff check .` / `ruff format --check .` — clean

Closes #28