### PR TITLE
feat(exporters): add Kaggle exporter and publisher (#41)

### DIFF
--- a/src/kpubdata_builder/exporters/__init__.py
+++ b/src/kpubdata_builder/exporters/__init__.py
@@ -14,6 +14,7 @@ from .base import BaseExporter, ExportResult, ensure_output_dir
 from .csv import CsvExporter
 from .huggingface import HuggingFaceExporter
 from .jsonl import JsonlExporter
+from .kaggle import KaggleExporter
 from .markdown import MarkdownExporter
 from .parquet import ParquetExporter
 from .registry import (
@@ -29,6 +30,7 @@ register_exporter(CsvExporter(), override=True)
 register_exporter(HuggingFaceExporter(), override=True)
 register_exporter(JsonlExporter(), override=True)
 register_exporter(MarkdownExporter(), override=True)
+register_exporter(KaggleExporter(), override=True)
 register_exporter(ParquetExporter(), override=True)
 
 __all__ = [
@@ -39,6 +41,7 @@ __all__ = [
     "ExportResult",
     "HuggingFaceExporter",
     "JsonlExporter",
+    "KaggleExporter",
     "MarkdownExporter",
     "ParquetExporter",
     "ensure_output_dir",

--- a/src/kpubdata_builder/exporters/kaggle.py
+++ b/src/kpubdata_builder/exporters/kaggle.py
@@ -1,0 +1,69 @@
+"""Kaggle 호환 데이터셋 디렉터리를 생성하는 exporter.
+
+출력 구조::
+    {output_dir}/{output_path}       ← CSV 데이터 파일
+    {output_dir}/dataset-metadata.json  ← Kaggle 메타데이터
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from pathlib import Path
+
+from ..artifact import ArtifactDataset
+from ..errors import ExportError
+from ..spec import ExportTarget
+from .base import BaseExporter, ExportResult, ensure_output_dir
+
+
+class KaggleExporter(BaseExporter):
+    """Kaggle 형식(CSV + dataset-metadata.json)으로 내보내는 exporter."""
+
+    @property
+    def name(self) -> str:
+        return "kaggle"
+
+    def export(
+        self, artifact: ArtifactDataset, target: ExportTarget, output_dir: Path
+    ) -> ExportResult:
+        destination = ensure_output_dir(output_dir, target.output_path)
+
+        if not artifact.records:
+            content = ""
+        else:
+            fieldnames = list(artifact.records[0].keys())
+            buf = io.StringIO()
+            writer = csv.DictWriter(buf, fieldnames=fieldnames, extrasaction="ignore")
+            writer.writeheader()
+            for record in artifact.records:
+                writer.writerow(record)
+            content = buf.getvalue()
+
+        try:
+            _ = destination.write_text(content, encoding="utf-8")
+        except OSError as exc:
+            raise ExportError(f"Failed to export Kaggle artifact to {destination}: {exc}") from exc
+
+        metadata_path = destination.parent / "dataset-metadata.json"
+        dataset_id = artifact.metadata.get("dataset_id", "unknown/dataset")
+        metadata = {
+            "title": artifact.metadata.get("title", "Dataset"),
+            "id": dataset_id,
+            "licenses": [{"name": "CC-BY-4.0"}],
+            "resources": [{"path": destination.name, "description": "Main dataset file"}],
+        }
+        try:
+            metadata_path.write_text(
+                json.dumps(metadata, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            raise ExportError(f"Failed to write Kaggle metadata to {metadata_path}: {exc}") from exc
+
+        return ExportResult(
+            output_path=destination,
+            file_size=destination.stat().st_size,
+            format=self.name,
+        )

--- a/src/kpubdata_builder/publishers/kaggle.py
+++ b/src/kpubdata_builder/publishers/kaggle.py
@@ -1,0 +1,52 @@
+"""Kaggle API를 통해 데이터셋을 퍼블리시하는 publisher."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .base import BasePublisher, PublishResult
+
+
+class KagglePublisher(BasePublisher):
+    """Kaggle API로 dataset-metadata.json이 있는 디렉터리를 업로드한다."""
+
+    @property
+    def name(self) -> str:
+        return "kaggle"
+
+    def publish(self, artifact_paths: tuple[Path, ...], *, destination: str) -> PublishResult:
+        """Kaggle 데이터셋을 새 버전으로 업로드한다.
+
+        Args:
+            artifact_paths: dataset-metadata.json을 포함하는 디렉터리 경로.
+            destination: Kaggle dataset ID (e.g. "username/dataset-name").
+        """
+        try:
+            from kaggle.api.kaggle_api_extended import KaggleApi  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise RuntimeError(
+                "kaggle is required for Kaggle publishing. Install it with: pip install kaggle"
+            ) from exc
+
+        api = KaggleApi()
+        api.authenticate()
+        count = 0
+
+        for path in artifact_paths:
+            if not path.is_dir():
+                raise RuntimeError(
+                    f"KagglePublisher expects a directory with dataset-metadata.json, "
+                    f"got file: {path}"
+                )
+            api.dataset_create_version(
+                str(path),
+                version_notes="Update via kpubdata-builder",
+                dir_mode="zip",
+            )
+            count += 1
+
+        return PublishResult(
+            publisher=self.name,
+            reference=f"https://www.kaggle.com/datasets/{destination}",
+            artifact_count=count,
+        )


### PR DESCRIPTION
## Summary
- `KaggleExporter`: CSV + `dataset-metadata.json` layout (registered in plugin registry)
- `KagglePublisher`: uploads via Kaggle API (lazy import, `dataset_create_version`)

Rebased on current main. No conflicts.

## Test plan
- [x] 302 tests passed
- [x] mypy clean
- [x] ruff clean

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)