### PR TITLE
feat(spec): 재사용 가능한 빌드 템플릿 추가 (#14)

### DIFF
--- a/src/kpubdata_builder/spec/__init__.py
+++ b/src/kpubdata_builder/spec/__init__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from .loader import load_spec, parse_spec
 from .models import BuildSpec, ExportTarget, JsonPrimitive, JsonValue, SourceRef
+from .template import load_template, render_template
 
 __all__ = [
     "BuildSpec",
@@ -21,5 +22,7 @@ __all__ = [
     "JsonValue",
     "SourceRef",
     "load_spec",
+    "load_template",
     "parse_spec",
+    "render_template",
 ]

--- a/src/kpubdata_builder/spec/template.py
+++ b/src/kpubdata_builder/spec/template.py
@@ -1,0 +1,105 @@
+"""재사용 가능한 빌드 템플릿 렌더링 (#14).
+
+자주 쓰는 빌드 패턴을 `_template` 메타 블록 + ``{{ param }}`` 플레이스홀더를 가진
+YAML 템플릿으로 정의하고, 파라미터만 바꿔 완성된 BuildSpec YAML을 생성한다.
+외부 의존성 없이 stdlib 정규식 치환을 사용한다.
+
+주요 함수:
+    - render_template: 템플릿 + 파라미터 → 완성된 YAML 문자열
+    - load_template: 템플릿을 렌더링해 BuildSpec으로 로드
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+from ..errors import SpecLoadError
+from .loader import parse_spec
+from .models import BuildSpec
+
+_PLACEHOLDER = re.compile(r"\{\{\s*(\w+)\s*\}\}")
+
+
+def _effective_params(template_meta: dict[str, object], params: dict[str, str]) -> dict[str, str]:
+    """선언된 파라미터 기본값에 사용자 파라미터를 덮어써 최종 값을 만든다."""
+    effective: dict[str, str] = {}
+    declared = template_meta.get("parameters", {})
+    if isinstance(declared, dict):
+        for name, meta in declared.items():
+            if isinstance(meta, dict) and "default" in meta:
+                effective[str(name)] = str(meta["default"])
+    for name, value in params.items():
+        effective[name] = str(value)
+    return effective
+
+
+def render_template(path: str | Path, params: dict[str, str]) -> str:
+    """템플릿 YAML을 파라미터로 렌더링해 완성된 YAML 문자열을 반환한다.
+
+    매개변수:
+        path: 템플릿 YAML 경로.
+        params: 플레이스홀더에 채울 파라미터(선언된 기본값을 덮어쓴다).
+
+    반환값:
+        str: `_template` 블록이 제거되고 플레이스홀더가 치환된 YAML.
+
+    예외:
+        SpecLoadError: 파일 로드 실패, 최상위가 매핑이 아님, 또는 값이 없는
+            플레이스홀더가 남은 경우.
+    """
+    try:
+        raw = Path(path).read_text(encoding="utf-8")
+        loaded = yaml.safe_load(raw)
+    except (OSError, yaml.YAMLError) as exc:
+        raise SpecLoadError(f"Failed to load template from {path}: {exc}") from exc
+
+    if not isinstance(loaded, dict):
+        raise SpecLoadError(f"Failed to render template {path}: top-level YAML must be a mapping")
+
+    data: dict[str, object] = dict(loaded)
+    template_meta = data.pop("_template", {})
+    meta = template_meta if isinstance(template_meta, dict) else {}
+    effective = _effective_params(meta, params)
+
+    body_yaml = yaml.safe_dump(data, allow_unicode=True, sort_keys=False)
+
+    missing: list[str] = []
+
+    def _replace(match: re.Match[str]) -> str:
+        name = match.group(1)
+        if name not in effective:
+            missing.append(name)
+            return match.group(0)
+        return effective[name]
+
+    rendered = _PLACEHOLDER.sub(_replace, body_yaml)
+    if missing:
+        unique = ", ".join(sorted(set(missing)))
+        raise SpecLoadError(f"Missing template parameter(s): {unique}")
+    return rendered
+
+
+def load_template(path: str | Path, params: dict[str, str]) -> BuildSpec:
+    """템플릿을 렌더링한 뒤 BuildSpec으로 파싱한다.
+
+    매개변수:
+        path: 템플릿 YAML 경로.
+        params: 플레이스홀더 파라미터.
+
+    반환값:
+        BuildSpec: 렌더링·파싱된 빌드 명세.
+
+    예외:
+        SpecLoadError: 렌더링 또는 파싱 실패 시.
+    """
+    rendered = render_template(path, params)
+    loaded = yaml.safe_load(rendered)
+    if not isinstance(loaded, dict):
+        raise SpecLoadError(f"Rendered template {path} is not a mapping")
+    return parse_spec(loaded)
+
+
+__all__ = ["load_template", "render_template"]

--- a/tests/unit/test_template.py
+++ b/tests/unit/test_template.py
@@ -1,0 +1,85 @@
+"""재사용 가능한 빌드 템플릿(#14) 렌더링·로딩을 검증한다."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from kpubdata_builder.errors import SpecLoadError
+from kpubdata_builder.spec import load_template, render_template
+
+_TEMPLATE = """\
+_template:
+  name: air quality
+  parameters:
+    station_name:
+      default: 종로구
+    fmt:
+      default: jsonl
+dataset_id: "air_quality_{{ station_name }}"
+title: "{{ station_name }} 대기오염"
+description: "air quality for {{ station_name }}"
+sources:
+  - provider: datago
+    dataset: air_quality
+    params:
+      stationName: "{{ station_name }}"
+exports:
+  - kind: "{{ fmt }}"
+    output_path: "data.{{ fmt }}"
+"""
+
+
+def _write_template(tmp_path: Path) -> Path:
+    path = tmp_path / "air_quality.yaml"
+    path.write_text(_TEMPLATE, encoding="utf-8")
+    return path
+
+
+def test_render_uses_defaults_when_no_params(tmp_path: Path) -> None:
+    rendered = render_template(_write_template(tmp_path), {})
+
+    data = yaml.safe_load(rendered)
+    assert data["dataset_id"] == "air_quality_종로구"
+    assert data["exports"][0]["kind"] == "jsonl"
+    # _template 메타 블록은 제거되어야 한다.
+    assert "_template" not in data
+
+
+def test_render_overrides_defaults_with_params(tmp_path: Path) -> None:
+    rendered = render_template(_write_template(tmp_path), {"station_name": "강남구", "fmt": "csv"})
+
+    data = yaml.safe_load(rendered)
+    assert data["dataset_id"] == "air_quality_강남구"
+    assert data["title"] == "강남구 대기오염"
+    assert data["sources"][0]["params"]["stationName"] == "강남구"
+    assert data["exports"][0]["output_path"] == "data.csv"
+
+
+def test_load_template_returns_valid_build_spec(tmp_path: Path) -> None:
+    spec = load_template(_write_template(tmp_path), {"station_name": "강남구"})
+
+    assert spec.dataset_id == "air_quality_강남구"
+    assert spec.sources[0].provider == "datago"
+    assert spec.exports[0].kind == "jsonl"
+
+
+def test_render_raises_on_missing_parameter(tmp_path: Path) -> None:
+    # 기본값도 없고 제공되지도 않은 플레이스홀더가 있으면 오류.
+    path = tmp_path / "t.yaml"
+    path.write_text(
+        '_template:\n  name: t\ndataset_id: "{{ missing }}"\ntitle: t\n', encoding="utf-8"
+    )
+
+    with pytest.raises(SpecLoadError, match="Missing template parameter"):
+        render_template(path, {})
+
+
+def test_render_rejects_non_mapping_template(tmp_path: Path) -> None:
+    path = tmp_path / "bad.yaml"
+    path.write_text("- just\n- a\n- list\n", encoding="utf-8")
+
+    with pytest.raises(SpecLoadError, match="must be a mapping"):
+        render_template(path, {})


### PR DESCRIPTION
## 요약
이슈 #14 (`[v0.3] Reusable build templates`)를 해결합니다. 자주 쓰는 빌드 패턴을 템플릿으로 정의하고 파라미터만 바꿔 BuildSpec을 빠르게 생성합니다.

## 변경 내용
- `src/kpubdata_builder/spec/template.py` 신규 — `render_template`, `load_template`
- `spec/__init__.py` — 템플릿 API export
- `tests/unit/test_template.py` 신규 — 5건

## 동작
- 템플릿 YAML은 `_template` 메타 블록(`parameters`의 `default` 포함)과 `{{ param }}` 플레이스홀더를 가짐
- `render_template(path, params)`: `_template` 블록 제거 → 선언된 default에 `params`를 덮어써 플레이스홀더 치환 → 완성 YAML 문자열 반환
- `load_template(path, params)`: 렌더링 후 `parse_spec`으로 `BuildSpec` 반환
- 값이 없는(default도 없고 미제공) 플레이스홀더가 남으면 `SpecLoadError`
- **Jinja2 등 외부 의존성 없이** stdlib 정규식 치환 사용

## 검증
- `pytest tests/unit` — 145 passed (template 5건 신규)
- `mypy src` — no issues (49 files)
- `ruff check .` / `ruff format --check` — 통과

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)