### PR TITLE
feat: add localdata bulk HuggingFace publish configs and generator (#69)

### DIFF
--- a/scripts/configs/localdata/animal_hospital.yaml
+++ b/scripts/configs/localdata/animal_hospital.yaml
@@ -1,0 +1,67 @@
+# 동물병원 (Animal Hospital) — Auto-generated localdata config
+source:
+  provider: localdata
+  dataset: animal_hospital
+  list_all: true
+  fetch_params:
+  - {}
+transform:
+  column_mapping:
+    opnSfTeamCode: district_code
+    mgtNo: management_number
+    opnSvcNm: service_name
+    bplcNm: business_name
+    siteWhlAddr: full_address
+    rdnWhlAddr: road_address
+    siteTel: phone
+    trdStateGbn: status_code
+    trdStateNm: status_name
+    dtlStateGbn: detail_status_code
+    dtlStateNm: detail_status_name
+    dcbYmd: closure_date
+    apvPermYmd: approval_date
+    x: longitude
+    y: latitude
+  dtypes:
+    longitude: float
+    latitude: float
+  derived: []
+  filters: []
+output:
+  staging_dir: ./staging/localdata-animal-hospital
+  parquet_filename: data/train.parquet
+  hf_repo: kpubdata/localdata-animal-hospital
+card:
+  title: Korea Animal Hospital Business Licenses (동물병원)
+  description: 'Business license data for animal hospital (동물병원) establishments in
+    Korea.
+
+
+    Data sourced from Korea''s Local Government Data (지방행정인허가 데이터)
+
+    via the localdata.go.kr API.
+
+    '
+  license: cc-by-4.0
+  language:
+  - ko
+  tags:
+  - korea
+  - business-license
+  - localdata
+  - public-data
+  features:
+  - name: business_name
+    description: Business/establishment name (사업장명)
+  - name: full_address
+    description: Full address (소재지전체주소)
+  - name: road_address
+    description: Road name address (도로명전체주소)
+  - name: status_name
+    description: Business status (영업상태명)
+  - name: approval_date
+    description: License approval date (인허가일자)
+  - name: longitude
+    description: Longitude (X좌표)
+  - name: latitude
+    description: Latitude (Y좌표)

--- a/scripts/configs/localdata/bakery.yaml
+++ b/scripts/configs/localdata/bakery.yaml
@@ -1,0 +1,66 @@
+# 제과점 (Bakery) — Auto-generated localdata config
+source:
+  provider: localdata
+  dataset: bakery
+  list_all: true
+  fetch_params:
+  - {}
+transform:
+  column_mapping:
+    opnSfTeamCode: district_code
+    mgtNo: management_number
+    opnSvcNm: service_name
+    bplcNm: business_name
+    siteWhlAddr: full_address
+    rdnWhlAddr: road_address
+    siteTel: phone
+    trdStateGbn: status_code
+    trdStateNm: status_name
+    dtlStateGbn: detail_status_code
+    dtlStateNm: detail_status_name
+    dcbYmd: closure_date
+    apvPermYmd: approval_date
+    x: longitude
+    y: latitude
+  dtypes:
+    longitude: float
+    latitude: float
+  derived: []
+  filters: []
+output:
+  staging_dir: ./staging/localdata-bakery
+  parquet_filename: data/train.parquet
+  hf_repo: kpubdata/localdata-bakery
+card:
+  title: Korea Bakery Business Licenses (제과점)
+  description: 'Business license data for bakery (제과점) establishments in Korea.
+
+
+    Data sourced from Korea''s Local Government Data (지방행정인허가 데이터)
+
+    via the localdata.go.kr API.
+
+    '
+  license: cc-by-4.0
+  language:
+  - ko
+  tags:
+  - korea
+  - business-license
+  - localdata
+  - public-data
+  features:
+  - name: business_name
+    description: Business/establishment name (사업장명)
+  - name: full_address
+    description: Full address (소재지전체주소)
+  - name: road_address
+    description: Road name address (도로명전체주소)
+  - name: status_name
+    description: Business status (영업상태명)
+  - name: approval_date
+    description: License approval date (인허가일자)
+  - name: longitude
+    description: Longitude (X좌표)
+  - name: latitude
+    description: Latitude (Y좌표)

--- a/scripts/configs/localdata/clinic.yaml
+++ b/scripts/configs/localdata/clinic.yaml
@@ -1,0 +1,66 @@
+# 의원 (Clinic) — Auto-generated localdata config
+source:
+  provider: localdata
+  dataset: clinic
+  list_all: true
+  fetch_params:
+  - {}
+transform:
+  column_mapping:
+    opnSfTeamCode: district_code
+    mgtNo: management_number
+    opnSvcNm: service_name
+    bplcNm: business_name
+    siteWhlAddr: full_address
+    rdnWhlAddr: road_address
+    siteTel: phone
+    trdStateGbn: status_code
+    trdStateNm: status_name
+    dtlStateGbn: detail_status_code
+    dtlStateNm: detail_status_name
+    dcbYmd: closure_date
+    apvPermYmd: approval_date
+    x: longitude
+    y: latitude
+  dtypes:
+    longitude: float
+    latitude: float
+  derived: []
+  filters: []
+output:
+  staging_dir: ./staging/localdata-clinic
+  parquet_filename: data/train.parquet
+  hf_repo: kpubdata/localdata-clinic
+card:
+  title: Korea Clinic Business Licenses (의원)
+  description: 'Business license data for clinic (의원) establishments in Korea.
+
+
+    Data sourced from Korea''s Local Government Data (지방행정인허가 데이터)
+
+    via the localdata.go.kr API.
+
+    '
+  license: cc-by-4.0
+  language:
+  - ko
+  tags:
+  - korea
+  - business-license
+  - localdata
+  - public-data
+  features:
+  - name: business_name
+    description: Business/establishment name (사업장명)
+  - name: full_address
+    description: Full address (소재지전체주소)
+  - name: road_address
+    description: Road name address (도로명전체주소)
+  - name: status_name
+    description: Business status (영업상태명)
+  - name: approval_date
+    description: License approval date (인허가일자)
+  - name: longitude
+    description: Longitude (X좌표)
+  - name: latitude
+    description: Latitude (Y좌표)

--- a/scripts/configs/localdata/convenience_store.yaml
+++ b/scripts/configs/localdata/convenience_store.yaml
@@ -1,0 +1,67 @@
+# 편의점 (Convenience Store) — Auto-generated localdata config
+source:
+  provider: localdata
+  dataset: convenience_store
+  list_all: true
+  fetch_params:
+  - {}
+transform:
+  column_mapping:
+    opnSfTeamCode: district_code
+    mgtNo: management_number
+    opnSvcNm: service_name
+    bplcNm: business_name
+    siteWhlAddr: full_address
+    rdnWhlAddr: road_address
+    siteTel: phone
+    trdStateGbn: status_code
+    trdStateNm: status_name
+    dtlStateGbn: detail_status_code
+    dtlStateNm: detail_status_name
+    dcbYmd: closure_date
+    apvPermYmd: approval_date
+    x: longitude
+    y: latitude
+  dtypes:
+    longitude: float
+    latitude: float
+  derived: []
+  filters: []
+output:
+  staging_dir: ./staging/localdata-convenience-store
+  parquet_filename: data/train.parquet
+  hf_repo: kpubdata/localdata-convenience-store
+card:
+  title: Korea Convenience Store Business Licenses (편의점)
+  description: 'Business license data for convenience store (편의점) establishments in
+    Korea.
+
+
+    Data sourced from Korea''s Local Government Data (지방행정인허가 데이터)
+
+    via the localdata.go.kr API.
+
+    '
+  license: cc-by-4.0
+  language:
+  - ko
+  tags:
+  - korea
+  - business-license
+  - localdata
+  - public-data
+  features:
+  - name: business_name
+    description: Business/establishment name (사업장명)
+  - name: full_address
+    description: Full address (소재지전체주소)
+  - name: road_address
+    description: Road name address (도로명전체주소)
+  - name: status_name
+    description: Business status (영업상태명)
+  - name: approval_date
+    description: License approval date (인허가일자)
+  - name: longitude
+    description: Longitude (X좌표)
+  - name: latitude
+    description: Latitude (Y좌표)

--- a/scripts/configs/localdata/dental_clinic.yaml
+++ b/scripts/configs/localdata/dental_clinic.yaml
@@ -1,0 +1,66 @@
+# 치과의원 (Dental Clinic) — Auto-generated localdata config
+source:
+  provider: localdata
+  dataset: dental_clinic
+  list_all: true
+  fetch_params:
+  - {}
+transform:
+  column_mapping:
+    opnSfTeamCode: district_code
+    mgtNo: management_number
+    opnSvcNm: service_name
+    bplcNm: business_name
+    siteWhlAddr: full_address
+    rdnWhlAddr: road_address
+    siteTel: phone
+    trdStateGbn: status_code
+    trdStateNm: status_name
+    dtlStateGbn: detail_status_code
+    dtlStateNm: detail_status_name
+    dcbYmd: closure_date
+    apvPermYmd: approval_date
+    x: longitude
+    y: latitude
+  dtypes:
+    longitude: float
+    latitude: float
+  derived: []
+  filters: []
+output:
+  staging_dir: ./staging/localdata-dental-clinic
+  parquet_filename: data/train.parquet
+  hf_repo: kpubdata/localdata-dental-clinic
+card:
+  title: Korea Dental Clinic Business Licenses (치과의원)
+  description: 'Business license data for dental clinic (치과의원) establishments in Korea.
+
+
+    Data sourced from Korea''s Local Government Data (지방행정인허가 데이터)
+
+    via the localdata.go.kr API.
+
+    '
+  license: cc-by-4.0
+  language:
+  - ko
+  tags:
+  - korea
+  - business-license
+  - localdata
+  - public-data
+  features:
+  - name: business_name
+    description: Business/establishment name (사업장명)
+  - name: full_address
+    description: Full address (소재지전체주소)
+  - name: road_address
+    description: Road name address (도로명전체주소)
+  - name: status_name
+    description: Business status (영업상태명)
+  - name: approval_date
+    description: License approval date (인허가일자)
+  - name: longitude
+    description: Longitude (X좌표)
+  - name: latitude
+    description: Latitude (Y좌표)

--- a/scripts/configs/localdata/fitness_center.yaml
+++ b/scripts/configs/localdata/fitness_center.yaml
@@ -1,0 +1,67 @@
+# 체력단련장 (Fitness Center) — Auto-generated localdata config
+source:
+  provider: localdata
+  dataset: fitness_center
+  list_all: true
+  fetch_params:
+  - {}
+transform:
+  column_mapping:
+    opnSfTeamCode: district_code
+    mgtNo: management_number
+    opnSvcNm: service_name
+    bplcNm: business_name
+    siteWhlAddr: full_address
+    rdnWhlAddr: road_address
+    siteTel: phone
+    trdStateGbn: status_code
+    trdStateNm: status_name
+    dtlStateGbn: detail_status_code
+    dtlStateNm: detail_status_name
+    dcbYmd: closure_date
+    apvPermYmd: approval_date
+    x: longitude
+    y: latitude
+  dtypes:
+    longitude: float
+    latitude: float
+  derived: []
+  filters: []
+output:
+  staging_dir: ./staging/localdata-fitness-center
+  parquet_filename: data/train.parquet
+  hf_repo: kpubdata/localdata-fitness-center
+card:
+  title: Korea Fitness Center Business Licenses (체력단련장)
+  description: 'Business license data for fitness center (체력단련장) establishments in
+    Korea.
+
+
+    Data sourced from Korea''s Local Government Data (지방행정인허가 데이터)
+
+    via the localdata.go.kr API.
+
+    '
+  license: cc-by-4.0
+  language:
+  - ko
+  tags:
+  - korea
+  - business-license
+  - localdata
+  - public-data
+  features:
+  - name: business_name
+    description: Business/establishment name (사업장명)
+  - name: full_address
+    description: Full address (소재지전체주소)
+  - name: road_address
+    description: Road name address (도로명전체주소)
+  - name: status_name
+    description: Business status (영업상태명)
+  - name: approval_date
+    description: License approval date (인허가일자)
+  - name: longitude
+    description: Longitude (X좌표)
+  - name: latitude
+    description: Latitude (Y좌표)

--- a/scripts/configs/localdata/general_accommodation.yaml
+++ b/scripts/configs/localdata/general_accommodation.yaml
@@ -1,0 +1,67 @@
+# 일반숙박업 (General Accommodation) — Auto-generated localdata config
+source:
+  provider: localdata
+  dataset: general_accommodation
+  list_all: true
+  fetch_params:
+  - {}
+transform:
+  column_mapping:
+    opnSfTeamCode: district_code
+    mgtNo: management_number
+    opnSvcNm: service_name
+    bplcNm: business_name
+    siteWhlAddr: full_address
+    rdnWhlAddr: road_address
+    siteTel: phone
+    trdStateGbn: status_code
+    trdStateNm: status_name
+    dtlStateGbn: detail_status_code
+    dtlStateNm: detail_status_name
+    dcbYmd: closure_date
+    apvPermYmd: approval_date
+    x: longitude
+    y: latitude
+  dtypes:
+    longitude: float
+    latitude: float
+  derived: []
+  filters: []
+output:
+  staging_dir: ./staging/localdata-general-accommodation
+  parquet_filename: data/train.parquet
+  hf_repo: kpubdata/localdata-general-accommodation
+card:
+  title: Korea General Accommodation Business Licenses (일반숙박업)
+  description: 'Business license data for general accommodation (일반숙박업) establishments
+    in Korea.
+
+
+    Data sourced from Korea''s Local Government Data (지방행정인허가 데이터)
+
+    via the localdata.go.kr API.
+
+    '
+  license: cc-by-4.0
+  language:
+  - ko
+  tags:
+  - korea
+  - business-license
+  - localdata
+  - public-data
+  features:
+  - name: business_name
+    description: Business/establishment name (사업장명)
+  - name: full_address
+    description: Full address (소재지전체주소)
+  - name: road_address
+    description: Road name address (도로명전체주소)
+  - name: status_name
+    description: Business status (영업상태명)
+  - name: approval_date
+    description: License approval date (인허가일자)
+  - name: longitude
+    description: Longitude (X좌표)
+  - name: latitude
+    description: Latitude (Y좌표)

--- a/scripts/configs/localdata/general_restaurant.yaml
+++ b/scripts/configs/localdata/general_restaurant.yaml
@@ -1,0 +1,67 @@
+# 일반음식점 (General Restaurant) — Auto-generated localdata config
+source:
+  provider: localdata
+  dataset: general_restaurant
+  list_all: true
+  fetch_params:
+  - {}
+transform:
+  column_mapping:
+    opnSfTeamCode: district_code
+    mgtNo: management_number
+    opnSvcNm: service_name
+    bplcNm: business_name
+    siteWhlAddr: full_address
+    rdnWhlAddr: road_address
+    siteTel: phone
+    trdStateGbn: status_code
+    trdStateNm: status_name
+    dtlStateGbn: detail_status_code
+    dtlStateNm: detail_status_name
+    dcbYmd: closure_date
+    apvPermYmd: approval_date
+    x: longitude
+    y: latitude
+  dtypes:
+    longitude: float
+    latitude: float
+  derived: []
+  filters: []
+output:
+  staging_dir: ./staging/localdata-general-restaurant
+  parquet_filename: data/train.parquet
+  hf_repo: kpubdata/localdata-general-restaurant
+card:
+  title: Korea General Restaurant Business Licenses (일반음식점)
+  description: 'Business license data for general restaurant (일반음식점) establishments
+    in Korea.
+
+
+    Data sourced from Korea''s Local Government Data (지방행정인허가 데이터)
+
+    via the localdata.go.kr API.
+
+    '
+  license: cc-by-4.0
+  language:
+  - ko
+  tags:
+  - korea
+  - business-license
+  - localdata
+  - public-data
+  features:
+  - name: business_name
+    description: Business/establishment name (사업장명)
+  - name: full_address
+    description: Full address (소재지전체주소)
+  - name: road_address
+    description: Road name address (도로명전체주소)
+  - name: status_name
+    description: Business status (영업상태명)
+  - name: approval_date
+    description: License approval date (인허가일자)
+  - name: longitude
+    description: Longitude (X좌표)
+  - name: latitude
+    description: Latitude (Y좌표)

--- a/scripts/configs/localdata/hospital.yaml
+++ b/scripts/configs/localdata/hospital.yaml
@@ -1,0 +1,66 @@
+# 병원 (Hospital) — Auto-generated localdata config
+source:
+  provider: localdata
+  dataset: hospital
+  list_all: true
+  fetch_params:
+  - {}
+transform:
+  column_mapping:
+    opnSfTeamCode: district_code
+    mgtNo: management_number
+    opnSvcNm: service_name
+    bplcNm: business_name
+    siteWhlAddr: full_address
+    rdnWhlAddr: road_address
+    siteTel: phone
+    trdStateGbn: status_code
+    trdStateNm: status_name
+    dtlStateGbn: detail_status_code
+    dtlStateNm: detail_status_name
+    dcbYmd: closure_date
+    apvPermYmd: approval_date
+    x: longitude
+    y: latitude
+  dtypes:
+    longitude: float
+    latitude: float
+  derived: []
+  filters: []
+output:
+  staging_dir: ./staging/localdata-hospital
+  parquet_filename: data/train.parquet
+  hf_repo: kpubdata/localdata-hospital
+card:
+  title: Korea Hospital Business Licenses (병원)
+  description: 'Business license data for hospital (병원) establishments in Korea.
+
+
+    Data sourced from Korea''s Local Government Data (지방행정인허가 데이터)
+
+    via the localdata.go.kr API.
+
+    '
+  license: cc-by-4.0
+  language:
+  - ko
+  tags:
+  - korea
+  - business-license
+  - localdata
+  - public-data
+  features:
+  - name: business_name
+    description: Business/establishment name (사업장명)
+  - name: full_address
+    description: Full address (소재지전체주소)
+  - name: road_address
+    description: Road name address (도로명전체주소)
+  - name: status_name
+    description: Business status (영업상태명)
+  - name: approval_date
+    description: License approval date (인허가일자)
+  - name: longitude
+    description: Longitude (X좌표)
+  - name: latitude
+    description: Latitude (Y좌표)

--- a/scripts/configs/localdata/pet_grooming.yaml
+++ b/scripts/configs/localdata/pet_grooming.yaml
@@ -1,0 +1,66 @@
+# 동물미용업 (Pet Grooming) — Auto-generated localdata config
+source:
+  provider: localdata
+  dataset: pet_grooming
+  list_all: true
+  fetch_params:
+  - {}
+transform:
+  column_mapping:
+    opnSfTeamCode: district_code
+    mgtNo: management_number
+    opnSvcNm: service_name
+    bplcNm: business_name
+    siteWhlAddr: full_address
+    rdnWhlAddr: road_address
+    siteTel: phone
+    trdStateGbn: status_code
+    trdStateNm: status_name
+    dtlStateGbn: detail_status_code
+    dtlStateNm: detail_status_name
+    dcbYmd: closure_date
+    apvPermYmd: approval_date
+    x: longitude
+    y: latitude
+  dtypes:
+    longitude: float
+    latitude: float
+  derived: []
+  filters: []
+output:
+  staging_dir: ./staging/localdata-pet-grooming
+  parquet_filename: data/train.parquet
+  hf_repo: kpubdata/localdata-pet-grooming
+card:
+  title: Korea Pet Grooming Business Licenses (동물미용업)
+  description: 'Business license data for pet grooming (동물미용업) establishments in Korea.
+
+
+    Data sourced from Korea''s Local Government Data (지방행정인허가 데이터)
+
+    via the localdata.go.kr API.
+
+    '
+  license: cc-by-4.0
+  language:
+  - ko
+  tags:
+  - korea
+  - business-license
+  - localdata
+  - public-data
+  features:
+  - name: business_name
+    description: Business/establishment name (사업장명)
+  - name: full_address
+    description: Full address (소재지전체주소)
+  - name: road_address
+    description: Road name address (도로명전체주소)
+  - name: status_name
+    description: Business status (영업상태명)
+  - name: approval_date
+    description: License approval date (인허가일자)
+  - name: longitude
+    description: Longitude (X좌표)
+  - name: latitude
+    description: Latitude (Y좌표)

--- a/scripts/configs/localdata/pharmacy.yaml
+++ b/scripts/configs/localdata/pharmacy.yaml
@@ -1,0 +1,66 @@
+# 약국 (Pharmacy) — Auto-generated localdata config
+source:
+  provider: localdata
+  dataset: pharmacy
+  list_all: true
+  fetch_params:
+  - {}
+transform:
+  column_mapping:
+    opnSfTeamCode: district_code
+    mgtNo: management_number
+    opnSvcNm: service_name
+    bplcNm: business_name
+    siteWhlAddr: full_address
+    rdnWhlAddr: road_address
+    siteTel: phone
+    trdStateGbn: status_code
+    trdStateNm: status_name
+    dtlStateGbn: detail_status_code
+    dtlStateNm: detail_status_name
+    dcbYmd: closure_date
+    apvPermYmd: approval_date
+    x: longitude
+    y: latitude
+  dtypes:
+    longitude: float
+    latitude: float
+  derived: []
+  filters: []
+output:
+  staging_dir: ./staging/localdata-pharmacy
+  parquet_filename: data/train.parquet
+  hf_repo: kpubdata/localdata-pharmacy
+card:
+  title: Korea Pharmacy Business Licenses (약국)
+  description: 'Business license data for pharmacy (약국) establishments in Korea.
+
+
+    Data sourced from Korea''s Local Government Data (지방행정인허가 데이터)
+
+    via the localdata.go.kr API.
+
+    '
+  license: cc-by-4.0
+  language:
+  - ko
+  tags:
+  - korea
+  - business-license
+  - localdata
+  - public-data
+  features:
+  - name: business_name
+    description: Business/establishment name (사업장명)
+  - name: full_address
+    description: Full address (소재지전체주소)
+  - name: road_address
+    description: Road name address (도로명전체주소)
+  - name: status_name
+    description: Business status (영업상태명)
+  - name: approval_date
+    description: License approval date (인허가일자)
+  - name: longitude
+    description: Longitude (X좌표)
+  - name: latitude
+    description: Latitude (Y좌표)

--- a/scripts/configs/localdata/private_academy.yaml
+++ b/scripts/configs/localdata/private_academy.yaml
@@ -1,0 +1,66 @@
+# 학원 (Private Academy) — Auto-generated localdata config
+source:
+  provider: localdata
+  dataset: private_academy
+  list_all: true
+  fetch_params:
+  - {}
+transform:
+  column_mapping:
+    opnSfTeamCode: district_code
+    mgtNo: management_number
+    opnSvcNm: service_name
+    bplcNm: business_name
+    siteWhlAddr: full_address
+    rdnWhlAddr: road_address
+    siteTel: phone
+    trdStateGbn: status_code
+    trdStateNm: status_name
+    dtlStateGbn: detail_status_code
+    dtlStateNm: detail_status_name
+    dcbYmd: closure_date
+    apvPermYmd: approval_date
+    x: longitude
+    y: latitude
+  dtypes:
+    longitude: float
+    latitude: float
+  derived: []
+  filters: []
+output:
+  staging_dir: ./staging/localdata-private-academy
+  parquet_filename: data/train.parquet
+  hf_repo: kpubdata/localdata-private-academy
+card:
+  title: Korea Private Academy Business Licenses (학원)
+  description: 'Business license data for private academy (학원) establishments in Korea.
+
+
+    Data sourced from Korea''s Local Government Data (지방행정인허가 데이터)
+
+    via the localdata.go.kr API.
+
+    '
+  license: cc-by-4.0
+  language:
+  - ko
+  tags:
+  - korea
+  - business-license
+  - localdata
+  - public-data
+  features:
+  - name: business_name
+    description: Business/establishment name (사업장명)
+  - name: full_address
+    description: Full address (소재지전체주소)
+  - name: road_address
+    description: Road name address (도로명전체주소)
+  - name: status_name
+    description: Business status (영업상태명)
+  - name: approval_date
+    description: License approval date (인허가일자)
+  - name: longitude
+    description: Longitude (X좌표)
+  - name: latitude
+    description: Latitude (Y좌표)

--- a/scripts/configs/localdata/rest_cafe.yaml
+++ b/scripts/configs/localdata/rest_cafe.yaml
@@ -1,0 +1,66 @@
+# 휴게음식점 (Cafe/Bakery) — Auto-generated localdata config
+source:
+  provider: localdata
+  dataset: rest_cafe
+  list_all: true
+  fetch_params:
+  - {}
+transform:
+  column_mapping:
+    opnSfTeamCode: district_code
+    mgtNo: management_number
+    opnSvcNm: service_name
+    bplcNm: business_name
+    siteWhlAddr: full_address
+    rdnWhlAddr: road_address
+    siteTel: phone
+    trdStateGbn: status_code
+    trdStateNm: status_name
+    dtlStateGbn: detail_status_code
+    dtlStateNm: detail_status_name
+    dcbYmd: closure_date
+    apvPermYmd: approval_date
+    x: longitude
+    y: latitude
+  dtypes:
+    longitude: float
+    latitude: float
+  derived: []
+  filters: []
+output:
+  staging_dir: ./staging/localdata-rest-cafe
+  parquet_filename: data/train.parquet
+  hf_repo: kpubdata/localdata-rest-cafe
+card:
+  title: Korea Cafe/Bakery Business Licenses (휴게음식점)
+  description: 'Business license data for cafe/bakery (휴게음식점) establishments in Korea.
+
+
+    Data sourced from Korea''s Local Government Data (지방행정인허가 데이터)
+
+    via the localdata.go.kr API.
+
+    '
+  license: cc-by-4.0
+  language:
+  - ko
+  tags:
+  - korea
+  - business-license
+  - localdata
+  - public-data
+  features:
+  - name: business_name
+    description: Business/establishment name (사업장명)
+  - name: full_address
+    description: Full address (소재지전체주소)
+  - name: road_address
+    description: Road name address (도로명전체주소)
+  - name: status_name
+    description: Business status (영업상태명)
+  - name: approval_date
+    description: License approval date (인허가일자)
+  - name: longitude
+    description: Longitude (X좌표)
+  - name: latitude
+    description: Latitude (Y좌표)

--- a/scripts/configs/localdata/swimming_pool.yaml
+++ b/scripts/configs/localdata/swimming_pool.yaml
@@ -1,0 +1,66 @@
+# 수영장 (Swimming Pool) — Auto-generated localdata config
+source:
+  provider: localdata
+  dataset: swimming_pool
+  list_all: true
+  fetch_params:
+  - {}
+transform:
+  column_mapping:
+    opnSfTeamCode: district_code
+    mgtNo: management_number
+    opnSvcNm: service_name
+    bplcNm: business_name
+    siteWhlAddr: full_address
+    rdnWhlAddr: road_address
+    siteTel: phone
+    trdStateGbn: status_code
+    trdStateNm: status_name
+    dtlStateGbn: detail_status_code
+    dtlStateNm: detail_status_name
+    dcbYmd: closure_date
+    apvPermYmd: approval_date
+    x: longitude
+    y: latitude
+  dtypes:
+    longitude: float
+    latitude: float
+  derived: []
+  filters: []
+output:
+  staging_dir: ./staging/localdata-swimming-pool
+  parquet_filename: data/train.parquet
+  hf_repo: kpubdata/localdata-swimming-pool
+card:
+  title: Korea Swimming Pool Business Licenses (수영장)
+  description: 'Business license data for swimming pool (수영장) establishments in Korea.
+
+
+    Data sourced from Korea''s Local Government Data (지방행정인허가 데이터)
+
+    via the localdata.go.kr API.
+
+    '
+  license: cc-by-4.0
+  language:
+  - ko
+  tags:
+  - korea
+  - business-license
+  - localdata
+  - public-data
+  features:
+  - name: business_name
+    description: Business/establishment name (사업장명)
+  - name: full_address
+    description: Full address (소재지전체주소)
+  - name: road_address
+    description: Road name address (도로명전체주소)
+  - name: status_name
+    description: Business status (영업상태명)
+  - name: approval_date
+    description: License approval date (인허가일자)
+  - name: longitude
+    description: Longitude (X좌표)
+  - name: latitude
+    description: Latitude (Y좌표)

--- a/scripts/configs/localdata/tourist_accommodation.yaml
+++ b/scripts/configs/localdata/tourist_accommodation.yaml
@@ -1,0 +1,67 @@
+# 관광숙박업 (Tourist Accommodation) — Auto-generated localdata config
+source:
+  provider: localdata
+  dataset: tourist_accommodation
+  list_all: true
+  fetch_params:
+  - {}
+transform:
+  column_mapping:
+    opnSfTeamCode: district_code
+    mgtNo: management_number
+    opnSvcNm: service_name
+    bplcNm: business_name
+    siteWhlAddr: full_address
+    rdnWhlAddr: road_address
+    siteTel: phone
+    trdStateGbn: status_code
+    trdStateNm: status_name
+    dtlStateGbn: detail_status_code
+    dtlStateNm: detail_status_name
+    dcbYmd: closure_date
+    apvPermYmd: approval_date
+    x: longitude
+    y: latitude
+  dtypes:
+    longitude: float
+    latitude: float
+  derived: []
+  filters: []
+output:
+  staging_dir: ./staging/localdata-tourist-accommodation
+  parquet_filename: data/train.parquet
+  hf_repo: kpubdata/localdata-tourist-accommodation
+card:
+  title: Korea Tourist Accommodation Business Licenses (관광숙박업)
+  description: 'Business license data for tourist accommodation (관광숙박업) establishments
+    in Korea.
+
+
+    Data sourced from Korea''s Local Government Data (지방행정인허가 데이터)
+
+    via the localdata.go.kr API.
+
+    '
+  license: cc-by-4.0
+  language:
+  - ko
+  tags:
+  - korea
+  - business-license
+  - localdata
+  - public-data
+  features:
+  - name: business_name
+    description: Business/establishment name (사업장명)
+  - name: full_address
+    description: Full address (소재지전체주소)
+  - name: road_address
+    description: Road name address (도로명전체주소)
+  - name: status_name
+    description: Business status (영업상태명)
+  - name: approval_date
+    description: License approval date (인허가일자)
+  - name: longitude
+    description: Longitude (X좌표)
+  - name: latitude
+    description: Latitude (Y좌표)

--- a/scripts/configs/templates/localdata_template.yaml
+++ b/scripts/configs/templates/localdata_template.yaml
@@ -1,0 +1,70 @@
+# Localdata (지방행정인허가) — Common Template
+# NOTE: dataset and output fields are filled by generate_localdata_configs.py
+
+source:
+  provider: localdata
+  dataset: "__DATASET_ID__"
+  list_all: true
+  fetch_params:
+    - {}
+
+transform:
+  column_mapping:
+    opnSfTeamCode: district_code
+    mgtNo: management_number
+    opnSvcNm: service_name
+    bplcNm: business_name
+    siteWhlAddr: full_address
+    rdnWhlAddr: road_address
+    siteTel: phone
+    trdStateGbn: status_code
+    trdStateNm: status_name
+    dtlStateGbn: detail_status_code
+    dtlStateNm: detail_status_name
+    dcbYmd: closure_date
+    apvPermYmd: approval_date
+    x: longitude
+    y: latitude
+
+  dtypes:
+    longitude: float
+    latitude: float
+
+  derived: []
+  filters: []
+
+output:
+  staging_dir: "./staging/__HF_SLUG__"
+  parquet_filename: "data/train.parquet"
+  hf_repo: "kpubdata/__HF_SLUG__"
+
+card:
+  title: "__TITLE__"
+  description: |
+    __DESCRIPTION__
+
+    Data sourced from Korea's Local Government Data (지방행정인허가 데이터)
+    via the localdata.go.kr API.
+  license: cc-by-4.0
+  language:
+    - ko
+  tags:
+    - korea
+    - business-license
+    - localdata
+    - public-data
+  features:
+    - name: business_name
+      description: Business/establishment name (사업장명)
+    - name: full_address
+      description: Full address (소재지전체주소)
+    - name: road_address
+      description: Road name address (도로명전체주소)
+    - name: status_name
+      description: Business status (영업상태명)
+    - name: approval_date
+      description: License approval date (인허가일자)
+    - name: longitude
+      description: Longitude (X좌표)
+    - name: latitude
+      description: Latitude (Y좌표)

--- a/scripts/generate_localdata_configs.py
+++ b/scripts/generate_localdata_configs.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Generate HuggingFace publishing configs for localdata datasets in bulk.
+
+Usage:
+    python generate_localdata_configs.py --output-dir scripts/configs/localdata/
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import yaml
+
+# Representative localdata datasets grouped by category.
+# Each entry: (dataset_id, hf_slug, title_en, title_ko)
+LOCALDATA_DATASETS: list[tuple[str, str, str, str]] = [
+    # Food & Beverage
+    ("general_restaurant", "localdata-general-restaurant", "General Restaurant", "일반음식점"),
+    ("rest_cafe", "localdata-rest-cafe", "Cafe/Bakery", "휴게음식점"),
+    ("bakery", "localdata-bakery", "Bakery", "제과점"),
+    # Healthcare
+    ("hospital", "localdata-hospital", "Hospital", "병원"),
+    ("clinic", "localdata-clinic", "Clinic", "의원"),
+    ("pharmacy", "localdata-pharmacy", "Pharmacy", "약국"),
+    ("dental_clinic", "localdata-dental-clinic", "Dental Clinic", "치과의원"),
+    # Accommodation & Tourism
+    ("tourist_accommodation", "localdata-tourist-accommodation", "Tourist Accommodation", "관광숙박업"),
+    ("general_accommodation", "localdata-general-accommodation", "General Accommodation", "일반숙박업"),
+    # Sports & Leisure
+    ("fitness_center", "localdata-fitness-center", "Fitness Center", "체력단련장"),
+    ("swimming_pool", "localdata-swimming-pool", "Swimming Pool", "수영장"),
+    # Animals
+    ("animal_hospital", "localdata-animal-hospital", "Animal Hospital", "동물병원"),
+    ("pet_grooming", "localdata-pet-grooming", "Pet Grooming", "동물미용업"),
+    # Education
+    ("private_academy", "localdata-private-academy", "Private Academy", "학원"),
+    # Retail
+    ("convenience_store", "localdata-convenience-store", "Convenience Store", "편의점"),
+]
+
+
+def generate_config(
+    dataset_id: str,
+    hf_slug: str,
+    title_en: str,
+    title_ko: str,
+    template_path: Path,
+) -> dict[str, object]:
+    """Generate a config dict from the common template."""
+    with open(template_path, encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+
+    config["source"]["dataset"] = dataset_id
+    config["output"]["staging_dir"] = f"./staging/{hf_slug}"
+    config["output"]["hf_repo"] = f"kpubdata/{hf_slug}"
+    config["card"]["title"] = f"Korea {title_en} Business Licenses ({title_ko})"
+    config["card"]["description"] = (
+        f"Business license data for {title_en.lower()} ({title_ko}) "
+        f"establishments in Korea.\n\n"
+        f"Data sourced from Korea's Local Government Data (지방행정인허가 데이터)\n"
+        f"via the localdata.go.kr API.\n"
+    )
+
+    return config
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate localdata HF configs in bulk")
+    parser.add_argument(
+        "--template",
+        default="scripts/configs/templates/localdata_template.yaml",
+        help="Path to common template",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="scripts/configs/localdata",
+        help="Output directory for generated configs",
+    )
+    args = parser.parse_args()
+
+    template_path = Path(args.template)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for dataset_id, hf_slug, title_en, title_ko in LOCALDATA_DATASETS:
+        config = generate_config(dataset_id, hf_slug, title_en, title_ko, template_path)
+        output_path = output_dir / f"{dataset_id}.yaml"
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write(f"# {title_ko} ({title_en}) — Auto-generated localdata config\n")
+            yaml.dump(config, f, allow_unicode=True, default_flow_style=False, sort_keys=False)
+        print(f"  Generated: {output_path}")
+
+    print(f"\nTotal: {len(LOCALDATA_DATASETS)} configs generated in {output_dir}/")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add common localdata template (shared column_mapping for business license data)
- Add bulk config generator script (`generate_localdata_configs.py`)
- Generate 15 representative dataset configs across categories (food, healthcare, accommodation, sports, animals, education, retail)

## Test plan
- [x] `python scripts/generate_localdata_configs.py` runs successfully
- [x] 15 YAML configs generated

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)