### PR TITLE
feat(catalog): 정적 데이터 카탈로그 페이지 생성기 추가 (#42)

### DIFF
--- a/src/kpubdata_builder/catalog.py
+++ b/src/kpubdata_builder/catalog.py
@@ -1,0 +1,128 @@
+"""정적 데이터 카탈로그 페이지 생성기 (#42).
+
+빌드 매니페스트를 기반으로 브랜드 배포용 정적 HTML 카탈로그 페이지를 만든다.
+각 데이터셋의 제목·설명·레코드 수·소스 수·산출물 목록을 카드로 나열한다.
+모든 동적 텍스트는 HTML 이스케이프되어 안전하게 삽입된다.
+
+주요 구성:
+    - CatalogEntry: 카탈로그 한 항목
+    - catalog_entry_from_manifest: BuildManifest → CatalogEntry
+    - render_catalog_html: 항목 목록 → 완성된 HTML 문서
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from html import escape
+
+from .manifest import BuildManifest
+
+
+@dataclass(frozen=True)
+class CatalogEntry:
+    """카탈로그 페이지의 단일 데이터셋 항목.
+
+    속성:
+        dataset_id: 데이터셋 식별자.
+        title: 표시 제목.
+        description: 설명.
+        record_count: 총 레코드 수.
+        source_count: 소스 수.
+        outputs: 산출물 경로 목록.
+    """
+
+    dataset_id: str
+    title: str
+    description: str = ""
+    record_count: int = 0
+    source_count: int = 0
+    outputs: tuple[str, ...] = field(default_factory=tuple)
+
+
+def catalog_entry_from_manifest(
+    manifest: BuildManifest,
+    *,
+    dataset_id: str,
+    title: str,
+    description: str = "",
+) -> CatalogEntry:
+    """BuildManifest에서 카탈로그 항목을 파생한다.
+
+    레코드 수는 row_counts 합, 소스 수는 inputs 길이로 계산한다.
+
+    매개변수:
+        manifest: 통계를 가져올 빌드 매니페스트.
+        dataset_id: 데이터셋 식별자.
+        title: 표시 제목.
+        description: 설명.
+
+    반환값:
+        CatalogEntry: 렌더링 가능한 카탈로그 항목.
+    """
+    return CatalogEntry(
+        dataset_id=dataset_id,
+        title=title,
+        description=description,
+        record_count=sum(manifest.row_counts.values()),
+        source_count=len(manifest.inputs),
+        outputs=tuple(manifest.outputs),
+    )
+
+
+def _render_entry(entry: CatalogEntry) -> list[str]:
+    """단일 카탈로그 항목을 HTML 카드로 렌더링한다."""
+    lines = [
+        '    <article class="dataset-card">',
+        f"      <h2>{escape(entry.title)}</h2>",
+        f'      <p class="dataset-id">{escape(entry.dataset_id)}</p>',
+    ]
+    if entry.description:
+        lines.append(f"      <p>{escape(entry.description)}</p>")
+    lines += [
+        '      <ul class="stats">',
+        f"        <li>Records: {entry.record_count}</li>",
+        f"        <li>Sources: {entry.source_count}</li>",
+        f"        <li>Outputs: {len(entry.outputs)}</li>",
+        "      </ul>",
+    ]
+    if entry.outputs:
+        lines.append('      <ul class="outputs">')
+        lines += [f"        <li>{escape(path)}</li>" for path in entry.outputs]
+        lines.append("      </ul>")
+    lines.append("    </article>")
+    return lines
+
+
+def render_catalog_html(entries: list[CatalogEntry], *, site_title: str = "Data Catalog") -> str:
+    """카탈로그 항목 목록을 완성된 정적 HTML 문서로 렌더링한다.
+
+    매개변수:
+        entries: 표시할 카탈로그 항목 (주어진 순서를 보존).
+        site_title: 페이지 제목.
+
+    반환값:
+        str: 마지막 줄바꿈을 포함한 HTML 문서.
+    """
+    head = [
+        "<!DOCTYPE html>",
+        '<html lang="ko">',
+        "<head>",
+        '  <meta charset="utf-8">',
+        f"  <title>{escape(site_title)}</title>",
+        "</head>",
+        "<body>",
+        f"  <h1>{escape(site_title)}</h1>",
+        f'  <p class="count">{len(entries)} dataset(s)</p>',
+        '  <main class="catalog">',
+    ]
+    body: list[str] = []
+    if entries:
+        for entry in entries:
+            body += _render_entry(entry)
+    else:
+        body.append("    <p>No datasets available.</p>")
+    tail = ["  </main>", "</body>", "</html>"]
+    return "\n".join(head + body + tail) + "\n"
+
+
+__all__ = ["CatalogEntry", "catalog_entry_from_manifest", "render_catalog_html"]

--- a/tests/unit/test_catalog.py
+++ b/tests/unit/test_catalog.py
@@ -1,0 +1,84 @@
+"""Data catalog page 생성기(#42)를 검증한다."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from kpubdata_builder.catalog import (
+    CatalogEntry,
+    catalog_entry_from_manifest,
+    render_catalog_html,
+)
+from kpubdata_builder.manifest import BuildManifest
+
+_TS = datetime(2026, 5, 26, 1, 0, 0, tzinfo=timezone.utc)
+
+
+def test_entry_from_manifest_derives_counts() -> None:
+    manifest = BuildManifest(
+        build_id="run1",
+        started_at=_TS,
+        finished_at=_TS,
+        inputs=("datago.apt_trade", "datago.air_quality"),
+        outputs=("out/a.jsonl", "out/b.jsonl"),
+        row_counts={"datago.apt_trade": 100, "datago.air_quality": 50},
+    )
+
+    entry = catalog_entry_from_manifest(
+        manifest, dataset_id="seoul", title="Seoul", description="desc"
+    )
+
+    assert entry.record_count == 150
+    assert entry.source_count == 2
+    assert entry.outputs == ("out/a.jsonl", "out/b.jsonl")
+
+
+def test_render_lists_entries_with_stats() -> None:
+    entries = [
+        CatalogEntry(
+            dataset_id="seoul",
+            title="Seoul Apartments",
+            description="trades",
+            record_count=150,
+            source_count=2,
+            outputs=("out/a.jsonl",),
+        )
+    ]
+
+    html = render_catalog_html(entries, site_title="KPubData Catalog")
+
+    assert html.startswith("<!DOCTYPE html>")
+    assert "<title>KPubData Catalog</title>" in html
+    assert "1 dataset(s)" in html
+    assert "Seoul Apartments" in html
+    assert "Records: 150" in html
+    assert "Sources: 2" in html
+    assert "out/a.jsonl" in html
+    assert html.endswith("\n")
+
+
+def test_render_escapes_html_in_dynamic_text() -> None:
+    entries = [CatalogEntry(dataset_id="x", title="<script>alert(1)</script>")]
+
+    html = render_catalog_html(entries)
+
+    assert "<script>alert(1)</script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_render_empty_catalog() -> None:
+    html = render_catalog_html([])
+
+    assert "0 dataset(s)" in html
+    assert "No datasets available." in html
+
+
+def test_render_preserves_entry_order() -> None:
+    entries = [
+        CatalogEntry(dataset_id="b", title="B"),
+        CatalogEntry(dataset_id="a", title="A"),
+    ]
+
+    html = render_catalog_html(entries)
+
+    assert html.index("B") < html.index("A")


### PR DESCRIPTION
## 요약
이슈 #42 (`[v0.3] Data catalog page exporter`)를 해결합니다. 빌드 매니페스트를 기반으로 브랜드 배포용 **정적 HTML 카탈로그 페이지**를 생성합니다.

## 변경 내용
- `src/kpubdata_builder/catalog.py` 신규 — `CatalogEntry`, `catalog_entry_from_manifest`, `render_catalog_html`
- `tests/unit/test_catalog.py` 신규 — 5건

## 동작
- `catalog_entry_from_manifest(manifest, ...)`: `record_count`(=`row_counts` 합), `source_count`(=`inputs` 길이), `outputs`를 매니페스트에서 파생
- `render_catalog_html(entries, site_title=...)`: 각 데이터셋을 제목/설명/통계/산출물 카드로 나열한 완성 HTML 문서 생성
- 모든 동적 텍스트를 `html.escape`로 이스케이프(XSS 방지), 입력 순서 보존, 빈 카탈로그도 안전 렌더링

## 설계 노트
카탈로그는 여러 데이터셋을 가로질러 집계하는 **사이트 생성기** 성격이라 per-artifact `BaseExporter`가 아닌 독립 모듈로 구현했습니다. dataset card(#37) 정보가 머지되면 카드 메타데이터를 추가로 엮을 수 있습니다.

## 검증
- `pytest tests/unit` — 145 passed (catalog 5건 신규)
- `mypy src` — no issues (49 files)
- `ruff check .` / `ruff format --check` — 통과

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)