### PR TITLE
refactor: deprecate BuildSpec.from_yaml() to separate model from I/O (#126)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -88,10 +88,11 @@ kpubdata-builder validate spec.yaml
 코드에서 직접 빌드 과정을 제어할 수도 있습니다:
 
 ```python
-from kpubdata_builder import Assembler, BuildSpec
+from kpubdata_builder import Assembler
+from kpubdata_builder.spec import load_spec
 
 # YAML 기획서 불러오기
-spec = BuildSpec.from_yaml("spec.yaml")
+spec = load_spec("spec.yaml")
 
 # 빌드 실행
 assembler = Assembler(spec)

--- a/src/kpubdata_builder/spec.py
+++ b/src/kpubdata_builder/spec.py
@@ -49,6 +49,18 @@ class BuildSpec:
 
     @classmethod
     def from_yaml(cls, path: str | Path) -> BuildSpec:
+        """Convenience factory that delegates to load_spec.
+
+        .. deprecated::
+            Use ``load_spec(path)`` directly to keep model and I/O separate.
+        """
+        import warnings
+
+        warnings.warn(
+            "BuildSpec.from_yaml() is deprecated, use load_spec() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return load_spec(Path(path))
 
 

--- a/tests/unit/test_spec.py
+++ b/tests/unit/test_spec.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from kpubdata_builder.spec import BuildSpec, ExportTarget, SourceRef
 
 
@@ -16,3 +18,23 @@ def test_build_spec_instantiation() -> None:
     )
 
     assert spec.dataset_id == "dataset.sample"
+
+
+def test_from_yaml_emits_deprecation_warning(tmp_path: Path) -> None:
+    import warnings
+
+    spec_path = tmp_path / "spec.yaml"
+    spec_path.write_text(
+        "dataset_id: test\ntitle: T\ndescription: D\n"
+        "sources:\n  - provider: p\n    dataset: d\n"
+        "exports:\n  - kind: jsonl\n    output_path: o.jsonl\n",
+        encoding="utf-8",
+    )
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        spec = BuildSpec.from_yaml(spec_path)
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert "load_spec" in str(w[0].message)
+    assert spec.dataset_id == "test"


### PR DESCRIPTION
## Summary
- Mark `BuildSpec.from_yaml()` as deprecated with DeprecationWarning
- Direct users to `load_spec()` for clean model/I/O separation
- Update docs

## Test plan
- [x] 55 tests passed
- [x] mypy, ruff clean

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)