### PR TITLE
feat(publishers): implement registry with Local and HuggingFace backends (#40)

### DIFF
--- a/src/kpubdata_builder/publishers/__init__.py
+++ b/src/kpubdata_builder/publishers/__init__.py
@@ -3,7 +3,17 @@
 from __future__ import annotations
 
 from .base import BasePublisher
+from .huggingface import HuggingFacePublisher
+from .local import LocalPublisher
 
-PUBLISHER_REGISTRY: dict[str, BasePublisher] = {}
+PUBLISHER_REGISTRY: dict[str, type[BasePublisher]] = {
+    "local": LocalPublisher,
+    "huggingface": HuggingFacePublisher,
+}
 
-__all__ = ["BasePublisher", "PUBLISHER_REGISTRY"]
+__all__ = [
+    "BasePublisher",
+    "HuggingFacePublisher",
+    "LocalPublisher",
+    "PUBLISHER_REGISTRY",
+]

--- a/src/kpubdata_builder/publishers/huggingface.py
+++ b/src/kpubdata_builder/publishers/huggingface.py
@@ -1,0 +1,61 @@
+"""Hugging Face Hub publisher — uploads artifacts to a HF dataset repo."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .base import BasePublisher
+
+
+@dataclass(frozen=True)
+class HuggingFacePublisher(BasePublisher):
+    """Upload artifact files to a Hugging Face Hub dataset repository."""
+
+    repo_id: str
+    token_env: str = "HF_TOKEN"
+    commit_message: str = "Update dataset via kpubdata-builder"
+    revision: str = "main"
+    extras: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def name(self) -> str:
+        return "huggingface"
+
+    def publish(self, artifact_paths: tuple[Path, ...]) -> None:
+        try:
+            from huggingface_hub import HfApi  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise RuntimeError(
+                "huggingface_hub is required for HuggingFace publishing. "
+                "Install it with: pip install huggingface_hub"
+            ) from exc
+
+        token = os.environ.get(self.token_env)
+        if not token:
+            raise RuntimeError(
+                f"Environment variable {self.token_env} is not set. "
+                "A Hugging Face API token is required for publishing."
+            )
+
+        api = HfApi(token=token)
+
+        for path in artifact_paths:
+            if path.is_dir():
+                api.upload_folder(
+                    folder_path=str(path),
+                    repo_id=self.repo_id,
+                    repo_type="dataset",
+                    revision=self.revision,
+                    commit_message=self.commit_message,
+                )
+            else:
+                api.upload_file(
+                    path_or_fileobj=str(path),
+                    path_in_repo=path.name,
+                    repo_id=self.repo_id,
+                    repo_type="dataset",
+                    revision=self.revision,
+                    commit_message=self.commit_message,
+                )

--- a/src/kpubdata_builder/publishers/local.py
+++ b/src/kpubdata_builder/publishers/local.py
@@ -1,0 +1,29 @@
+"""Local filesystem publisher — copies artifacts to a destination directory."""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+from .base import BasePublisher
+
+
+@dataclass(frozen=True)
+class LocalPublisher(BasePublisher):
+    """Copy artifact files to a local destination directory."""
+
+    destination: Path
+
+    @property
+    def name(self) -> str:
+        return "local"
+
+    def publish(self, artifact_paths: tuple[Path, ...]) -> None:
+        self.destination.mkdir(parents=True, exist_ok=True)
+        for src in artifact_paths:
+            dst = self.destination / src.name
+            if src.is_dir():
+                shutil.copytree(src, dst, dirs_exist_ok=True)
+            else:
+                shutil.copy2(src, dst)

--- a/tests/unit/test_publishers.py
+++ b/tests/unit/test_publishers.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kpubdata_builder.publishers import PUBLISHER_REGISTRY, LocalPublisher
+from kpubdata_builder.publishers.huggingface import HuggingFacePublisher
+
+
+def test_publisher_registry_contains_local_and_huggingface() -> None:
+    assert "local" in PUBLISHER_REGISTRY
+    assert "huggingface" in PUBLISHER_REGISTRY
+
+
+def test_local_publisher_copies_files(tmp_path: Path) -> None:
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "data.parquet").write_text("fake parquet")
+    (src_dir / "README.md").write_text("# Dataset")
+
+    dest = tmp_path / "dest"
+    publisher = LocalPublisher(destination=dest)
+
+    assert publisher.name == "local"
+    publisher.publish((src_dir / "data.parquet", src_dir / "README.md"))
+
+    assert (dest / "data.parquet").read_text() == "fake parquet"
+    assert (dest / "README.md").read_text() == "# Dataset"
+
+
+def test_local_publisher_copies_directories(tmp_path: Path) -> None:
+    src_dir = tmp_path / "src" / "data"
+    src_dir.mkdir(parents=True)
+    (src_dir / "train.parquet").write_text("train data")
+
+    dest = tmp_path / "dest"
+    publisher = LocalPublisher(destination=dest)
+    publisher.publish((src_dir,))
+
+    assert (dest / "data" / "train.parquet").read_text() == "train data"
+
+
+def test_huggingface_publisher_name() -> None:
+    publisher = HuggingFacePublisher(repo_id="kpubdata/test")
+    assert publisher.name == "huggingface"
+
+
+def test_huggingface_publisher_requires_token(tmp_path: Path) -> None:
+    publisher = HuggingFacePublisher(repo_id="kpubdata/test", token_env="MISSING_TOKEN")
+    src = tmp_path / "data.parquet"
+    src.write_text("data")
+
+    fake_hf = MagicMock()
+    with (
+        patch.dict("os.environ", {}, clear=True),
+        patch.dict("sys.modules", {"huggingface_hub": fake_hf}),
+        pytest.raises(RuntimeError, match="not set"),
+    ):
+        publisher.publish((src,))
+
+
+def test_huggingface_publisher_requires_library(tmp_path: Path) -> None:
+    publisher = HuggingFacePublisher(repo_id="kpubdata/test")
+    src = tmp_path / "data.parquet"
+    src.write_text("data")
+
+    with (
+        patch.dict("os.environ", {"HF_TOKEN": "fake-token"}),
+        patch.dict("sys.modules", {"huggingface_hub": None}),
+        pytest.raises(RuntimeError, match="huggingface_hub"),
+    ):
+        publisher.publish((src,))


### PR DESCRIPTION
## Summary
- Add `LocalPublisher` (filesystem copy) and `HuggingFacePublisher` (HF Hub upload)
- Register both in `PUBLISHER_REGISTRY`
- HuggingFace publisher uses lazy import to avoid hard dependency

## Test plan
- [x] `uv run pytest` — 60 passed
- [x] `uv run mypy src` — no errors
- [x] `uv run ruff check .` — all passed

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)