### PR TITLE
feat(spec,gold): BuildSpec split 정의와 분할 로직 추가 (#38)

### DIFF
--- a/src/kpubdata_builder/spec/__init__.py
+++ b/src/kpubdata_builder/spec/__init__.py
@@ -12,7 +12,7 @@ models와 loader의 공개 심볼을 re-export 한다. validate_spec은 exporter
 from __future__ import annotations
 
 from .loader import load_spec, parse_spec
-from .models import BuildSpec, ExportTarget, JsonPrimitive, JsonValue, SourceRef
+from .models import BuildSpec, ExportTarget, JsonPrimitive, JsonValue, SourceRef, SplitSpec
 from .template import load_template, render_template
 
 __all__ = [
@@ -21,6 +21,7 @@ __all__ = [
     "JsonPrimitive",
     "JsonValue",
     "SourceRef",
+    "SplitSpec",
     "load_spec",
     "load_template",
     "parse_spec",

--- a/src/kpubdata_builder/spec/loader.py
+++ b/src/kpubdata_builder/spec/loader.py
@@ -16,7 +16,7 @@ from typing import cast
 import yaml
 
 from ..errors import SpecLoadError
-from .models import BuildSpec, ExportTarget, JsonValue, SourceRef
+from .models import BuildSpec, ExportTarget, JsonValue, SourceRef, SplitSpec
 
 
 def parse_spec(data: dict[str, object]) -> BuildSpec:
@@ -40,6 +40,7 @@ def parse_spec(data: dict[str, object]) -> BuildSpec:
         publish = _parse_bool(data.get("publish", False), field_name="publish")
         sources = _parse_sources(_require_present(data, "sources"))
         exports = _parse_exports(_require_present(data, "exports"))
+        splits = _parse_splits(data.get("splits"))
     except (KeyError, TypeError, ValueError) as exc:
         raise SpecLoadError(f"Failed to parse build spec: {exc}") from exc
 
@@ -52,6 +53,7 @@ def parse_spec(data: dict[str, object]) -> BuildSpec:
         transforms=transforms,
         metadata=metadata,
         publish=publish,
+        splits=splits,
     )
 
 
@@ -199,6 +201,35 @@ def _parse_exports(value: object) -> tuple[ExportTarget, ...]:
         )
         parsed_exports.append(ExportTarget(kind=kind, output_path=output_path, options=options))
     return tuple(parsed_exports)
+
+
+def _parse_splits(value: object) -> SplitSpec | None:
+    """splits 매핑을 SplitSpec으로 변환한다(없으면 None)."""
+    if value is None:
+        return None
+    mapping = _ensure_mapping(value, field_name="splits")
+    mode = _require_string(mapping, "mode", prefix="splits")
+
+    seed_obj = mapping.get("seed", 0)
+    if not isinstance(seed_obj, int) or isinstance(seed_obj, bool):
+        raise TypeError("splits.seed must be an integer")
+
+    ratios: dict[str, float] = {}
+    ratios_obj = mapping.get("ratios", {})
+    if not isinstance(ratios_obj, dict):
+        raise TypeError("splits.ratios must be a mapping")
+    for name, fraction in cast(dict[object, object], ratios_obj).items():
+        if not isinstance(name, str):
+            raise TypeError("splits.ratios keys must be strings")
+        if isinstance(fraction, bool) or not isinstance(fraction, (int, float)):
+            raise TypeError("splits.ratios values must be numbers")
+        ratios[name] = float(fraction)
+
+    key_obj = mapping.get("key", "")
+    if not isinstance(key_obj, str):
+        raise TypeError("splits.key must be a string")
+
+    return SplitSpec(mode=mode, ratios=ratios, key=key_obj, seed=seed_obj)
 
 
 def _ensure_mapping(value: object, *, field_name: str) -> dict[str, object]:

--- a/src/kpubdata_builder/spec/models.py
+++ b/src/kpubdata_builder/spec/models.py
@@ -54,6 +54,24 @@ class ExportTarget:
 
 
 @dataclass(frozen=True)
+class SplitSpec:
+    """데이터셋을 명명된 분할로 나누는 방법 정의 (#38).
+
+    속성:
+        mode: 분할 방식. "ratio"는 비율 기반(train/val/test), "key"는 컬럼 값
+            기반(연도/지역/카테고리)으로 나눈다.
+        ratios: ratio 모드에서 분할 이름 → 비율 매핑 (합이 1.0이어야 한다).
+        key: key 모드에서 분할 기준이 되는 컬럼 이름.
+        seed: ratio 모드의 결정적 셔플 시드.
+    """
+
+    mode: str
+    ratios: dict[str, float] = field(default_factory=dict)
+    key: str = ""
+    seed: int = 0
+
+
+@dataclass(frozen=True)
 class BuildSpec:
     """데이터셋 산출물을 위한 선언적 빌드 명세.
 
@@ -66,6 +84,7 @@ class BuildSpec:
         transforms: 적용 예정인 변환 단계 이름 목록.
         metadata: 산출물에 실을 임의 메타데이터.
         publish: 빌드 후 게시까지 수행할지 여부.
+        splits: 데이터셋 분할 정의. 없으면 분할하지 않는다.
 
     예시:
         >>> BuildSpec.from_yaml("specs/sample.yaml")
@@ -79,6 +98,7 @@ class BuildSpec:
     transforms: tuple[str, ...] = ()
     metadata: dict[str, str] = field(default_factory=dict)
     publish: bool = False
+    splits: SplitSpec | None = None
 
     @classmethod
     def from_yaml(cls, path: str | Path) -> BuildSpec:
@@ -102,4 +122,5 @@ __all__ = [
     "JsonPrimitive",
     "JsonValue",
     "SourceRef",
+    "SplitSpec",
 ]

--- a/src/kpubdata_builder/spec/validator.py
+++ b/src/kpubdata_builder/spec/validator.py
@@ -50,8 +50,33 @@ def validate_spec(spec: BuildSpec) -> None:
         if not key.strip():
             problems.append("metadata keys must be non-empty strings")
             break
+    problems.extend(_split_problems(spec))
     if problems:
         raise ValidationError(problems)
+
+
+def _split_problems(spec: BuildSpec) -> list[str]:
+    """splits 정의의 검증 문제를 모은다."""
+    split = spec.splits
+    if split is None:
+        return []
+    problems: list[str] = []
+    if split.mode == "ratio":
+        if not split.ratios:
+            problems.append("splits.ratios must define at least one split")
+        if any(not name.strip() for name in split.ratios):
+            problems.append("splits.ratios names must be non-empty strings")
+        if any(fraction <= 0 for fraction in split.ratios.values()):
+            problems.append("splits.ratios values must be positive")
+        total = sum(split.ratios.values())
+        if split.ratios and abs(total - 1.0) > 1e-6:
+            problems.append(f"splits.ratios must sum to 1.0 (got {total})")
+    elif split.mode == "key":
+        if not split.key.strip():
+            problems.append("splits.key must be a non-empty column name for key mode")
+    else:
+        problems.append(f"splits.mode {split.mode!r} is not supported; use 'ratio' or 'key'")
+    return problems
 
 
 __all__ = ["validate_spec"]

--- a/src/kpubdata_builder/stages/gold/__init__.py
+++ b/src/kpubdata_builder/stages/gold/__init__.py
@@ -16,6 +16,7 @@ from .build import build_gold_package
 from .card import CardField, DatasetCard, build_dataset_card, render_dataset_card
 from .models import ExportPlan, GoldPackage
 from .persist import GoldPersistResult, persist_gold_package
+from .split import apply_splits
 
 __all__ = [
     "CardField",
@@ -23,6 +24,7 @@ __all__ = [
     "ExportPlan",
     "GoldPackage",
     "GoldPersistResult",
+    "apply_splits",
     "build_dataset_card",
     "build_gold_package",
     "persist_gold_package",

--- a/src/kpubdata_builder/stages/gold/split.py
+++ b/src/kpubdata_builder/stages/gold/split.py
@@ -1,0 +1,82 @@
+"""레코드를 명명된 분할로 나누는 로직 (#38).
+
+SplitSpec에 따라 레코드 시퀀스를 train/val/test 같은 비율 분할 또는 컬럼 값
+기반(연도/지역/카테고리) 분할로 나눈다. 비율 분할은 시드 기반으로 결정적이며,
+레코드 순서와 무관하게 재현 가능하다.
+
+주요 함수:
+    - apply_splits: 레코드 + SplitSpec → {split 이름: 레코드 튜플}
+"""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Sequence
+
+from ...spec import JsonValue, SplitSpec
+
+Record = dict[str, JsonValue]
+
+
+def _allocate_counts(total: int, ratios: dict[str, float], names: list[str]) -> dict[str, int]:
+    """비율을 정수 카운트로 배분한다(합 = total). 잔여는 큰 소수부 순으로 분배한다."""
+    ratio_sum = sum(ratios.values())
+    exact = {name: total * ratios[name] / ratio_sum for name in names}
+    counts = {name: int(exact[name]) for name in names}
+    remainder = total - sum(counts.values())
+    # 소수부가 큰 순서(동률이면 이름 순)로 잔여를 배분해 결정성을 보장한다.
+    by_fraction = sorted(names, key=lambda name: (exact[name] - counts[name], name), reverse=True)
+    for name in by_fraction[:remainder]:
+        counts[name] += 1
+    return counts
+
+
+def _ratio_split(
+    records: Sequence[Record], ratios: dict[str, float], seed: int
+) -> dict[str, tuple[Record, ...]]:
+    """비율에 따라 레코드를 결정적으로 분할한다."""
+    names = sorted(ratios)
+    counts = _allocate_counts(len(records), ratios, names)
+    order = list(range(len(records)))
+    random.Random(seed).shuffle(order)
+
+    result: dict[str, tuple[Record, ...]] = {}
+    position = 0
+    for name in names:
+        chosen = order[position : position + counts[name]]
+        position += counts[name]
+        # 원본 순서를 보존해 결과를 안정적으로 만든다.
+        result[name] = tuple(records[index] for index in sorted(chosen))
+    return result
+
+
+def _key_split(records: Sequence[Record], key: str) -> dict[str, tuple[Record, ...]]:
+    """컬럼 값에 따라 레코드를 그룹으로 분할한다(값 → 분할 이름)."""
+    grouped: dict[str, list[Record]] = {}
+    for record in records:
+        bucket = str(record.get(key, ""))
+        grouped.setdefault(bucket, []).append(record)
+    return {name: tuple(rows) for name, rows in grouped.items()}
+
+
+def apply_splits(records: Sequence[Record], spec: SplitSpec) -> dict[str, tuple[Record, ...]]:
+    """SplitSpec에 따라 레코드를 명명된 분할로 나눈다.
+
+    매개변수:
+        records: 분할할 레코드 시퀀스.
+        spec: 분할 정의.
+
+    반환값:
+        dict[str, tuple[Record, ...]]: 분할 이름 → 레코드 튜플.
+
+    예외:
+        ValueError: 지원하지 않는 split 모드인 경우.
+    """
+    if spec.mode == "ratio":
+        return _ratio_split(records, spec.ratios, spec.seed)
+    if spec.mode == "key":
+        return _key_split(records, spec.key)
+    raise ValueError(f"Unsupported split mode: {spec.mode!r}")
+
+
+__all__ = ["apply_splits"]

--- a/tests/unit/test_split.py
+++ b/tests/unit/test_split.py
@@ -1,0 +1,119 @@
+"""Split 지원(#38): 분할 로직·spec 로딩·검증을 확인한다."""
+
+from __future__ import annotations
+
+import pytest
+
+from kpubdata_builder import ValidationError
+from kpubdata_builder.spec import JsonValue, SplitSpec, parse_spec
+from kpubdata_builder.spec.validator import validate_spec
+from kpubdata_builder.stages.gold import apply_splits
+
+
+def _records(n: int) -> list[dict[str, JsonValue]]:
+    return [{"id": str(i)} for i in range(n)]
+
+
+def test_ratio_split_allocates_exact_counts_and_partitions() -> None:
+    spec = SplitSpec(mode="ratio", ratios={"train": 0.8, "test": 0.2}, seed=0)
+    records = _records(10)
+
+    result = apply_splits(records, spec)
+
+    assert len(result["train"]) == 8
+    assert len(result["test"]) == 2
+    # 분할은 원본을 완전 분할(disjoint + 합집합 = 전체)해야 한다.
+    train_ids = {row["id"] for row in result["train"]}
+    test_ids = {row["id"] for row in result["test"]}
+    assert train_ids.isdisjoint(test_ids)
+    assert train_ids | test_ids == {row["id"] for row in records}
+
+
+def test_ratio_split_is_reproducible_with_seed() -> None:
+    spec = SplitSpec(mode="ratio", ratios={"train": 0.5, "test": 0.5}, seed=42)
+    records = _records(20)
+
+    assert apply_splits(records, spec) == apply_splits(records, spec)
+
+
+def test_ratio_split_preserves_original_order_within_split() -> None:
+    spec = SplitSpec(mode="ratio", ratios={"a": 0.5, "b": 0.5}, seed=1)
+    records = _records(6)
+
+    result = apply_splits(records, spec)
+
+    for rows in result.values():
+        ids = [int(row["id"]) for row in rows]  # type: ignore[arg-type]
+        assert ids == sorted(ids)
+
+
+def test_key_split_groups_by_column_value() -> None:
+    spec = SplitSpec(mode="key", key="year")
+    records: list[dict[str, JsonValue]] = [
+        {"id": "1", "year": "2024"},
+        {"id": "2", "year": "2025"},
+        {"id": "3", "year": "2024"},
+    ]
+
+    result = apply_splits(records, spec)
+
+    assert set(result) == {"2024", "2025"}
+    assert len(result["2024"]) == 2
+    assert len(result["2025"]) == 1
+
+
+def test_apply_splits_rejects_unknown_mode() -> None:
+    with pytest.raises(ValueError, match="split mode"):
+        apply_splits(_records(1), SplitSpec(mode="bogus"))
+
+
+def _base_spec_dict() -> dict[str, object]:
+    return {
+        "dataset_id": "apt_trade",
+        "title": "Apartment Trades",
+        "description": "seoul apartment trades",
+        "sources": [{"provider": "datago", "dataset": "apt_trade"}],
+        "exports": [{"kind": "jsonl", "output_path": "data.jsonl"}],
+    }
+
+
+def test_parse_spec_reads_ratio_splits() -> None:
+    data = _base_spec_dict()
+    data["splits"] = {"mode": "ratio", "ratios": {"train": 0.8, "test": 0.2}, "seed": 7}
+
+    spec = parse_spec(data)
+
+    assert spec.splits == SplitSpec(
+        mode="ratio", ratios={"train": 0.8, "test": 0.2}, key="", seed=7
+    )
+
+
+def test_parse_spec_splits_default_none() -> None:
+    assert parse_spec(_base_spec_dict()).splits is None
+
+
+def test_validate_spec_rejects_ratios_not_summing_to_one() -> None:
+    data = _base_spec_dict()
+    data["splits"] = {"mode": "ratio", "ratios": {"train": 0.7, "test": 0.2}}
+
+    with pytest.raises(ValidationError) as exc_info:
+        validate_spec(parse_spec(data))
+
+    assert any("sum to 1.0" in p for p in exc_info.value.problems)
+
+
+def test_validate_spec_rejects_key_mode_without_key() -> None:
+    data = _base_spec_dict()
+    data["splits"] = {"mode": "key"}
+
+    with pytest.raises(ValidationError) as exc_info:
+        validate_spec(parse_spec(data))
+
+    assert any("splits.key" in p for p in exc_info.value.problems)
+
+
+def test_validate_spec_accepts_valid_ratio_splits() -> None:
+    data = _base_spec_dict()
+    data["splits"] = {"mode": "ratio", "ratios": {"train": 0.8, "test": 0.2}}
+
+    validate_spec(parse_spec(data))  # 예외가 없어야 한다.


### PR DESCRIPTION
## 요약
이슈 #38 (`[v0.2] Split support in BuildSpec and exporters`)을 해결합니다. 데이터셋을 명명된 분할(train/val/test, by year/region/category)로 나누는 기능을 BuildSpec과 분할 로직에 추가합니다.

## 변경 내용
- `spec/models.py`: `SplitSpec` 모델(`ratio`/`key` 모드) + `BuildSpec.splits` 필드
- `spec/loader.py`: YAML `splits` 파싱 (`_parse_splits`)
- `spec/validator.py`: 분할 검증 (ratio 합 1.0·양수·이름, key 모드 컬럼명, 지원 모드)
- `stages/gold/split.py`: `apply_splits(records, spec)`
- 테스트: `tests/unit/test_split.py` (분할 로직 + spec 로딩 + 검증)

## 분할 모드
- **ratio**: 비율 기반(train/val/test). 시드 기반 **결정적**(재현 가능) 셔플 + 정확한 카운트 배분(잔여는 큰 소수부 순). 분할 내 원본 순서 보존.
- **key**: 컬럼 값 기반(연도/지역/카테고리)으로 그룹 분할.

## 범위 노트
export-per-split의 **전면 파이프라인 연결**은 stage-aware exporter(#28, 진행 중)에 의존하므로, 본 PR은 **spec 계약 + 분할 로직 + 검증**을 제공합니다. exporter/pipeline은 `apply_splits`를 호출해 분할별로 내보낼 수 있습니다.

## 검증
- `pytest tests/unit` — 150 passed (split 10건 신규)
- `mypy src` — no issues (49 files)
- `ruff check .` / `ruff format --check` — 통과

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)