### PR TITLE
feat: Markdown exporter를 README 스타일 문서로 완성

### DIFF
--- a/src/kpubdata_builder/exporters/markdown.py
+++ b/src/kpubdata_builder/exporters/markdown.py
@@ -1,4 +1,4 @@
-"""Markdown exporter stub implementation."""
+"""Markdown exporter: render an ArtifactDataset as a human-readable document."""
 
 from __future__ import annotations
 
@@ -9,9 +9,11 @@ from ..errors import ExportError
 from ..spec import ExportTarget
 from .base import BaseExporter, ExportResult, ensure_output_dir
 
+SAMPLE_ROW_LIMIT = 5
+
 
 class MarkdownExporter(BaseExporter):
-    """Exporter that emits a simple Markdown dataset summary."""
+    """Exporter that emits a README-style Markdown summary of a dataset."""
 
     @property
     def name(self) -> str:
@@ -21,21 +23,96 @@ class MarkdownExporter(BaseExporter):
     def export(
         self, artifact: ArtifactDataset, target: ExportTarget, output_dir: Path
     ) -> ExportResult:
-        """Export artifact metadata and row count as Markdown."""
+        """Export the artifact as a human-readable Markdown document."""
         destination = ensure_output_dir(output_dir, target.output_path)
-        lines = [
-            "# Dataset Artifact",
-            "",
-            f"- Records: {len(artifact.records)}",
-            f"- Provenance entries: {len(artifact.provenance)}",
-        ]
+        content = _render_markdown(artifact)
         try:
-            _ = destination.write_text("\n".join(lines) + "\n", encoding="utf-8")
+            _ = destination.write_text(content, encoding="utf-8")
         except OSError as exc:
             raise ExportError(
                 f"Failed to export Markdown artifact to {destination}: {exc}"
             ) from exc
-
         return ExportResult(
             output_path=destination, file_size=destination.stat().st_size, format=self.name
         )
+
+
+def _render_markdown(artifact: ArtifactDataset) -> str:
+    """Assemble the Markdown document from artifact sections."""
+    lines: list[str] = []
+    lines.extend(_title_section(artifact))
+    lines.extend(_schema_section(artifact))
+    lines.extend(_sample_section(artifact))
+    lines.extend(_provenance_section(artifact))
+    return "\n".join(lines) + "\n"
+
+
+def _title_section(artifact: ArtifactDataset) -> list[str]:
+    """Title from metadata, followed by an optional description paragraph."""
+    title = artifact.metadata.get("title", "Dataset Artifact")
+    lines = [f"# {title}", ""]
+    description = artifact.metadata.get("description")
+    if description:
+        lines.extend([description, ""])
+    lines.extend([f"- Records: {len(artifact.records)}", ""])
+    return lines
+
+
+def _column_names(artifact: ArtifactDataset) -> list[str]:
+    """Schema column names, falling back to the first record's keys."""
+    if artifact.schema:
+        return list(artifact.schema.keys())
+    if artifact.records:
+        return list(artifact.records[0].keys())
+    return []
+
+
+def _schema_section(artifact: ArtifactDataset) -> list[str]:
+    """Render the schema as a Markdown table (field | type)."""
+    lines = ["## Schema", ""]
+    columns = _column_names(artifact)
+    if not columns:
+        lines.extend(["_No schema available._", ""])
+        return lines
+    lines.append("| field | type |")
+    lines.append("| --- | --- |")
+    for name in columns:
+        dtype = artifact.schema.get(name, "unknown") if artifact.schema else "unknown"
+        lines.append(f"| {name} | {dtype} |")
+    lines.append("")
+    return lines
+
+
+def _sample_section(artifact: ArtifactDataset) -> list[str]:
+    """Render up to SAMPLE_ROW_LIMIT records as a Markdown table."""
+    lines = ["## Sample Rows", ""]
+    if not artifact.records:
+        lines.extend(["_No records available._", ""])
+        return lines
+    columns = _column_names(artifact)
+    lines.append("| " + " | ".join(columns) + " |")
+    lines.append("| " + " | ".join("---" for _ in columns) + " |")
+    for record in artifact.records[:SAMPLE_ROW_LIMIT]:
+        cells = [_format_cell(record.get(col)) for col in columns]
+        lines.append("| " + " | ".join(cells) + " |")
+    lines.append("")
+    return lines
+
+
+def _provenance_section(artifact: ArtifactDataset) -> list[str]:
+    """List provenance entries (source names) as a bullet list."""
+    lines = ["## Provenance", ""]
+    if not artifact.provenance:
+        lines.extend(["_No provenance recorded._", ""])
+        return lines
+    for source in artifact.provenance:
+        lines.append(f"- {source}")
+    lines.append("")
+    return lines
+
+
+def _format_cell(value: object) -> str:
+    """Render a cell value safely for a Markdown table."""
+    if value is None:
+        return ""
+    return str(value).replace("|", "\\|").replace("\n", " ")

