### PR TITLE
feat(diff): 빌드 매니페스트 diff/compare 도구 추가 (#16)

### DIFF
--- a/src/kpubdata_builder/diff.py
+++ b/src/kpubdata_builder/diff.py
@@ -1,0 +1,145 @@
+"""두 빌드 매니페스트를 비교하는 diff 도구 (#16).
+
+이 모듈은 두 BuildManifest를 받아 소스/레코드 수/산출물/오류·경고의 변화를
+구조화된 차이 목록으로 반환한다. 빌드 간 무엇이 추가·삭제·변경되었는지 한눈에
+파악할 수 있게 한다.
+
+주요 구성:
+    - DiffItem: 단일 변경 항목
+    - BuildDiff: 비교 결과
+    - compare_manifests: 두 BuildManifest 비교
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .manifest import BuildManifest
+
+ADDED = "added"
+REMOVED = "removed"
+MODIFIED = "modified"
+
+
+@dataclass(frozen=True)
+class DiffItem:
+    """두 빌드 사이의 단일 변경 항목.
+
+    속성:
+        field: 변경된 항목 식별자 (예: "row_count:datago.apt_trade").
+        old_value: 이전 값 (추가된 경우 빈 문자열).
+        new_value: 새 값 (삭제된 경우 빈 문자열).
+        change_type: "added" | "removed" | "modified".
+    """
+
+    field: str
+    old_value: str
+    new_value: str
+    change_type: str
+
+
+@dataclass(frozen=True)
+class BuildDiff:
+    """두 BuildManifest 비교 결과.
+
+    속성:
+        manifest_a: 기준(이전) 빌드 ID.
+        manifest_b: 비교(이후) 빌드 ID.
+        diffs: 변경 항목 목록 (결정적 순서).
+        summary: 사람이 읽는 한 줄 요약.
+    """
+
+    manifest_a: str
+    manifest_b: str
+    diffs: tuple[DiffItem, ...]
+    summary: str
+
+    @property
+    def changed(self) -> bool:
+        """변경 항목이 하나라도 있으면 True."""
+        return bool(self.diffs)
+
+
+def _diff_set(field_prefix: str, before: tuple[str, ...], after: tuple[str, ...]) -> list[DiffItem]:
+    """집합 형태 필드(소스/산출물)의 추가·삭제를 비교한다."""
+    before_set, after_set = set(before), set(after)
+    items = [
+        DiffItem(field=f"{field_prefix}:{value}", old_value="", new_value=value, change_type=ADDED)
+        for value in sorted(after_set - before_set)
+    ]
+    items += [
+        DiffItem(
+            field=f"{field_prefix}:{value}", old_value=value, new_value="", change_type=REMOVED
+        )
+        for value in sorted(before_set - after_set)
+    ]
+    return items
+
+
+def _diff_row_counts(before: dict[str, int], after: dict[str, int]) -> list[DiffItem]:
+    """소스별 레코드 수의 추가·삭제·변경을 비교한다."""
+    items: list[DiffItem] = []
+    for key in sorted(set(before) | set(after)):
+        in_before, in_after = key in before, key in after
+        if in_before and in_after:
+            if before[key] != after[key]:
+                items.append(
+                    DiffItem(
+                        field=f"row_count:{key}",
+                        old_value=str(before[key]),
+                        new_value=str(after[key]),
+                        change_type=MODIFIED,
+                    )
+                )
+        elif in_after:
+            items.append(
+                DiffItem(
+                    field=f"row_count:{key}",
+                    old_value="",
+                    new_value=str(after[key]),
+                    change_type=ADDED,
+                )
+            )
+        else:
+            items.append(
+                DiffItem(
+                    field=f"row_count:{key}",
+                    old_value=str(before[key]),
+                    new_value="",
+                    change_type=REMOVED,
+                )
+            )
+    return items
+
+
+def compare_manifests(a: BuildManifest, b: BuildManifest) -> BuildDiff:
+    """두 BuildManifest를 비교해 BuildDiff를 만든다.
+
+    매개변수:
+        a: 기준(이전) 매니페스트.
+        b: 비교(이후) 매니페스트.
+
+    반환값:
+        BuildDiff: 결정적 순서의 변경 목록과 한 줄 요약.
+    """
+    diffs: list[DiffItem] = []
+    diffs += _diff_set("source", a.inputs, b.inputs)
+    diffs += _diff_row_counts(a.row_counts, b.row_counts)
+    diffs += _diff_set("output", a.outputs, b.outputs)
+    diffs += _diff_set("error", a.errors, b.errors)
+    diffs += _diff_set("warning", a.warnings, b.warnings)
+
+    if diffs:
+        added = sum(1 for item in diffs if item.change_type == ADDED)
+        removed = sum(1 for item in diffs if item.change_type == REMOVED)
+        modified = sum(1 for item in diffs if item.change_type == MODIFIED)
+        summary = f"{len(diffs)} change(s): {added} added, {removed} removed, {modified} modified"
+    else:
+        summary = "no changes"
+
+    return BuildDiff(
+        manifest_a=a.build_id, manifest_b=b.build_id, diffs=tuple(diffs), summary=summary
+    )
+
+
+__all__ = ["ADDED", "MODIFIED", "REMOVED", "BuildDiff", "DiffItem", "compare_manifests"]

--- a/tests/unit/test_diff.py
+++ b/tests/unit/test_diff.py
@@ -1,0 +1,101 @@
+"""Build diff/compare 도구(#16)를 검증한다."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from kpubdata_builder.diff import BuildDiff, DiffItem, compare_manifests
+from kpubdata_builder.manifest import BuildManifest
+
+_TS = datetime(2026, 5, 26, 1, 0, 0, tzinfo=timezone.utc)
+
+
+def _manifest(
+    build_id: str,
+    *,
+    inputs: tuple[str, ...] = (),
+    outputs: tuple[str, ...] = (),
+    errors: tuple[str, ...] = (),
+    warnings: tuple[str, ...] = (),
+    row_counts: dict[str, int] | None = None,
+) -> BuildManifest:
+    return BuildManifest(
+        build_id=build_id,
+        started_at=_TS,
+        finished_at=_TS,
+        inputs=inputs,
+        outputs=outputs,
+        errors=errors,
+        warnings=warnings,
+        row_counts=row_counts or {},
+    )
+
+
+def test_identical_manifests_have_no_diffs() -> None:
+    a = _manifest("a", inputs=("datago.apt_trade",), row_counts={"datago.apt_trade": 10})
+    b = _manifest("b", inputs=("datago.apt_trade",), row_counts={"datago.apt_trade": 10})
+
+    result = compare_manifests(a, b)
+
+    assert isinstance(result, BuildDiff)
+    assert result.diffs == ()
+    assert result.changed is False
+    assert result.summary == "no changes"
+    assert (result.manifest_a, result.manifest_b) == ("a", "b")
+
+
+def test_detects_row_count_modification() -> None:
+    a = _manifest("a", row_counts={"datago.apt_trade": 1000})
+    b = _manifest("b", row_counts={"datago.apt_trade": 1200})
+
+    result = compare_manifests(a, b)
+
+    assert DiffItem("row_count:datago.apt_trade", "1000", "1200", "modified") in result.diffs
+    assert result.changed is True
+
+
+def test_detects_added_and_removed_sources() -> None:
+    a = _manifest("a", inputs=("datago.apt_trade",))
+    b = _manifest("b", inputs=("datago.air_quality",))
+
+    result = compare_manifests(a, b)
+
+    assert DiffItem("source:datago.air_quality", "", "datago.air_quality", "added") in result.diffs
+    assert DiffItem("source:datago.apt_trade", "datago.apt_trade", "", "removed") in result.diffs
+
+
+def test_detects_added_row_count_and_output_and_error() -> None:
+    a = _manifest("a")
+    b = _manifest(
+        "b",
+        row_counts={"datago.apt_trade": 5},
+        outputs=("out/data.jsonl",),
+        errors=("datago.x: boom",),
+    )
+
+    result = compare_manifests(a, b)
+    fields = {(item.field, item.change_type) for item in result.diffs}
+
+    assert ("row_count:datago.apt_trade", "added") in fields
+    assert ("output:out/data.jsonl", "added") in fields
+    assert ("error:datago.x: boom", "added") in fields
+
+
+def test_summary_counts_change_types() -> None:
+    a = _manifest("a", inputs=("s1",), row_counts={"s1": 10})
+    b = _manifest("b", inputs=("s2",), row_counts={"s1": 20})
+
+    result = compare_manifests(a, b)
+
+    # s2 added, s1 removed (source), row_count s1 modified.
+    assert result.summary == "3 change(s): 1 added, 1 removed, 1 modified"
+
+
+def test_diffs_are_deterministic_order() -> None:
+    a = _manifest("a", row_counts={})
+    b = _manifest("b", row_counts={"b_src": 1, "a_src": 1})
+
+    result = compare_manifests(a, b)
+
+    fields = [item.field for item in result.diffs]
+    assert fields == sorted(fields)


### PR DESCRIPTION
## 요약
이슈 #16 (`[v0.3] Build diff/compare tools`)을 해결합니다. 두 BuildManifest를 비교해 무엇이 달라졌는지 구조화된 차이로 보여주는 `compare_manifests`를 구현합니다.

## 변경 내용
- `src/kpubdata_builder/diff.py` 신규 — `DiffItem`, `BuildDiff`, `compare_manifests`
- `tests/unit/test_diff.py` 신규 — 6건

## 동작
- 비교 대상: 소스(`inputs`), 소스별 레코드 수(`row_counts`), 산출물(`outputs`), 오류/경고
- 각 변경은 `DiffItem(field, old_value, new_value, change_type)` (`added`/`removed`/`modified`)
- `BuildDiff`는 결정적 순서의 변경 목록 + 한 줄 요약(`"N change(s): a added, r removed, m modified"`) + `changed` 프로퍼티
- 동일 manifest → `no changes`

## 범위 노트
upstream/main의 `BuildManifest` 필드(inputs/row_counts/outputs/errors/warnings)를 비교합니다. 스키마 변화 diff는 `schema_summaries`(#11) 머지 이후 자연스럽게 확장 가능합니다.

## 검증
- `pytest tests/unit` — 146 passed (diff 6건 신규)
- `mypy src` — no issues (49 files)
- `ruff check .` / `ruff format --check` — 통과

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)