### PR TITLE
feat(exporters): 플러그인 exporter 등록·발견 API 추가 (#13)

### DIFF
--- a/src/kpubdata_builder/exporters/__init__.py
+++ b/src/kpubdata_builder/exporters/__init__.py
@@ -1,10 +1,11 @@
-"""내장 내보내기 구현을 위한 내보내기 도구 레지스트리.
+"""내장 내보내기 구현과 플러그인 레지스트리.
 
-이 모듈은 기본 exporter 구현을 import 시점에 등록하여 kind 문자열만으로
-구현 객체를 찾을 수 있게 한다.
+내장 exporter를 import 시점에 레지스트리에 등록하고, 제3자 exporter 등록·발견을
+위한 플러그인 API(registry.py)를 함께 노출한다.
 
 주요 구성:
     - EXPORTER_REGISTRY: kind -> exporter 인스턴스 매핑
+    - register_exporter / get_exporter / load_entry_point_exporters: 플러그인 API
 """
 
 from __future__ import annotations
@@ -15,23 +16,33 @@ from .huggingface import HuggingFaceExporter
 from .jsonl import JsonlExporter
 from .markdown import MarkdownExporter
 from .parquet import ParquetExporter
+from .registry import (
+    EXPORTER_ENTRY_POINT_GROUP,
+    EXPORTER_REGISTRY,
+    get_exporter,
+    load_entry_point_exporters,
+    register_exporter,
+)
 
-EXPORTER_REGISTRY: dict[str, BaseExporter] = {
-    "csv": CsvExporter(),
-    "huggingface": HuggingFaceExporter(),
-    "jsonl": JsonlExporter(),
-    "markdown": MarkdownExporter(),
-    "parquet": ParquetExporter(),
-}
+# 내장 exporter 등록 (이미 등록된 경우 재import 시 덮어쓴다).
+register_exporter(CsvExporter(), override=True)
+register_exporter(HuggingFaceExporter(), override=True)
+register_exporter(JsonlExporter(), override=True)
+register_exporter(MarkdownExporter(), override=True)
+register_exporter(ParquetExporter(), override=True)
 
 __all__ = [
+    "EXPORTER_ENTRY_POINT_GROUP",
+    "EXPORTER_REGISTRY",
     "BaseExporter",
     "CsvExporter",
-    "EXPORTER_REGISTRY",
     "ExportResult",
     "HuggingFaceExporter",
     "JsonlExporter",
     "MarkdownExporter",
     "ParquetExporter",
     "ensure_output_dir",
+    "get_exporter",
+    "load_entry_point_exporters",
+    "register_exporter",
 ]

--- a/src/kpubdata_builder/exporters/registry.py
+++ b/src/kpubdata_builder/exporters/registry.py
@@ -1,0 +1,91 @@
+"""내보내기 도구 레지스트리와 플러그인 등록 API (#13).
+
+이 모듈은 kind 문자열 → exporter 인스턴스 매핑을 보관하고, 제3자 exporter를
+두 가지 방식으로 등록할 수 있게 한다.
+
+방식 A (코드 내 등록):
+    register_exporter(MyExporter())
+
+방식 B (entry points 자동 발견):
+    외부 패키지가 pyproject.toml에 entry point를 선언하면, 명시적으로
+    load_entry_point_exporters()를 호출해 발견·등록한다 (import 시 임의의
+    서드파티 코드를 실행하지 않도록 자동 로드는 하지 않는다).
+
+        [project.entry-points."kpubdata_builder.exporters"]
+        csv = "my_package:CsvExporter"
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import entry_points
+
+from .base import BaseExporter
+
+EXPORTER_ENTRY_POINT_GROUP = "kpubdata_builder.exporters"
+
+EXPORTER_REGISTRY: dict[str, BaseExporter] = {}
+
+
+def register_exporter(exporter: BaseExporter, *, override: bool = False) -> None:
+    """exporter 인스턴스를 그 name으로 레지스트리에 등록한다.
+
+    매개변수:
+        exporter: 등록할 BaseExporter 인스턴스.
+        override: 같은 이름이 이미 있을 때 덮어쓸지 여부.
+
+    예외:
+        ValueError: 같은 이름이 이미 등록되어 있고 override가 False인 경우.
+    """
+    name = exporter.name
+    if name in EXPORTER_REGISTRY and not override:
+        raise ValueError(f"exporter {name!r} is already registered")
+    EXPORTER_REGISTRY[name] = exporter
+
+
+def get_exporter(name: str) -> BaseExporter:
+    """등록된 exporter를 kind 이름으로 조회한다.
+
+    매개변수:
+        name: exporter kind 문자열.
+
+    반환값:
+        BaseExporter: 등록된 인스턴스.
+
+    예외:
+        KeyError: 등록되지 않은 이름인 경우.
+    """
+    if name not in EXPORTER_REGISTRY:
+        raise KeyError(f"unknown exporter kind: {name!r}; registered: {sorted(EXPORTER_REGISTRY)}")
+    return EXPORTER_REGISTRY[name]
+
+
+def load_entry_point_exporters(*, override: bool = False) -> list[str]:
+    """entry point 그룹에서 외부 exporter 플러그인을 발견·등록한다.
+
+    각 entry point는 BaseExporter 인스턴스 또는 인자 없이 생성 가능한 클래스를
+    가리켜야 한다. 클래스면 인스턴스화한 뒤 등록한다.
+
+    매개변수:
+        override: 기존 등록을 덮어쓸지 여부.
+
+    반환값:
+        list[str]: 등록된 exporter 이름 목록(이름 순).
+    """
+    registered: list[str] = []
+    for entry_point in entry_points(group=EXPORTER_ENTRY_POINT_GROUP):
+        loaded = entry_point.load()
+        exporter = loaded() if isinstance(loaded, type) else loaded
+        if not isinstance(exporter, BaseExporter):
+            raise TypeError(f"entry point {entry_point.name!r} did not resolve to a BaseExporter")
+        register_exporter(exporter, override=override)
+        registered.append(exporter.name)
+    return sorted(registered)
+
+
+__all__ = [
+    "EXPORTER_ENTRY_POINT_GROUP",
+    "EXPORTER_REGISTRY",
+    "get_exporter",
+    "load_entry_point_exporters",
+    "register_exporter",
+]

--- a/tests/unit/test_plugin_exporter.py
+++ b/tests/unit/test_plugin_exporter.py
@@ -1,0 +1,129 @@
+"""Plugin exporter API(#13): 코드 내 등록과 entry point 발견을 검증한다."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+import kpubdata_builder.exporters.registry as registry
+from kpubdata_builder import ArtifactDataset
+from kpubdata_builder.exporters import (
+    EXPORTER_REGISTRY,
+    BaseExporter,
+    ExportResult,
+    get_exporter,
+    load_entry_point_exporters,
+    register_exporter,
+)
+from kpubdata_builder.spec import ExportTarget
+
+
+class _FakeExporter(BaseExporter):
+    @property
+    def name(self) -> str:
+        return "fake"
+
+    def export(
+        self, artifact: ArtifactDataset, target: ExportTarget, output_dir: Path
+    ) -> ExportResult:
+        destination = output_dir / target.output_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        _ = destination.write_text("fake", encoding="utf-8")
+        return ExportResult(
+            output_path=destination, file_size=destination.stat().st_size, format=self.name
+        )
+
+
+class _FakeExporter2(_FakeExporter):
+    @property
+    def name(self) -> str:
+        return "fake2"
+
+
+class _FakeEntryPoint:
+    def __init__(self, name: str, value: object) -> None:
+        self.name = name
+        self._value = value
+
+    def load(self) -> object:
+        return self._value
+
+
+@pytest.fixture(autouse=True)
+def _restore_registry() -> Iterator[None]:
+    # 전역 레지스트리를 스냅샷 후 복원해 테스트 간 오염을 막는다.
+    snapshot = dict(EXPORTER_REGISTRY)
+    try:
+        yield
+    finally:
+        EXPORTER_REGISTRY.clear()
+        EXPORTER_REGISTRY.update(snapshot)
+
+
+def test_builtin_exporters_are_registered() -> None:
+    assert set(EXPORTER_REGISTRY) >= {"jsonl", "markdown"}
+
+
+def test_register_and_get_exporter() -> None:
+    register_exporter(_FakeExporter())
+
+    assert isinstance(get_exporter("fake"), _FakeExporter)
+
+
+def test_register_duplicate_without_override_raises() -> None:
+    register_exporter(_FakeExporter())
+
+    with pytest.raises(ValueError, match="already registered"):
+        register_exporter(_FakeExporter())
+
+
+def test_register_duplicate_with_override_replaces() -> None:
+    first = _FakeExporter()
+    second = _FakeExporter()
+    register_exporter(first)
+
+    register_exporter(second, override=True)
+
+    assert get_exporter("fake") is second
+
+
+def test_get_exporter_unknown_raises() -> None:
+    with pytest.raises(KeyError, match="unknown exporter kind"):
+        get_exporter("does-not-exist")
+
+
+def test_load_entry_point_exporters_discovers_class_and_instance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # 클래스(인스턴스화 필요)와 인스턴스 둘 다 entry point에서 발견·등록되는지 확인한다.
+    eps = [
+        _FakeEntryPoint("by-class", _FakeExporter),
+        _FakeEntryPoint("by-instance", _FakeExporter2()),
+    ]
+
+    def fake_entry_points(*, group: str) -> list[_FakeEntryPoint]:
+        assert group == registry.EXPORTER_ENTRY_POINT_GROUP
+        return eps
+
+    monkeypatch.setattr(registry, "entry_points", fake_entry_points)
+
+    loaded = load_entry_point_exporters(override=True)
+
+    assert loaded == ["fake", "fake2"]
+    assert isinstance(get_exporter("fake"), _FakeExporter)
+    assert isinstance(get_exporter("fake2"), _FakeExporter2)
+
+
+def test_load_entry_point_exporters_rejects_non_exporter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_entry_points(*, group: str) -> list[_FakeEntryPoint]:
+        del group
+        return [_FakeEntryPoint("bad", object())]
+
+    monkeypatch.setattr(registry, "entry_points", fake_entry_points)
+
+    with pytest.raises(TypeError, match="did not resolve to a BaseExporter"):
+        load_entry_point_exporters()


### PR DESCRIPTION
## 요약
이슈 #13 (`[v0.3] Plugin exporter API`)을 해결합니다. 외부 개발자가 자신의 exporter를 등록해 쓸 수 있는 플러그인 인터페이스를 제공합니다.

## 변경 내용
- `src/kpubdata_builder/exporters/registry.py` 신규 — `EXPORTER_REGISTRY` + `register_exporter` / `get_exporter` / `load_entry_point_exporters`
- `exporters/__init__.py` — 레지스트리 API re-export + 내장 jsonl/markdown 등록
- `tests/unit/test_plugin_exporter.py` 신규 — 7건

## 두 가지 등록 방식
- **방식 A (코드 내)**: `register_exporter(MyExporter())` — 중복은 `override`로 제어, 미등록 조회는 `get_exporter`가 `KeyError`
- **방식 B (entry points)**: `[project.entry-points."kpubdata_builder.exporters"]` 그룹을 `load_entry_point_exporters()`로 발견·등록. 클래스는 인스턴스화하고, `BaseExporter`가 아니면 `TypeError`

## 설계 노트
- entry point 자동 발견은 **명시적 함수 호출**로 제공합니다(import 시점에 임의의 서드파티 코드를 실행하지 않도록). 
- `EXPORTER_REGISTRY`는 단일 소스(registry.py)로 유지되며 `__init__`에서 내장 exporter를 등록합니다. `validate_spec` 등 기존 사용처는 그대로 동작합니다.

## 검증
- `pytest tests/unit` — 147 passed (plugin 7건 신규)
- `mypy src` — no issues (49 files)
- `ruff check .` / `ruff format --check` — 통과

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)