### PR TITLE
feat(manifest): add richer provenance tracking with data checksum (#12)

### DIFF
--- a/src/kpubdata_builder/__init__.py
+++ b/src/kpubdata_builder/__init__.py
@@ -12,7 +12,7 @@ from .errors import (
     SpecLoadError,
     ValidationError,
 )
-from .manifest import BuildManifest, manifest_writer
+from .manifest import BuildManifest, SourceProvenance, manifest_writer
 from .spec import BuildSpec, ExportTarget, SourceRef
 from .validator import validate_spec
 
@@ -27,6 +27,7 @@ __all__ = [
     "ExportError",
     "ManifestError",
     "ExportTarget",
+    "SourceProvenance",
     "SourceRef",
     "SpecLoadError",
     "ValidationError",

--- a/src/kpubdata_builder/manifest.py
+++ b/src/kpubdata_builder/manifest.py
@@ -11,6 +11,18 @@ from .errors import ManifestError
 
 
 @dataclass(frozen=True)
+class SourceProvenance:
+    """Provenance record for a single data source in a build."""
+
+    provider: str
+    dataset: str
+    fetched_at: str
+    params: dict[str, object] = field(default_factory=dict)
+    record_count: int = 0
+    data_checksum: str = ""
+
+
+@dataclass(frozen=True)
 class BuildManifest:
     """Execution summary artifact for build auditing."""
 
@@ -22,6 +34,18 @@ class BuildManifest:
     warnings: tuple[str, ...] = ()
     errors: tuple[str, ...] = ()
     row_counts: dict[str, int] = field(default_factory=dict)
+    provenance: tuple[SourceProvenance, ...] = ()
+
+
+def _serialize_provenance(prov: SourceProvenance) -> dict[str, object]:
+    return {
+        "provider": prov.provider,
+        "dataset": prov.dataset,
+        "fetched_at": prov.fetched_at,
+        "params": prov.params,
+        "record_count": prov.record_count,
+        "data_checksum": prov.data_checksum,
+    }
 
 
 def manifest_writer(manifest: BuildManifest, output_path: Path) -> None:
@@ -35,6 +59,7 @@ def manifest_writer(manifest: BuildManifest, output_path: Path) -> None:
         "warnings": list(manifest.warnings),
         "errors": list(manifest.errors),
         "row_counts": manifest.row_counts,
+        "provenance": [_serialize_provenance(p) for p in manifest.provenance],
     }
     serialized = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
     try:
@@ -49,4 +74,4 @@ def write_manifest(manifest: BuildManifest, output_path: Path) -> None:
     manifest_writer(manifest, output_path)
 
 
-__all__ = ["BuildManifest", "manifest_writer", "write_manifest"]
+__all__ = ["BuildManifest", "SourceProvenance", "manifest_writer", "write_manifest"]

--- a/src/kpubdata_builder/stages/bronze/__init__.py
+++ b/src/kpubdata_builder/stages/bronze/__init__.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 from .build import build_bronze_artifact
-from .models import BronzeArtifact, ProvenanceEvent
+from .models import BronzeArtifact, ProvenanceEvent, compute_data_checksum
 from .persist import BronzePersistResult, persist_bronze_artifact
 
 __all__ = [
     "BronzeArtifact",
     "BronzePersistResult",
     "ProvenanceEvent",
+    "compute_data_checksum",
     "build_bronze_artifact",
     "persist_bronze_artifact",
 ]

--- a/src/kpubdata_builder/stages/bronze/build.py
+++ b/src/kpubdata_builder/stages/bronze/build.py
@@ -7,7 +7,13 @@ from datetime import datetime
 from typing import Protocol
 
 from ...spec import JsonValue
-from .models import BronzeArtifact, ProvenanceEvent, require_timezone_aware, utc_now
+from .models import (
+    BronzeArtifact,
+    ProvenanceEvent,
+    compute_data_checksum,
+    require_timezone_aware,
+    utc_now,
+)
 
 
 class DatasetResult(Protocol):
@@ -51,6 +57,8 @@ def build_bronze_artifact(
         source_key=source_key,
         fetch_params=resolved_params,
         fetched_at=resolved_fetched_at,
+        record_count=len(raw_records),
+        data_checksum=compute_data_checksum(raw_records),
     )
 
     return BronzeArtifact(

--- a/src/kpubdata_builder/stages/bronze/models.py
+++ b/src/kpubdata_builder/stages/bronze/models.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
@@ -19,6 +21,16 @@ def require_timezone_aware(value: datetime, *, field_name: str) -> None:
         raise ValueError(f"{field_name} must be timezone-aware")
 
 
+def compute_data_checksum(records: tuple[dict[str, JsonValue], ...]) -> str:
+    """Compute a deterministic SHA-256 checksum over sorted-key JSON of records."""
+    serialized = json.dumps(
+        [dict(sorted(r.items())) for r in records],
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
 @dataclass(frozen=True)
 class ProvenanceEvent:
     """Record where and when a Bronze source fetch happened."""
@@ -27,6 +39,8 @@ class ProvenanceEvent:
     fetch_params: dict[str, JsonValue] = field(default_factory=dict)
     fetched_at: datetime = field(default_factory=utc_now)
     operation: str = "fetch"
+    record_count: int = 0
+    data_checksum: str = ""
 
     def __post_init__(self) -> None:
         require_timezone_aware(self.fetched_at, field_name="fetched_at")

--- a/src/kpubdata_builder/stages/bronze/persist.py
+++ b/src/kpubdata_builder/stages/bronze/persist.py
@@ -129,6 +129,8 @@ def _provenance_to_dict(provenance: ProvenanceEvent) -> dict[str, JsonValue]:
         "source_key": provenance.source_key,
         "fetch_params": provenance.fetch_params,
         "fetched_at": _format_datetime(provenance.fetched_at),
+        "record_count": provenance.record_count,
+        "data_checksum": provenance.data_checksum,
     }
 
 

--- a/tests/unit/test_bronze.py
+++ b/tests/unit/test_bronze.py
@@ -12,6 +12,7 @@ from kpubdata_builder.stages.bronze import (
     BronzeArtifact,
     ProvenanceEvent,
     build_bronze_artifact,
+    compute_data_checksum,
     persist_bronze_artifact,
 )
 from kpubdata_builder.stages.bronze.build import DatasetResult, SourceDataset
@@ -96,11 +97,12 @@ def test_build_bronze_artifact_fetches_raw_records_without_transforming() -> Non
     assert artifact.raw_records == tuple(records)
     assert artifact.raw_records[0] is records[0]
     assert artifact.record_count == 2
-    assert artifact.provenance == ProvenanceEvent(
-        source_key="datago.apt_trade",
-        fetch_params={"lawd_cd": "11680", "deal_ymd": "202501"},
-        fetched_at=fetched_at,
-    )
+    assert artifact.provenance is not None
+    assert artifact.provenance.source_key == "datago.apt_trade"
+    assert artifact.provenance.fetch_params == {"lawd_cd": "11680", "deal_ymd": "202501"}
+    assert artifact.provenance.fetched_at == fetched_at
+    assert artifact.provenance.record_count == 2
+    assert artifact.provenance.data_checksum != ""
 
 
 def test_persist_bronze_artifact_writes_jsonl_and_metadata(tmp_path: Path) -> None:
@@ -117,6 +119,13 @@ def test_persist_bronze_artifact_writes_jsonl_and_metadata(tmp_path: Path) -> No
             source_key="datago.apt_trade",
             fetch_params={"lawd_cd": "11680"},
             fetched_at=fetched_at,
+            record_count=2,
+            data_checksum=compute_data_checksum(
+                (
+                    {"id": "1", "name": "강남구", "nested": {"b": 2, "a": 1}},
+                    {"id": "2", "name": "서초구", "amount": None},
+                )
+            ),
         ),
     )
 
