### PR TITLE
fix: enforce JsonValue type validation in YAML spec loader (#123)

### DIFF
--- a/src/kpubdata_builder/spec.py
+++ b/src/kpubdata_builder/spec.py
@@ -120,12 +120,36 @@ def _parse_string_dict(value: object, *, field_name: str) -> dict[str, str]:
     return dict(value)
 
 
+def _validate_json_value(value: object, *, field_name: str) -> JsonValue:
+    """Recursively validate that a value conforms to the JsonValue type."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, list):
+        return [
+            _validate_json_value(item, field_name=f"{field_name}[{i}]")
+            for i, item in enumerate(value)
+        ]
+    if isinstance(value, dict):
+        result: dict[str, JsonValue] = {}
+        for k, v in value.items():
+            if not isinstance(k, str):
+                raise TypeError(f"{field_name} keys must be strings, got {type(k).__name__}")
+            result[k] = _validate_json_value(v, field_name=f"{field_name}.{k}")
+        return result
+    raise TypeError(
+        f"{field_name} contains non-JSON value of type {type(value).__name__}: {value!r}"
+    )
+
+
 def _parse_json_mapping(value: object, *, field_name: str) -> dict[str, JsonValue]:
     if not isinstance(value, dict):
         raise TypeError(f"{field_name} must be a mapping")
     if not all(isinstance(key, str) for key in value):
         raise TypeError(f"{field_name} keys must be strings")
-    return {key: item for key, item in value.items()}
+    return {
+        key: _validate_json_value(item, field_name=f"{field_name}.{key}")
+        for key, item in value.items()
+    }
 
 
 def _parse_sources(value: object) -> tuple[SourceRef, ...]:

--- a/tests/unit/test_spec.py
+++ b/tests/unit/test_spec.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from kpubdata_builder.spec import BuildSpec, ExportTarget, SourceRef
+import datetime
+
+import pytest
+
+from kpubdata_builder.errors import SpecLoadError
+from kpubdata_builder.spec import BuildSpec, ExportTarget, SourceRef, parse_spec
 
 
 def test_build_spec_instantiation() -> None:
@@ -16,3 +21,71 @@ def test_build_spec_instantiation() -> None:
     )
 
     assert spec.dataset_id == "dataset.sample"
+
+
+def _valid_spec(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "dataset_id": "test.ds",
+        "title": "Test",
+        "description": "desc",
+        "sources": [{"provider": "datago", "dataset": "air_quality"}],
+        "exports": [{"kind": "jsonl", "output_path": "out.jsonl"}],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_parse_spec_accepts_valid_json_params() -> None:
+    data = _valid_spec(
+        sources=[
+            {
+                "provider": "datago",
+                "dataset": "air_quality",
+                "params": {"page": 1, "nested": {"a": [1, 2, True, None]}},
+            }
+        ]
+    )
+    spec = parse_spec(data)
+    assert spec.sources[0].params["page"] == 1
+
+
+def test_parse_spec_rejects_datetime_in_params() -> None:
+    data = _valid_spec(
+        sources=[
+            {
+                "provider": "datago",
+                "dataset": "air_quality",
+                "params": {"ts": datetime.datetime(2026, 1, 1)},
+            }
+        ]
+    )
+    with pytest.raises(SpecLoadError, match="non-JSON value"):
+        parse_spec(data)
+
+
+def test_parse_spec_rejects_date_in_params() -> None:
+    data = _valid_spec(
+        sources=[
+            {
+                "provider": "datago",
+                "dataset": "air_quality",
+                "params": {"d": datetime.date(2026, 1, 1)},
+            }
+        ]
+    )
+    with pytest.raises(SpecLoadError, match="non-JSON value"):
+        parse_spec(data)
+
+
+def test_parse_spec_rejects_non_json_in_export_options() -> None:
+    data = _valid_spec(
+        exports=[
+            {
+                "kind": "jsonl",
+                "output_path": "out.jsonl",
+                "options": {"bad": datetime.date(2026, 1, 1)},
+            }
+        ]
+    )
+    with pytest.raises(SpecLoadError, match="non-JSON value"):
+        parse_spec(data)


### PR DESCRIPTION
## Summary
- Add recursive `_validate_json_value()` to reject non-JSON types (datetime, date, etc.)
- Fails fast at spec parse time instead of late serialization failures

## Test plan
- [x] 58 tests passed
- [x] mypy, ruff clean

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)