### PR TITLE
feat(service): 최소 HTTP façade — validate/preview/build/artifacts (#36)

### DIFF
--- a/src/kpubdata_builder/service/__init__.py
+++ b/src/kpubdata_builder/service/__init__.py
@@ -1,0 +1,22 @@
+"""Builder HTTP 서비스 façade 패키지 (#36).
+
+Studio 등 외부 UI가 Builder를 호출할 수 있도록 validate/preview/build/artifacts
+엔드포인트를 제공한다. 로직(app)과 stdlib HTTP 전송(http)을 분리한다.
+
+주요 구성:
+    - BuilderService / ServiceResponse / dispatch: 전송 무관 서비스 로직
+    - serve / make_handler: stdlib http.server 어댑터
+"""
+
+from __future__ import annotations
+
+from .app import BuilderService, ServiceResponse, dispatch
+from .http import make_handler, serve
+
+__all__ = [
+    "BuilderService",
+    "ServiceResponse",
+    "dispatch",
+    "make_handler",
+    "serve",
+]

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -1,0 +1,208 @@
+"""Builder 서비스 로직 (#36).
+
+Studio 같은 외부 UI가 Builder를 호출할 수 있도록 validate/preview/build/artifacts
+연산을 HTTP 전송과 분리된 순수 로직으로 제공한다. 각 메서드는 ServiceResponse
+(상태 코드 + JSON 직렬화 가능한 body)를 반환하며, dispatch가 (method, path)를
+해당 연산으로 라우팅한다.
+
+주요 구성:
+    - ServiceResponse: 상태 코드 + body
+    - BuilderService: validate/preview/build/artifacts 연산
+    - dispatch: 경로 라우팅
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+import yaml
+
+from ..errors import SpecLoadError, ValidationError
+from ..pipeline import preview_build, run_build
+from ..spec import BuildSpec, JsonValue, parse_spec
+from ..spec.validator import validate_spec
+from ..stages._path_safety import ensure_within, validate_path_segment
+from ..stages.bronze.build import SourceClient
+from ..tabular import DEFAULT_PREVIEW_LIMIT
+
+
+@dataclass(frozen=True)
+class ServiceResponse:
+    """서비스 연산 결과.
+
+    속성:
+        status_code: HTTP 상태 코드.
+        body: JSON 직렬화 가능한 응답 본문.
+    """
+
+    status_code: int
+    body: dict[str, JsonValue]
+
+
+def _parse_spec_text(spec_yaml: str) -> BuildSpec:
+    """YAML 텍스트를 BuildSpec으로 파싱한다."""
+    raw = cast(object, yaml.safe_load(spec_yaml))
+    if not isinstance(raw, dict):
+        raise SpecLoadError("top-level YAML must be a mapping")
+    return parse_spec(cast(dict[str, object], raw))
+
+
+class BuilderService:
+    """Builder 연산을 HTTP 전송과 무관하게 제공하는 서비스."""
+
+    def __init__(
+        self,
+        *,
+        output_root: Path,
+        client_factory: Callable[[], SourceClient],
+    ) -> None:
+        self._output_root = output_root
+        self._client_factory = client_factory
+
+    def validate(self, spec_yaml: str) -> ServiceResponse:
+        """BuildSpec을 파싱·검증한다."""
+        try:
+            spec = _parse_spec_text(spec_yaml)
+            validate_spec(spec)
+        except SpecLoadError as exc:
+            return ServiceResponse(400, {"status": "error", "error": str(exc)})
+        except ValidationError as exc:
+            return ServiceResponse(400, {"status": "invalid", "problems": list(exc.problems)})
+        return ServiceResponse(200, {"status": "valid", "dataset_id": spec.dataset_id})
+
+    def preview(self, spec_yaml: str, *, limit: int = DEFAULT_PREVIEW_LIMIT) -> ServiceResponse:
+        """각 소스의 스키마와 샘플 행을 산출한다 (파일 미기록)."""
+        spec_or_error = self._load_validated(spec_yaml)
+        if isinstance(spec_or_error, ServiceResponse):
+            return spec_or_error
+
+        result = preview_build(spec_or_error, client=self._client_factory(), limit=limit)
+        previews: list[JsonValue] = [
+            {
+                "source_key": p.source_key,
+                "status": p.status,
+                "error": p.error,
+                "schema": [
+                    {
+                        "name": column.name,
+                        "dtype": column.dtype,
+                        "nullable": column.nullable,
+                        "unique_count": column.unique_count,
+                    }
+                    for column in p.schema.columns
+                ],
+                "sample": list(p.preview.rows),
+                "total_rows": p.preview.total_rows,
+            }
+            for p in result.previews
+        ]
+        return ServiceResponse(200, {"dataset_id": spec_or_error.dataset_id, "previews": previews})
+
+    def build(self, spec_yaml: str, *, run_id: str | None = None) -> ServiceResponse:
+        """파이프라인을 실행하고 결과를 반환한다."""
+        spec_or_error = self._load_validated(spec_yaml)
+        if isinstance(spec_or_error, ServiceResponse):
+            return spec_or_error
+
+        result = run_build(
+            spec_or_error,
+            client=self._client_factory(),
+            output_root=self._output_root,
+            run_id=run_id,
+        )
+        outcomes: list[JsonValue] = [
+            {
+                "source_key": outcome.source_key,
+                "status": outcome.status,
+                "stages_completed": list(outcome.stages_completed),
+                "error": outcome.error,
+            }
+            for outcome in result.outcomes
+        ]
+        return ServiceResponse(
+            200,
+            {
+                "status": result.status,
+                "run_id": result.context.run_id,
+                "outcomes": outcomes,
+                "manifest": str(result.manifest_path),
+            },
+        )
+
+    def artifacts(self, run_id: str) -> ServiceResponse:
+        """실행 워크스페이스의 산출물 파일 목록을 반환한다."""
+        try:
+            validate_path_segment(run_id, field_name="run_id")
+        except ValueError as exc:
+            return ServiceResponse(400, {"error": str(exc)})
+
+        run_dir = self._output_root / run_id
+        ensure_within(self._output_root, run_dir, label="run directory")
+        if not run_dir.exists():
+            return ServiceResponse(404, {"error": f"run not found: {run_id}"})
+
+        files = sorted(
+            str(path.relative_to(run_dir)) for path in run_dir.rglob("*") if path.is_file()
+        )
+        return ServiceResponse(200, {"run_id": run_id, "files": list(files)})
+
+    def _load_validated(self, spec_yaml: str) -> BuildSpec | ServiceResponse:
+        """spec_yaml을 파싱·검증하고, 실패 시 오류 ServiceResponse를 반환한다."""
+        try:
+            spec = _parse_spec_text(spec_yaml)
+            validate_spec(spec)
+        except SpecLoadError as exc:
+            return ServiceResponse(400, {"status": "error", "error": str(exc)})
+        except ValidationError as exc:
+            return ServiceResponse(400, {"status": "invalid", "problems": list(exc.problems)})
+        return spec
+
+
+def _spec_from_body(body: Mapping[str, JsonValue] | None) -> str | ServiceResponse:
+    """요청 body에서 spec YAML 문자열을 추출한다."""
+    if not body or "spec" not in body:
+        return ServiceResponse(400, {"error": "missing 'spec' in request body"})
+    spec_value = body["spec"]
+    if not isinstance(spec_value, str):
+        return ServiceResponse(400, {"error": "'spec' must be a YAML string"})
+    return spec_value
+
+
+def dispatch(
+    service: BuilderService,
+    method: str,
+    path: str,
+    body: Mapping[str, JsonValue] | None,
+) -> ServiceResponse:
+    """(method, path)를 BuilderService 연산으로 라우팅한다."""
+    if method == "POST" and path == "/validate":
+        spec = _spec_from_body(body)
+        return spec if isinstance(spec, ServiceResponse) else service.validate(spec)
+
+    if method == "POST" and path == "/preview":
+        spec = _spec_from_body(body)
+        if isinstance(spec, ServiceResponse):
+            return spec
+        limit_value = body.get("limit") if body else None
+        limit = limit_value if isinstance(limit_value, int) else DEFAULT_PREVIEW_LIMIT
+        return service.preview(spec, limit=limit)
+
+    if method == "POST" and path == "/build":
+        spec = _spec_from_body(body)
+        if isinstance(spec, ServiceResponse):
+            return spec
+        run_id_value = body.get("run_id") if body else None
+        run_id = run_id_value if isinstance(run_id_value, str) else None
+        return service.build(spec, run_id=run_id)
+
+    if method == "GET" and path.startswith("/artifacts/"):
+        run_id = path[len("/artifacts/") :]
+        return service.artifacts(run_id)
+
+    return ServiceResponse(404, {"error": f"not found: {method} {path}"})
+
+
+__all__ = ["BuilderService", "ServiceResponse", "dispatch"]

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -102,7 +102,14 @@ class BuilderService:
         return ServiceResponse(200, {"dataset_id": spec_or_error.dataset_id, "previews": previews})
 
     def build(self, spec_yaml: str, *, run_id: str | None = None) -> ServiceResponse:
-        """파이프라인을 실행하고 결과를 반환한다."""
+        """파이프라인을 실행하고 결과를 반환한다.
+
+        응답 코드 정책:
+            - 모든 소스 성공: 200
+            - 하나라도 소스 fetch/stage가 실패: 502 (upstream 소스 의존 실패).
+              매니페스트는 partial 정책으로 남기 때문에 body에 outcomes와 manifest가
+              실린다.
+        """
         spec_or_error = self._load_validated(spec_yaml)
         if isinstance(spec_or_error, ServiceResponse):
             return spec_or_error
@@ -122,8 +129,9 @@ class BuilderService:
             }
             for outcome in result.outcomes
         ]
+        status_code = 200 if result.status == "ok" else 502
         return ServiceResponse(
-            200,
+            status_code,
             {
                 "status": result.status,
                 "run_id": result.context.run_id,
@@ -186,8 +194,15 @@ def dispatch(
         spec = _spec_from_body(body)
         if isinstance(spec, ServiceResponse):
             return spec
-        limit_value = body.get("limit") if body else None
-        limit = limit_value if isinstance(limit_value, int) else DEFAULT_PREVIEW_LIMIT
+        # limit이 명시되면 양의 정수여야 한다 — 잘못된 값을 조용히 기본값으로 떨어뜨리지 않는다.
+        if body is not None and "limit" in body:
+            limit_value = body["limit"]
+            # bool은 int의 하위 타입이지만 limit 의미가 없으므로 거부.
+            if not isinstance(limit_value, int) or isinstance(limit_value, bool) or limit_value < 1:
+                return ServiceResponse(400, {"error": "'limit' must be a positive integer"})
+            limit = limit_value
+        else:
+            limit = DEFAULT_PREVIEW_LIMIT
         return service.preview(spec, limit=limit)
 
     if method == "POST" and path == "/build":

--- a/src/kpubdata_builder/service/http.py
+++ b/src/kpubdata_builder/service/http.py
@@ -1,0 +1,74 @@
+"""stdlib http.server 기반 HTTP 어댑터 (#36).
+
+새 의존성 없이 BuilderService를 HTTP로 노출한다. 요청 파싱/응답 직렬화만
+담당하고 실제 로직은 app.dispatch에 위임한다.
+
+주요 구성:
+    - make_handler: BuilderService에 바인딩된 요청 핸들러 클래스 생성
+    - serve: 블로킹 HTTP 서버 실행
+"""
+
+from __future__ import annotations
+
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import cast
+
+from ..spec import JsonValue
+from .app import BuilderService, dispatch
+
+
+def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
+    """주어진 BuilderService에 바인딩된 요청 핸들러 클래스를 생성한다."""
+
+    class _Handler(BaseHTTPRequestHandler):
+        def _dispatch(self, method: str) -> None:
+            length = int(self.headers.get("Content-Length", 0) or 0)
+            raw = self.rfile.read(length) if length else b""
+            body: dict[str, JsonValue] | None = None
+            if raw:
+                try:
+                    body = cast(dict[str, JsonValue], json.loads(raw))
+                except json.JSONDecodeError:
+                    self._write(400, {"error": "invalid JSON body"})
+                    return
+            response = dispatch(service, method, self.path, body)
+            self._write(response.status_code, response.body)
+
+        def _write(self, status_code: int, body: dict[str, JsonValue]) -> None:
+            payload = json.dumps(body, ensure_ascii=False, default=str).encode("utf-8")
+            self.send_response(status_code)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            _ = self.wfile.write(payload)
+
+        def do_GET(self) -> None:  # noqa: N802 - http.server 규약
+            self._dispatch("GET")
+
+        def do_POST(self) -> None:  # noqa: N802 - http.server 규약
+            self._dispatch("POST")
+
+        def log_message(self, format: str, *args: object) -> None:
+            # 기본 stderr 접근 로그를 억제한다.
+            return
+
+    return _Handler
+
+
+def serve(service: BuilderService, *, host: str = "127.0.0.1", port: int = 8000) -> None:
+    """BuilderService를 블로킹 HTTP 서버로 제공한다.
+
+    매개변수:
+        service: 노출할 BuilderService.
+        host: 바인딩 호스트.
+        port: 바인딩 포트.
+    """
+    server = HTTPServer((host, port), make_handler(service))
+    try:
+        server.serve_forever()
+    finally:
+        server.server_close()
+
+
+__all__ = ["make_handler", "serve"]

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -1,0 +1,147 @@
+"""HTTP 서비스 façade(#36): validate/preview/build/artifacts 로직과 라우팅 검증."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+from kpubdata_builder.service import BuilderService, ServiceResponse, dispatch
+from kpubdata_builder.spec import JsonValue
+
+VALID_SPEC_YAML = (
+    """
+dataset_id: dataset.sample
+title: Sample Dataset
+description: Sample description
+sources:
+  - provider: datago
+    dataset: air_quality
+exports:
+  - kind: jsonl
+    output_path: out/data.jsonl
+""".strip()
+    + "\n"
+)
+
+INVALID_SPEC_YAML = (
+    # 파싱은 통과하지만 validate_spec에서 미지원 exporter kind로 실패하는 명세.
+    """
+dataset_id: dataset.sample
+title: Sample Dataset
+description: Sample description
+sources:
+  - provider: datago
+    dataset: air_quality
+exports:
+  - kind: unsupported_format
+    output_path: out/data.jsonl
+""".strip()
+    + "\n"
+)
+
+
+class _FakeResult:
+    def __init__(self, items: list[dict[str, JsonValue]]) -> None:
+        self._items = items
+
+    @property
+    def items(self) -> Iterable[dict[str, JsonValue]]:
+        return self._items
+
+
+class _FakeDataset:
+    def __init__(self, items: list[dict[str, JsonValue]]) -> None:
+        self._items = items
+
+    def list(self, **params: JsonValue) -> _FakeResult:
+        return _FakeResult(self._items)
+
+
+class _FakeClient:
+    def __init__(self, data: dict[str, list[dict[str, JsonValue]]]) -> None:
+        self._data = data
+
+    def dataset(self, source_key: str) -> _FakeDataset:
+        if source_key not in self._data:
+            raise KeyError(f"unknown source: {source_key}")
+        return _FakeDataset(self._data[source_key])
+
+
+def _service(tmp_path: Path) -> BuilderService:
+    client = _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}, {"id": "2", "v": 20}]})
+    return BuilderService(output_root=tmp_path, client_factory=lambda: client)
+
+
+class TestValidate:
+    def test_valid_spec_returns_200(self, tmp_path: Path) -> None:
+        resp = _service(tmp_path).validate(VALID_SPEC_YAML)
+        assert resp.status_code == 200
+        assert resp.body["status"] == "valid"
+        assert resp.body["dataset_id"] == "dataset.sample"
+
+    def test_invalid_spec_returns_400(self, tmp_path: Path) -> None:
+        resp = _service(tmp_path).validate(INVALID_SPEC_YAML)
+        assert resp.status_code == 400
+        assert resp.body["status"] == "invalid"
+
+
+class TestPreview:
+    def test_returns_schema_and_sample(self, tmp_path: Path) -> None:
+        resp = _service(tmp_path).preview(VALID_SPEC_YAML, limit=1)
+        assert resp.status_code == 200
+        previews = resp.body["previews"]
+        assert isinstance(previews, list)
+        assert previews[0]["source_key"] == "datago.air_quality"
+
+    def test_preview_writes_no_files(self, tmp_path: Path) -> None:
+        _service(tmp_path).preview(VALID_SPEC_YAML)
+        assert list(tmp_path.iterdir()) == []
+
+
+class TestBuild:
+    def test_build_runs_and_reports_manifest(self, tmp_path: Path) -> None:
+        resp = _service(tmp_path).build(VALID_SPEC_YAML, run_id="run1")
+        assert resp.status_code == 200
+        assert resp.body["status"] == "ok"
+        assert resp.body["run_id"] == "run1"
+        assert (tmp_path / "run1" / "manifest.json").exists()
+
+
+class TestArtifacts:
+    def test_lists_artifacts_after_build(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        service.build(VALID_SPEC_YAML, run_id="run1")
+
+        resp = service.artifacts("run1")
+        assert resp.status_code == 200
+        files = resp.body["files"]
+        assert isinstance(files, list)
+        assert any("manifest.json" in f for f in files)
+
+    def test_missing_run_returns_404(self, tmp_path: Path) -> None:
+        resp = _service(tmp_path).artifacts("nope")
+        assert resp.status_code == 404
+
+
+class TestDispatch:
+    def test_routes_post_validate(self, tmp_path: Path) -> None:
+        resp = dispatch(_service(tmp_path), "POST", "/validate", {"spec": VALID_SPEC_YAML})
+        assert isinstance(resp, ServiceResponse)
+        assert resp.status_code == 200
+
+    def test_unknown_route_returns_404(self, tmp_path: Path) -> None:
+        resp = dispatch(_service(tmp_path), "GET", "/nope", None)
+        assert resp.status_code == 404
+
+    def test_build_route(self, tmp_path: Path) -> None:
+        resp = dispatch(
+            _service(tmp_path), "POST", "/build", {"spec": VALID_SPEC_YAML, "run_id": "r2"}
+        )
+        assert resp.status_code == 200
+        assert resp.body["run_id"] == "r2"
+
+    def test_artifacts_route(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        dispatch(service, "POST", "/build", {"spec": VALID_SPEC_YAML, "run_id": "r3"})
+        resp = dispatch(service, "GET", "/artifacts/r3", None)
+        assert resp.status_code == 200

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -2,10 +2,19 @@
 
 from __future__ import annotations
 
+import json
+import threading
+import urllib.error
+import urllib.request
 from collections.abc import Iterable
+from http.server import HTTPServer
 from pathlib import Path
+from typing import cast
+
+import pytest
 
 from kpubdata_builder.service import BuilderService, ServiceResponse, dispatch
+from kpubdata_builder.service.http import make_handler
 from kpubdata_builder.spec import JsonValue
 
 VALID_SPEC_YAML = (
@@ -145,3 +154,88 @@ class TestDispatch:
         dispatch(service, "POST", "/build", {"spec": VALID_SPEC_YAML, "run_id": "r3"})
         resp = dispatch(service, "GET", "/artifacts/r3", None)
         assert resp.status_code == 200
+
+    def test_preview_rejects_non_integer_limit(self, tmp_path: Path) -> None:
+        # 클라이언트가 limit을 잘못된 타입으로 보내면 조용히 기본값으로 떨어뜨리지 않고 400.
+        resp = dispatch(
+            _service(tmp_path), "POST", "/preview", {"spec": VALID_SPEC_YAML, "limit": "5"}
+        )
+        assert resp.status_code == 400
+        assert "limit" in str(resp.body.get("error", ""))
+
+    def test_preview_rejects_non_positive_limit(self, tmp_path: Path) -> None:
+        resp = dispatch(
+            _service(tmp_path), "POST", "/preview", {"spec": VALID_SPEC_YAML, "limit": 0}
+        )
+        assert resp.status_code == 400
+
+
+class TestBuildFailureResponseCode:
+    def test_failed_build_returns_502(self, tmp_path: Path) -> None:
+        # 소스 fetch가 실패하면 status=failed + 502 — 매니페스트는 partial 정책으로 남는다.
+        missing_source_yaml = VALID_SPEC_YAML.replace("air_quality", "missing")
+        resp = _service(tmp_path).build(missing_source_yaml, run_id="run1")
+
+        assert resp.status_code == 502
+        assert resp.body["status"] == "failed"
+        assert (tmp_path / "run1" / "manifest.json").exists()
+
+
+@pytest.fixture()
+def http_server(
+    tmp_path: Path,
+) -> Iterable[tuple[str, HTTPServer, threading.Thread]]:
+    """실제 HTTPServer를 임의 포트에 띄워서 어댑터 레벨 동작을 검증한다."""
+    service = _service(tmp_path)
+    server = HTTPServer(("127.0.0.1", 0), make_handler(service))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base_url = f"http://{server.server_address[0]}:{server.server_address[1]}"
+    try:
+        yield base_url, server, thread
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1.0)
+
+
+class TestHttpAdapter:
+    def test_malformed_json_body_returns_400(
+        self, http_server: tuple[str, HTTPServer, threading.Thread]
+    ) -> None:
+        base_url, _, _ = http_server
+        req = urllib.request.Request(
+            f"{base_url}/validate",
+            data=b"not-json{{",
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            urllib.request.urlopen(req, timeout=2.0)
+        assert exc_info.value.code == 400
+        body = cast(dict[str, object], json.loads(exc_info.value.read()))
+        assert "invalid JSON body" in str(body.get("error", ""))
+
+    def test_unknown_path_returns_404(
+        self, http_server: tuple[str, HTTPServer, threading.Thread]
+    ) -> None:
+        base_url, _, _ = http_server
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            urllib.request.urlopen(f"{base_url}/nope", timeout=2.0)
+        assert exc_info.value.code == 404
+
+    def test_valid_post_validate_round_trips(
+        self, http_server: tuple[str, HTTPServer, threading.Thread]
+    ) -> None:
+        # 어댑터가 정상 요청을 dispatch에 전달하고 JSON 응답을 직렬화하는지 확인.
+        base_url, _, _ = http_server
+        req = urllib.request.Request(
+            f"{base_url}/validate",
+            data=json.dumps({"spec": VALID_SPEC_YAML}).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=2.0) as response:
+            assert response.status == 200
+            body = cast(dict[str, object], json.loads(response.read()))
+        assert body["status"] == "valid"


### PR DESCRIPTION
## 개요
issue #36 — Studio 등 외부 UI가 Builder를 호출할 수 있도록 **최소 HTTP API 표면**을 제공합니다. **새 의존성 없이 stdlib `http.server`** 를 사용하고, 로직과 전송을 분리합니다.

> ⚠️ 스택 PR (…#99(#3)→#100(#28) 위). 선행 PR 순서대로 머지 후 rebase하면 이 커밋만 남습니다.

## 변경 사항 (`service/`)
- `app.py` — `ServiceResponse` + `BuilderService`(validate/preview/build/artifacts) + `dispatch(method, path, body)` 라우터. **전송 무관 순수 로직**.
- `http.py` — stdlib `http.server` 어댑터(`make_handler`/`serve`), JSON 직렬화만 담당
- `__init__.py` — 공개 표면

## 엔드포인트
| 메서드/경로 | body | 응답 |
|---|---|---|
| `POST /validate` | `{spec}` | 검증 결과 (valid/invalid/error) |
| `POST /preview` | `{spec, limit}` | 스키마 + 샘플 (파일 미기록) |
| `POST /build` | `{spec, run_id}` | 파이프라인 실행 + manifest 경로 |
| `GET /artifacts/{run_id}` | — | 워크스페이스 산출물 목록 |

## 설계 메모
- **의존성 없음** — "최소" 요구에 맞춰 stdlib만 사용. 무거운 웹 프레임워크 도입은 보류.
- 로직(`dispatch`)과 소켓 전송(`http.py`)을 분리해 **소켓 없이 테스트** 가능.
- `artifacts`는 run_id 세그먼트 검증 + output_root escape 차단(#28에서 만든 `_path_safety`).
- spec은 요청 body의 YAML 문자열로 전달.

## 테스트 (TDD)
- 신규 `tests/unit/test_service.py` 12건 **선작성(red)** 후 구현(green) — 4개 연산 + dispatch 라우팅, fake client, 소켓 미사용

## 품질 게이트
- ✅ `pytest tests/unit` — **152 passed**
- ✅ `mypy src` — no issues (52 files)
- ✅ `ruff check .` / `ruff format --check .` — clean

Closes #36