--- a/tests/unit/test_markdown_exporter.py
+++ b/tests/unit/test_markdown_exporter.py
@@ -1,0 +1,109 @@
+"""Tests for the Markdown exporter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kpubdata_builder.artifact import ArtifactDataset
+from kpubdata_builder.exporters.markdown import MarkdownExporter
+from kpubdata_builder.spec import ExportTarget
+
+
+def _export(artifact: ArtifactDataset, tmp_path: Path) -> str:
+    target = ExportTarget(kind="markdown", output_path="dataset.md")
+    result = MarkdownExporter().export(artifact, target, tmp_path)
+    assert result.output_path.exists()
+    assert result.format == "markdown"
+    return result.output_path.read_text(encoding="utf-8")
+
+
+def test_title_and_description_rendered(tmp_path: Path) -> None:
+    artifact = ArtifactDataset(
+        records=({"date": "2025-04-01", "temp": 15},),
+        schema={"date": "string", "temp": "int"},
+        metadata={"title": "날씨 데이터셋", "description": "기상청 API 기반 데이터셋."},
+        provenance=("datago.weather",),
+    )
+    content = _export(artifact, tmp_path)
+    assert "# 날씨 데이터셋" in content
+    assert "기상청 API 기반 데이터셋." in content
+
+
+def test_schema_table_rendered(tmp_path: Path) -> None:
+    artifact = ArtifactDataset(
+        records=({"date": "2025-04-01", "temp": 15},),
+        schema={"date": "string", "temp": "int"},
+    )
+    content = _export(artifact, tmp_path)
+    assert "## Schema" in content
+    assert "| field | type |" in content
+    assert "| date | string |" in content
+    assert "| temp | int |" in content
+
+
+def test_sample_rows_rendered(tmp_path: Path) -> None:
+    artifact = ArtifactDataset(
+        records=(
+            {"date": "2025-04-01", "sky": "맑음"},
+            {"date": "2025-04-02", "sky": "흐림"},
+        ),
+        schema={"date": "string", "sky": "string"},
+    )
+    content = _export(artifact, tmp_path)
+    assert "## Sample Rows" in content
+    assert "맑음" in content
+    assert "흐림" in content
+
+
+def test_sample_rows_limited_to_five(tmp_path: Path) -> None:
+    artifact = ArtifactDataset(
+        records=tuple({"n": i} for i in range(10)),
+        schema={"n": "int"},
+    )
+    content = _export(artifact, tmp_path)
+    sample_part = content.split("## Sample Rows")[1].split("## Provenance")[0]
+    data_rows = [
+        line
+        for line in sample_part.splitlines()
+        if line.startswith("|") and "---" not in line and "| n |" not in line
+    ]
+    assert len(data_rows) == 5
+
+
+def test_provenance_rendered(tmp_path: Path) -> None:
+    artifact = ArtifactDataset(
+        records=({"a": 1},),
+        schema={"a": "int"},
+        provenance=("datago.weather", "datago.air_quality"),
+    )
+    content = _export(artifact, tmp_path)
+    assert "## Provenance" in content
+    assert "- datago.weather" in content
+    assert "- datago.air_quality" in content
+
+
+def test_schema_falls_back_to_record_keys(tmp_path: Path) -> None:
+    artifact = ArtifactDataset(
+        records=({"city": "Seoul", "pop": 1000},),
+    )
+    content = _export(artifact, tmp_path)
+    assert "| city | unknown |" in content
+    assert "| pop | unknown |" in content
+
+
+def test_empty_dataset_does_not_break(tmp_path: Path) -> None:
+    artifact = ArtifactDataset()
+    content = _export(artifact, tmp_path)
+    assert "# Dataset Artifact" in content
+    assert "_No schema available._" in content
+    assert "_No records available._" in content
+    assert "_No provenance recorded._" in content
+
+
+def test_cell_with_pipe_is_escaped(tmp_path: Path) -> None:
+    artifact = ArtifactDataset(
+        records=({"note": "a|b"},),
+        schema={"note": "string"},
+    )
+    content = _export(artifact, tmp_path)
+    assert "a\\|b" in content


### PR DESCRIPTION
Close #5

## 개요

기존에 레코드 수만 출력하던 Markdown exporter stub를, 사람이 읽기 좋은 README 스타일 문서를 생성하도록 완성합니다. EXPORT_MODEL.md 3.1의 요구사항(데이터셋 설명, 스키마 테이블, 샘플 행, 출처 섹션)을 따릅니다.

## 구현

- **제목/설명**: `artifact.metadata`의 title·description을 사용하고, 레코드 수를 함께 표시합니다.
- **스키마 테이블**: `field | type` 형식으로 출력합니다. `artifact.schema`가 비어 있으면 첫 레코드의 키를 fallback으로 사용합니다.
- **샘플 행**: 최대 5건까지 테이블로 출력합니다. 셀 값의 `|`와 줄바꿈을 이스케이프해 테이블이 깨지지 않게 처리했습니다.
- **출처(Provenance)**: source 이름을 불릿 목록으로 표시합니다.
- **빈 데이터 방어**: records/schema/provenance가 비어 있어도 placeholder 문구로 안전하게 렌더링됩니다.

## 테스트

`tests/unit/test_markdown_exporter.py` 신규 추가 (8개):
- 제목·설명 렌더링
- 스키마 테이블 렌더링
- 샘플 행 렌더링 (한글 포함)
- 샘플 행 5건 제한
- 출처 섹션 렌더링
- schema 없을 때 레코드 키 fallback
- 빈 데이터셋에서도 형식 유지
- 셀 내 파이프 이스케이프

## 완료 조건

- [x] `uv run pytest tests/unit/test_markdown_exporter.py` 통과
- [x] `uv run mypy src` 에러 없음
- [x] `uv run ruff check .` 경고 없음
- [x] 생성된 Markdown에 schema table·sample rows·provenance section 모두 포함
- [x] 빈 데이터셋에서도 형식이 깨지지 않음