### PR TITLE
refactor(cli): SourceClient 경계 정리 — return-value ignore 제거 (#96)

### DIFF
--- a/src/kpubdata_builder/cli.py
+++ b/src/kpubdata_builder/cli.py
@@ -15,6 +15,7 @@ import argparse
 import sys
 from collections.abc import Sequence
 from pathlib import Path
+from typing import cast
 
 from . import __version__
 from .build import execute_build
@@ -106,10 +107,17 @@ def _run_validate(spec_path: str) -> int:
 
 
 def _make_default_client() -> SourceClient:
-    """Create the default kpubdata client. Isolated for test injection."""
+    """Create the default kpubdata client. Isolated for test injection.
+
+    kpubdata's concrete ``Client`` satisfies the ``SourceClient`` Protocol at
+    runtime (duck typing), but mypy cannot confirm structural compatibility
+    across the package boundary: ``Client.dataset`` returns kpubdata's concrete
+    ``Dataset`` rather than our minimal ``SourceDataset`` Protocol. This single,
+    explicit cast localizes that boundary instead of suppressing it line-by-line.
+    """
     from kpubdata import Client
 
-    return Client.from_env()    # type: ignore[return-value]
+    return cast(SourceClient, Client.from_env())
 
 
 def _run_build(spec_path: str, output_dir: str) -> int:


### PR DESCRIPTION
## 요약
이슈 #96 (`cli.py의 SourceClient typing 경계 정리 — return-value ignore 제거`)을 해결합니다.

`_make_default_client`의 `# type: ignore[return-value]`를 제거하고, 단일 경계 지점에서 명시적 `typing.cast(SourceClient, ...)`로 의도를 드러냅니다.

## 배경 — mypy가 거부하던 정확한 이유
`# type: ignore`를 제거하면 mypy는 다음을 보고합니다:

```
error: Incompatible return value type (got "Client", expected "SourceClient")  [return-value]
note:   Expected: def dataset(self, dataset_id: str) -> SourceDataset
note:   Got:      def dataset(self, dataset_id: str) -> Dataset
```

kpubdata의 구체 `Client`는 런타임에 `SourceClient` Protocol을 만족(duck typing)하지만, `Client.dataset`가 우리의 최소 Protocol `SourceDataset` 대신 kpubdata 구체 타입 `Dataset`을 반환합니다. 이 중첩 반환 타입 체인을 mypy가 cross-package로 구조 검증하지 못해 직접 대입을 거부합니다. 그래서 기존 ignore는 "정당"했습니다.

## 변경 내용
- `src/kpubdata_builder/cli.py`
  - `from typing import cast` 추가
  - `Client.from_env()  # type: ignore[return-value]` → `cast(SourceClient, Client.from_env())`
  - 왜 cast가 필요한지(런타임 호환 vs mypy 한계) docstring으로 명시

## 선택한 접근
- **명시적 `cast` (채택)**: blanket error 억제(`# type: ignore`)를 의도가 드러나는 단일 경계 assertion으로 교체. 향후 유사 ignore 확산을 막고 경계를 한 곳에 모읍니다.
- 대안인 *kpubdata 코어에서 `SourceClient` Protocol export*는 별도 패키지(다른 레포) 변경이라 본 PR 범위 밖입니다. *완전한 nested adapter*(`SourceDataset`/`DatasetResult`까지 래핑)는 p3 부채 정리에 비해 과도하다고 판단했습니다.

## 부수 효과
- 해당 줄의 과다 공백(`from_env()    # ...`)이 정리되어, 기존에 `ruff format --check .`가 지적하던 `cli.py` 포맷 문제도 해소됩니다.

## 검증
- `mypy src` — no issues (48 files), `# type: ignore` 잔존 없음
- `pytest tests/unit` — 140 passed (`_make_default_client`는 테스트에서 monkeypatch로 주입되어 동작 영향 없음)
- `ruff check .` / `ruff format --check .` — 전체 통과

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)