### PR TITLE
feat(gold): dataset card(README) 계약·템플릿 추가 (#37)

### DIFF
--- a/src/kpubdata_builder/pipeline/orchestrator.py
+++ b/src/kpubdata_builder/pipeline/orchestrator.py
@@ -25,6 +25,7 @@ from ..stages.bronze.build import SourceClient, build_bronze_artifact
 from ..stages.bronze.models import BronzeArtifact, utc_now
 from ..stages.bronze.persist import persist_bronze_artifact
 from ..stages.gold.build import build_gold_package
+from ..stages.gold.card import build_dataset_card, render_dataset_card
 from ..stages.gold.persist import persist_gold_package
 from ..stages.silver.build import build_silver_dataset
 from ..stages.silver.persist import persist_silver_dataset
@@ -134,6 +135,21 @@ def _run_source_pipeline(
         )
         completed.append("gold")
         _record_output_paths(outputs, gold_paths.table_path, gold_paths.package_path)
+
+        card = build_dataset_card(
+            title=context.spec.title,
+            description=context.spec.description,
+            sources=(fetch_key,),
+            fields=(
+                (column.name, column.dtype, column.nullable) for column in silver.schema.columns
+            ),
+            sample_rows=silver.preview.rows,
+            license=context.spec.metadata.get("license", ""),
+            version=context.spec.metadata.get("version", ""),
+        )
+        card_path = gold_paths.gold_dir / "README.md"
+        _ = card_path.write_text(render_dataset_card(card), encoding="utf-8")
+        _record_output_paths(outputs, card_path)
 
         row_counts[output_key] = silver.statistics.row_count
         return SourceBuildOutcome(

--- a/src/kpubdata_builder/stages/gold/__init__.py
+++ b/src/kpubdata_builder/stages/gold/__init__.py
@@ -7,18 +7,24 @@ Silver 정제 테이블을 export-ready 패키지(GoldPackage)로 만드는 Gold
     - GoldPackage / ExportPlan: 산출물·내보내기 계획 모델
     - build_gold_package: SilverDataset → GoldPackage
     - persist_gold_package: Gold 산출물 영속화
+    - DatasetCard / build_dataset_card / render_dataset_card: 데이터셋 카드 (#37)
 """
 
 from __future__ import annotations
 
 from .build import build_gold_package
+from .card import CardField, DatasetCard, build_dataset_card, render_dataset_card
 from .models import ExportPlan, GoldPackage
 from .persist import GoldPersistResult, persist_gold_package
 
 __all__ = [
+    "CardField",
+    "DatasetCard",
     "ExportPlan",
     "GoldPackage",
     "GoldPersistResult",
+    "build_dataset_card",
     "build_gold_package",
     "persist_gold_package",
+    "render_dataset_card",
 ]

--- a/src/kpubdata_builder/stages/gold/card.py
+++ b/src/kpubdata_builder/stages/gold/card.py
@@ -1,0 +1,172 @@
+"""데이터셋 카드(README) 계약과 Markdown 템플릿 (#37).
+
+이 모듈은 빌드 산출물에 자동 생성되는 dataset card의 데이터 계약(DatasetCard)과,
+이를 사람이 읽는 Markdown README로 렌더링하는 함수를 정의한다. 카드는 소스,
+스키마 요약, 샘플 미리보기, 라이선스, 버전 정보를 담는다.
+
+주요 구성:
+    - CardField: 단일 컬럼 요약 (이름/타입/nullable)
+    - DatasetCard: 데이터셋 카드 계약
+    - build_dataset_card: 원시 입력 → DatasetCard
+    - render_dataset_card: DatasetCard → Markdown 문자열
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+
+from ...spec import JsonValue
+
+
+@dataclass(frozen=True)
+class CardField:
+    """카드 스키마 섹션의 단일 컬럼.
+
+    속성:
+        name: 컬럼명.
+        type: 컬럼 타입 문자열.
+        nullable: null 허용 여부.
+    """
+
+    name: str
+    type: str
+    nullable: bool
+
+
+@dataclass(frozen=True)
+class DatasetCard:
+    """데이터셋 카드(README) 계약.
+
+    속성:
+        title: 데이터셋 제목.
+        description: 데이터셋 설명.
+        sources: provider.dataset 형태 소스 식별자 목록.
+        fields: 스키마 요약(컬럼) 목록.
+        sample_rows: 미리보기 샘플 행.
+        license: 라이선스 표기. 비어 있으면 "N/A"로 렌더링.
+        version: 버전 표기. 비어 있으면 "unversioned"로 렌더링.
+    """
+
+    title: str
+    description: str = ""
+    sources: tuple[str, ...] = ()
+    fields: tuple[CardField, ...] = ()
+    sample_rows: tuple[dict[str, JsonValue], ...] = ()
+    license: str = ""
+    version: str = ""
+
+
+def build_dataset_card(
+    *,
+    title: str,
+    description: str = "",
+    sources: Iterable[str] = (),
+    fields: Iterable[tuple[str, str, bool]] = (),
+    sample_rows: Iterable[Mapping[str, JsonValue]] = (),
+    license: str = "",
+    version: str = "",
+) -> DatasetCard:
+    """원시 입력으로부터 DatasetCard를 조립한다.
+
+    매개변수:
+        title: 데이터셋 제목.
+        description: 데이터셋 설명.
+        sources: provider.dataset 소스 식별자.
+        fields: (name, type, nullable) 컬럼 시퀀스.
+        sample_rows: 미리보기 샘플 행.
+        license: 라이선스 표기.
+        version: 버전 표기.
+
+    반환값:
+        DatasetCard: 렌더링 가능한 카드 계약.
+    """
+    return DatasetCard(
+        title=title,
+        description=description,
+        sources=tuple(sources),
+        fields=tuple(CardField(name=n, type=t, nullable=nl) for n, t, nl in fields),
+        sample_rows=tuple(dict(row) for row in sample_rows),
+        license=license,
+        version=version,
+    )
+
+
+def _cell(value: JsonValue) -> str:
+    """Markdown 표 셀로 안전한 문자열을 만든다(파이프/개행 이스케이프)."""
+    if value is None:
+        text = ""
+    elif isinstance(value, bool):
+        text = "true" if value else "false"
+    elif isinstance(value, (str, int, float)):
+        text = str(value)
+    else:
+        text = json.dumps(value, ensure_ascii=False, sort_keys=True)
+    return text.replace("\\", "\\\\").replace("|", "\\|").replace("\n", " ")
+
+
+def _render_schema(fields: Sequence[CardField]) -> list[str]:
+    """스키마 요약 섹션을 렌더링한다."""
+    lines = ["## Schema", ""]
+    if not fields:
+        lines.append("_No schema available._")
+        return lines
+    lines.append("| Column | Type | Nullable |")
+    lines.append("| --- | --- | --- |")
+    for column in fields:
+        nullable = "yes" if column.nullable else "no"
+        lines.append(f"| {_cell(column.name)} | {_cell(column.type)} | {nullable} |")
+    return lines
+
+
+def _render_sample(card: DatasetCard) -> list[str]:
+    """샘플 미리보기 섹션을 렌더링한다."""
+    lines = ["## Sample", ""]
+    columns = [column.name for column in card.fields]
+    if not columns or not card.sample_rows:
+        lines.append("_No sample rows available._")
+        return lines
+    lines.append("| " + " | ".join(_cell(name) for name in columns) + " |")
+    lines.append("| " + " | ".join("---" for _ in columns) + " |")
+    for row in card.sample_rows:
+        lines.append("| " + " | ".join(_cell(row.get(name)) for name in columns) + " |")
+    return lines
+
+
+def render_dataset_card(card: DatasetCard) -> str:
+    """DatasetCard를 Markdown README 문자열로 렌더링한다.
+
+    매개변수:
+        card: 렌더링할 데이터셋 카드.
+
+    반환값:
+        str: 마지막 줄바꿈을 포함한 Markdown 문서.
+    """
+    lines: list[str] = [f"# {card.title}", ""]
+    if card.description:
+        lines += [card.description, ""]
+
+    lines += ["## Sources", ""]
+    if card.sources:
+        lines += [f"- {source}" for source in card.sources]
+    else:
+        lines.append("_No sources recorded._")
+    lines.append("")
+
+    lines += _render_schema(card.fields)
+    lines.append("")
+    lines += _render_sample(card)
+    lines.append("")
+
+    lines += ["## License", "", card.license or "N/A", ""]
+    lines += ["## Version", "", card.version or "unversioned"]
+    return "\n".join(lines) + "\n"
+
+
+__all__ = [
+    "CardField",
+    "DatasetCard",
+    "build_dataset_card",
+    "render_dataset_card",
+]

--- a/tests/unit/test_dataset_card.py
+++ b/tests/unit/test_dataset_card.py
@@ -1,0 +1,81 @@
+"""데이터셋 카드(#37) 계약과 Markdown 렌더링을 검증한다."""
+
+from __future__ import annotations
+
+from kpubdata_builder.stages.gold import (
+    DatasetCard,
+    build_dataset_card,
+    render_dataset_card,
+)
+
+
+def _card() -> DatasetCard:
+    return build_dataset_card(
+        title="Apartment Trades",
+        description="seoul apartment trades",
+        sources=("datago.apt_trade",),
+        fields=[("id", "String", False), ("amount", "Int64", True)],
+        sample_rows=[{"id": "1", "amount": 1000}, {"id": "2", "amount": 2500}],
+        license="KOGL Type 1",
+        version="2026.05.26",
+    )
+
+
+def test_build_dataset_card_maps_primitive_fields() -> None:
+    # (name, type, nullable) 시퀀스가 CardField로 매핑되는지 확인한다.
+    card = _card()
+
+    assert [(f.name, f.type, f.nullable) for f in card.fields] == [
+        ("id", "String", False),
+        ("amount", "Int64", True),
+    ]
+    assert card.sources == ("datago.apt_trade",)
+
+
+def test_render_includes_all_contract_sections() -> None:
+    # 렌더링된 README가 계약의 모든 섹션을 포함하는지 확인한다.
+    text = render_dataset_card(_card())
+
+    assert text.startswith("# Apartment Trades\n")
+    assert "seoul apartment trades" in text
+    for heading in ("## Sources", "## Schema", "## Sample", "## License", "## Version"):
+        assert heading in text
+    assert "- datago.apt_trade" in text
+    assert "KOGL Type 1" in text
+    assert "2026.05.26" in text
+    assert text.endswith("\n")
+
+
+def test_render_schema_and_sample_as_markdown_tables() -> None:
+    # 스키마/샘플이 Markdown 표로 렌더링되고 nullable 표기가 정확한지 확인한다.
+    text = render_dataset_card(_card())
+
+    assert "| Column | Type | Nullable |" in text
+    assert "| id | String | no |" in text
+    assert "| amount | Int64 | yes |" in text
+    # 샘플 표 헤더와 행.
+    assert "| id | amount |" in text
+    assert "| 1 | 1000 |" in text
+
+
+def test_render_escapes_pipe_and_newline_in_cells() -> None:
+    # 셀 값의 파이프/개행이 이스케이프되어 표가 깨지지 않는지 확인한다.
+    card = build_dataset_card(
+        title="t",
+        fields=[("v", "String", False)],
+        sample_rows=[{"v": "a|b\nc"}],
+    )
+
+    text = render_dataset_card(card)
+
+    assert "a\\|b c" in text
+
+
+def test_render_handles_empty_schema_and_sample() -> None:
+    # 스키마/샘플이 없을 때 안내 문구로 안전하게 렌더링되는지 확인한다.
+    text = render_dataset_card(build_dataset_card(title="empty"))
+
+    assert "_No schema available._" in text
+    assert "_No sample rows available._" in text
+    assert "N/A" in text  # license 기본값
+    assert "unversioned" in text  # version 기본값

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -110,6 +110,29 @@ def test_run_build_executes_full_pipeline_and_writes_workspace(tmp_path: Path) -
     ]
 
 
+def test_run_build_writes_dataset_card_readme(tmp_path: Path) -> None:
+    # 성공한 빌드의 gold 디렉터리에 dataset card README.md가 생성되는지 검증한다 (#37).
+    spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
+    client = _FakeClient(
+        {"datago.apt_trade": [{"id": "1", "amount": 1000}, {"id": "2", "amount": 2500}]}
+    )
+
+    result = run_build(spec, client=client, output_root=tmp_path, run_id="run1")
+
+    readme = tmp_path / "run1" / "gold" / "datago.apt_trade" / "README.md"
+    assert readme.exists()
+    text = readme.read_text(encoding="utf-8")
+    assert "# Apartment Trades" in text
+    assert "## Schema" in text
+    assert "- datago.apt_trade" in text
+
+    manifest = cast(
+        dict[str, JsonValue], json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    )
+    outputs = cast(list[str], manifest["outputs"])
+    assert str(readme) in outputs
+
+
 def test_run_build_uses_alias_as_source_key(tmp_path: Path) -> None:
     spec = _spec(SourceRef(provider="datago", dataset="apt_trade", alias="trades"))
     client = _FakeClient({"datago.apt_trade": [{"id": "1"}]})


### PR DESCRIPTION
## 요약
이슈 #37 (`[v0.2] Dataset card contract and template`)을 해결합니다. 빌드 산출물에 자동 생성되는 dataset card(README)를 도입합니다.

## 변경 내용
- `src/kpubdata_builder/stages/gold/card.py` 신규 — `DatasetCard` 계약, `build_dataset_card`, `render_dataset_card`
- `stages/gold/__init__.py` — 카드 API export
- `pipeline/orchestrator.py` — gold 디렉터리에 `README.md` 생성 + manifest outputs 기록
- 테스트: `test_dataset_card.py`(계약/렌더링), `test_pipeline.py`(통합)

## 카드 계약/템플릿
README는 다음 섹션을 포함합니다 (이슈 요구: source, schema summary, sample preview, license, version):
- `# {title}` + 설명
- `## Sources` — provider.dataset 목록
- `## Schema` — `| Column | Type | Nullable |` 표 (silver 스키마에서)
- `## Sample` — 미리보기 행 표 (silver preview에서)
- `## License` — `spec.metadata["license"]`, 없으면 `N/A`
- `## Version` — `spec.metadata["version"]`, 없으면 `unversioned`

## 견고성
- 표 셀의 `|`·개행·백슬래시를 이스케이프해 Markdown 표가 깨지지 않습니다.
- 스키마/샘플이 없으면 안내 문구(`_No schema available._` 등)로 안전하게 렌더링합니다.
- 계약(`DatasetCard`)과 렌더러를 분리해 단위 테스트가 쉽고, 파이프라인 외부에서도 재사용 가능합니다.

## 검증
- `pytest tests/unit` — 146 passed
- `mypy src` — no issues (49 files)
- `ruff check .` / `ruff format --check` — 통과

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)