@@ -142,12 +151,13 @@ def test_persist_bronze_artifact_writes_jsonl_and_metadata(tmp_path: Path) -> No
         "records": "raw_records.jsonl",
         "metadata": "metadata.json",
     }
-    assert metadata["provenance"] == {
-        "operation": "fetch",
-        "source_key": "datago.apt_trade",
-        "fetch_params": {"lawd_cd": "11680"},
-        "fetched_at": "2026-05-08T12:00:00+00:00",
-    }
+    prov = metadata["provenance"]
+    assert prov["operation"] == "fetch"
+    assert prov["source_key"] == "datago.apt_trade"
+    assert prov["fetch_params"] == {"lawd_cd": "11680"}
+    assert prov["fetched_at"] == "2026-05-08T12:00:00+00:00"
+    assert prov["record_count"] == 2
+    assert prov["data_checksum"] != ""
 
 
 def test_persist_bronze_artifact_separates_different_params(tmp_path: Path) -> None:
@@ -189,3 +199,23 @@ def test_persist_bronze_artifact_rejects_unsafe_run_id(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="must not be empty"):
         persist_bronze_artifact(artifact, output_root=tmp_path, run_id="")
+
+
+# --- compute_data_checksum ---
+
+
+def test_compute_data_checksum_deterministic() -> None:
+    records: tuple[dict[str, JsonValue], ...] = ({"a": 1, "b": 2}, {"c": 3})
+    assert compute_data_checksum(records) == compute_data_checksum(records)
+
+
+def test_compute_data_checksum_differs_for_different_data() -> None:
+    r1: tuple[dict[str, JsonValue], ...] = ({"a": 1},)
+    r2: tuple[dict[str, JsonValue], ...] = ({"a": 2},)
+    assert compute_data_checksum(r1) != compute_data_checksum(r2)
+
+
+def test_compute_data_checksum_empty() -> None:
+    checksum = compute_data_checksum(())
+    assert isinstance(checksum, str)
+    assert len(checksum) == 64

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from kpubdata_builder import ManifestError
-from kpubdata_builder.manifest import BuildManifest, manifest_writer
+from kpubdata_builder.manifest import BuildManifest, SourceProvenance, manifest_writer
 
 
 def test_build_manifest_instantiation() -> None:
