### PR TITLE
fix(ci): add --no-sources to uv sync for CI compatibility

### DIFF
--- a/.github/workflows/publish-dataset.yml
+++ b/.github/workflows/publish-dataset.yml
@@ -50,7 +50,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Install dependencies
-        run: uv sync --extra dev --extra publish
+        run: uv sync --extra dev --extra publish --no-sources
 
       - name: Publish dataset (atomic, guarded by secrets)
         env:


### PR DESCRIPTION
## Summary
- CI의 `uv sync` 명령에 `--no-sources` 플래그 추가
- `[tool.uv.sources]`에 정의된 로컬 경로(`../kpubdata`)가 GitHub Actions에 존재하지 않아 Install dependencies 단계에서 실패하던 문제 해결
- CI에서는 PyPI의 `kpubdata` 패키지를 사용하고, 로컬 개발 환경에서는 기존대로 editable 소스 유지

## Test plan
- [ ] PR 머지 후 scheduled workflow (Air Quality, Weather 등) 정상 실행 확인
- [ ] `uv sync --extra dev --extra publish --no-sources`로 kpubdata가 PyPI에서 정상 설치되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)