### PR TITLE
feat(ci): add scheduled dataset publish workflows (#70)

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -1,0 +1,23 @@
+# Manual backfill workflow — trigger via workflow_dispatch
+name: "Backfill Dataset"
+
+on:
+  workflow_dispatch:
+    inputs:
+      config:
+        description: "Path to dataset config YAML"
+        required: true
+        type: string
+      dry_run:
+        description: "Dry run (skip HF upload)"
+        type: boolean
+        default: true
+
+jobs:
+  backfill:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: ${{ inputs.config }}
+      strategy: full_refresh
+      dry_run: ${{ inputs.dry_run }}
+    secrets: inherit

--- a/.github/workflows/publish-dataset.yml
+++ b/.github/workflows/publish-dataset.yml
@@ -1,0 +1,64 @@
+# Reusable workflow: publish a single dataset to HuggingFace
+# Usage: called by per-dataset scheduled workflows
+name: Publish Dataset
+
+on:
+  workflow_call:
+    inputs:
+      config:
+        description: "Path to dataset config YAML"
+        required: true
+        type: string
+      strategy:
+        description: "Update strategy: full_refresh | incremental | append_only"
+        required: false
+        type: string
+        default: "full_refresh"
+      dry_run:
+        description: "Dry run mode (skip HF upload)"
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      KPUBDATA_DATAGO_API_KEY:
+        required: true
+      HF_TOKEN:
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Fetch and publish dataset
+        env:
+          KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          ARGS="--config ${{ inputs.config }}"
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            ARGS="$ARGS --dry-run"
+          fi
+          uv run python scripts/publish_to_hf.py $ARGS
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "### Dataset Publish Result" >> $GITHUB_STEP_SUMMARY
+          echo "- Config: \`${{ inputs.config }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Strategy: ${{ inputs.strategy }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Dry run: ${{ inputs.dry_run }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Status: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/scheduled-air-quality.yml
+++ b/.github/workflows/scheduled-air-quality.yml
@@ -1,0 +1,21 @@
+# 대기오염정보 — frequent append-only
+name: "Scheduled: Air Quality"
+
+on:
+  schedule:
+    - cron: "15 */2 * * *"  # every 2 hours at :15
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run"
+        type: boolean
+        default: false
+
+jobs:
+  air-quality:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/air_quality.yaml
+      strategy: append_only
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets: inherit

--- a/.github/workflows/scheduled-dur.yml
+++ b/.github/workflows/scheduled-dur.yml
@@ -1,0 +1,85 @@
+# DUR 의약품 — weekly full refresh (Saturday 01:00 UTC)
+name: "Scheduled: DUR Medication"
+
+on:
+  schedule:
+    - cron: "0 1 * * 6"  # UTC 01:00 every Saturday
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run"
+        type: boolean
+        default: false
+
+jobs:
+  dur-usjnt-taboo:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/dur_usjnt_taboo.yaml
+      strategy: full_refresh
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets: inherit
+
+  dur-pregnancy-taboo:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/dur_pregnancy_taboo.yaml
+      strategy: full_refresh
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets: inherit
+
+  dur-age-taboo:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/dur_age_taboo.yaml
+      strategy: full_refresh
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets: inherit
+
+  dur-older-adult-caution:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/dur_older_adult_caution.yaml
+      strategy: full_refresh
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets: inherit
+
+  dur-dosage-caution:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/dur_dosage_caution.yaml
+      strategy: full_refresh
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets: inherit
+
+  dur-medication-period-caution:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/dur_medication_period_caution.yaml
+      strategy: full_refresh
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets: inherit
+
+  dur-efficacy-duplication:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/dur_efficacy_duplication.yaml
+      strategy: full_refresh
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets: inherit
+
+  dur-product-info:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/dur_product_info.yaml
+      strategy: full_refresh
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets: inherit
+
+  dur-er-tablet-split-caution:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/dur_er_tablet_split_caution.yaml
+      strategy: full_refresh
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets: inherit

--- a/.github/workflows/scheduled-real-estate.yml
+++ b/.github/workflows/scheduled-real-estate.yml
@@ -1,0 +1,29 @@
+# 부동산 실거래가 — monthly incremental update (1st~10th of month)
+name: "Scheduled: Real Estate"
+
+on:
+  schedule:
+    - cron: "30 0 1-10 * *"  # UTC 00:30, 1st-10th of each month
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run"
+        type: boolean
+        default: false
+
+jobs:
+  apt-trade:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/seoul_apartment_trades.yaml
+      strategy: incremental
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets: inherit
+
+  apt-rent:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/seoul_apartment_rent.yaml
+      strategy: incremental
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets: inherit

--- a/.github/workflows/scheduled-tourism.yml
+++ b/.github/workflows/scheduled-tourism.yml
@@ -1,0 +1,45 @@
+# 한국관광공사 — weekly full refresh (Monday 02:00 UTC)
+name: "Scheduled: Tourism"
+
+on:
+  schedule:
+    - cron: "0 2 * * 1"  # UTC 02:00 every Monday
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run"
+        type: boolean
+        default: false
+
+jobs:
+  tour-area:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/tour_kor_area.yaml
+      strategy: full_refresh
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets: inherit
+
+  tour-location:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/tour_kor_location.yaml
+      strategy: full_refresh
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets: inherit
+
+  tour-keyword:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/tour_kor_keyword.yaml
+      strategy: full_refresh
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets: inherit
+
+  tour-festival:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/tour_kor_festival.yaml
+      strategy: incremental
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets: inherit

--- a/.github/workflows/scheduled-weather.yml
+++ b/.github/workflows/scheduled-weather.yml
@@ -1,0 +1,29 @@
+# 기상청 날씨 — frequent append-only
+name: "Scheduled: Weather"
+
+on:
+  schedule:
+    - cron: "20 */3 * * *"  # every 3 hours at :20
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run"
+        type: boolean
+        default: false
+
+jobs:
+  village-forecast:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/weather_village_fcst.yaml
+      strategy: append_only
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets: inherit
+
+  ultra-short-term:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/weather_ultra_srt_ncst.yaml
+      strategy: append_only
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Reusable `publish-dataset.yml` workflow with inputs (config, strategy, dry_run)
- Per-dataset scheduled workflows: real estate, DUR, weather, tourism, air quality
- Manual `backfill.yml` for on-demand republishing

## Schedules
| Dataset | Cron (UTC) | Strategy |
|---------|-----------|----------|
| Real estate | 00:30 1st-10th monthly | incremental |
| DUR medication | 01:00 Saturday | full_refresh |
| Weather | :20 every 3h | append_only |
| Tourism | 02:00 Monday | full_refresh |
| Air quality | :15 every 2h | append_only |

## Test plan
- [x] YAML syntax valid
- [x] All workflows reference existing config files

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)