### PR TITLE
feat(exporters): add CSV exporter (#39)

### DIFF
--- a/src/kpubdata_builder/exporters/__init__.py
+++ b/src/kpubdata_builder/exporters/__init__.py
@@ -3,16 +3,19 @@
 from __future__ import annotations
 
 from .base import BaseExporter, ExportResult, ensure_output_dir
+from .csv import CsvExporter
 from .jsonl import JsonlExporter
 from .markdown import MarkdownExporter
 
 EXPORTER_REGISTRY: dict[str, BaseExporter] = {
+    "csv": CsvExporter(),
     "jsonl": JsonlExporter(),
     "markdown": MarkdownExporter(),
 }
 
 __all__ = [
     "BaseExporter",
+    "CsvExporter",
     "EXPORTER_REGISTRY",
     "ExportResult",
     "JsonlExporter",

--- a/src/kpubdata_builder/exporters/csv.py
+++ b/src/kpubdata_builder/exporters/csv.py
@@ -1,0 +1,45 @@
+"""CSV exporter implementation."""
+
+from __future__ import annotations
+
+import csv
+import io
+from pathlib import Path
+
+from ..artifact import ArtifactDataset
+from ..errors import ExportError
+from ..spec import ExportTarget
+from .base import BaseExporter, ExportResult, ensure_output_dir
+
+
+class CsvExporter(BaseExporter):
+    """Exporter that writes records as comma-separated values."""
+
+    @property
+    def name(self) -> str:
+        return "csv"
+
+    def export(
+        self, artifact: ArtifactDataset, target: ExportTarget, output_dir: Path
+    ) -> ExportResult:
+        destination = ensure_output_dir(output_dir, target.output_path)
+
+        if not artifact.records:
+            content = ""
+        else:
+            fieldnames = list(artifact.records[0].keys())
+            buf = io.StringIO()
+            writer = csv.DictWriter(buf, fieldnames=fieldnames, extrasaction="ignore")
+            writer.writeheader()
+            for record in artifact.records:
+                writer.writerow(record)
+            content = buf.getvalue()
+
+        try:
+            _ = destination.write_text(content, encoding="utf-8")
+        except OSError as exc:
+            raise ExportError(f"Failed to export CSV artifact to {destination}: {exc}") from exc
+
+        return ExportResult(
+            output_path=destination, file_size=destination.stat().st_size, format=self.name
+        )

--- a/tests/unit/test_exporters.py
+++ b/tests/unit/test_exporters.py
@@ -5,19 +5,20 @@ from pathlib import Path
 import pytest
 
 from kpubdata_builder import ArtifactDataset, ExportError
-from kpubdata_builder.exporters import JsonlExporter, MarkdownExporter
+from kpubdata_builder.exporters import CsvExporter, JsonlExporter, MarkdownExporter
 from kpubdata_builder.spec import ExportTarget
 
 
 @pytest.mark.parametrize(
     ("exporter", "target"),
     [
+        (CsvExporter(), ExportTarget(kind="csv", output_path="out/data.csv")),
         (JsonlExporter(), ExportTarget(kind="jsonl", output_path="out/data.jsonl")),
         (MarkdownExporter(), ExportTarget(kind="markdown", output_path="out/README.md")),
     ],
 )
 def test_exporters_raise_export_error_on_bad_path(
-    exporter: JsonlExporter | MarkdownExporter,
+    exporter: CsvExporter | JsonlExporter | MarkdownExporter,
     target: ExportTarget,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -43,3 +44,31 @@ def test_markdown_exporter_returns_export_metadata(tmp_path: Path) -> None:
     assert result.output_path == tmp_path / "out/README.md"
     assert result.file_size > 0
     assert result.format == "markdown"
+
+
+def test_csv_exporter_writes_header_and_rows(tmp_path: Path) -> None:
+    artifact = ArtifactDataset(
+        records=({"id": "1", "name": "Alice"}, {"id": "2", "name": "Bob"}),
+        provenance=("test",),
+    )
+    target = ExportTarget(kind="csv", output_path="out/data.csv")
+
+    result = CsvExporter().export(artifact, target, tmp_path)
+
+    assert result.output_path == tmp_path / "out/data.csv"
+    assert result.file_size > 0
+    assert result.format == "csv"
+
+    lines = result.output_path.read_text(encoding="utf-8").splitlines()
+    assert lines[0] == "id,name"
+    assert lines[1] == "1,Alice"
+    assert lines[2] == "2,Bob"
+
+
+def test_csv_exporter_empty_records(tmp_path: Path) -> None:
+    artifact = ArtifactDataset(records=(), provenance=("test",))
+    target = ExportTarget(kind="csv", output_path="out/empty.csv")
+
+    result = CsvExporter().export(artifact, target, tmp_path)
+
+    assert result.output_path.read_text(encoding="utf-8") == ""


### PR DESCRIPTION
## Summary
- Implement `CsvExporter` following existing JSONL/Markdown pattern
- Register in `EXPORTER_REGISTRY` as "csv"
- Add tests for header/rows and empty records

## Test plan
- [x] `uv run pytest` — 57 passed
- [x] `uv run mypy src` — no errors
- [x] `uv run ruff check .` — all passed

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)