### PR TITLE
feat(exporters): add Kaggle dataset exporter and publisher (#41)

### DIFF
--- a/src/kpubdata_builder/exporters/__init__.py
+++ b/src/kpubdata_builder/exporters/__init__.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from .base import BaseExporter, ExportResult, ensure_output_dir
 from .jsonl import JsonlExporter
+from .kaggle import KaggleExporter
 from .markdown import MarkdownExporter
 
 EXPORTER_REGISTRY: dict[str, BaseExporter] = {
     "jsonl": JsonlExporter(),
+    "kaggle": KaggleExporter(),
     "markdown": MarkdownExporter(),
 }
 
@@ -16,6 +18,7 @@ __all__ = [
     "EXPORTER_REGISTRY",
     "ExportResult",
     "JsonlExporter",
+    "KaggleExporter",
     "MarkdownExporter",
     "ensure_output_dir",
 ]

--- a/src/kpubdata_builder/exporters/kaggle.py
+++ b/src/kpubdata_builder/exporters/kaggle.py
@@ -1,0 +1,77 @@
+"""Kaggle dataset exporter — generates Kaggle-compatible dataset directory."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ..artifact import ArtifactDataset
+from ..errors import ExportError
+from ..spec import ExportTarget
+from .base import BaseExporter, ExportResult, ensure_output_dir
+
+
+class KaggleExporter(BaseExporter):
+    """Exporter that produces a Kaggle-compatible dataset layout.
+
+    Output structure::
+
+        {output_dir}/
+        ├── dataset-metadata.json
+        └── data.csv  (or data.jsonl)
+    """
+
+    @property
+    def name(self) -> str:
+        return "kaggle"
+
+    def export(
+        self, artifact: ArtifactDataset, target: ExportTarget, output_dir: Path
+    ) -> ExportResult:
+        destination = ensure_output_dir(output_dir, target.output_path)
+
+        # Write data as CSV
+        import csv
+        import io
+
+        if not artifact.records:
+            content = ""
+        else:
+            fieldnames = list(artifact.records[0].keys())
+            buf = io.StringIO()
+            writer = csv.DictWriter(buf, fieldnames=fieldnames, extrasaction="ignore")
+            writer.writeheader()
+            for record in artifact.records:
+                writer.writerow(record)
+            content = buf.getvalue()
+
+        try:
+            _ = destination.write_text(content, encoding="utf-8")
+        except OSError as exc:
+            raise ExportError(f"Failed to export Kaggle artifact to {destination}: {exc}") from exc
+
+        # Write dataset-metadata.json alongside the data file
+        metadata_path = destination.parent / "dataset-metadata.json"
+        dataset_id = artifact.metadata.get("dataset_id", "unknown/dataset")
+        metadata = {
+            "title": artifact.metadata.get("title", "Dataset"),
+            "id": dataset_id,
+            "licenses": [{"name": "CC-BY-4.0"}],
+            "resources": [
+                {
+                    "path": destination.name,
+                    "description": "Main dataset file",
+                }
+            ],
+        }
+        try:
+            metadata_path.write_text(
+                json.dumps(metadata, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            raise ExportError(f"Failed to write Kaggle metadata to {metadata_path}: {exc}") from exc
+
+        return ExportResult(
+            output_path=destination, file_size=destination.stat().st_size, format=self.name
+        )

--- a/src/kpubdata_builder/publishers/kaggle.py
+++ b/src/kpubdata_builder/publishers/kaggle.py
@@ -1,0 +1,44 @@
+"""Kaggle dataset publisher — uploads artifacts via the Kaggle API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .base import BasePublisher
+
+
+@dataclass(frozen=True)
+class KagglePublisher(BasePublisher):
+    """Upload a Kaggle-formatted dataset directory via the Kaggle API."""
+
+    dataset_id: str
+    message: str = "Update dataset via kpubdata-builder"
+
+    @property
+    def name(self) -> str:
+        return "kaggle"
+
+    def publish(self, artifact_paths: tuple[Path, ...]) -> None:
+        try:
+            from kaggle.api.kaggle_api_extended import KaggleApi  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise RuntimeError(
+                "kaggle is required for Kaggle publishing. Install it with: pip install kaggle"
+            ) from exc
+
+        api = KaggleApi()
+        api.authenticate()
+
+        for path in artifact_paths:
+            if path.is_dir():
+                api.dataset_create_version(
+                    str(path),
+                    version_notes=self.message,
+                    dir_mode="zip",
+                )
+            else:
+                raise RuntimeError(
+                    f"KagglePublisher expects a directory with dataset-metadata.json, "
+                    f"got file: {path}"
+                )

--- a/tests/unit/test_exporters.py
+++ b/tests/unit/test_exporters.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from kpubdata_builder import ArtifactDataset, ExportError
-from kpubdata_builder.exporters import JsonlExporter, MarkdownExporter
+from kpubdata_builder.exporters import JsonlExporter, KaggleExporter, MarkdownExporter
 from kpubdata_builder.spec import ExportTarget
 
 
@@ -43,3 +43,39 @@ def test_markdown_exporter_returns_export_metadata(tmp_path: Path) -> None:
     assert result.output_path == tmp_path / "out/README.md"
     assert result.file_size > 0
     assert result.format == "markdown"
+
+
+def test_kaggle_exporter_creates_csv_and_metadata(tmp_path: Path) -> None:
+    artifact = ArtifactDataset(
+        records=({"id": "1", "name": "test"}, {"id": "2", "name": "test2"}),
+        metadata={"dataset_id": "user/my-dataset", "title": "My Dataset"},
+        provenance=("test",),
+    )
+    target = ExportTarget(kind="kaggle", output_path="kaggle_out/data.csv")
+
+    result = KaggleExporter().export(artifact, target, tmp_path)
+
+    assert result.format == "kaggle"
+    assert result.output_path.exists()
+    assert result.file_size > 0
+
+    # Check CSV content
+    lines = result.output_path.read_text(encoding="utf-8").splitlines()
+    assert lines[0] == "id,name"
+
+    # Check metadata file
+    import json
+
+    meta_path = result.output_path.parent / "dataset-metadata.json"
+    assert meta_path.exists()
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    assert meta["id"] == "user/my-dataset"
+    assert meta["title"] == "My Dataset"
+
+
+def test_kaggle_exporter_empty_records(tmp_path: Path) -> None:
+    artifact = ArtifactDataset(records=(), provenance=("test",))
+    target = ExportTarget(kind="kaggle", output_path="kaggle_out/data.csv")
+
+    result = KaggleExporter().export(artifact, target, tmp_path)
+    assert result.output_path.read_text(encoding="utf-8") == ""


### PR DESCRIPTION
## Summary
- `KaggleExporter` generates Kaggle-compatible layout (CSV + dataset-metadata.json)
- `KagglePublisher` uploads via Kaggle API with lazy import
- Register `KaggleExporter` in `EXPORTER_REGISTRY`

## Test plan
- [x] `uv run pytest` — 56 passed
- [x] `uv run mypy src` — no errors
- [x] `uv run ruff check .` — all passed

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)