### PR TITLE
feat(exporters): Hugging Face 레이아웃 exporter 추가 (#9)

### DIFF
--- a/src/kpubdata_builder/exporters/__init__.py
+++ b/src/kpubdata_builder/exporters/__init__.py
@@ -11,12 +11,14 @@ from __future__ import annotations
 
 from .base import BaseExporter, ExportResult, ensure_output_dir
 from .csv import CsvExporter
+from .huggingface import HuggingFaceExporter
 from .jsonl import JsonlExporter
 from .markdown import MarkdownExporter
 from .parquet import ParquetExporter
 
 EXPORTER_REGISTRY: dict[str, BaseExporter] = {
     "csv": CsvExporter(),
+    "huggingface": HuggingFaceExporter(),
     "jsonl": JsonlExporter(),
     "markdown": MarkdownExporter(),
     "parquet": ParquetExporter(),
@@ -27,6 +29,7 @@ __all__ = [
     "CsvExporter",
     "EXPORTER_REGISTRY",
     "ExportResult",
+    "HuggingFaceExporter",
     "JsonlExporter",
     "MarkdownExporter",
     "ParquetExporter",

--- a/src/kpubdata_builder/exporters/huggingface.py
+++ b/src/kpubdata_builder/exporters/huggingface.py
@@ -1,0 +1,139 @@
+"""Hugging Face Hub 레이아웃 내보내기 도구 (#9).
+
+이 모듈은 ArtifactDataset을 Hugging Face Hub 업로드 규격의 디렉터리 레이아웃으로
+내보낸다. 데이터 파일(data/), 데이터셋 카드(README.md, YAML front matter 포함),
+메타데이터(dataset_infos.json)를 생성한다. 실제 업로드는 수행하지 않는다.
+
+레이아웃::
+
+    {output_path}/
+    ├── data/
+    │   └── train-00000-of-00001.{parquet|jsonl}
+    ├── README.md
+    └── dataset_infos.json
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import polars as pl
+import yaml
+
+from ..artifact import ArtifactDataset
+from ..errors import ExportError
+from ..spec import ExportTarget
+from ..tabular.convert import records_to_dataframe
+from .base import BaseExporter, ExportResult
+
+_SUPPORTED_FORMATS = ("parquet", "jsonl")
+
+
+def _resolve_format(target: ExportTarget) -> str:
+    """target.options에서 데이터 파일 형식을 결정한다(기본 parquet)."""
+    raw = target.options.get("format", "parquet")
+    fmt = raw if isinstance(raw, str) else "parquet"
+    if fmt not in _SUPPORTED_FORMATS:
+        raise ExportError(
+            f"Unsupported huggingface data format: {fmt!r}. "
+            f"Supported: {', '.join(_SUPPORTED_FORMATS)}"
+        )
+    return fmt
+
+
+def _write_data_file(artifact: ArtifactDataset, data_dir: Path, fmt: str) -> Path:
+    """data/ 아래에 단일 shard 데이터 파일을 기록하고 경로를 반환한다."""
+    data_path = data_dir / f"train-00000-of-00001.{fmt}"
+    if fmt == "parquet":
+        records_to_dataframe(list(artifact.records)).write_parquet(data_path)
+    else:
+        content = "\n".join(
+            json.dumps(record, ensure_ascii=False, sort_keys=True) for record in artifact.records
+        )
+        _ = data_path.write_text(f"{content}\n" if content else "", encoding="utf-8")
+    return data_path
+
+
+def _render_card(artifact: ArtifactDataset) -> str:
+    """YAML front matter + Markdown 본문의 데이터셋 카드를 만든다."""
+    metadata = artifact.metadata
+    front_matter: dict[str, object] = {
+        "language": [metadata.get("language", "ko")],
+        "pretty_name": metadata.get("title", "dataset"),
+    }
+    if metadata.get("license"):
+        front_matter["license"] = metadata["license"]
+    front_yaml = yaml.safe_dump(front_matter, allow_unicode=True, sort_keys=True).strip()
+
+    title = metadata.get("title", "dataset")
+    description = metadata.get("description", "")
+    body = [f"---\n{front_yaml}\n---", "", f"# {title}", ""]
+    if description:
+        body += [description, ""]
+    body += ["## 출처", ""]
+    if artifact.provenance:
+        body += [f"- {entry}" for entry in artifact.provenance]
+    else:
+        body.append("공공데이터포털 (data.go.kr)")
+    return "\n".join(body) + "\n"
+
+
+def _dataset_infos(artifact: ArtifactDataset) -> dict[str, object]:
+    """HF dataset_infos.json에 실을 메타데이터를 구성한다."""
+    return {
+        "features": dict(artifact.schema),
+        "num_examples": len(artifact.records),
+        "provenance": list(artifact.provenance),
+        "metadata": dict(artifact.metadata),
+    }
+
+
+class HuggingFaceExporter(BaseExporter):
+    """ArtifactDataset을 Hugging Face Hub 레이아웃으로 내보낸다.
+
+    예시:
+        >>> HuggingFaceExporter().name
+        'huggingface'
+    """
+
+    @property
+    def name(self) -> str:
+        """내보내기 도구 이름을 반환한다."""
+        return "huggingface"
+
+    def export(
+        self, artifact: ArtifactDataset, target: ExportTarget, output_dir: Path
+    ) -> ExportResult:
+        """ArtifactDataset을 HF 디렉터리 레이아웃으로 내보낸다.
+
+        매개변수:
+            artifact: 내보낼 산출물.
+            target: output_path(레이아웃 루트)와 options(format)을 담은 대상.
+            output_dir: 빌드 기준 출력 디렉터리.
+
+        반환값:
+            ExportResult: 레이아웃 루트 디렉터리와 총 바이트 크기.
+
+        예외:
+            ExportError: 지원하지 않는 형식이거나 파일 쓰기에 실패한 경우.
+        """
+        fmt = _resolve_format(target)
+        hf_dir = output_dir / target.output_path
+        data_dir = hf_dir / "data"
+        try:
+            data_dir.mkdir(parents=True, exist_ok=True)
+            data_path = _write_data_file(artifact, data_dir, fmt)
+            readme_path = hf_dir / "README.md"
+            _ = readme_path.write_text(_render_card(artifact), encoding="utf-8")
+            infos_path = hf_dir / "dataset_infos.json"
+            _ = infos_path.write_text(
+                json.dumps(_dataset_infos(artifact), ensure_ascii=False, indent=2, sort_keys=True)
+                + "\n",
+                encoding="utf-8",
+            )
+        except (OSError, pl.exceptions.PolarsError) as exc:
+            raise ExportError(f"Failed to export Hugging Face layout to {hf_dir}: {exc}") from exc
+
+        total_size = sum(path.stat().st_size for path in (data_path, readme_path, infos_path))
+        return ExportResult(output_path=hf_dir, file_size=total_size, format=self.name)

--- a/tests/unit/test_huggingface_exporter.py
+++ b/tests/unit/test_huggingface_exporter.py
@@ -1,0 +1,107 @@
+"""HuggingFaceExporter(#9)의 레이아웃·카드·메타데이터 생성을 검증한다."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from kpubdata_builder import ArtifactDataset, ExportError
+from kpubdata_builder.exporters import EXPORTER_REGISTRY, HuggingFaceExporter
+from kpubdata_builder.spec import ExportTarget
+
+
+def _artifact() -> ArtifactDataset:
+    return ArtifactDataset(
+        records=({"id": "1", "name": "강남구"}, {"id": "2", "name": "서초구"}),
+        schema={"id": "str", "name": "str"},
+        metadata={
+            "title": "아파트 실거래가",
+            "description": "서울 아파트 실거래가",
+            "license": "cc-by-4.0",
+        },
+        provenance=("datago.apt_trade",),
+    )
+
+
+def test_creates_hf_directory_layout(tmp_path: Path) -> None:
+    # data/ + README.md + dataset_infos.json의 HF 표준 레이아웃을 생성한다.
+    target = ExportTarget(kind="huggingface", output_path="hf/apt_trade")
+
+    result = HuggingFaceExporter().export(_artifact(), target, tmp_path)
+
+    assert result.output_path == tmp_path / "hf/apt_trade"
+    assert (result.output_path / "data").is_dir()
+    assert (result.output_path / "README.md").is_file()
+    assert (result.output_path / "dataset_infos.json").is_file()
+    assert result.format == "huggingface"
+    assert result.file_size > 0
+
+
+def test_default_format_is_parquet_and_round_trips(tmp_path: Path) -> None:
+    # 기본 형식은 parquet이며 데이터가 round-trip 보존되는지 확인한다.
+    target = ExportTarget(kind="huggingface", output_path="hf/apt_trade")
+
+    result = HuggingFaceExporter().export(_artifact(), target, tmp_path)
+
+    data_file = result.output_path / "data" / "train-00000-of-00001.parquet"
+    assert data_file.is_file()
+    assert pl.read_parquet(data_file).to_dicts() == [
+        {"id": "1", "name": "강남구"},
+        {"id": "2", "name": "서초구"},
+    ]
+
+
+def test_jsonl_format_option(tmp_path: Path) -> None:
+    # format=jsonl 옵션이면 jsonl shard를 한 줄당 한 레코드로 기록한다.
+    target = ExportTarget(
+        kind="huggingface", output_path="hf/apt_trade", options={"format": "jsonl"}
+    )
+
+    result = HuggingFaceExporter().export(_artifact(), target, tmp_path)
+
+    data_file = result.output_path / "data" / "train-00000-of-00001.jsonl"
+    lines = data_file.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0]) == {"id": "1", "name": "강남구"}
+
+
+def test_readme_has_yaml_front_matter_and_unicode(tmp_path: Path) -> None:
+    # README.md가 YAML front matter로 시작하고 한글이 보존되는지 확인한다.
+    target = ExportTarget(kind="huggingface", output_path="hf/apt_trade")
+
+    result = HuggingFaceExporter().export(_artifact(), target, tmp_path)
+
+    text = (result.output_path / "README.md").read_text(encoding="utf-8")
+    assert text.startswith("---\n")
+    assert text.count("---") >= 2  # front matter 시작/끝
+    assert "license: cc-by-4.0" in text
+    assert "# 아파트 실거래가" in text
+    assert "- datago.apt_trade" in text
+
+
+def test_dataset_infos_is_valid_json_with_features(tmp_path: Path) -> None:
+    # dataset_infos.json이 유효 JSON이며 features/num_examples를 담는지 확인한다.
+    target = ExportTarget(kind="huggingface", output_path="hf/apt_trade")
+
+    result = HuggingFaceExporter().export(_artifact(), target, tmp_path)
+
+    infos = json.loads((result.output_path / "dataset_infos.json").read_text(encoding="utf-8"))
+    assert infos["features"] == {"id": "str", "name": "str"}
+    assert infos["num_examples"] == 2
+    assert infos["provenance"] == ["datago.apt_trade"]
+
+
+def test_rejects_unsupported_format(tmp_path: Path) -> None:
+    # 지원하지 않는 format은 ExportError로 거부한다.
+    target = ExportTarget(kind="huggingface", output_path="hf/apt_trade", options={"format": "xml"})
+
+    with pytest.raises(ExportError, match="format"):
+        HuggingFaceExporter().export(_artifact(), target, tmp_path)
+
+
+def test_registry_exposes_huggingface_exporter() -> None:
+    # HF exporter가 kind "huggingface"로 레지스트리에 등록되어 있는지 확인한다.
+    assert isinstance(EXPORTER_REGISTRY["huggingface"], HuggingFaceExporter)


### PR DESCRIPTION
## 요약
이슈 #9 (`[v0.2] Hugging Face layout exporter`)를 해결합니다. ArtifactDataset을 Hugging Face Hub 업로드 규격의 **디렉터리 레이아웃**으로 내보내는 `HuggingFaceExporter`를 구현합니다. (실제 업로드는 수행하지 않습니다 — 레이아웃 생성만.)

## 생성 레이아웃
```
{output_path}/
├── data/
│   └── train-00000-of-00001.{parquet|jsonl}
├── README.md          # YAML front matter + 데이터셋 카드
└── dataset_infos.json # features/num_examples/provenance
```

## 변경 내용
- `src/kpubdata_builder/exporters/huggingface.py` 신규 — `HuggingFaceExporter`
- `exporters/__init__.py` — `EXPORTER_REGISTRY`에 `"huggingface"` 등록 + export
- `tests/unit/test_huggingface_exporter.py` 신규 — 7건

## 동작
- 데이터 형식은 `options.format` ∈ {`parquet`(기본), `jsonl`}. parquet은 polars 네이티브 writer 사용(추가 의존성 없음)
- `README.md`는 `---` YAML front matter(`language`/`license`/`pretty_name`) + 본문(title/description/출처). 한글 보존(`allow_unicode`)
- `dataset_infos.json`은 `artifact.schema`→features, 레코드 수, provenance를 결정적 JSON으로 기록
- 지원하지 않는 format은 `ExportError`로 거부, 쓰기 실패도 `ExportError`로 래핑
- 카드/메타데이터 내용은 `artifact.metadata`(title/description/license/language)에서 가져옴

## 검증
- `pytest tests/unit` — 147 passed (HF 7건 신규)
- `mypy src` — no issues (49 files)
- `ruff check .` / `ruff format --check` — 통과

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)