### PR TITLE
test(exporters): JSONL exporter 동작 규칙 회귀 테스트 추가 (#6)

### DIFF
--- a/tests/unit/test_jsonl_exporter.py
+++ b/tests/unit/test_jsonl_exporter.py
@@ -1,0 +1,84 @@
+"""JsonlExporter의 출력 규칙을 테스트로 고정한다.
+
+JSONL은 "한 줄 = 한 레코드"라는 계약이 핵심이므로, 줄 수·유니코드 보존·
+키 정렬·빈 데이터 정책·반환 메타데이터를 회귀 테스트로 못 박는다.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from kpubdata_builder import ArtifactDataset
+from kpubdata_builder.exporters import JsonlExporter
+from kpubdata_builder.spec import ExportTarget
+
+
+def test_each_record_is_one_json_line(tmp_path: Path) -> None:
+    # 레코드 2개면 파일도 정확히 2줄이어야 하고, 각 줄은 독립 JSON이어야 한다.
+    artifact = ArtifactDataset(records=({"id": "1"}, {"id": "2"}))
+    target = ExportTarget(kind="jsonl", output_path="out/data.jsonl")
+
+    result = JsonlExporter().export(artifact, target, tmp_path)
+
+    lines = result.output_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    assert [json.loads(line) for line in lines] == [{"id": "1"}, {"id": "2"}]
+
+
+def test_unicode_is_preserved_without_ascii_escaping(tmp_path: Path) -> None:
+    # 한글이 \uXXXX로 escape되지 않고 그대로 보존되는지 확인한다.
+    artifact = ArtifactDataset(records=({"name": "대기오염정보"},))
+    target = ExportTarget(kind="jsonl", output_path="out/data.jsonl")
+
+    result = JsonlExporter().export(artifact, target, tmp_path)
+
+    raw = result.output_path.read_text(encoding="utf-8")
+    assert "대기오염정보" in raw
+    assert "\\u" not in raw
+
+
+def test_keys_are_sorted_for_deterministic_output(tmp_path: Path) -> None:
+    # 삽입 순서와 무관하게 키가 정렬되어 결정적(deterministic) 출력이 되는지 확인한다.
+    artifact = ArtifactDataset(records=({"b": "2", "a": "1"},))
+    target = ExportTarget(kind="jsonl", output_path="out/data.jsonl")
+
+    result = JsonlExporter().export(artifact, target, tmp_path)
+
+    assert result.output_path.read_text(encoding="utf-8") == '{"a": "1", "b": "2"}\n'
+
+
+def test_non_empty_output_ends_with_single_trailing_newline(tmp_path: Path) -> None:
+    # 비어있지 않은 출력은 마지막 줄바꿈 1개로 끝나야 한다(끝에 빈 줄이 없어야 함).
+    artifact = ArtifactDataset(records=({"id": "1"},))
+    target = ExportTarget(kind="jsonl", output_path="out/data.jsonl")
+
+    result = JsonlExporter().export(artifact, target, tmp_path)
+
+    raw = result.output_path.read_text(encoding="utf-8")
+    assert raw.endswith("\n")
+    assert not raw.endswith("\n\n")
+
+
+def test_empty_records_write_empty_file(tmp_path: Path) -> None:
+    # 빈 데이터는 빈 파일(내용 없음)로 기록되는 정책을 고정한다.
+    artifact = ArtifactDataset(records=())
+    target = ExportTarget(kind="jsonl", output_path="out/data.jsonl")
+
+    result = JsonlExporter().export(artifact, target, tmp_path)
+
+    assert result.output_path.read_text(encoding="utf-8") == ""
+    assert result.file_size == 0
+
+
+def test_returns_metadata_pointing_to_created_file(tmp_path: Path) -> None:
+    # 반환된 Path가 실제로 생성된 파일을 가리키고 메타데이터가 정확한지 확인한다.
+    artifact = ArtifactDataset(records=({"id": "1"},))
+    target = ExportTarget(kind="jsonl", output_path="out/data.jsonl")
+
+    result = JsonlExporter().export(artifact, target, tmp_path)
+
+    assert result.output_path == tmp_path / "out/data.jsonl"
+    assert result.output_path.is_file()
+    assert result.file_size == result.output_path.stat().st_size
+    assert result.format == "jsonl"

--- a/tests/unit/test_jsonl_exporter.py
+++ b/tests/unit/test_jsonl_exporter.py
@@ -8,10 +8,13 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import cast
+
+import pytest
 
 from kpubdata_builder import ArtifactDataset
 from kpubdata_builder.exporters import JsonlExporter
-from kpubdata_builder.spec import ExportTarget
+from kpubdata_builder.spec import ExportTarget, JsonValue
 
 
 def test_each_record_is_one_json_line(tmp_path: Path) -> None:
@@ -82,3 +85,14 @@ def test_returns_metadata_pointing_to_created_file(tmp_path: Path) -> None:
     assert result.output_path.is_file()
     assert result.file_size == result.output_path.stat().st_size
     assert result.format == "jsonl"
+
+
+def test_non_serializable_value_surfaces_type_error(tmp_path: Path) -> None:
+    # JsonValue 밖의 직렬화 불가 값(예: set)은 json.dumps에서 TypeError로 표면화된다.
+    # write 실패의 OSError와 달리 ExportError로 감싸지 않는 경계를 명시적으로 고정한다.
+    bad_record = cast(dict[str, JsonValue], {"bad": {1, 2}})
+    artifact = ArtifactDataset(records=(bad_record,))
+    target = ExportTarget(kind="jsonl", output_path="out/data.jsonl")
+
+    with pytest.raises(TypeError):
+        JsonlExporter().export(artifact, target, tmp_path)


### PR DESCRIPTION
## 요약
이슈 #6 (`[v0.1] JSONL exporter`)을 해결합니다.

`JsonlExporter`는 이미 구현되어 있어, 이슈 가이드대로 **출력 계약을 회귀 테스트로 고정**하는 데 집중했습니다. 동작에 문제가 없어 구현 코드는 변경하지 않았습니다.

## 변경 내용
- `tests/unit/test_jsonl_exporter.py` 추가 (구현 코드 변경 없음)

## 테스트로 고정한 동작 규칙
- 레코드당 정확히 한 줄의 독립 JSON (`json.loads`로 줄 단위 파싱 검증)
- `ensure_ascii=False` 유니코드(한글) 보존, `\uXXXX` escape 없음
- `sort_keys=True` 결정적 키 정렬
- 비어있지 않은 출력은 단일 trailing newline으로 종료
- 빈 `records`는 빈 파일(크기 0)로 기록
- 반환 `ExportResult`가 실제 생성된 파일·크기·`format`을 정확히 가리킴

## 검증
- `pytest tests/unit` — 146 passed
- `mypy src` — no issues (48 files)
- `ruff check .` / `ruff format --check` — 통과

## 완료 조건 체크리스트
- [x] 각 레코드가 정확히 한 줄의 JSON으로 저장됨
- [x] 한글/유니코드가 깨지지 않고 저장됨
- [x] `pytest` / `mypy src` / `ruff check .` 통과

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)