### PR TITLE
fix: batch bug fixes #146-#162

### DIFF
--- a/scripts/generate_fetch_params.py
+++ b/scripts/generate_fetch_params.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import sys
 from pathlib import Path
 
 import yaml
@@ -26,10 +27,20 @@ def generate_params(district_codes: list[str], start_ym: str, end_ym: str) -> li
     return params
 
 
+def _validate_yyyymm(value: str, *, label: str) -> tuple[int, int]:
+    """Validate YYYYMM format and return (year, month)."""
+    if len(value) != 6 or not value.isdigit():
+        raise ValueError(f"{label} must be exactly 6 digits in YYYYMM format, got: {value!r}")
+    year, month = int(value[:4]), int(value[4:6])
+    if month < 1 or month > 12:
+        raise ValueError(f"{label} has invalid month {month:02d} (must be 01-12): {value!r}")
+    return year, month
+
+
 def _month_range(start: str, end: str) -> list[str]:
     """Generate YYYYMM strings from start to end inclusive."""
-    sy, sm = int(start[:4]), int(start[4:6])
-    ey, em = int(end[:4]), int(end[4:6])
+    sy, sm = _validate_yyyymm(start, label="start")
+    ey, em = _validate_yyyymm(end, label="end")
     months: list[str] = []
     y, m = sy, sm
     while (y, m) <= (ey, em):
@@ -63,6 +74,10 @@ def main() -> None:
     args = parser.parse_args()
 
     codes = load_district_codes(args.districts)
+    if not codes:
+        print(f"error: no district codes found in {args.districts}", file=sys.stderr)
+        sys.exit(1)
+
     params = generate_params(codes, args.start, args.end)
 
     template_path = Path(args.template)
@@ -72,9 +87,10 @@ def main() -> None:
     config["source"]["fetch_params"] = params
 
     total = len(params)
+    months_count = total // len(codes) if codes else 0
     header_comment = (
         f"# Auto-generated config: {len(codes)} districts × "
-        f"{total // len(codes)} months = {total} API calls\n"
+        f"{months_count} months = {total} API calls\n"
         f"# Generated from template: {args.template}\n\n"
     )
 

