### PR TITLE
feat(contract): Builder Service Contract OpenAPI 3.1 정의 (#63)

### DIFF
--- a/contract/builder-api.yaml
+++ b/contract/builder-api.yaml
@@ -1,0 +1,366 @@
+openapi: 3.1.0
+info:
+  title: KPubData Builder Service API
+  version: "1.0.0"
+  description: >-
+    Builder 중심 서비스 계약. BuildSpec 검증, preview, build 실행, manifest/artifact
+    조회, publish 실행을 제공한다. CLI와 HTTP service mode가 동일한 도메인 계약을
+    공유한다. 본 문서는 API_CONTRACT.md의 기계 판독용(OpenAPI 3.1) 단일 소스이며,
+    Studio 같은 소비자가 타입 클라이언트를 생성하는 기준이 된다.
+servers:
+  - url: http://localhost:8000
+    description: 로컬 builder 개발 서버
+
+paths:
+  /datasets:
+    get:
+      operationId: listDatasets
+      summary: 사용 가능한 dataset/source 메타데이터 조회 (동기식)
+      responses:
+        "200":
+          description: dataset 카탈로그
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DatasetCatalog"
+
+  /spec/validate:
+    post:
+      operationId: validateSpec
+      summary: BuildSpec 검증 (동기식)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SpecRequest"
+      responses:
+        "200":
+          description: 검증 결과
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidateResponse"
+        "422":
+          $ref: "#/components/responses/ErrorResponse"
+
+  /preview:
+    post:
+      operationId: previewBuild
+      summary: 샘플 실행 및 export preview (동기식)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PreviewRequest"
+      responses:
+        "200":
+          description: preview 결과
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PreviewResponse"
+        "422":
+          $ref: "#/components/responses/ErrorResponse"
+
+  /builds:
+    post:
+      operationId: createBuild
+      summary: 새로운 build 실행 시작 (비동기식)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SpecRequest"
+      responses:
+        "202":
+          description: build 수락됨
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BuildAccepted"
+        "422":
+          $ref: "#/components/responses/ErrorResponse"
+
+  /builds/{id}:
+    get:
+      operationId: getBuild
+      summary: build 상태 조회 (비동기식)
+      parameters:
+        - $ref: "#/components/parameters/BuildId"
+      responses:
+        "200":
+          description: build 상태
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BuildStatus"
+        "404":
+          $ref: "#/components/responses/ErrorResponse"
+
+  /builds/{id}/manifest:
+    get:
+      operationId: getBuildManifest
+      summary: build manifest 조회 (manifested 이상 상태)
+      parameters:
+        - $ref: "#/components/parameters/BuildId"
+      responses:
+        "200":
+          description: manifest 본문
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ManifestResponse"
+        "404":
+          $ref: "#/components/responses/ErrorResponse"
+
+  /builds/{id}/artifacts:
+    get:
+      operationId: listBuildArtifacts
+      summary: build artifact 목록 조회 (exported 이상 상태)
+      parameters:
+        - $ref: "#/components/parameters/BuildId"
+      responses:
+        "200":
+          description: artifact 목록
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ArtifactsResponse"
+        "404":
+          $ref: "#/components/responses/ErrorResponse"
+
+  /publish:
+    post:
+      operationId: publishArtifacts
+      summary: 이미 생성된 build artifact 게시 (비동기식)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PublishRequest"
+      responses:
+        "202":
+          description: publish 수락됨
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PublishAccepted"
+        "422":
+          $ref: "#/components/responses/ErrorResponse"
+
+components:
+  parameters:
+    BuildId:
+      name: id
+      in: path
+      required: true
+      description: build 실행 식별자
+      schema:
+        type: string
+
+  responses:
+    ErrorResponse:
+      description: 표준 오류 응답
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+
+  schemas:
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: object
+          required: [code, message]
+          properties:
+            code:
+              type: string
+              description: 안정적인 기계 판독용 오류 코드
+            message:
+              type: string
+              description: 사람이 읽는 요약 메시지
+            details:
+              type: array
+              items:
+                type: object
+                properties:
+                  field:
+                    type: string
+                  reason:
+                    type: string
+
+    BuildState:
+      type: string
+      enum: [draft, validated, running, exported, manifested, published, failed]
+
+    BuildSpec:
+      type: object
+      description: 선언적 빌드 명세. 세부 스키마는 spec 모델을 따른다.
+      additionalProperties: true
+
+    SpecRequest:
+      type: object
+      required: [spec]
+      properties:
+        spec:
+          $ref: "#/components/schemas/BuildSpec"
+
+    PreviewRequest:
+      type: object
+      required: [spec]
+      properties:
+        spec:
+          $ref: "#/components/schemas/BuildSpec"
+        limit:
+          type: integer
+          minimum: 1
+          default: 5
+
+    DatasetCatalog:
+      type: object
+      required: [datasets]
+      properties:
+        datasets:
+          type: array
+          items:
+            type: object
+            required: [provider, dataset]
+            properties:
+              provider:
+                type: string
+              dataset:
+                type: string
+              supports_preview:
+                type: boolean
+              supported_exports:
+                type: array
+                items:
+                  type: string
+
+    ValidateResponse:
+      type: object
+      required: [valid]
+      properties:
+        valid:
+          type: boolean
+        issues:
+          type: array
+          items:
+            type: string
+
+    PreviewResponse:
+      type: object
+      required: [records, schema]
+      properties:
+        stage:
+          type: string
+        records:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        schema:
+          type: object
+          additionalProperties:
+            type: string
+        export_preview:
+          type: object
+          properties:
+            format:
+              type: string
+            artifact_path:
+              type: string
+
+    BuildAccepted:
+      type: object
+      required: [build_id, state]
+      properties:
+        build_id:
+          type: string
+        state:
+          $ref: "#/components/schemas/BuildState"
+        status_url:
+          type: string
+
+    BuildStatus:
+      type: object
+      required: [build_id, state]
+      properties:
+        build_id:
+          type: string
+        dataset:
+          type: string
+        state:
+          $ref: "#/components/schemas/BuildState"
+        started_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    Artifact:
+      type: object
+      required: [path, format]
+      properties:
+        path:
+          type: string
+        format:
+          type: string
+        size_bytes:
+          type: integer
+
+    ManifestResponse:
+      type: object
+      required: [build_id, manifest]
+      properties:
+        build_id:
+          type: string
+        state:
+          $ref: "#/components/schemas/BuildState"
+        manifest:
+          type: object
+          additionalProperties: true
+
+    ArtifactsResponse:
+      type: object
+      required: [build_id, artifacts]
+      properties:
+        build_id:
+          type: string
+        artifacts:
+          type: array
+          items:
+            $ref: "#/components/schemas/Artifact"
+
+    PublishRequest:
+      type: object
+      required: [build_id, target]
+      properties:
+        build_id:
+          type: string
+        target:
+          type: object
+          required: [kind]
+          properties:
+            kind:
+              type: string
+            repository:
+              type: string
+
+    PublishAccepted:
+      type: object
+      required: [publish_id, build_id, state]
+      properties:
+        publish_id:
+          type: string
+        build_id:
+          type: string
+        state:
+          type: string

--- a/tests/unit/test_service_contract.py
+++ b/tests/unit/test_service_contract.py
@@ -1,0 +1,111 @@
+"""Builder Service Contract(#63) OpenAPI 스펙의 구조 검증.
+
+설치된 OpenAPI validator가 없으므로, 계약이 OpenAPI 3.1이고 API_CONTRACT.md의
+8개 엔드포인트와 표준 오류 스키마를 모두 담는지 구조적으로 검증한다. 실행 중인
+builder dev server 대비 계약 테스트는 service mode(#36) 도입 후 확장한다.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+_CONTRACT_PATH = Path(__file__).parents[2] / "contract" / "builder-api.yaml"
+
+# (path, method) 형태의 계약 필수 오퍼레이션.
+_REQUIRED_OPERATIONS = [
+    ("/datasets", "get"),
+    ("/spec/validate", "post"),
+    ("/preview", "post"),
+    ("/builds", "post"),
+    ("/builds/{id}", "get"),
+    ("/builds/{id}/manifest", "get"),
+    ("/builds/{id}/artifacts", "get"),
+    ("/publish", "post"),
+]
+
+
+def _load_contract() -> dict[str, Any]:
+    return cast(dict[str, Any], yaml.safe_load(_CONTRACT_PATH.read_text(encoding="utf-8")))
+
+
+def test_contract_file_exists() -> None:
+    assert _CONTRACT_PATH.is_file()
+
+
+def test_is_openapi_3_1_with_info() -> None:
+    contract = _load_contract()
+
+    assert str(contract["openapi"]).startswith("3.1")
+    assert contract["info"]["title"]
+    assert contract["info"]["version"]
+
+
+def test_covers_all_required_operations() -> None:
+    paths = _load_contract()["paths"]
+
+    for path, method in _REQUIRED_OPERATIONS:
+        assert path in paths, f"missing path: {path}"
+        assert method in paths[path], f"missing {method.upper()} {path}"
+        assert paths[path][method].get("operationId"), f"missing operationId for {method} {path}"
+
+
+def test_operation_ids_are_unique() -> None:
+    paths = _load_contract()["paths"]
+    operation_ids = [
+        operation["operationId"]
+        for methods in paths.values()
+        for operation in methods.values()
+        if isinstance(operation, dict) and "operationId" in operation
+    ]
+
+    assert len(operation_ids) == len(set(operation_ids))
+
+
+def test_defines_standard_error_schema() -> None:
+    schemas = _load_contract()["components"]["schemas"]
+
+    assert "Error" in schemas
+    error_props = schemas["Error"]["properties"]["error"]["properties"]
+    assert {"code", "message", "details"} <= set(error_props)
+
+
+def test_build_state_enum_matches_contract() -> None:
+    schemas = _load_contract()["components"]["schemas"]
+
+    assert set(schemas["BuildState"]["enum"]) == {
+        "draft",
+        "validated",
+        "running",
+        "exported",
+        "manifested",
+        "published",
+        "failed",
+    }
+
+
+def test_referenced_schemas_resolve() -> None:
+    # 모든 로컬 $ref("#/components/...")가 실제로 존재하는지 확인한다.
+    contract = _load_contract()
+
+    def _iter_refs(node: object) -> list[str]:
+        refs: list[str] = []
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key == "$ref" and isinstance(value, str):
+                    refs.append(value)
+                else:
+                    refs.extend(_iter_refs(value))
+        elif isinstance(node, list):
+            for item in node:
+                refs.extend(_iter_refs(item))
+        return refs
+
+    for ref in _iter_refs(contract):
+        assert ref.startswith("#/"), f"unexpected external ref: {ref}"
+        target: Any = contract
+        for part in ref.lstrip("#/").split("/"):
+            assert part in target, f"unresolved $ref: {ref}"
+            target = target[part]


### PR DESCRIPTION
## 요약
이슈 #63 (`Define official Builder Service Contract (OpenAPI/JSON Schema)`)을 해결합니다. `API_CONTRACT.md`의 Builder 중심 계약을 **기계 판독용 OpenAPI 3.1** 스펙으로 형식화해, Studio 등 소비자가 손으로 쓴 stub 대신 타입 클라이언트를 생성할 단일 소스를 제공합니다.

## 변경 내용
- `contract/builder-api.yaml` 신규 — OpenAPI 3.1 스펙
- `tests/unit/test_service_contract.py` 신규 — 계약 구조 검증 7건

## 커버 범위 (API_CONTRACT.md의 8개 엔드포인트)
`GET /datasets`, `POST /spec/validate`, `POST /preview`, `POST /builds`, `GET /builds/{id}`, `GET /builds/{id}/manifest`, `GET /builds/{id}/artifacts`, `POST /publish` + 표준 `Error` 응답 스키마 + `BuildState` enum(draft…published/failed).

## 계약 테스트
설치된 OpenAPI validator가 없어 pyyaml 기반 **구조 검증**을 수행합니다: OpenAPI 3.1 여부, 8개 오퍼레이션 모두 커버, `operationId` 유일성, 표준 Error 스키마, 모든 로컬 `$ref` 해소 가능성.

## 범위 노트
"실행 중인 builder dev server 대비 계약 테스트"(수락 기준 2번)는 HTTP service mode(#36)에 의존하므로, #36 머지 후 dev server 대상 테스트로 확장할 수 있습니다. 본 PR은 **단일 소스 스펙 + 구조 계약 테스트**를 제공합니다.

## 검증
- `pytest tests/unit` — 147 passed (contract 7건 신규)
- `mypy src` — no issues
- `ruff check .` / `ruff format --check` — 통과

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)