### PR TITLE
feat(manifest): add schema summary to BuildManifest (#11)

### DIFF
--- a/src/kpubdata_builder/__init__.py
+++ b/src/kpubdata_builder/__init__.py
@@ -12,7 +12,13 @@ from .errors import (
     SpecLoadError,
     ValidationError,
 )
-from .manifest import BuildManifest, manifest_writer
+from .manifest import (
+    BuildManifest,
+    FieldSummary,
+    SchemaSummary,
+    extract_schema_summary,
+    manifest_writer,
+)
 from .spec import BuildSpec, ExportTarget, SourceRef
 from .validator import validate_spec
 
@@ -23,6 +29,9 @@ __all__ = [
     "BuildError",
     "BuildManifest",
     "BuildSpec",
+    "FieldSummary",
+    "SchemaSummary",
+    "extract_schema_summary",
     "ExecutionError",
     "ExportError",
     "ManifestError",

--- a/src/kpubdata_builder/manifest.py
+++ b/src/kpubdata_builder/manifest.py
@@ -11,6 +11,58 @@ from .errors import ManifestError
 
 
 @dataclass(frozen=True)
+class FieldSummary:
+    """Schema description for a single field."""
+
+    name: str
+    type: str
+    nullable: bool
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class SchemaSummary:
+    """Aggregated schema information for an artifact."""
+
+    fields: tuple[FieldSummary, ...]
+    total_fields: int
+
+
+def extract_schema_summary(
+    records: tuple[dict[str, object], ...],
+) -> SchemaSummary | None:
+    """Derive a SchemaSummary from raw records.
+
+    Returns ``None`` when *records* is empty.
+    """
+    if not records:
+        return None
+
+    all_keys: dict[str, None] = {}
+    for rec in records:
+        for k in rec:
+            all_keys.setdefault(k, None)
+
+    field_summaries: list[FieldSummary] = []
+    for key in all_keys:
+        types: set[str] = set()
+        has_none = False
+        for rec in records:
+            val = rec.get(key)
+            if val is None:
+                has_none = True
+            else:
+                types.add(type(val).__name__)
+        inferred_type = ", ".join(sorted(types)) if types else "unknown"
+        field_summaries.append(FieldSummary(name=key, type=inferred_type, nullable=has_none))
+
+    return SchemaSummary(
+        fields=tuple(field_summaries),
+        total_fields=len(field_summaries),
+    )
+
+
+@dataclass(frozen=True)
 class BuildManifest:
     """Execution summary artifact for build auditing."""
 
@@ -22,6 +74,19 @@ class BuildManifest:
     warnings: tuple[str, ...] = ()
     errors: tuple[str, ...] = ()
     row_counts: dict[str, int] = field(default_factory=dict)
+    schema_summary: SchemaSummary | None = None
+
+
+def _serialize_schema_summary(summary: SchemaSummary | None) -> dict[str, object] | None:
+    if summary is None:
+        return None
+    return {
+        "fields": [
+            {"name": f.name, "type": f.type, "nullable": f.nullable, "description": f.description}
+            for f in summary.fields
+        ],
+        "total_fields": summary.total_fields,
+    }
 
 
 def manifest_writer(manifest: BuildManifest, output_path: Path) -> None:
@@ -35,6 +100,7 @@ def manifest_writer(manifest: BuildManifest, output_path: Path) -> None:
         "warnings": list(manifest.warnings),
         "errors": list(manifest.errors),
         "row_counts": manifest.row_counts,
+        "schema_summary": _serialize_schema_summary(manifest.schema_summary),
     }
     serialized = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
     try:
@@ -49,4 +115,11 @@ def write_manifest(manifest: BuildManifest, output_path: Path) -> None:
     manifest_writer(manifest, output_path)
 
 
-__all__ = ["BuildManifest", "manifest_writer", "write_manifest"]
+__all__ = [
+    "BuildManifest",
+    "FieldSummary",
+    "SchemaSummary",
+    "extract_schema_summary",
+    "manifest_writer",
+    "write_manifest",
+]

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -8,7 +8,13 @@ from pathlib import Path
 import pytest
 
 from kpubdata_builder import ManifestError
-from kpubdata_builder.manifest import BuildManifest, manifest_writer
+from kpubdata_builder.manifest import (
+    BuildManifest,
+    FieldSummary,
+    SchemaSummary,
+    extract_schema_summary,
+    manifest_writer,
+)
 
 
 def test_build_manifest_instantiation() -> None:
@@ -50,3 +56,103 @@ def test_manifest_writer_wraps_io_failures(tmp_path: Path, monkeypatch: pytest.M
 
     with pytest.raises(ManifestError):
         manifest_writer(manifest, output_path)
+
+
+# --- extract_schema_summary ---
+
+
+def test_extract_schema_summary_empty_records() -> None:
+    assert extract_schema_summary(()) is None
+
+
+def test_extract_schema_summary_basic() -> None:
+    records: tuple[dict[str, object], ...] = (
+        {"name": "Alice", "age": 30},
+        {"name": "Bob", "age": 25},
+    )
+    summary = extract_schema_summary(records)
+    assert summary is not None
+    assert summary.total_fields == 2
+    assert len(summary.fields) == 2
+
+    by_name = {f.name: f for f in summary.fields}
+    assert by_name["name"].type == "str"
+    assert by_name["name"].nullable is False
+    assert by_name["age"].type == "int"
+    assert by_name["age"].nullable is False
+
+
+def test_extract_schema_summary_nullable() -> None:
+    records: tuple[dict[str, object], ...] = (
+        {"value": 1},
+        {"value": None},
+    )
+    summary = extract_schema_summary(records)
+    assert summary is not None
+    assert summary.fields[0].nullable is True
+
+
+def test_extract_schema_summary_missing_key_is_nullable() -> None:
+    records: tuple[dict[str, object], ...] = (
+        {"a": 1, "b": 2},
+        {"a": 3},
+    )
+    summary = extract_schema_summary(records)
+    assert summary is not None
+    by_name = {f.name: f for f in summary.fields}
+    assert by_name["b"].nullable is True
+
+
+def test_extract_schema_summary_mixed_types() -> None:
+    records: tuple[dict[str, object], ...] = (
+        {"val": 1},
+        {"val": "hello"},
+    )
+    summary = extract_schema_summary(records)
+    assert summary is not None
+    assert summary.fields[0].type == "int, str"
+
+
+# --- manifest with schema_summary ---
+
+
+def test_manifest_writer_includes_schema_summary(tmp_path: Path) -> None:
+    summary = SchemaSummary(
+        fields=(
+            FieldSummary(name="id", type="int", nullable=False),
+            FieldSummary(name="name", type="str", nullable=True, description="person name"),
+        ),
+        total_fields=2,
+    )
+    manifest = BuildManifest(
+        build_id="build-schema",
+        started_at=datetime.now(tz=timezone.utc),
+        finished_at=datetime.now(tz=timezone.utc),
+        schema_summary=summary,
+    )
+    output_path = tmp_path / "manifest.json"
+    manifest_writer(manifest, output_path)
+
+    import json as _json
+
+    data = _json.loads(output_path.read_text(encoding="utf-8"))
+    assert "schema_summary" in data
+    assert data["schema_summary"]["total_fields"] == 2
+    assert len(data["schema_summary"]["fields"]) == 2
+    assert data["schema_summary"]["fields"][0]["name"] == "id"
+    assert data["schema_summary"]["fields"][1]["nullable"] is True
+
+
+def test_manifest_writer_schema_summary_none(tmp_path: Path) -> None:
+    manifest = BuildManifest(
+        build_id="build-no-schema",
+        started_at=datetime.now(tz=timezone.utc),
+        finished_at=datetime.now(tz=timezone.utc),
+    )
+    output_path = tmp_path / "manifest.json"
+    manifest_writer(manifest, output_path)
+
+    import json as _json
+
+    data = _json.loads(output_path.read_text(encoding="utf-8"))
+    assert data["schema_summary"] is None


### PR DESCRIPTION
## Summary
- Add `FieldSummary`, `SchemaSummary` models and `extract_schema_summary()` function
- `BuildManifest` now includes optional `schema_summary` field
- manifest JSON output includes schema_summary section

## Test plan
- [x] `uv run pytest` — 61 passed
- [x] `uv run mypy src` — no errors
- [x] `uv run ruff check .` — all passed

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)