### PR TITLE
feat(cli): add publish command with local and HuggingFace targets (#10)

### DIFF
--- a/src/kpubdata_builder/cli.py
+++ b/src/kpubdata_builder/cli.py
@@ -46,6 +46,23 @@ def build_parser() -> argparse.ArgumentParser:
     )
     build_cmd.add_argument("spec", nargs="?", help="Path to the BuildSpec YAML file.")
 
+    publish_cmd = subparsers.add_parser(
+        "publish",
+        help="Publish build artifacts to a destination (local or HuggingFace).",
+    )
+    publish_cmd.add_argument("source", help="Path to the build output directory to publish.")
+    publish_cmd.add_argument(
+        "--target",
+        choices=["local", "huggingface"],
+        default="local",
+        help="Publish target (default: local).",
+    )
+    publish_cmd.add_argument(
+        "--destination",
+        default="./published",
+        help="Destination path (for local) or HF repo ID (for huggingface).",
+    )
+
     return parser
 
 
@@ -74,10 +91,48 @@ def _run_reserved(command: str) -> int:
     return 1
 
 
+def _run_publish(source: str, target: str, destination: str) -> int:
+    source_path = Path(source)
+    if not source_path.exists():
+        print(f"error: source path does not exist: {source}", file=sys.stderr)
+        return 1
+
+    artifact_paths = tuple(source_path.iterdir()) if source_path.is_dir() else (source_path,)
+    if not artifact_paths:
+        print("error: no artifacts found to publish", file=sys.stderr)
+        return 1
+
+    from .publishers.base import BasePublisher
+
+    publisher: BasePublisher
+    if target == "local":
+        from .publishers.local import LocalPublisher
+
+        publisher = LocalPublisher(destination=Path(destination))
+    elif target == "huggingface":
+        from .publishers.huggingface import HuggingFacePublisher
+
+        publisher = HuggingFacePublisher(repo_id=destination)
+    else:
+        print(f"error: unsupported publish target: {target}", file=sys.stderr)
+        return 1
+
+    try:
+        publisher.publish(artifact_paths)
+    except RuntimeError as exc:
+        print(f"error: publish failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"published to {target}: {destination}")
+    return 0
+
+
 def dispatch(args: argparse.Namespace) -> int:
     command = args.command
     if command == "validate":
         return _run_validate(args.spec)
+    if command == "publish":
+        return _run_publish(args.source, args.target, args.destination)
     if command in _RESERVED_COMMANDS:
         return _run_reserved(command)
     # Unreachable via normal CLI (argparse rejects unknown subcommands),

--- a/src/kpubdata_builder/publishers/huggingface.py
+++ b/src/kpubdata_builder/publishers/huggingface.py
@@ -1,0 +1,61 @@
+"""Hugging Face Hub publisher — uploads artifacts to a HF dataset repo."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .base import BasePublisher
+
+
+@dataclass(frozen=True)
+class HuggingFacePublisher(BasePublisher):
+    """Upload artifact files to a Hugging Face Hub dataset repository."""
+
+    repo_id: str
+    token_env: str = "HF_TOKEN"
+    commit_message: str = "Update dataset via kpubdata-builder"
+    revision: str = "main"
+    extras: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def name(self) -> str:
+        return "huggingface"
+
+    def publish(self, artifact_paths: tuple[Path, ...]) -> None:
+        try:
+            from huggingface_hub import HfApi  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise RuntimeError(
+                "huggingface_hub is required for HuggingFace publishing. "
+                "Install it with: pip install huggingface_hub"
+            ) from exc
+
+        token = os.environ.get(self.token_env)
+        if not token:
+            raise RuntimeError(
+                f"Environment variable {self.token_env} is not set. "
+                "A Hugging Face API token is required for publishing."
+            )
+
+        api = HfApi(token=token)
+
+        for path in artifact_paths:
+            if path.is_dir():
+                api.upload_folder(
+                    folder_path=str(path),
+                    repo_id=self.repo_id,
+                    repo_type="dataset",
+                    revision=self.revision,
+                    commit_message=self.commit_message,
+                )
+            else:
+                api.upload_file(
+                    path_or_fileobj=str(path),
+                    path_in_repo=path.name,
+                    repo_id=self.repo_id,
+                    repo_type="dataset",
+                    revision=self.revision,
+                    commit_message=self.commit_message,
+                )

--- a/src/kpubdata_builder/publishers/local.py
+++ b/src/kpubdata_builder/publishers/local.py
@@ -1,0 +1,29 @@
+"""Local filesystem publisher — copies artifacts to a destination directory."""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+from .base import BasePublisher
+
+
+@dataclass(frozen=True)
+class LocalPublisher(BasePublisher):
+    """Copy artifact files to a local destination directory."""
+
+    destination: Path
+
+    @property
+    def name(self) -> str:
+        return "local"
+
+    def publish(self, artifact_paths: tuple[Path, ...]) -> None:
+        self.destination.mkdir(parents=True, exist_ok=True)
+        for src in artifact_paths:
+            dst = self.destination / src.name
+            if src.is_dir():
+                shutil.copytree(src, dst, dirs_exist_ok=True)
+            else:
+                shutil.copy2(src, dst)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -163,3 +163,28 @@ def test_validate_fails_for_malformed_yaml(
 
     assert exit_code == 1
     assert "failed to load spec" in captured.err
+
+
+# --- publish command ---
+
+
+def test_publish_local_copies_files(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    src = tmp_path / "artifacts"
+    src.mkdir()
+    (src / "data.parquet").write_text("fake data")
+
+    dest = tmp_path / "published"
+    exit_code = main(["publish", str(src), "--target", "local", "--destination", str(dest)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "published to local" in captured.out
+    assert (dest / "data.parquet").exists()
+
+
+def test_publish_missing_source(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main(["publish", str(tmp_path / "missing"), "--target", "local"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "does not exist" in captured.err


### PR DESCRIPTION
## Summary
- Add `kpubdata-builder publish <source> --target <local|huggingface>` subcommand
- Includes `LocalPublisher` and `HuggingFacePublisher` backends
- Includes CLI tests for publish success and error cases

## Test plan
- [x] `uv run pytest` — 56 passed
- [x] `uv run mypy src` — no errors
- [x] `uv run ruff check .` — all passed

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)