### PR TITLE
feat: HuggingFacePublisher + JsonValue validation + deprecations + scheduled workflows (#40,#70,#122,#123,#126)

### DIFF
--- a/.github/workflows/scheduled-air-quality.yml
+++ b/.github/workflows/scheduled-air-quality.yml
@@ -10,5 +10,6 @@ jobs:
   air-quality:
     uses: ./.github/workflows/publish-dataset.yml
     with:
+      mode: ""
       config: scripts/configs/air_quality.yaml
     secrets: inherit

--- a/.github/workflows/scheduled-air-quality.yml
+++ b/.github/workflows/scheduled-air-quality.yml
@@ -1,0 +1,14 @@
+# 대기오염 — every 2 hours append-only
+name: "Scheduled: Air Quality"
+
+on:
+  schedule:
+    - cron: "15 */2 * * *"
+  workflow_dispatch:
+
+jobs:
+  air-quality:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/air_quality.yaml
+    secrets: inherit

--- a/.github/workflows/scheduled-dur.yml
+++ b/.github/workflows/scheduled-dur.yml
@@ -1,0 +1,62 @@
+# DUR 의약품 — weekly full refresh (Saturday)
+name: "Scheduled: DUR Medication"
+
+on:
+  schedule:
+    - cron: "0 1 * * 6"
+  workflow_dispatch:
+
+jobs:
+  dur-usjnt-taboo:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/dur_usjnt_taboo.yaml
+    secrets: inherit
+
+  dur-pregnancy-taboo:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/dur_pregnancy_taboo.yaml
+    secrets: inherit
+
+  dur-age-taboo:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/dur_age_taboo.yaml
+    secrets: inherit
+
+  dur-older-adult-caution:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/dur_older_adult_caution.yaml
+    secrets: inherit
+
+  dur-dosage-caution:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/dur_dosage_caution.yaml
+    secrets: inherit
+
+  dur-medication-period-caution:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/dur_medication_period_caution.yaml
+    secrets: inherit
+
+  dur-efficacy-duplication:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/dur_efficacy_duplication.yaml
+    secrets: inherit
+
+  dur-product-info:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/dur_product_info.yaml
+    secrets: inherit
+
+  dur-er-tablet-split-caution:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/dur_er_tablet_split_caution.yaml
+    secrets: inherit

--- a/.github/workflows/scheduled-dur.yml
+++ b/.github/workflows/scheduled-dur.yml
@@ -10,53 +10,62 @@ jobs:
   dur-usjnt-taboo:
     uses: ./.github/workflows/publish-dataset.yml
     with:
+      mode: ""
       config: scripts/configs/dur_usjnt_taboo.yaml
     secrets: inherit
 
   dur-pregnancy-taboo:
     uses: ./.github/workflows/publish-dataset.yml
     with:
+      mode: ""
       config: scripts/configs/dur_pregnancy_taboo.yaml
     secrets: inherit
 
   dur-age-taboo:
     uses: ./.github/workflows/publish-dataset.yml
     with:
+      mode: ""
       config: scripts/configs/dur_age_taboo.yaml
     secrets: inherit
 
   dur-older-adult-caution:
     uses: ./.github/workflows/publish-dataset.yml
     with:
+      mode: ""
       config: scripts/configs/dur_older_adult_caution.yaml
     secrets: inherit
 
   dur-dosage-caution:
     uses: ./.github/workflows/publish-dataset.yml
     with:
+      mode: ""
       config: scripts/configs/dur_dosage_caution.yaml
     secrets: inherit
 
   dur-medication-period-caution:
     uses: ./.github/workflows/publish-dataset.yml
     with:
+      mode: ""
       config: scripts/configs/dur_medication_period_caution.yaml
     secrets: inherit
 
   dur-efficacy-duplication:
     uses: ./.github/workflows/publish-dataset.yml
     with:
+      mode: ""
       config: scripts/configs/dur_efficacy_duplication.yaml
     secrets: inherit
 
   dur-product-info:
     uses: ./.github/workflows/publish-dataset.yml
     with:
+      mode: ""
       config: scripts/configs/dur_product_info.yaml
     secrets: inherit
 
   dur-er-tablet-split-caution:
     uses: ./.github/workflows/publish-dataset.yml
     with:
+      mode: ""
       config: scripts/configs/dur_er_tablet_split_caution.yaml
     secrets: inherit

--- a/.github/workflows/scheduled-real-estate.yml
+++ b/.github/workflows/scheduled-real-estate.yml
@@ -10,11 +10,13 @@ jobs:
   apt-trade:
     uses: ./.github/workflows/publish-dataset.yml
     with:
+      mode: ""
       config: scripts/configs/seoul_apartment_trades.yaml
     secrets: inherit
 
   apt-rent:
     uses: ./.github/workflows/publish-dataset.yml
     with:
+      mode: ""
       config: scripts/configs/seoul_apartment_rent.yaml
     secrets: inherit

--- a/.github/workflows/scheduled-real-estate.yml
+++ b/.github/workflows/scheduled-real-estate.yml
@@ -1,0 +1,20 @@
+# 부동산 실거래가 — monthly incremental (1st~10th)
+name: "Scheduled: Real Estate"
+
+on:
+  schedule:
+    - cron: "30 0 1-10 * *"
+  workflow_dispatch:
+
+jobs:
+  apt-trade:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/seoul_apartment_trades.yaml
+    secrets: inherit
+
+  apt-rent:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/seoul_apartment_rent.yaml
+    secrets: inherit

--- a/.github/workflows/scheduled-tourism.yml
+++ b/.github/workflows/scheduled-tourism.yml
@@ -10,23 +10,27 @@ jobs:
   tour-area:
     uses: ./.github/workflows/publish-dataset.yml
     with:
+      mode: ""
       config: scripts/configs/tour_kor_area.yaml
     secrets: inherit
 
   tour-location:
     uses: ./.github/workflows/publish-dataset.yml
     with:
+      mode: ""
       config: scripts/configs/tour_kor_location.yaml
     secrets: inherit
 
   tour-keyword:
     uses: ./.github/workflows/publish-dataset.yml
     with:
+      mode: ""
       config: scripts/configs/tour_kor_keyword.yaml
     secrets: inherit
 
   tour-festival:
     uses: ./.github/workflows/publish-dataset.yml
     with:
+      mode: ""
       config: scripts/configs/tour_kor_festival.yaml
     secrets: inherit

--- a/.github/workflows/scheduled-tourism.yml
+++ b/.github/workflows/scheduled-tourism.yml
@@ -1,0 +1,32 @@
+# 관광공사 — weekly (Monday)
+name: "Scheduled: Tourism"
+
+on:
+  schedule:
+    - cron: "0 2 * * 1"
+  workflow_dispatch:
+
+jobs:
+  tour-area:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/tour_kor_area.yaml
+    secrets: inherit
+
+  tour-location:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/tour_kor_location.yaml
+    secrets: inherit
+
+  tour-keyword:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/tour_kor_keyword.yaml
+    secrets: inherit
+
+  tour-festival:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/tour_kor_festival.yaml
+    secrets: inherit

--- a/.github/workflows/scheduled-weather.yml
+++ b/.github/workflows/scheduled-weather.yml
@@ -10,11 +10,13 @@ jobs:
   village-forecast:
     uses: ./.github/workflows/publish-dataset.yml
     with:
+      mode: ""
       config: scripts/configs/weather_village_fcst.yaml
     secrets: inherit
 
   ultra-short-term:
     uses: ./.github/workflows/publish-dataset.yml
     with:
+      mode: ""
       config: scripts/configs/weather_ultra_srt_ncst.yaml
     secrets: inherit

--- a/.github/workflows/scheduled-weather.yml
+++ b/.github/workflows/scheduled-weather.yml
@@ -1,0 +1,20 @@
+# 기상청 — every 3 hours append-only
+name: "Scheduled: Weather"
+
+on:
+  schedule:
+    - cron: "20 */3 * * *"
+  workflow_dispatch:
+
+jobs:
+  village-forecast:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/weather_village_fcst.yaml
+    secrets: inherit
+
+  ultra-short-term:
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      config: scripts/configs/weather_ultra_srt_ncst.yaml
+    secrets: inherit

--- a/scripts/generate_localdata_configs.py
+++ b/scripts/generate_localdata_configs.py
@@ -25,8 +25,18 @@ LOCALDATA_DATASETS: list[tuple[str, str, str, str]] = [
     ("pharmacy", "localdata-pharmacy", "Pharmacy", "약국"),
     ("dental_clinic", "localdata-dental-clinic", "Dental Clinic", "치과의원"),
     # Accommodation & Tourism
-    ("tourist_accommodation", "localdata-tourist-accommodation", "Tourist Accommodation", "관광숙박업"),
-    ("general_accommodation", "localdata-general-accommodation", "General Accommodation", "일반숙박업"),
+    (  # noqa: E501
+        "tourist_accommodation",
+        "localdata-tourist-accommodation",
+        "Tourist Accommodation",
+        "관광숙박업",
+    ),
+    (  # noqa: E501
+        "general_accommodation",
+        "localdata-general-accommodation",
+        "General Accommodation",
+        "일반숙박업",
+    ),
     # Sports & Leisure
     ("fitness_center", "localdata-fitness-center", "Fitness Center", "체력단련장"),
     ("swimming_pool", "localdata-swimming-pool", "Swimming Pool", "수영장"),

--- a/src/kpubdata_builder/executor.py
+++ b/src/kpubdata_builder/executor.py
@@ -38,6 +38,9 @@ class ExecutionResult:
 def source_executor(spec: BuildSpec) -> ExecutionResult:
     """선언된 소스를 실행하고 최소한의 조립 산출물 스텁을 반환한다.
 
+    .. deprecated::
+        Use the Medallion pipeline (pipeline/orchestrator) instead.
+
     현재 구현은 실제 네트워크 호출 대신 BuildSpec 검증과 provenance 구성에
     집중한다. 따라서 후속 단계가 기대하는 최소 ArtifactDataset을 안정적으로
     만들어 주는 것이 목적이다.
@@ -52,6 +55,14 @@ def source_executor(spec: BuildSpec) -> ExecutionResult:
         ValidationError: 명세 검증 실패 시.
         ExecutionError: provenance 구성 중 예기치 않은 오류가 발생한 경우.
     """
+    import warnings
+
+    warnings.warn(
+        "source_executor() is deprecated. Use the Medallion pipeline instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     try:
         validate_spec(spec)
     except ValidationError:

--- a/src/kpubdata_builder/publishers/__init__.py
+++ b/src/kpubdata_builder/publishers/__init__.py
@@ -14,15 +14,18 @@ kind 문자열로 찾을 수 있게 한다. HuggingFace/GitHub 등 원격 대상
 from __future__ import annotations
 
 from .base import BasePublisher, PublishResult
+from .huggingface import HuggingFacePublisher
 from .local import LocalPublisher
 
 PUBLISHER_REGISTRY: dict[str, BasePublisher] = {
     "local": LocalPublisher(),
+    "huggingface": HuggingFacePublisher(),
 }
 
 __all__ = [
     "PUBLISHER_REGISTRY",
     "BasePublisher",
+    "HuggingFacePublisher",
     "LocalPublisher",
     "PublishResult",
 ]

--- a/src/kpubdata_builder/publishers/huggingface.py
+++ b/src/kpubdata_builder/publishers/huggingface.py
@@ -1,0 +1,65 @@
+"""Hugging Face Hub publisher — uploads artifacts to a HF dataset repo."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from .base import BasePublisher, PublishResult
+
+
+class HuggingFacePublisher(BasePublisher):
+    """Upload artifact files to a Hugging Face Hub dataset repository."""
+
+    @property
+    def name(self) -> str:
+        return "huggingface"
+
+    def publish(self, artifact_paths: tuple[Path, ...], *, destination: str) -> PublishResult:
+        """Publish artifacts to a HuggingFace dataset repo.
+
+        Args:
+            artifact_paths: Files/directories to upload.
+            destination: HF repo ID (e.g. "kpubdata/air-quality").
+        """
+        try:
+            from huggingface_hub import HfApi  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise RuntimeError(
+                "huggingface_hub is required for HuggingFace publishing. "
+                "Install it with: pip install huggingface_hub"
+            ) from exc
+
+        token = os.environ.get("HF_TOKEN")
+        if not token:
+            raise RuntimeError(
+                "Environment variable HF_TOKEN is not set. "
+                "A Hugging Face API token is required for publishing."
+            )
+
+        api = HfApi(token=token)
+        count = 0
+
+        for path in artifact_paths:
+            if path.is_dir():
+                api.upload_folder(
+                    folder_path=str(path),
+                    repo_id=destination,
+                    repo_type="dataset",
+                    commit_message="Update dataset via kpubdata-builder",
+                )
+            else:
+                api.upload_file(
+                    path_or_fileobj=str(path),
+                    path_in_repo=path.name,
+                    repo_id=destination,
+                    repo_type="dataset",
+                    commit_message="Update dataset via kpubdata-builder",
+                )
+            count += 1
+
+        return PublishResult(
+            publisher=self.name,
+            reference=f"https://huggingface.co/datasets/{destination}",
+            artifact_count=count,
+        )

--- a/src/kpubdata_builder/spec/loader.py
+++ b/src/kpubdata_builder/spec/loader.py
@@ -133,17 +133,40 @@ def _parse_string_dict(value: object, *, field_name: str) -> dict[str, str]:
     return parsed
 
 
+def _validate_json_value(value: object, *, field_name: str) -> JsonValue:
+    """값이 JSON 프리미티브/컨테이너인지 재귀적으로 검증한다."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, list):
+        return [
+            _validate_json_value(item, field_name=f"{field_name}[{i}]")
+            for i, item in enumerate(value)
+        ]
+    if isinstance(value, dict):
+        result: dict[str, JsonValue] = {}
+        for k, v in cast(dict[object, object], value).items():
+            if not isinstance(k, str):
+                raise TypeError(
+                    f"{field_name} keys must be strings, got {type(k).__name__}"
+                )
+            result[k] = _validate_json_value(v, field_name=f"{field_name}.{k}")
+        return result
+    raise TypeError(
+        f"{field_name} contains non-JSON value of type {type(value).__name__}: {value!r}"
+    )
+
+
 def _parse_json_mapping(value: object, *, field_name: str) -> dict[str, JsonValue]:
     """JSON 호환 값만 담는 매핑 필드를 검증한다."""
     if not isinstance(value, dict):
         raise TypeError(f"{field_name} must be a mapping")
 
-    raw_mapping = cast(dict[object, JsonValue], value)
+    raw_mapping = cast(dict[object, object], value)
     parsed: dict[str, JsonValue] = {}
     for key, item in raw_mapping.items():
         if not isinstance(key, str):
             raise TypeError(f"{field_name} keys must be strings")
-        parsed[key] = item
+        parsed[key] = _validate_json_value(item, field_name=f"{field_name}.{key}")
     return parsed
 
 

--- a/src/kpubdata_builder/spec/models.py
+++ b/src/kpubdata_builder/spec/models.py
@@ -104,12 +104,22 @@ class BuildSpec:
     def from_yaml(cls, path: str | Path) -> BuildSpec:
         """YAML 파일에서 BuildSpec을 로드한다.
 
+        .. deprecated::
+            Use ``load_spec(path)`` directly to keep model and I/O separate.
+
         매개변수:
             path: YAML 파일 경로.
 
         반환값:
             BuildSpec: 파싱 완료된 불변 명세 객체.
         """
+        import warnings
+
+        warnings.warn(
+            "BuildSpec.from_yaml() is deprecated, use load_spec() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         # models <-> loader 순환 import를 피하기 위한 지연 import.
         from .loader import load_spec
 


### PR DESCRIPTION
## Summary

Consolidated PR addressing review feedback. All changes are rebased on current main.

### Changes
1. **HuggingFacePublisher** (#40) — new publisher using `huggingface_hub` API
2. **JsonValue validation** (#123) — recursive `_validate_json_value()` in `spec/loader.py`
3. **BuildSpec.from_yaml() deprecation** (#126) — DeprecationWarning added in `spec/models.py`
4. **source_executor() deprecation** (#122) — DeprecationWarning directing to Medallion pipeline
5. **Scheduled workflows** (#70) — per-dataset cron schedules (real estate, DUR, weather, tourism, air quality)
6. **Lint fix** — `generate_localdata_configs.py` line length

## Test plan
- [x] 302 tests passed
- [x] mypy — no errors (66 source files)
- [x] ruff check — all passed
- [x] DeprecationWarning emitted correctly for `source_executor()` and `from_yaml()`

Closes #40, closes #70, closes #122, closes #123, closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)