### PR TITLE
feat(ci): 재사용 가능한 dataset 퍼블리시 워크플로 추가 (#70)

### DIFF
--- a/.github/workflows/publish-dataset.yml
+++ b/.github/workflows/publish-dataset.yml
@@ -1,0 +1,66 @@
+name: Publish dataset
+
+# DATA_FRESHNESS.md의 업데이트 전략을 실행하는 재사용 가능한 퍼블리시 워크플로.
+#
+# - workflow_call: 데이터셋별 스케줄 워크플로가 config/mode를 넘겨 호출한다.
+# - workflow_dispatch: 운영자가 수동(백필 포함)으로 실행한다.
+#
+# Atomic publish 원칙(로컬 빌드 → 검증 → 단일 HF commit)은 scripts/publish_to_hf.py가
+# 담당한다. 시크릿(API key)이 없으면 라이브 실행을 건너뛰어 no-op으로 성공 처리한다.
+# 데이터셋별 cron 스케줄은 시크릿/구성이 준비된 뒤 별도 스케줄 워크플로에서
+# 본 워크플로를 호출해 활성화한다(DATA_FRESHNESS.md의 스케줄 표 참고).
+
+on:
+  workflow_call:
+    inputs:
+      config:
+        description: 퍼블리시 config YAML 경로
+        required: true
+        type: string
+      mode:
+        description: "퍼블리시 모드 플래그 (--local-only | --dry-run | 빈 문자열=라이브)"
+        required: false
+        type: string
+        default: "--local-only"
+    secrets:
+      KPUBDATA_DATAGO_API_KEY:
+        required: false
+      HF_TOKEN:
+        required: false
+  workflow_dispatch:
+    inputs:
+      config:
+        description: 퍼블리시 config YAML 경로
+        required: true
+        type: string
+      mode:
+        description: "퍼블리시 모드 플래그 (--local-only | --dry-run | 빈 문자열=라이브)"
+        required: false
+        type: string
+        default: "--local-only"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv sync --extra dev --extra publish
+
+      - name: Publish dataset (atomic, guarded by secrets)
+        env:
+          KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          CONFIG: ${{ inputs.config }}
+          MODE: ${{ inputs.mode }}
+        run: |
+          if [ -z "${KPUBDATA_DATAGO_API_KEY}" ]; then
+            echo "::notice::KPUBDATA_DATAGO_API_KEY 미설정 — 라이브 실행을 건너뜁니다(no-op)."
+            exit 0
+          fi
+          uv run python scripts/publish_to_hf.py "${CONFIG}" ${MODE}

--- a/tests/unit/test_publish_workflow.py
+++ b/tests/unit/test_publish_workflow.py
@@ -1,0 +1,55 @@
+"""scheduled dataset update workflow(#70)의 퍼블리시 워크플로 구조를 검증한다.
+
+GitHub Actions 러너 없이 실행 결과를 검증할 수 없으므로, 워크플로 YAML이
+파싱되고 재사용/수동 트리거·퍼블리시 스크립트 호출·시크릿 가드를 갖췄는지
+구조적으로 확인한다. 데이터셋별 cron 스케줄 전략은 DATA_FRESHNESS.md에 정의된다.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+_ROOT = Path(__file__).parents[2]
+_WORKFLOW = _ROOT / ".github" / "workflows" / "publish-dataset.yml"
+
+
+def _load_workflow() -> dict[Any, Any]:
+    return cast(dict[Any, Any], yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8")))
+
+
+def _triggers(workflow: dict[Any, Any]) -> dict[str, Any]:
+    # PyYAML(YAML 1.1)은 bare `on:` 키를 boolean True로 파싱한다(GitHub Actions 관용).
+    raw = workflow.get("on", workflow.get(True))
+    return cast(dict[str, Any], raw)
+
+
+def test_workflow_file_exists_and_parses() -> None:
+    assert _WORKFLOW.is_file()
+    assert isinstance(_load_workflow(), dict)
+
+
+def test_supports_reusable_and_manual_triggers() -> None:
+    triggers = _triggers(_load_workflow())
+
+    assert "workflow_call" in triggers
+    assert "workflow_dispatch" in triggers
+    # 재사용 호출은 config 입력을 요구한다.
+    assert "config" in triggers["workflow_call"]["inputs"]
+
+
+def test_publish_step_invokes_publish_script_with_guard() -> None:
+    workflow = _load_workflow()
+    steps = workflow["jobs"]["publish"]["steps"]
+    run_blocks = "\n".join(step.get("run", "") for step in steps)
+
+    assert "scripts/publish_to_hf.py" in run_blocks
+    # 시크릿 미설정 시 라이브 실행을 건너뛰는 가드가 있어야 한다.
+    assert "KPUBDATA_DATAGO_API_KEY" in run_blocks
+
+
+def test_data_freshness_policy_doc_exists() -> None:
+    # 스케줄 전략의 단일 소스 문서가 존재해야 한다.
+    assert (_ROOT / "DATA_FRESHNESS.md").is_file()


### PR DESCRIPTION
## 요약
이슈 #70 (`Implement scheduled dataset update workflows (CI/CD)`)의 **Phase 1 (core infrastructure)**을 구현합니다. `DATA_FRESHNESS.md`(이미 존재)에 정의된 업데이트 전략을 실행할 재사용 가능한 GitHub Actions 퍼블리시 워크플로를 추가합니다.

## 변경 내용
- `.github/workflows/publish-dataset.yml` 신규 — 재사용/수동 퍼블리시 워크플로
- `tests/unit/test_publish_workflow.py` 신규 — 워크플로 구조 검증 4건

## 동작
- `workflow_call`: 데이터셋별 스케줄 워크플로가 `config`/`mode`를 넘겨 호출
- `workflow_dispatch`: 운영자가 수동(백필 포함) 실행
- Atomic publish(로컬 빌드 → 검증 → 단일 HF commit)는 기존 `scripts/publish_to_hf.py`에 위임
- 시크릿(`KPUBDATA_DATAGO_API_KEY`)이 없으면 라이브 실행을 건너뛰어 **no-op 성공** 처리

## 의도적 범위 (Phase 2/3 후속)
- `DATA_FRESHNESS.md`에 9개 데이터셋의 cron 스케줄·전략(append-only/incremental/full refresh)·모니터링이 **이미 문서화**되어 있습니다.
- **활성 `on: schedule` cron은 추가하지 않았습니다**: (1) 시크릿/구성이 없으면 매일 실패하는 run이 upstream에 생기고, (2) 일부 데이터셋 config는 아직 없습니다. 시크릿·config가 준비되면 본 재사용 워크플로를 호출하는 스케줄 워크플로로 데이터셋별 활성화할 수 있습니다(문서의 스케줄 표 기준).
- Phase 3(API 호출 수 추적, retry/알림, 월간 reconcile)은 라이브 퍼블리시 활성화와 함께 후속으로 둡니다.

## 검증
- `pytest tests/unit` — 144 passed (workflow 4건 신규)
- 워크플로 YAML 파싱·트리거·스크립트 호출·시크릿 가드 구조 검증
- `mypy src` / `ruff check .` / `ruff format --check` — 통과

부분 구현(Phase 1)이므로 이슈를 자동 종료하지 않습니다. Refs #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)