@@ -50,3 +50,51 @@ def test_manifest_writer_wraps_io_failures(tmp_path: Path, monkeypatch: pytest.M
 
     with pytest.raises(ManifestError):
         manifest_writer(manifest, output_path)
+
+
+# --- provenance in manifest ---
+
+
+def test_manifest_writer_includes_provenance(tmp_path: Path) -> None:
+    prov = SourceProvenance(
+        provider="datago",
+        dataset="apt_trade",
+        fetched_at="2026-05-08T12:00:00+00:00",
+        params={"lawd_cd": "11680"},
+        record_count=10,
+        data_checksum="abc123",
+    )
+    manifest = BuildManifest(
+        build_id="build-prov",
+        started_at=datetime.now(tz=timezone.utc),
+        finished_at=datetime.now(tz=timezone.utc),
+        provenance=(prov,),
+    )
+    output_path = tmp_path / "manifest.json"
+    manifest_writer(manifest, output_path)
+
+    import json
+
+    data = json.loads(output_path.read_text(encoding="utf-8"))
+    assert len(data["provenance"]) == 1
+    p = data["provenance"][0]
+    assert p["provider"] == "datago"
+    assert p["dataset"] == "apt_trade"
+    assert p["record_count"] == 10
+    assert p["data_checksum"] == "abc123"
+    assert p["params"] == {"lawd_cd": "11680"}
+
+
+def test_manifest_provenance_defaults_to_empty(tmp_path: Path) -> None:
+    manifest = BuildManifest(
+        build_id="build-no-prov",
+        started_at=datetime.now(tz=timezone.utc),
+        finished_at=datetime.now(tz=timezone.utc),
+    )
+    output_path = tmp_path / "manifest.json"
+    manifest_writer(manifest, output_path)
+
+    import json
+
+    data = json.loads(output_path.read_text(encoding="utf-8"))
+    assert data["provenance"] == []


### PR DESCRIPTION
## Summary
- Add `compute_data_checksum()` for deterministic SHA-256 over records
- Extend `ProvenanceEvent` with `record_count` and `data_checksum` fields
- Add `SourceProvenance` model and provenance list to `BuildManifest`

## Test plan
- [x] `uv run pytest` — 59 passed
- [x] `uv run mypy src` — no errors
- [x] `uv run ruff check .` — all passed

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)