### PR TITLE
feat(exporters): Parquet exporter 추가 (#8)

### DIFF
--- a/src/kpubdata_builder/exporters/__init__.py
+++ b/src/kpubdata_builder/exporters/__init__.py
@@ -12,10 +12,12 @@ from __future__ import annotations
 from .base import BaseExporter, ExportResult, ensure_output_dir
 from .jsonl import JsonlExporter
 from .markdown import MarkdownExporter
+from .parquet import ParquetExporter
 
 EXPORTER_REGISTRY: dict[str, BaseExporter] = {
     "jsonl": JsonlExporter(),
     "markdown": MarkdownExporter(),
+    "parquet": ParquetExporter(),
 }
 
 __all__ = [
@@ -24,5 +26,6 @@ __all__ = [
     "ExportResult",
     "JsonlExporter",
     "MarkdownExporter",
+    "ParquetExporter",
     "ensure_output_dir",
 ]

--- a/src/kpubdata_builder/exporters/parquet.py
+++ b/src/kpubdata_builder/exporters/parquet.py
@@ -1,0 +1,72 @@
+"""Parquet 내보내기 도구 구현.
+
+이 모듈은 ArtifactDataset의 레코드를 열(columnar) 기반 Parquet 파일로
+직렬화하는 exporter를 제공한다. 직렬화는 저장소가 이미 사용하는 polars의
+네이티브 Parquet writer에 위임하므로 별도의 pyarrow 의존성이 필요하지 않다.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+
+from ..artifact import ArtifactDataset
+from ..errors import ExportError
+from ..spec import ExportTarget
+from ..tabular.convert import records_to_dataframe
+from .base import BaseExporter, ExportResult, ensure_output_dir
+
+
+def _build_frame(artifact: ArtifactDataset) -> pl.DataFrame:
+    """artifact를 Parquet 직렬화용 DataFrame으로 변환한다.
+
+    레코드가 있으면 레코드에서 컬럼 구조를 추론하고, 레코드가 비어 있어도
+    schema가 선언되어 있으면 0행이지만 컬럼 이름을 보존한 빈 테이블을 만든다.
+    """
+    if artifact.records:
+        return records_to_dataframe(list(artifact.records))
+    if artifact.schema:
+        return pl.DataFrame(schema={name: pl.Utf8 for name in artifact.schema})
+    return pl.DataFrame()
+
+
+class ParquetExporter(BaseExporter):
+    """레코드를 Parquet로 기록하는 내보내기 도구.
+
+    예시:
+        >>> ParquetExporter().name
+        'parquet'
+    """
+
+    @property
+    def name(self) -> str:
+        """내보내기 도구 이름을 반환한다."""
+        return "parquet"
+
+    def export(
+        self, artifact: ArtifactDataset, target: ExportTarget, output_dir: Path
+    ) -> ExportResult:
+        """표준 레코드를 Parquet 파일로 내보낸다.
+
+        매개변수:
+            artifact: Parquet로 직렬화할 레코드 묶음.
+            target: 출력 경로와 옵션을 담은 내보내기 대상.
+            output_dir: 빌드 기준 출력 디렉터리.
+
+        반환값:
+            ExportResult: 생성된 Parquet 파일 메타데이터.
+
+        예외:
+            ExportError: 파일 쓰기에 실패한 경우.
+        """
+        destination = ensure_output_dir(output_dir, target.output_path)
+        frame = _build_frame(artifact)
+        try:
+            frame.write_parquet(destination)
+        except (OSError, pl.exceptions.PolarsError) as exc:
+            raise ExportError(f"Failed to export Parquet artifact to {destination}: {exc}") from exc
+
+        return ExportResult(
+            output_path=destination, file_size=destination.stat().st_size, format=self.name
+        )

--- a/tests/unit/test_parquet_exporter.py
+++ b/tests/unit/test_parquet_exporter.py
@@ -1,0 +1,109 @@
+"""ParquetExporter의 출력 규칙을 테스트로 고정한다.
+
+Parquet은 바이너리 columnar 포맷이므로, polars로 다시 읽었을 때 레코드가
+보존되는지·컬럼 타입이 유지되는지·빈 데이터 정책·반환 메타데이터를 회귀
+테스트로 못 박는다.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from kpubdata_builder import ArtifactDataset, ExportError
+from kpubdata_builder.exporters import EXPORTER_REGISTRY, ParquetExporter
+from kpubdata_builder.spec import ExportTarget
+
+
+def test_records_round_trip_through_parquet(tmp_path: Path) -> None:
+    # 레코드 2개를 기록한 뒤 read_parquet로 되읽어 원본과 일치하는지 검증한다.
+    records = ({"id": "1", "amount": 1000}, {"id": "2", "amount": 2500})
+    artifact = ArtifactDataset(records=records)
+    target = ExportTarget(kind="parquet", output_path="out/data.parquet")
+
+    result = ParquetExporter().export(artifact, target, tmp_path)
+
+    frame = pl.read_parquet(result.output_path)
+    assert frame.to_dicts() == [dict(record) for record in records]
+
+
+def test_column_types_are_preserved(tmp_path: Path) -> None:
+    # int 컬럼이 round-trip 후에도 정수 타입으로 유지되는지 확인한다.
+    artifact = ArtifactDataset(records=({"id": "1", "amount": 1000},))
+    target = ExportTarget(kind="parquet", output_path="out/data.parquet")
+
+    result = ParquetExporter().export(artifact, target, tmp_path)
+
+    frame = pl.read_parquet(result.output_path)
+    assert frame.schema["amount"] == pl.Int64
+    assert frame.schema["id"] == pl.Utf8
+
+
+def test_preserves_unicode(tmp_path: Path) -> None:
+    # 한글 값이 round-trip 후에도 보존되는지 확인한다.
+    artifact = ArtifactDataset(records=({"district": "강남구"},))
+    target = ExportTarget(kind="parquet", output_path="out/data.parquet")
+
+    result = ParquetExporter().export(artifact, target, tmp_path)
+
+    assert pl.read_parquet(result.output_path).to_dicts() == [{"district": "강남구"}]
+
+
+def test_empty_records_with_schema_keeps_columns(tmp_path: Path) -> None:
+    # 빈 데이터라도 schema가 있으면 0행이지만 컬럼 이름을 보존한다.
+    artifact = ArtifactDataset(records=(), schema={"id": "str", "amount": "int"})
+    target = ExportTarget(kind="parquet", output_path="out/data.parquet")
+
+    result = ParquetExporter().export(artifact, target, tmp_path)
+
+    frame = pl.read_parquet(result.output_path)
+    assert frame.height == 0
+    assert frame.columns == ["id", "amount"]
+
+
+def test_empty_records_without_schema_writes_readable_empty_file(tmp_path: Path) -> None:
+    # schema도 records도 없으면 0행·0열의 읽을 수 있는 Parquet 파일이 된다.
+    artifact = ArtifactDataset(records=())
+    target = ExportTarget(kind="parquet", output_path="out/data.parquet")
+
+    result = ParquetExporter().export(artifact, target, tmp_path)
+
+    frame = pl.read_parquet(result.output_path)
+    assert frame.shape == (0, 0)
+
+
+def test_returns_metadata_pointing_to_created_file(tmp_path: Path) -> None:
+    # 반환된 Path가 실제 생성된 파일을 가리키고 메타데이터가 정확한지 확인한다.
+    artifact = ArtifactDataset(records=({"id": "1"},))
+    target = ExportTarget(kind="parquet", output_path="out/data.parquet")
+
+    result = ParquetExporter().export(artifact, target, tmp_path)
+
+    assert result.output_path == tmp_path / "out/data.parquet"
+    assert result.output_path.is_file()
+    assert result.file_size == result.output_path.stat().st_size
+    assert result.format == "parquet"
+
+
+def test_registry_exposes_parquet_exporter() -> None:
+    # Parquet exporter가 kind 문자열 "parquet"로 레지스트리에 등록되어 있는지 확인한다.
+    assert isinstance(EXPORTER_REGISTRY["parquet"], ParquetExporter)
+
+
+def test_wraps_write_failure_in_export_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Parquet 쓰기 실패가 ExportError로 래핑되는지 확인한다.
+    artifact = ArtifactDataset(records=({"id": "1"},))
+    target = ExportTarget(kind="parquet", output_path="out/data.parquet")
+
+    def raise_os_error(self: pl.DataFrame, *args: object, **kwargs: object) -> None:
+        del self, args, kwargs
+        raise OSError("disk full")
+
+    monkeypatch.setattr(pl.DataFrame, "write_parquet", raise_os_error)
+
+    with pytest.raises(ExportError):
+        ParquetExporter().export(artifact, target, tmp_path)


### PR DESCRIPTION
## 요약
이슈 #8 (`[v0.2] Parquet exporter`)를 해결합니다. CSV/JSONL exporter 패턴을 따라 `ParquetExporter`를 구현하고 레지스트리에 `"parquet"` kind로 등록합니다.

## pyarrow 대신 polars
이슈는 pyarrow를 제안하지만, 이 저장소는 이미 **polars**를 사용하고 Silver 단계도 `df.write_parquet()`로 parquet을 기록합니다. polars의 네이티브 Parquet writer로 round-trip이 정상 동작함을 확인했으므로 **새 의존성(pyarrow)을 추가하지 않고** 기존 스택(`records_to_dataframe` + polars)을 재사용했습니다. (pyproject 변경 없음)

## 변경 내용
- `src/kpubdata_builder/exporters/parquet.py` 신규 — `ParquetExporter`
- `src/kpubdata_builder/exporters/__init__.py` — `EXPORTER_REGISTRY`에 `"parquet"` 등록 + export
- `tests/unit/test_parquet_exporter.py` 신규 — 회귀 테스트 8건

## 동작 규칙
- 레코드 → `records_to_dataframe` → `write_parquet`. `read_parquet` round-trip으로 레코드 보존 검증
- 컬럼 타입 유지(예: int → `Int64`), 유니코드(한글) 보존
- 빈 데이터라도 `schema`가 있으면 0행이지만 컬럼명 보존, schema·records 모두 없으면 0×0의 읽을 수 있는 빈 파일
- 쓰기 실패는 `ExportError`로 래핑

## 검증
- `pytest tests/unit` — 148 passed (Parquet 8건 신규)
- `mypy src` — no issues (49 files)
- `ruff check .` / `ruff format --check`(변경 파일) — 통과

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)