### PR TITLE
feat(exporters): CSV exporter 추가 (#39)

### DIFF
--- a/src/kpubdata_builder/exporters/__init__.py
+++ b/src/kpubdata_builder/exporters/__init__.py
@@ -10,16 +10,19 @@
 from __future__ import annotations
 
 from .base import BaseExporter, ExportResult, ensure_output_dir
+from .csv import CsvExporter
 from .jsonl import JsonlExporter
 from .markdown import MarkdownExporter
 
 EXPORTER_REGISTRY: dict[str, BaseExporter] = {
+    "csv": CsvExporter(),
     "jsonl": JsonlExporter(),
     "markdown": MarkdownExporter(),
 }
 
 __all__ = [
     "BaseExporter",
+    "CsvExporter",
     "EXPORTER_REGISTRY",
     "ExportResult",
     "JsonlExporter",

--- a/src/kpubdata_builder/exporters/csv.py
+++ b/src/kpubdata_builder/exporters/csv.py
@@ -1,0 +1,99 @@
+"""CSV 내보내기 도구 구현.
+
+이 모듈은 ArtifactDataset의 레코드를 RFC 4180 스타일의 CSV 파일로 직렬화하는
+exporter를 제공한다. 컬럼은 artifact.schema가 있으면 그 순서를, 없으면 레코드에서
+처음 등장한 순서를 따른다. 콤마/따옴표/개행이 포함된 값은 stdlib csv가 자동으로
+인용 처리한다.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from pathlib import Path
+
+from ..artifact import ArtifactDataset
+from ..errors import ExportError
+from ..spec import ExportTarget, JsonValue
+from .base import BaseExporter, ExportResult, ensure_output_dir
+
+
+def _resolve_columns(artifact: ArtifactDataset) -> list[str]:
+    """CSV 헤더로 사용할 컬럼 순서를 결정한다.
+
+    schema가 선언되어 있으면 그 키 순서를, 없으면 레코드에서 처음 등장한
+    순서를 사용한다. 결과는 입력에 대해 결정적이다.
+    """
+    if artifact.schema:
+        return list(artifact.schema.keys())
+    columns: dict[str, None] = {}
+    for record in artifact.records:
+        for key in record:
+            columns.setdefault(key, None)
+    return list(columns.keys())
+
+
+def _format_cell(value: JsonValue) -> str:
+    """단일 셀 값을 CSV 문자열로 변환한다.
+
+    None은 빈 문자열, bool은 소문자 JSON 표기, 중첩 list/dict는 결정적 JSON
+    문자열로 직렬화한다. 그 외 스칼라는 str()로 변환한다.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (str, int, float)):
+        return str(value)
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
+class CsvExporter(BaseExporter):
+    """레코드를 CSV로 기록하는 내보내기 도구.
+
+    예시:
+        >>> CsvExporter().name
+        'csv'
+    """
+
+    @property
+    def name(self) -> str:
+        """내보내기 도구 이름을 반환한다."""
+        return "csv"
+
+    def export(
+        self, artifact: ArtifactDataset, target: ExportTarget, output_dir: Path
+    ) -> ExportResult:
+        """표준 레코드를 CSV 파일로 내보낸다.
+
+        매개변수:
+            artifact: CSV로 직렬화할 레코드 묶음.
+            target: 출력 경로와 옵션을 담은 내보내기 대상.
+            output_dir: 빌드 기준 출력 디렉터리.
+
+        반환값:
+            ExportResult: 생성된 CSV 파일 메타데이터.
+
+        예외:
+            ExportError: 파일 쓰기에 실패한 경우.
+        """
+        destination = ensure_output_dir(output_dir, target.output_path)
+        columns = _resolve_columns(artifact)
+
+        buffer = io.StringIO()
+        if columns:
+            writer = csv.writer(buffer, lineterminator="\n")
+            writer.writerow(columns)
+            for record in artifact.records:
+                writer.writerow([_format_cell(record.get(column)) for column in columns])
+        content = buffer.getvalue()
+
+        try:
+            _ = destination.write_text(content, encoding="utf-8")
+        except OSError as exc:
+            raise ExportError(f"Failed to export CSV artifact to {destination}: {exc}") from exc
+
+        return ExportResult(
+            output_path=destination, file_size=destination.stat().st_size, format=self.name
+        )

--- a/tests/unit/test_csv_exporter.py
+++ b/tests/unit/test_csv_exporter.py
@@ -1,0 +1,149 @@
+"""CsvExporter의 출력 규칙을 테스트로 고정한다.
+
+CSV는 콤마/따옴표/개행이 포함된 값을 올바르게 인용해야 하고, 컬럼 순서가
+결정적이어야 한다. 헤더 구성·셀 포매팅·빈 데이터 정책·반환 메타데이터를
+회귀 테스트로 못 박는다.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from pathlib import Path
+
+import pytest
+
+from kpubdata_builder import ArtifactDataset, ExportError
+from kpubdata_builder.exporters import EXPORTER_REGISTRY, CsvExporter
+from kpubdata_builder.spec import ExportTarget
+
+
+def _read_rows(path: Path) -> list[list[str]]:
+    # 기록된 CSV를 csv.reader로 되읽어 인용/이스케이프를 검증한다.
+    return list(csv.reader(io.StringIO(path.read_text(encoding="utf-8"))))
+
+
+def test_writes_header_and_one_row_per_record(tmp_path: Path) -> None:
+    # 레코드 2개면 헤더 1줄 + 데이터 2줄이 되어야 한다.
+    artifact = ArtifactDataset(records=({"id": "1", "name": "a"}, {"id": "2", "name": "b"}))
+    target = ExportTarget(kind="csv", output_path="out/data.csv")
+
+    result = CsvExporter().export(artifact, target, tmp_path)
+
+    assert _read_rows(result.output_path) == [["id", "name"], ["1", "a"], ["2", "b"]]
+
+
+def test_column_order_follows_schema_when_present(tmp_path: Path) -> None:
+    # schema가 있으면 헤더 순서는 schema 키 순서를 따른다.
+    artifact = ArtifactDataset(
+        records=({"b": "2", "a": "1"},),
+        schema={"a": "str", "b": "str"},
+    )
+    target = ExportTarget(kind="csv", output_path="out/data.csv")
+
+    result = CsvExporter().export(artifact, target, tmp_path)
+
+    assert _read_rows(result.output_path) == [["a", "b"], ["1", "2"]]
+
+
+def test_column_order_is_first_seen_when_no_schema(tmp_path: Path) -> None:
+    # schema가 없으면 레코드에서 처음 등장한 순서를 따르며, 누락 키는 빈 셀로 채운다.
+    artifact = ArtifactDataset(records=({"id": "1"}, {"id": "2", "extra": "x"}))
+    target = ExportTarget(kind="csv", output_path="out/data.csv")
+
+    result = CsvExporter().export(artifact, target, tmp_path)
+
+    assert _read_rows(result.output_path) == [["id", "extra"], ["1", ""], ["2", "x"]]
+
+
+def test_quotes_values_with_comma_quote_and_newline(tmp_path: Path) -> None:
+    # 콤마/따옴표/개행이 포함된 값이 인용되어 round-trip 되는지 검증한다.
+    artifact = ArtifactDataset(
+        records=({"v": 'a,b "c" \n d'},),
+        schema={"v": "str"},
+    )
+    target = ExportTarget(kind="csv", output_path="out/data.csv")
+
+    result = CsvExporter().export(artifact, target, tmp_path)
+
+    assert _read_rows(result.output_path) == [["v"], ['a,b "c" \n d']]
+
+
+def test_formats_special_cell_values(tmp_path: Path) -> None:
+    # None은 빈 셀, bool은 소문자, 중첩 list/dict는 결정적 JSON 문자열로 직렬화한다.
+    artifact = ArtifactDataset(
+        records=({"nullable": None, "flag": True, "nested": {"b": 2, "a": 1}, "items": [1, 2]},),
+        schema={"nullable": "str", "flag": "bool", "nested": "json", "items": "json"},
+    )
+    target = ExportTarget(kind="csv", output_path="out/data.csv")
+
+    result = CsvExporter().export(artifact, target, tmp_path)
+
+    rows = _read_rows(result.output_path)
+    assert rows[0] == ["nullable", "flag", "nested", "items"]
+    assert rows[1] == ["", "true", '{"a": 1, "b": 2}', "[1, 2]"]
+
+
+def test_preserves_unicode(tmp_path: Path) -> None:
+    # 한글이 깨지지 않고 그대로 보존되는지 확인한다.
+    artifact = ArtifactDataset(records=({"district": "강남구"},), schema={"district": "str"})
+    target = ExportTarget(kind="csv", output_path="out/data.csv")
+
+    result = CsvExporter().export(artifact, target, tmp_path)
+
+    raw = result.output_path.read_text(encoding="utf-8")
+    assert "강남구" in raw
+
+
+def test_empty_records_without_schema_writes_empty_file(tmp_path: Path) -> None:
+    # schema도 records도 없으면 빈 파일(크기 0)로 기록한다.
+    artifact = ArtifactDataset(records=())
+    target = ExportTarget(kind="csv", output_path="out/data.csv")
+
+    result = CsvExporter().export(artifact, target, tmp_path)
+
+    assert result.output_path.read_text(encoding="utf-8") == ""
+    assert result.file_size == 0
+
+
+def test_schema_without_records_writes_header_only(tmp_path: Path) -> None:
+    # schema는 있고 records가 없으면 헤더만 기록한다.
+    artifact = ArtifactDataset(records=(), schema={"id": "str", "name": "str"})
+    target = ExportTarget(kind="csv", output_path="out/data.csv")
+
+    result = CsvExporter().export(artifact, target, tmp_path)
+
+    assert result.output_path.read_text(encoding="utf-8") == "id,name\n"
+
+
+def test_returns_metadata_pointing_to_created_file(tmp_path: Path) -> None:
+    # 반환된 Path가 실제 생성된 파일을 가리키고 메타데이터가 정확한지 확인한다.
+    artifact = ArtifactDataset(records=({"id": "1"},), schema={"id": "str"})
+    target = ExportTarget(kind="csv", output_path="out/data.csv")
+
+    result = CsvExporter().export(artifact, target, tmp_path)
+
+    assert result.output_path == tmp_path / "out/data.csv"
+    assert result.output_path.is_file()
+    assert result.file_size == result.output_path.stat().st_size
+    assert result.format == "csv"
+
+
+def test_registry_exposes_csv_exporter() -> None:
+    # CSV exporter가 kind 문자열 "csv"로 레지스트리에 등록되어 있는지 확인한다.
+    assert isinstance(EXPORTER_REGISTRY["csv"], CsvExporter)
+
+
+def test_wraps_io_failure_in_export_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # 파일 쓰기 실패가 ExportError로 래핑되는지 확인한다.
+    artifact = ArtifactDataset(records=({"id": "1"},), schema={"id": "str"})
+    target = ExportTarget(kind="csv", output_path="out/data.csv")
+
+    def raise_io_error(self: Path, data: str, *, encoding: str) -> int:
+        del self, data, encoding
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "write_text", raise_io_error)
+
+    with pytest.raises(ExportError):
+        CsvExporter().export(artifact, target, tmp_path)

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -101,13 +101,13 @@ def test_validate_spec_rejects_unsupported_export_kind() -> None:
         title="Sample Dataset",
         description="Sample description",
         sources=_SRC,
-        exports=(ExportTarget(kind="csv", output_path="out/data.csv"),),
+        exports=(ExportTarget(kind="xml", output_path="out/data.xml"),),
     )
 
     with pytest.raises(ValidationError) as exc_info:
         validate_spec(spec)
 
-    assert any("csv" in p and "not supported" in p for p in exc_info.value.problems)
+    assert any("xml" in p and "not supported" in p for p in exc_info.value.problems)
 
 
 def test_validate_spec_rejects_empty_output_path() -> None:


### PR DESCRIPTION
## 요약
이슈 #39 (`[v0.2] CSV exporter`)를 해결합니다. Markdown/JSONL exporter 패턴을 따라 `CsvExporter`를 신규 구현하고 레지스트리에 `"csv"` kind로 등록합니다.

## 변경 내용
- `src/kpubdata_builder/exporters/csv.py` 신규 — `CsvExporter`
- `src/kpubdata_builder/exporters/__init__.py` — `EXPORTER_REGISTRY`에 `"csv"` 등록 + export
- `tests/unit/test_csv_exporter.py` 신규 — 동작 규칙 회귀 테스트
- `tests/unit/test_validator.py` — unsupported-kind 거부 테스트의 예시를 `csv` → `xml`로 변경 (csv가 이제 지원 kind가 되었으므로)

## 동작 규칙
- **컬럼 순서**: `artifact.schema`가 있으면 schema 키 순서, 없으면 레코드에서 처음 등장한 순서(결정적). 누락 키는 빈 셀
- **인용 처리**: 콤마/따옴표/개행이 포함된 값은 stdlib `csv`가 RFC 4180 방식으로 자동 인용 → `csv.reader` round-trip 검증
- **셀 포매팅**: `None`→빈 셀, `bool`→소문자(`true`/`false`), 중첩 `list`/`dict`→결정적 JSON 문자열, 그 외 스칼라→`str()`
- **빈 데이터 정책**: schema·records 모두 없으면 빈 파일(크기 0), schema만 있으면 헤더만 기록
- UTF-8, 유니코드(한글) 보존, `lineterminator="\n"`로 결정적 출력
- 파일 쓰기 실패는 `ExportError`로 래핑

## 검증
- `pytest tests/unit` — 151 passed (CSV 11건 신규 포함)
- `mypy src` — no issues (49 files)
- `ruff check` / `ruff format --check` (변경 파일) — 통과

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)