### PR TITLE
refactor: deprecate legacy pipeline (executor/assembler) (#122)

### DIFF
--- a/src/kpubdata_builder/assembler.py
+++ b/src/kpubdata_builder/assembler.py
@@ -1,13 +1,25 @@
-"""Assembly layer for combining source records into a canonical artifact."""
+"""Assembly layer for combining source records into a canonical artifact.
+
+.. deprecated::
+    This module is part of the legacy package pipeline. The canonical pipeline
+    is the Medallion pipeline in ``stages/`` and ``pipeline/``. This module
+    will be removed in a future version.
+"""
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Sequence
 from dataclasses import dataclass
 
 from .artifact import ArtifactDataset
 from .errors import AssemblyError
 from .spec import BuildSpec, JsonValue
+
+_DEPRECATION_MSG = (
+    "assemble_artifact() is part of the legacy pipeline. "
+    "Use the Medallion pipeline (stages/bronze → silver → gold) instead."
+)
 
 
 @dataclass(frozen=True)
@@ -20,15 +32,21 @@ def assemble_artifact(
     spec: BuildSpec,
     records_by_source: dict[str, Sequence[dict[str, JsonValue]]],
 ) -> AssemblyResult:
-    """Assemble source records with minimal deterministic merge behavior."""
+    """Assemble source records with minimal deterministic merge behavior.
+
+    .. deprecated::
+        Use the Medallion pipeline instead.
+    """
+    warnings.warn(_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+
     merged_records: list[dict[str, JsonValue]] = []
-    warnings: list[str] = []
+    warn_list: list[str] = []
     present_sources: list[str] = []
     for source in spec.sources:
         source_key = source.alias if source.alias else f"{source.provider}.{source.dataset}"
         source_records = records_by_source.get(source_key)
         if source_records is None:
-            warnings.append(f"Missing records for source: {source_key}")
+            warn_list.append(f"Missing records for source: {source_key}")
             continue
         present_sources.append(source_key)
         merged_records.extend(source_records)
@@ -43,7 +61,7 @@ def assemble_artifact(
         provenance=tuple(present_sources),
         statistics=statistics,
     )
-    return AssemblyResult(artifact=artifact, warnings=tuple(warnings))
+    return AssemblyResult(artifact=artifact, warnings=tuple(warn_list))
 
 
 __all__ = ["AssemblyResult", "assemble_artifact"]

--- a/src/kpubdata_builder/executor.py
+++ b/src/kpubdata_builder/executor.py
@@ -1,13 +1,25 @@
-"""Source execution layer for producing artifact-ready records."""
+"""Source execution layer for producing artifact-ready records.
+
+.. deprecated::
+    This module is part of the legacy package pipeline. The canonical pipeline
+    is the Medallion pipeline in ``stages/`` and ``pipeline/``. This module
+    will be removed in a future version.
+"""
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 
 from .artifact import ArtifactDataset
 from .errors import ExecutionError, ValidationError
 from .spec import BuildSpec
 from .validator import validate_spec
+
+_DEPRECATION_MSG = (
+    "source_executor() is part of the legacy pipeline. "
+    "Use the Medallion pipeline (stages/bronze → silver → gold) instead."
+)
 
 
 @dataclass(frozen=True)
@@ -18,7 +30,13 @@ class ExecutionResult:
 
 
 def source_executor(spec: BuildSpec) -> ExecutionResult:
-    """Execute declared sources and return a minimal assembled artifact stub."""
+    """Execute declared sources and return a minimal assembled artifact stub.
+
+    .. deprecated::
+        Use the Medallion pipeline instead.
+    """
+    warnings.warn(_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+
     try:
         validate_spec(spec)
     except ValidationError:


### PR DESCRIPTION
## Summary
- Mark `source_executor()` and `assemble_artifact()` as deprecated
- DeprecationWarning directs to Medallion pipeline (stages/bronze → silver → gold)

## Test plan
- [x] 54 tests passed, deprecation warnings emitted correctly
- [x] mypy, ruff clean

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)