### PR TITLE
perf: use streaming writes in Bronze persist and JSONL exporter (#124)

### DIFF
--- a/src/kpubdata_builder/exporters/jsonl.py
+++ b/src/kpubdata_builder/exporters/jsonl.py
@@ -24,14 +24,11 @@ class JsonlExporter(BaseExporter):
     ) -> ExportResult:
         """Export canonical records to a JSONL file."""
         destination = ensure_output_dir(output_dir, target.output_path)
-        content = "\n".join(
-            json.dumps(record, ensure_ascii=False, sort_keys=True) for record in artifact.records
-        )
         try:
-            if content:
-                _ = destination.write_text(f"{content}\n", encoding="utf-8")
-            else:
-                _ = destination.write_text("", encoding="utf-8")
+            with destination.open("w", encoding="utf-8") as f:
+                for record in artifact.records:
+                    f.write(json.dumps(record, ensure_ascii=False, sort_keys=True))
+                    f.write("\n")
         except OSError as exc:
             raise ExportError(f"Failed to export JSONL artifact to {destination}: {exc}") from exc
 

--- a/src/kpubdata_builder/stages/bronze/persist.py
+++ b/src/kpubdata_builder/stages/bronze/persist.py
@@ -78,11 +78,10 @@ def persist_bronze_artifact(
 
     bronze_dir.mkdir(parents=True, exist_ok=True)
 
-    records_content = "".join(
-        f"{json.dumps(record, ensure_ascii=False, sort_keys=True)}\n"
-        for record in artifact.raw_records
-    )
-    records_path.write_text(records_content, encoding="utf-8")
+    with records_path.open("w", encoding="utf-8") as f:
+        for record in artifact.raw_records:
+            f.write(json.dumps(record, ensure_ascii=False, sort_keys=True))
+            f.write("\n")
 
     metadata = _metadata_for_artifact(
         artifact,

--- a/tests/unit/test_exporters.py
+++ b/tests/unit/test_exporters.py
@@ -9,20 +9,32 @@ from kpubdata_builder.exporters import JsonlExporter, MarkdownExporter
 from kpubdata_builder.spec import ExportTarget
 
 
-@pytest.mark.parametrize(
-    ("exporter", "target"),
-    [
-        (JsonlExporter(), ExportTarget(kind="jsonl", output_path="out/data.jsonl")),
-        (MarkdownExporter(), ExportTarget(kind="markdown", output_path="out/README.md")),
-    ],
-)
-def test_exporters_raise_export_error_on_bad_path(
-    exporter: JsonlExporter | MarkdownExporter,
-    target: ExportTarget,
+def test_jsonl_exporter_raises_export_error_on_io_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     artifact = ArtifactDataset(records=({"id": "1"},), provenance=("datago.air_quality",))
+    target = ExportTarget(kind="jsonl", output_path="out/data.jsonl")
+
+    _orig_open = Path.open
+
+    def raise_on_open(self: Path, *args: object, **kwargs: object) -> object:
+        if "data.jsonl" in str(self):
+            raise OSError("permission denied")
+        return _orig_open(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "open", raise_on_open)
+
+    with pytest.raises(ExportError):
+        JsonlExporter().export(artifact, target, tmp_path)
+
+
+def test_markdown_exporter_raises_export_error_on_io_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = ArtifactDataset(records=({"id": "1"},), provenance=("datago.air_quality",))
+    target = ExportTarget(kind="markdown", output_path="out/README.md")
 
     def raise_io_error(self: Path, data: str, *, encoding: str) -> int:
         del self, data, encoding
@@ -31,7 +43,7 @@ def test_exporters_raise_export_error_on_bad_path(
     monkeypatch.setattr(Path, "write_text", raise_io_error)
 
     with pytest.raises(ExportError):
-        exporter.export(artifact, target, tmp_path)
+        MarkdownExporter().export(artifact, target, tmp_path)
 
 
 def test_markdown_exporter_returns_export_metadata(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Replace in-memory string concatenation with streaming file writes
- Bronze persist and JSONL exporter now write records line-by-line
- Reduces memory usage for large datasets

## Test plan
- [x] 54 tests passed
- [x] mypy, ruff clean

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)