### PR TITLE
feat: add DUR medication safety 8-type HuggingFace configs (#65)

### DIFF
--- a/scripts/configs/dur_age_taboo.yaml
+++ b/scripts/configs/dur_age_taboo.yaml
@@ -1,0 +1,60 @@
+# DUR 특정연령대금기 — HuggingFace Dataset Publishing Config
+# Dataset: kpubdata/dur-age-taboo
+# Source: data.go.kr DURPrdlstInfoService03
+
+source:
+  provider: datago
+  dataset: dur_age_taboo
+  source_url: "https://www.data.go.kr/data/15075057/openapi.do"
+  list_all: true
+  fetch_params:
+    - {}
+
+transform:
+  column_mapping:
+    ITEM_SEQ: item_seq
+    ITEM_NAME: item_name
+    ENTP_NAME: company_name
+    CHART: formulation
+    CLASS_NO: class_code
+    CLASS_NAME: class_name
+    PROHBT_CONTENT: prohibition_content
+    REMARK: remark
+    ITEM_PERMIT_DATE: item_permit_date
+    CHANGE_DATE: change_date
+
+  dtypes: {}
+  derived: []
+  filters: []
+
+output:
+  staging_dir: "./staging/dur-age-taboo"
+  parquet_filename: "data/train.parquet"
+  hf_repo: "kpubdata/dur-age-taboo"
+
+card:
+  title: "DUR Age-Specific Contraindication (특정연령대금기)"
+  description: |
+    Drug Utilization Review (DUR) data for drugs contraindicated
+    in specific age groups, from Korea's MFDS (식약처).
+  license: cc-by-4.0
+  language:
+    - ko
+  tags:
+    - healthcare
+    - pharmacy
+    - drug-safety
+    - korea
+    - dur
+    - public-data
+  task_categories:
+    - tabular-classification
+  features:
+    - name: item_seq
+      description: Drug item sequence number (품목기준코드)
+    - name: item_name
+      description: Drug name (품목명)
+    - name: company_name
+      description: Manufacturer name (업체명)
+    - name: prohibition_content
+      description: Age-specific contraindication details (금기 내용)

--- a/scripts/configs/dur_dosage_caution.yaml
+++ b/scripts/configs/dur_dosage_caution.yaml
@@ -1,0 +1,56 @@
+# DUR 용량주의 — HuggingFace Dataset Publishing Config
+# Dataset: kpubdata/dur-dosage-caution
+# Source: data.go.kr DURPrdlstInfoService03
+
+source:
+  provider: datago
+  dataset: dur_dosage_caution
+  source_url: "https://www.data.go.kr/data/15075057/openapi.do"
+  list_all: true
+  fetch_params:
+    - {}
+
+transform:
+  column_mapping:
+    ITEM_SEQ: item_seq
+    ITEM_NAME: item_name
+    ENTP_NAME: company_name
+    CHART: formulation
+    CLASS_NO: class_code
+    CLASS_NAME: class_name
+    PROHBT_CONTENT: caution_content
+    REMARK: remark
+    ITEM_PERMIT_DATE: item_permit_date
+    CHANGE_DATE: change_date
+
+  dtypes: {}
+  derived: []
+  filters: []
+
+output:
+  staging_dir: "./staging/dur-dosage-caution"
+  parquet_filename: "data/train.parquet"
+  hf_repo: "kpubdata/dur-dosage-caution"
+
+card:
+  title: "DUR Dosage Caution (용량주의 의약품)"
+  description: |
+    Drug Utilization Review (DUR) data for medications requiring
+    dosage caution, from Korea's MFDS (식약처).
+  license: cc-by-4.0
+  language:
+    - ko
+  tags:
+    - healthcare
+    - pharmacy
+    - drug-safety
+    - korea
+    - dur
+    - public-data
+  features:
+    - name: item_seq
+      description: Drug item sequence number (품목기준코드)
+    - name: item_name
+      description: Drug name (품목명)
+    - name: caution_content
+      description: Dosage caution details (용량주의 내용)

--- a/scripts/configs/dur_efficacy_duplication.yaml
+++ b/scripts/configs/dur_efficacy_duplication.yaml
@@ -1,0 +1,60 @@
+# DUR 효능군중복 — HuggingFace Dataset Publishing Config
+# Dataset: kpubdata/dur-efficacy-duplication
+# Source: data.go.kr DURPrdlstInfoService03
+
+source:
+  provider: datago
+  dataset: dur_efficacy_duplication
+  source_url: "https://www.data.go.kr/data/15075057/openapi.do"
+  list_all: true
+  fetch_params:
+    - {}
+
+transform:
+  column_mapping:
+    ITEM_SEQ: item_seq
+    ITEM_NAME: item_name
+    ENTP_NAME: company_name
+    CHART: formulation
+    CLASS_NO: class_code
+    CLASS_NAME: class_name
+    INGR_CODE: ingredient_code
+    INGR_ENG_NAME: ingredient_eng_name
+    INGR_KOR_NAME: ingredient_kor_name
+    REMARK: remark
+    ITEM_PERMIT_DATE: item_permit_date
+    CHANGE_DATE: change_date
+
+  dtypes: {}
+  derived: []
+  filters: []
+
+output:
+  staging_dir: "./staging/dur-efficacy-duplication"
+  parquet_filename: "data/train.parquet"
+  hf_repo: "kpubdata/dur-efficacy-duplication"
+
+card:
+  title: "DUR Efficacy Group Duplication (효능군중복 의약품)"
+  description: |
+    Drug Utilization Review (DUR) data for therapeutic duplication
+    (same efficacy group) warnings, from Korea's MFDS (식약처).
+  license: cc-by-4.0
+  language:
+    - ko
+  tags:
+    - healthcare
+    - pharmacy
+    - drug-safety
+    - korea
+    - dur
+    - public-data
+  features:
+    - name: item_seq
+      description: Drug item sequence number (품목기준코드)
+    - name: item_name
+      description: Drug name (품목명)
+    - name: ingredient_kor_name
+      description: Active ingredient Korean name (성분명 한글)
+    - name: ingredient_eng_name
+      description: Active ingredient English name (성분명 영문)

--- a/scripts/configs/dur_er_tablet_split_caution.yaml
+++ b/scripts/configs/dur_er_tablet_split_caution.yaml
@@ -1,0 +1,58 @@
+# DUR 서방정분할주의 — HuggingFace Dataset Publishing Config
+# Dataset: kpubdata/dur-er-tablet-split-caution
+# Source: data.go.kr DURPrdlstInfoService03
+
+source:
+  provider: datago
+  dataset: dur_er_tablet_split_caution
+  source_url: "https://www.data.go.kr/data/15075057/openapi.do"
+  list_all: true
+  fetch_params:
+    - {}
+
+transform:
+  column_mapping:
+    ITEM_SEQ: item_seq
+    ITEM_NAME: item_name
+    ENTP_NAME: company_name
+    CHART: formulation
+    CLASS_NO: class_code
+    CLASS_NAME: class_name
+    PROHBT_CONTENT: caution_content
+    REMARK: remark
+    ITEM_PERMIT_DATE: item_permit_date
+    CHANGE_DATE: change_date
+
+  dtypes: {}
+  derived: []
+  filters: []
+
+output:
+  staging_dir: "./staging/dur-er-tablet-split-caution"
+  parquet_filename: "data/train.parquet"
+  hf_repo: "kpubdata/dur-er-tablet-split-caution"
+
+card:
+  title: "DUR Extended-Release Tablet Split Caution (서방정분할주의)"
+  description: |
+    Drug Utilization Review (DUR) data for extended-release tablets
+    that should not be split or crushed, from Korea's MFDS (식약처).
+  license: cc-by-4.0
+  language:
+    - ko
+  tags:
+    - healthcare
+    - pharmacy
+    - drug-safety
+    - korea
+    - dur
+    - public-data
+  features:
+    - name: item_seq
+      description: Drug item sequence number (품목기준코드)
+    - name: item_name
+      description: Drug name (품목명)
+    - name: company_name
+      description: Manufacturer name (업체명)
+    - name: caution_content
+      description: Split caution details (서방정분할주의 내용)

--- a/scripts/configs/dur_medication_period_caution.yaml
+++ b/scripts/configs/dur_medication_period_caution.yaml
@@ -1,0 +1,56 @@
+# DUR 투여기간주의 — HuggingFace Dataset Publishing Config
+# Dataset: kpubdata/dur-medication-period-caution
+# Source: data.go.kr DURPrdlstInfoService03
+
+source:
+  provider: datago
+  dataset: dur_medication_period_caution
+  source_url: "https://www.data.go.kr/data/15075057/openapi.do"
+  list_all: true
+  fetch_params:
+    - {}
+
+transform:
+  column_mapping:
+    ITEM_SEQ: item_seq
+    ITEM_NAME: item_name
+    ENTP_NAME: company_name
+    CHART: formulation
+    CLASS_NO: class_code
+    CLASS_NAME: class_name
+    PROHBT_CONTENT: caution_content
+    REMARK: remark
+    ITEM_PERMIT_DATE: item_permit_date
+    CHANGE_DATE: change_date
+
+  dtypes: {}
+  derived: []
+  filters: []
+
+output:
+  staging_dir: "./staging/dur-medication-period-caution"
+  parquet_filename: "data/train.parquet"
+  hf_repo: "kpubdata/dur-medication-period-caution"
+
+card:
+  title: "DUR Medication Period Caution (투여기간주의 의약품)"
+  description: |
+    Drug Utilization Review (DUR) data for medications with
+    administration period warnings, from Korea's MFDS (식약처).
+  license: cc-by-4.0
+  language:
+    - ko
+  tags:
+    - healthcare
+    - pharmacy
+    - drug-safety
+    - korea
+    - dur
+    - public-data
+  features:
+    - name: item_seq
+      description: Drug item sequence number (품목기준코드)
+    - name: item_name
+      description: Drug name (품목명)
+    - name: caution_content
+      description: Medication period caution details (투여기간주의 내용)

--- a/scripts/configs/dur_older_adult_caution.yaml
+++ b/scripts/configs/dur_older_adult_caution.yaml
@@ -1,0 +1,61 @@
+# DUR 노인주의 정보 — HuggingFace Dataset Publishing Config
+# Dataset: kpubdata/dur-older-adult-caution
+# Source: data.go.kr DURPrdlstInfoService03
+
+source:
+  provider: datago
+  dataset: dur_older_adult_caution
+  source_url: "https://www.data.go.kr/data/15075057/openapi.do"
+  list_all: true
+  fetch_params:
+    - {}
+
+transform:
+  column_mapping:
+    ITEM_SEQ: item_seq
+    ITEM_NAME: item_name
+    ENTP_NAME: company_name
+    CHART: formulation
+    CLASS_NO: class_code
+    CLASS_NAME: class_name
+    PROHBT_CONTENT: caution_content
+    REMARK: remark
+    ITEM_PERMIT_DATE: item_permit_date
+    CHANGE_DATE: change_date
+
+  dtypes: {}
+  derived: []
+  filters: []
+
+output:
+  staging_dir: "./staging/dur-older-adult-caution"
+  parquet_filename: "data/train.parquet"
+  hf_repo: "kpubdata/dur-older-adult-caution"
+
+card:
+  title: "DUR Older Adult Caution Drugs (노인주의 의약품)"
+  description: |
+    Drug Utilization Review (DUR) data for medications requiring
+    caution in elderly patients, from Korea's MFDS (식약처).
+  license: cc-by-4.0
+  language:
+    - ko
+  tags:
+    - healthcare
+    - pharmacy
+    - drug-safety
+    - korea
+    - dur
+    - elderly
+    - public-data
+  task_categories:
+    - tabular-classification
+  features:
+    - name: item_seq
+      description: Drug item sequence number (품목기준코드)
+    - name: item_name
+      description: Drug name (품목명)
+    - name: company_name
+      description: Manufacturer name (업체명)
+    - name: caution_content
+      description: Caution details for elderly patients (노인주의 내용)

--- a/scripts/configs/dur_pregnancy_taboo.yaml
+++ b/scripts/configs/dur_pregnancy_taboo.yaml
@@ -1,0 +1,61 @@
+# DUR 임부금기 — HuggingFace Dataset Publishing Config
+# Dataset: kpubdata/dur-pregnancy-taboo
+# Source: data.go.kr DURPrdlstInfoService03
+
+source:
+  provider: datago
+  dataset: dur_pregnancy_taboo
+  source_url: "https://www.data.go.kr/data/15075057/openapi.do"
+  list_all: true
+  fetch_params:
+    - {}
+
+transform:
+  column_mapping:
+    ITEM_SEQ: item_seq
+    ITEM_NAME: item_name
+    ENTP_NAME: company_name
+    CHART: formulation
+    CLASS_NO: class_code
+    CLASS_NAME: class_name
+    PROHBT_CONTENT: prohibition_content
+    REMARK: remark
+    ITEM_PERMIT_DATE: item_permit_date
+    CHANGE_DATE: change_date
+
+  dtypes: {}
+  derived: []
+  filters: []
+
+output:
+  staging_dir: "./staging/dur-pregnancy-taboo"
+  parquet_filename: "data/train.parquet"
+  hf_repo: "kpubdata/dur-pregnancy-taboo"
+
+card:
+  title: "DUR Pregnancy Contraindication (임부금기 의약품)"
+  description: |
+    Drug Utilization Review (DUR) data for drugs contraindicated
+    during pregnancy, from Korea's MFDS (식약처).
+  license: cc-by-4.0
+  language:
+    - ko
+  tags:
+    - healthcare
+    - pharmacy
+    - drug-safety
+    - korea
+    - dur
+    - pregnancy
+    - public-data
+  task_categories:
+    - tabular-classification
+  features:
+    - name: item_seq
+      description: Drug item sequence number (품목기준코드)
+    - name: item_name
+      description: Drug name (품목명)
+    - name: company_name
+      description: Manufacturer name (업체명)
+    - name: prohibition_content
+      description: Pregnancy contraindication details (임부금기 내용)

--- a/scripts/configs/dur_product_info.yaml
+++ b/scripts/configs/dur_product_info.yaml
@@ -1,0 +1,58 @@
+# DUR 품목정보 — HuggingFace Dataset Publishing Config
+# Dataset: kpubdata/dur-product-info
+# Source: data.go.kr DURPrdlstInfoService03
+
+source:
+  provider: datago
+  dataset: dur_product_info
+  source_url: "https://www.data.go.kr/data/15075057/openapi.do"
+  list_all: true
+  fetch_params:
+    - {}
+
+transform:
+  column_mapping:
+    ITEM_SEQ: item_seq
+    ITEM_NAME: item_name
+    ENTP_NAME: company_name
+    CHART: formulation
+    CLASS_NO: class_code
+    CLASS_NAME: class_name
+    ETC_OTC_CODE: etc_otc_code
+    ITEM_PERMIT_DATE: item_permit_date
+    CHANGE_DATE: change_date
+
+  dtypes: {}
+  derived: []
+  filters: []
+
+output:
+  staging_dir: "./staging/dur-product-info"
+  parquet_filename: "data/train.parquet"
+  hf_repo: "kpubdata/dur-product-info"
+
+card:
+  title: "DUR Drug Product Information (DUR 품목정보)"
+  description: |
+    Drug Utilization Review (DUR) product master data from Korea's
+    Ministry of Food and Drug Safety (식약처). Contains basic product
+    information for drugs registered in the DUR system.
+  license: cc-by-4.0
+  language:
+    - ko
+  tags:
+    - healthcare
+    - pharmacy
+    - drug-safety
+    - korea
+    - dur
+    - public-data
+  features:
+    - name: item_seq
+      description: Drug item sequence number (품목기준코드)
+    - name: item_name
+      description: Drug name (품목명)
+    - name: company_name
+      description: Manufacturer name (업체명)
+    - name: class_name
+      description: Pharmacological class name (약효분류명)

--- a/scripts/configs/dur_usjnt_taboo.yaml
+++ b/scripts/configs/dur_usjnt_taboo.yaml
@@ -1,0 +1,71 @@
+# DUR 병용금기 품목정보 — HuggingFace Dataset Publishing Config
+# Dataset: kpubdata/dur-usjnt-taboo
+# Source: data.go.kr DURPrdlstInfoService03
+
+source:
+  provider: datago
+  dataset: dur_usjnt_taboo
+  source_url: "https://www.data.go.kr/data/15075057/openapi.do"
+  list_all: true
+  fetch_params:
+    - {}
+
+transform:
+  column_mapping:
+    ITEM_SEQ: item_seq
+    ITEM_NAME: item_name
+    ENTP_NAME: company_name
+    CHART: formulation
+    CLASS_NO: class_code
+    CLASS_NAME: class_name
+    MIXTURE_ITEM_SEQ: mixture_item_seq
+    MIXTURE_ITEM_NAME: mixture_item_name
+    MIXTURE_ENTP_NAME: mixture_company_name
+    MIXTURE_CHART: mixture_formulation
+    MIXTURE_CLASS_NO: mixture_class_code
+    MIXTURE_CLASS_NAME: mixture_class_name
+    PROHBT_CONTENT: prohibition_content
+    REMARK: remark
+    ITEM_PERMIT_DATE: item_permit_date
+    CHANGE_DATE: change_date
+
+  dtypes: {}
+  derived: []
+  filters: []
+
+output:
+  staging_dir: "./staging/dur-usjnt-taboo"
+  parquet_filename: "data/train.parquet"
+  hf_repo: "kpubdata/dur-usjnt-taboo"
+
+card:
+  title: "DUR Drug Combination Contraindication (병용금기 품목정보)"
+  description: |
+    Drug Utilization Review (DUR) contraindicated drug combination data
+    from Korea's Ministry of Food and Drug Safety (식약처).
+
+    Contains pairs of drugs that should not be used together,
+    including the reason for contraindication.
+  license: cc-by-4.0
+  language:
+    - ko
+  tags:
+    - healthcare
+    - pharmacy
+    - drug-safety
+    - korea
+    - dur
+    - public-data
+  task_categories:
+    - tabular-classification
+  features:
+    - name: item_seq
+      description: Drug item sequence number (품목기준코드)
+    - name: item_name
+      description: Drug name (품목명)
+    - name: company_name
+      description: Manufacturer name (업체명)
+    - name: mixture_item_name
+      description: Contraindicated drug name (병용금기 품목명)
+    - name: prohibition_content
+      description: Reason for contraindication (금기 사유)


### PR DESCRIPTION
## Summary
- Add publishing configs for all 9 DUR datasets (병용금기, 노인주의, 품목정보, 특정연령대금기, 용량주의, 투여기간주의, 효능군중복, 임부금기, 서방정분할주의)
- Each config includes column_mapping and HF dataset card

## Test plan
- [x] YAML syntax valid

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)