--- a/scripts/generate_localdata_configs.py
+++ b/scripts/generate_localdata_configs.py
@@ -25,8 +25,18 @@ LOCALDATA_DATASETS: list[tuple[str, str, str, str]] = [
     ("pharmacy", "localdata-pharmacy", "Pharmacy", "약국"),
     ("dental_clinic", "localdata-dental-clinic", "Dental Clinic", "치과의원"),
     # Accommodation & Tourism
-    ("tourist_accommodation", "localdata-tourist-accommodation", "Tourist Accommodation", "관광숙박업"),
-    ("general_accommodation", "localdata-general-accommodation", "General Accommodation", "일반숙박업"),
+    (
+        "tourist_accommodation",
+        "localdata-tourist-accommodation",
+        "Tourist Accommodation",
+        "관광숙박업",
+    ),
+    (
+        "general_accommodation",
+        "localdata-general-accommodation",
+        "General Accommodation",
+        "일반숙박업",
+    ),
     # Sports & Leisure
     ("fitness_center", "localdata-fitness-center", "Fitness Center", "체력단련장"),
     ("swimming_pool", "localdata-swimming-pool", "Swimming Pool", "수영장"),

--- a/scripts/pipeline/publish.py
+++ b/scripts/pipeline/publish.py
@@ -43,10 +43,7 @@ def upload_to_hf(staging_dir: Path, hf_repo: str, *, dry_run: bool = False) -> N
 
     data_dir = staging_dir / "data"
     if data_dir.exists():
-        dest_data = upload_dir / "data"
-        dest_data.mkdir()
-        for parquet_file in data_dir.glob("*.parquet"):
-            shutil.copy2(parquet_file, dest_data / parquet_file.name)
+        shutil.copytree(data_dir, upload_dir / "data", dirs_exist_ok=True)
 
     api = HfApi()
     api.create_repo(repo_id=hf_repo, repo_type="dataset", exist_ok=True)
@@ -88,8 +85,7 @@ def upload_to_kaggle(staging_dir: Path, config: dict[str, Any], *, dry_run: bool
 
     data_dir = staging_dir / "data"
     if data_dir.exists():
-        for parquet_file in data_dir.glob("*.parquet"):
-            shutil.copy2(parquet_file, upload_dir / parquet_file.name)
+        shutil.copytree(data_dir, upload_dir / "data", dirs_exist_ok=True)
 
     description = card.get("description", "").strip()
     attribution = card.get("attribution", "").strip()

--- a/scripts/pipeline/transform.py
+++ b/scripts/pipeline/transform.py
@@ -97,10 +97,15 @@ def _apply_filter(df: pl.DataFrame, expr_str: str) -> pl.DataFrame:
         logger.warning("Filter references unknown column '%s', skipping", col)
         return df
 
+    val: int | float | str
     try:
-        val: int | float = int(val_str)
+        val = int(val_str)
     except ValueError:
-        val = float(val_str)
+        try:
+            val = float(val_str)
+        except ValueError:
+            # Treat as string comparison (strip quotes if present)
+            val = val_str.strip("'\"")
 
     ops = {
         ">": pl.col(col) > val,

--- a/src/kpubdata_builder/exporters/csv.py
+++ b/src/kpubdata_builder/exporters/csv.py
@@ -22,12 +22,13 @@ from .base import BaseExporter, ExportResult, ensure_output_dir
 def _resolve_columns(artifact: ArtifactDataset) -> list[str]:
     """CSV 헤더로 사용할 컬럼 순서를 결정한다.
 
-    schema가 선언되어 있으면 그 키 순서를, 없으면 레코드에서 처음 등장한
-    순서를 사용한다. 결과는 입력에 대해 결정적이다.
+    schema가 선언되어 있으면 그 키 순서를 우선하고, 레코드에만 존재하는
+    추가 필드도 뒤에 포함한다. 결과는 입력에 대해 결정적이다.
     """
-    if artifact.schema:
-        return list(artifact.schema.keys())
     columns: dict[str, None] = {}
+    if artifact.schema:
+        for key in artifact.schema:
+            columns.setdefault(key, None)
     for record in artifact.records:
         for key in record:
             columns.setdefault(key, None)

--- a/src/kpubdata_builder/exporters/huggingface.py
+++ b/src/kpubdata_builder/exporters/huggingface.py
@@ -136,4 +136,6 @@ class HuggingFaceExporter(BaseExporter):
             raise ExportError(f"Failed to export Hugging Face layout to {hf_dir}: {exc}") from exc
 
         total_size = sum(path.stat().st_size for path in (data_path, readme_path, infos_path))
+        # HF exporter returns the layout directory (not a single file) since it
+        # produces multiple files. Consumers should use output_path as a directory.
         return ExportResult(output_path=hf_dir, file_size=total_size, format=self.name)

--- a/src/kpubdata_builder/exporters/markdown.py
+++ b/src/kpubdata_builder/exporters/markdown.py
@@ -59,11 +59,15 @@ def _title_section(artifact: ArtifactDataset) -> list[str]:
 
 
 def _column_names(artifact: ArtifactDataset) -> list[str]:
-    """스키마의 컬럼명을 반환하고, 없으면 첫 레코드의 키로 대체한다."""
+    """스키마의 컬럼명을 반환하고, 없으면 모든 레코드의 키를 합산한다."""
     if artifact.schema:
         return list(artifact.schema.keys())
     if artifact.records:
-        return list(artifact.records[0].keys())
+        columns: dict[str, None] = {}
+        for record in artifact.records:
+            for key in record:
+                columns.setdefault(key, None)
+        return list(columns.keys())
     return []
 
 

--- a/src/kpubdata_builder/exporters/parquet.py
+++ b/src/kpubdata_builder/exporters/parquet.py
@@ -29,9 +29,16 @@ def _build_frame(artifact: ArtifactDataset) -> pl.DataFrame:
     if artifact.schema:
         _TYPE_MAP: dict[str, type[pl.DataType]] = {
             "str": pl.Utf8,
+            "String": pl.Utf8,
+            "Utf8": pl.Utf8,
             "int": pl.Int64,
+            "Int64": pl.Int64,
+            "Int32": pl.Int32,
             "float": pl.Float64,
+            "Float64": pl.Float64,
+            "Float32": pl.Float32,
             "bool": pl.Boolean,
+            "Boolean": pl.Boolean,
         }
         schema = {
             name: _TYPE_MAP.get(dtype, pl.Utf8) for name, dtype in artifact.schema.items()

--- a/src/kpubdata_builder/exporters/parquet.py
+++ b/src/kpubdata_builder/exporters/parquet.py
@@ -27,7 +27,16 @@ def _build_frame(artifact: ArtifactDataset) -> pl.DataFrame:
     if artifact.records:
         return records_to_dataframe(list(artifact.records))
     if artifact.schema:
-        return pl.DataFrame(schema={name: pl.Utf8 for name in artifact.schema})
+        _TYPE_MAP: dict[str, type[pl.DataType]] = {
+            "str": pl.Utf8,
+            "int": pl.Int64,
+            "float": pl.Float64,
+            "bool": pl.Boolean,
+        }
+        schema = {
+            name: _TYPE_MAP.get(dtype, pl.Utf8) for name, dtype in artifact.schema.items()
+        }
+        return pl.DataFrame(schema=schema)
     return pl.DataFrame()
 
 

--- a/src/kpubdata_builder/manifest/provenance.py
+++ b/src/kpubdata_builder/manifest/provenance.py
@@ -56,12 +56,12 @@ def compute_data_checksum(records: Sequence[Mapping[str, JsonValue]]) -> str:
     반환값:
         str: "sha256:" 접두사가 붙은 16진 해시.
     """
-    payload = json.dumps(
-        [dict(record) for record in records],
-        ensure_ascii=False,
-        sort_keys=True,
-        default=str,
+    # Sort records by their serialized form to make checksum order-independent
+    serialized_records = sorted(
+        json.dumps(dict(record), ensure_ascii=False, sort_keys=True, default=str)
+        for record in records
     )
+    payload = "[" + ",".join(serialized_records) + "]"
     digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
     return f"sha256:{digest}"
 

--- a/src/kpubdata_builder/pipeline/context.py
+++ b/src/kpubdata_builder/pipeline/context.py
@@ -70,6 +70,8 @@ class BuildContext:
             ValueError: run_id에 안전하지 않은 문자가 포함된 경우.
         """
         started = started_at or _utc_now()
+        if started.tzinfo is None or started.utcoffset() is None:
+            raise ValueError("started_at must be timezone-aware")
         resolved_run_id = run_id or started.strftime("%Y%m%dT%H%M%S%fZ")
         _validate_run_id(resolved_run_id)
         return cls(

--- a/src/kpubdata_builder/spec/template.py
+++ b/src/kpubdata_builder/spec/template.py
@@ -70,6 +70,7 @@ def render_template(path: str | Path, params: dict[str, str]) -> str:
 
     def _substitute_in_value(value: object) -> object:
         if isinstance(value, str):
+
             def _replace(match: re.Match[str]) -> str:
                 name = match.group(1)
                 if name not in effective:

--- a/src/kpubdata_builder/spec/template.py
+++ b/src/kpubdata_builder/spec/template.py
@@ -64,21 +64,33 @@ def render_template(path: str | Path, params: dict[str, str]) -> str:
     meta = template_meta if isinstance(template_meta, dict) else {}
     effective = _effective_params(meta, params)
 
-    body_yaml = yaml.safe_dump(data, allow_unicode=True, sort_keys=False)
-
+    # Substitute in the data structure directly to avoid YAML structure corruption.
+    # Then re-dump so the output is valid YAML regardless of substitution values.
     missing: list[str] = []
 
-    def _replace(match: re.Match[str]) -> str:
-        name = match.group(1)
-        if name not in effective:
-            missing.append(name)
-            return match.group(0)
-        return effective[name]
+    def _substitute_in_value(value: object) -> object:
+        if isinstance(value, str):
+            def _replace(match: re.Match[str]) -> str:
+                name = match.group(1)
+                if name not in effective:
+                    missing.append(name)
+                    return match.group(0)
+                return effective[name]
 
-    rendered = _PLACEHOLDER.sub(_replace, body_yaml)
+            return _PLACEHOLDER.sub(_replace, value)
+        if isinstance(value, list):
+            return [_substitute_in_value(item) for item in value]
+        if isinstance(value, dict):
+            return {k: _substitute_in_value(v) for k, v in value.items()}
+        return value
+
+    substituted = _substitute_in_value(data)
+
     if missing:
         unique = ", ".join(sorted(set(missing)))
         raise SpecLoadError(f"Missing template parameter(s): {unique}")
+
+    rendered = yaml.safe_dump(substituted, allow_unicode=True, sort_keys=False)
     return rendered
 
 

--- a/src/kpubdata_builder/stages/bronze/persist.py
+++ b/src/kpubdata_builder/stages/bronze/persist.py
@@ -74,23 +74,40 @@ def persist_bronze_artifact(
 
     ensure_within(output_root, bronze_dir, label="bronze directory")
 
-    bronze_dir.mkdir(parents=True, exist_ok=True)
+    # Atomic write: write to temp dir, then rename to final location
+    import shutil
+    import tempfile
 
-    with records_path.open("w", encoding="utf-8") as f:
-        for record in artifact.raw_records:
-            f.write(json.dumps(record, ensure_ascii=False, sort_keys=True))
-            f.write("\n")
+    parent = bronze_dir.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    tmp_dir = Path(tempfile.mkdtemp(dir=parent, prefix=f".{artifact_id}_tmp_"))
+    try:
+        tmp_records = tmp_dir / "raw_records.jsonl"
+        tmp_metadata = tmp_dir / "metadata.json"
 
-    metadata = _metadata_for_artifact(
-        artifact,
-        records_path=records_path,
-        metadata_path=metadata_path,
-        bronze_dir=bronze_dir,
-    )
-    metadata_path.write_text(
-        json.dumps(metadata, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+        with tmp_records.open("w", encoding="utf-8") as f:
+            for record in artifact.raw_records:
+                f.write(json.dumps(record, ensure_ascii=False, sort_keys=True))
+                f.write("\n")
+
+        metadata = _metadata_for_artifact(
+            artifact,
+            records_path=records_path,
+            metadata_path=metadata_path,
+            bronze_dir=bronze_dir,
+        )
+        tmp_metadata.write_text(
+            json.dumps(metadata, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+        # Atomic rename (same filesystem)
+        if bronze_dir.exists():
+            shutil.rmtree(bronze_dir)
+        tmp_dir.rename(bronze_dir)
+    except BaseException:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise
 
     return BronzePersistResult(
         bronze_dir=bronze_dir,

--- a/src/kpubdata_builder/stages/gold/persist.py
+++ b/src/kpubdata_builder/stages/gold/persist.py
@@ -81,16 +81,30 @@ def persist_gold_package(
     gold_dir = output_root / run_id / "gold" / package.dataset_name
     ensure_within(output_root, gold_dir, label="gold directory")
 
-    gold_dir.mkdir(parents=True, exist_ok=True)
+    import shutil
+    import tempfile
+
+    gold_dir.parent.mkdir(parents=True, exist_ok=True)
 
     table_path = gold_dir / "table.parquet"
     package_path = gold_dir / "package.json"
 
-    package.table.write_parquet(table_path)
-    package_path.write_text(
-        json.dumps(_package_metadata(package), ensure_ascii=False, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+    # Atomic write: write to temp dir then rename
+    tmp_dir = Path(tempfile.mkdtemp(dir=gold_dir.parent, prefix=".gold_tmp_"))
+    try:
+        package.table.write_parquet(tmp_dir / "table.parquet")
+        (tmp_dir / "package.json").write_text(
+            json.dumps(_package_metadata(package), ensure_ascii=False, indent=2, sort_keys=True)
+            + "\n",
+            encoding="utf-8",
+        )
+
+        if gold_dir.exists():
+            shutil.rmtree(gold_dir)
+        tmp_dir.rename(gold_dir)
+    except BaseException:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise
 
     return GoldPersistResult(
         gold_dir=gold_dir,

--- a/src/kpubdata_builder/stages/gold/split.py
+++ b/src/kpubdata_builder/stages/gold/split.py
@@ -54,19 +54,23 @@ def _ratio_split(
 
 
 _MISSING_KEY_SENTINEL = "__missing__"
+_NULL_VALUE_SENTINEL = "__null__"
 
 
 def _key_split(records: Sequence[Record], key: str) -> dict[str, tuple[Record, ...]]:
     """컬럼 값에 따라 레코드를 그룹으로 분할한다(값 → 분할 이름).
 
-    키가 없는 레코드는 "__missing__" 버킷으로, 빈 문자열은 "" 버킷으로 분리한다.
+    키가 없는 레코드는 "__missing__" 버킷, None 값은 "__null__" 버킷,
+    빈 문자열은 "" 버킷으로 각각 분리한다.
     """
     grouped: dict[str, list[Record]] = {}
     for record in records:
         if key not in record:
             bucket = _MISSING_KEY_SENTINEL
+        elif record[key] is None:
+            bucket = _NULL_VALUE_SENTINEL
         else:
-            bucket = str(record[key]) if record[key] is not None else _MISSING_KEY_SENTINEL
+            bucket = str(record[key])
         grouped.setdefault(bucket, []).append(record)
     return {name: tuple(rows) for name, rows in grouped.items()}
 

--- a/src/kpubdata_builder/stages/gold/split.py
+++ b/src/kpubdata_builder/stages/gold/split.py
@@ -24,8 +24,11 @@ def _allocate_counts(total: int, ratios: dict[str, float], names: list[str]) -> 
     exact = {name: total * ratios[name] / ratio_sum for name in names}
     counts = {name: int(exact[name]) for name in names}
     remainder = total - sum(counts.values())
-    # 소수부가 큰 순서(동률이면 이름 순)로 잔여를 배분해 결정성을 보장한다.
-    by_fraction = sorted(names, key=lambda name: (exact[name] - counts[name], name), reverse=True)
+    # 소수부가 큰 순서(동률이면 이름 정순)로 잔여를 배분해 결정성을 보장한다.
+    by_fraction = sorted(
+        names,
+        key=lambda name: (-(exact[name] - counts[name]), name),
+    )
     for name in by_fraction[:remainder]:
         counts[name] += 1
     return counts
@@ -50,11 +53,20 @@ def _ratio_split(
     return result
 
 
+_MISSING_KEY_SENTINEL = "__missing__"
+
+
 def _key_split(records: Sequence[Record], key: str) -> dict[str, tuple[Record, ...]]:
-    """컬럼 값에 따라 레코드를 그룹으로 분할한다(값 → 분할 이름)."""
+    """컬럼 값에 따라 레코드를 그룹으로 분할한다(값 → 분할 이름).
+
+    키가 없는 레코드는 "__missing__" 버킷으로, 빈 문자열은 "" 버킷으로 분리한다.
+    """
     grouped: dict[str, list[Record]] = {}
     for record in records:
-        bucket = str(record.get(key, ""))
+        if key not in record:
+            bucket = _MISSING_KEY_SENTINEL
+        else:
+            bucket = str(record[key]) if record[key] is not None else _MISSING_KEY_SENTINEL
         grouped.setdefault(bucket, []).append(record)
     return {name: tuple(rows) for name, rows in grouped.items()}
 

--- a/src/kpubdata_builder/stages/silver/persist.py
+++ b/src/kpubdata_builder/stages/silver/persist.py
@@ -87,7 +87,10 @@ def persist_silver_dataset(
     silver_dir = output_root / run_id / "silver" / source_key_segment
     ensure_within(output_root, silver_dir, label="silver directory")
 
-    silver_dir.mkdir(parents=True, exist_ok=True)
+    import shutil
+    import tempfile
+
+    silver_dir.parent.mkdir(parents=True, exist_ok=True)
 
     table_path = silver_dir / "table.parquet"
     schema_path = silver_dir / "schema.json"
@@ -95,11 +98,21 @@ def persist_silver_dataset(
     preview_path = silver_dir / "preview.json"
     validation_path = silver_dir / "validation.json"
 
-    dataset.table.write_parquet(table_path)
-    _write_json(schema_path, asdict(dataset.schema))
-    _write_json(stats_path, asdict(dataset.statistics))
-    _write_json(preview_path, asdict(dataset.preview))
-    _write_json(validation_path, asdict(dataset.validation))
+    # Atomic write: write to temp dir then rename
+    tmp_dir = Path(tempfile.mkdtemp(dir=silver_dir.parent, prefix=".silver_tmp_"))
+    try:
+        dataset.table.write_parquet(tmp_dir / "table.parquet")
+        _write_json(tmp_dir / "schema.json", asdict(dataset.schema))
+        _write_json(tmp_dir / "stats.json", asdict(dataset.statistics))
+        _write_json(tmp_dir / "preview.json", asdict(dataset.preview))
+        _write_json(tmp_dir / "validation.json", asdict(dataset.validation))
+
+        if silver_dir.exists():
+            shutil.rmtree(silver_dir)
+        tmp_dir.rename(silver_dir)
+    except BaseException:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise
 
     return SilverPersistResult(
         silver_dir=silver_dir,


### PR DESCRIPTION
## Summary

Fixes 17 bugs in a single PR (rebased on current main, 302 tests pass).

### Core library fixes
| Issue | Fix |
|-------|-----|
| #146 | Checksum sorts records before hashing (order-independent) |
| #147 | Template substitution in data structure, not YAML text |
| #148 | Split remainder tiebreaker uses name ascending |
| #149 | Key-based split distinguishes missing key from empty string |
| #150 | Empty Parquet export respects schema types |
| #151 | CSV export includes all record fields, not just schema |
| #152 | Markdown fallback collects keys from all records |
| #153 | HF exporter documents directory return contract |
| #154 | BuildContext.create rejects naive datetime |
| #155 | Bronze persist atomic (temp dir + rename) |
| #156 | Silver persist atomic (temp dir + rename) |
| #157 | Gold persist atomic (temp dir + rename) |

### Script fixes
| Issue | Fix |
|-------|-----|
| #158 | HF upload copies full data/ tree (variant shards) |
| #159 | Kaggle upload copies full data/ tree (variant shards) |
| #160 | Filter parser falls back to string comparison |
| #161 | generate_fetch_params exits on empty CSV |
| #162 | Validate YYYYMM format (6 digits, month 01-12) |

## Test plan
- [x] 302 tests passed
- [x] mypy — no errors
- [x] ruff — all passed

Closes #146, closes #147, closes #148, closes #149, closes #150, closes #151, closes #152, closes #153, closes #154, closes #155, closes #156, closes #157, closes #158, closes #159, closes #160, closes #161, closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)