### PR TITLE
fix: batch bug fixes #146-#171 (rebased onto main, supersedes #163)

### DIFF
--- a/.github/workflows/publish-dataset.yml
+++ b/.github/workflows/publish-dataset.yml
@@ -63,4 +63,17 @@ jobs:
             echo "::notice::KPUBDATA_DATAGO_API_KEY 미설정 — 라이브 실행을 건너뜁니다(no-op)."
             exit 0
           fi
+          # 라이브 퍼블리시(--local-only/--dry-run 이 아닌 모드)는 HF_TOKEN 이 필요하다.
+          # 빌드를 모두 수행한 뒤 업로드에서 뒤늦게 실패(late failure)하지 않도록
+          # 실행 전에 토큰 존재 여부를 먼저 확인한다 (#171).
+          case " ${MODE} " in
+            *" --local-only "*|*" --dry-run "*)
+              ;;
+            *)
+              if [ -z "${HF_TOKEN}" ]; then
+                echo "::notice::HF_TOKEN 미설정 — 라이브 퍼블리시를 건너뜁니다(no-op)."
+                exit 0
+              fi
+              ;;
+          esac
           uv run python scripts/publish_to_hf.py "${CONFIG}" ${MODE}

--- a/scripts/generate_fetch_params.py
+++ b/scripts/generate_fetch_params.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import sys
 from pathlib import Path
 
 import yaml
@@ -26,10 +27,20 @@ def generate_params(district_codes: list[str], start_ym: str, end_ym: str) -> li
     return params
 
 
+def _validate_yyyymm(value: str, *, label: str) -> tuple[int, int]:
+    """Validate YYYYMM format and return (year, month)."""
+    if len(value) != 6 or not value.isdigit():
+        raise ValueError(f"{label} must be exactly 6 digits in YYYYMM format, got: {value!r}")
+    year, month = int(value[:4]), int(value[4:6])
+    if month < 1 or month > 12:
+        raise ValueError(f"{label} has invalid month {month:02d} (must be 01-12): {value!r}")
+    return year, month
+
+
 def _month_range(start: str, end: str) -> list[str]:
     """Generate YYYYMM strings from start to end inclusive."""
-    sy, sm = int(start[:4]), int(start[4:6])
-    ey, em = int(end[:4]), int(end[4:6])
+    sy, sm = _validate_yyyymm(start, label="start")
+    ey, em = _validate_yyyymm(end, label="end")
     months: list[str] = []
     y, m = sy, sm
     while (y, m) <= (ey, em):
@@ -63,6 +74,10 @@ def main() -> None:
     args = parser.parse_args()
 
     codes = load_district_codes(args.districts)
+    if not codes:
+        print(f"error: no district codes found in {args.districts}", file=sys.stderr)
+        sys.exit(1)
+
     params = generate_params(codes, args.start, args.end)
 
     template_path = Path(args.template)
@@ -72,9 +87,10 @@ def main() -> None:
     config["source"]["fetch_params"] = params
 
     total = len(params)
+    months_count = total // len(codes) if codes else 0
     header_comment = (
         f"# Auto-generated config: {len(codes)} districts × "
-        f"{total // len(codes)} months = {total} API calls\n"
+        f"{months_count} months = {total} API calls\n"
         f"# Generated from template: {args.template}\n\n"
     )
 

--- a/scripts/generate_localdata_configs.py
+++ b/scripts/generate_localdata_configs.py
@@ -25,13 +25,13 @@ LOCALDATA_DATASETS: list[tuple[str, str, str, str]] = [
     ("pharmacy", "localdata-pharmacy", "Pharmacy", "약국"),
     ("dental_clinic", "localdata-dental-clinic", "Dental Clinic", "치과의원"),
     # Accommodation & Tourism
-    (  # noqa: E501
+    (
         "tourist_accommodation",
         "localdata-tourist-accommodation",
         "Tourist Accommodation",
         "관광숙박업",
     ),
-    (  # noqa: E501
+    (
         "general_accommodation",
         "localdata-general-accommodation",
         "General Accommodation",

--- a/scripts/pipeline/publish.py
+++ b/scripts/pipeline/publish.py
@@ -43,10 +43,7 @@ def upload_to_hf(staging_dir: Path, hf_repo: str, *, dry_run: bool = False) -> N
 
     data_dir = staging_dir / "data"
     if data_dir.exists():
-        dest_data = upload_dir / "data"
-        dest_data.mkdir()
-        for parquet_file in data_dir.glob("*.parquet"):
-            shutil.copy2(parquet_file, dest_data / parquet_file.name)
+        shutil.copytree(data_dir, upload_dir / "data", dirs_exist_ok=True)
 
     api = HfApi()
     api.create_repo(repo_id=hf_repo, repo_type="dataset", exist_ok=True)
@@ -88,8 +85,7 @@ def upload_to_kaggle(staging_dir: Path, config: dict[str, Any], *, dry_run: bool
 
     data_dir = staging_dir / "data"
     if data_dir.exists():
-        for parquet_file in data_dir.glob("*.parquet"):
-            shutil.copy2(parquet_file, upload_dir / parquet_file.name)
+        shutil.copytree(data_dir, upload_dir / "data", dirs_exist_ok=True)
 
     description = card.get("description", "").strip()
     attribution = card.get("attribution", "").strip()

--- a/scripts/pipeline/transform.py
+++ b/scripts/pipeline/transform.py
@@ -97,10 +97,15 @@ def _apply_filter(df: pl.DataFrame, expr_str: str) -> pl.DataFrame:
         logger.warning("Filter references unknown column '%s', skipping", col)
         return df
 
+    val: int | float | str
     try:
-        val: int | float = int(val_str)
+        val = int(val_str)
     except ValueError:
-        val = float(val_str)
+        try:
+            val = float(val_str)
+        except ValueError:
+            # Treat as string comparison (strip quotes if present)
+            val = val_str.strip("'\"")
 
     ops = {
         ">": pl.col(col) > val,

--- a/src/kpubdata_builder/exporters/csv.py
+++ b/src/kpubdata_builder/exporters/csv.py
@@ -22,12 +22,13 @@ from .base import BaseExporter, ExportResult, ensure_output_dir
 def _resolve_columns(artifact: ArtifactDataset) -> list[str]:
     """CSV 헤더로 사용할 컬럼 순서를 결정한다.
 
-    schema가 선언되어 있으면 그 키 순서를, 없으면 레코드에서 처음 등장한
-    순서를 사용한다. 결과는 입력에 대해 결정적이다.
+    schema가 선언되어 있으면 그 키 순서를 우선하고, 레코드에만 존재하는
+    추가 필드도 뒤에 포함한다. 결과는 입력에 대해 결정적이다.
     """
-    if artifact.schema:
-        return list(artifact.schema.keys())
     columns: dict[str, None] = {}
+    if artifact.schema:
+        for key in artifact.schema:
+            columns.setdefault(key, None)
     for record in artifact.records:
         for key in record:
             columns.setdefault(key, None)

--- a/src/kpubdata_builder/exporters/huggingface.py
+++ b/src/kpubdata_builder/exporters/huggingface.py
@@ -136,4 +136,6 @@ class HuggingFaceExporter(BaseExporter):
             raise ExportError(f"Failed to export Hugging Face layout to {hf_dir}: {exc}") from exc
 
         total_size = sum(path.stat().st_size for path in (data_path, readme_path, infos_path))
+        # HF exporter returns the layout directory (not a single file) since it
+        # produces multiple files. Consumers should use output_path as a directory.
         return ExportResult(output_path=hf_dir, file_size=total_size, format=self.name)

--- a/src/kpubdata_builder/exporters/markdown.py
+++ b/src/kpubdata_builder/exporters/markdown.py
@@ -59,11 +59,15 @@ def _title_section(artifact: ArtifactDataset) -> list[str]:
 
 
 def _column_names(artifact: ArtifactDataset) -> list[str]:
-    """스키마의 컬럼명을 반환하고, 없으면 첫 레코드의 키로 대체한다."""
+    """스키마의 컬럼명을 반환하고, 없으면 모든 레코드의 키를 합산한다."""
     if artifact.schema:
         return list(artifact.schema.keys())
     if artifact.records:
-        return list(artifact.records[0].keys())
+        columns: dict[str, None] = {}
+        for record in artifact.records:
+            for key in record:
+                columns.setdefault(key, None)
+        return list(columns.keys())
     return []
 
 

--- a/src/kpubdata_builder/exporters/parquet.py
+++ b/src/kpubdata_builder/exporters/parquet.py
@@ -29,9 +29,16 @@ def _build_frame(artifact: ArtifactDataset) -> pl.DataFrame:
     if artifact.schema:
         _TYPE_MAP: dict[str, type[pl.DataType]] = {
             "str": pl.Utf8,
+            "String": pl.Utf8,
+            "Utf8": pl.Utf8,
             "int": pl.Int64,
+            "Int64": pl.Int64,
+            "Int32": pl.Int32,
             "float": pl.Float64,
+            "Float64": pl.Float64,
+            "Float32": pl.Float32,
             "bool": pl.Boolean,
+            "Boolean": pl.Boolean,
         }
         schema = {
             name: _TYPE_MAP.get(dtype, pl.Utf8) for name, dtype in artifact.schema.items()

--- a/src/kpubdata_builder/exporters/parquet.py
+++ b/src/kpubdata_builder/exporters/parquet.py
@@ -27,7 +27,16 @@ def _build_frame(artifact: ArtifactDataset) -> pl.DataFrame:
     if artifact.records:
         return records_to_dataframe(list(artifact.records))
     if artifact.schema:
-        return pl.DataFrame(schema={name: pl.Utf8 for name in artifact.schema})
+        _TYPE_MAP: dict[str, type[pl.DataType]] = {
+            "str": pl.Utf8,
+            "int": pl.Int64,
+            "float": pl.Float64,
+            "bool": pl.Boolean,
+        }
+        schema = {
+            name: _TYPE_MAP.get(dtype, pl.Utf8) for name, dtype in artifact.schema.items()
+        }
+        return pl.DataFrame(schema=schema)
     return pl.DataFrame()
 
 

--- a/src/kpubdata_builder/manifest/provenance.py
+++ b/src/kpubdata_builder/manifest/provenance.py
@@ -56,12 +56,12 @@ def compute_data_checksum(records: Sequence[Mapping[str, JsonValue]]) -> str:
     반환값:
         str: "sha256:" 접두사가 붙은 16진 해시.
     """
-    payload = json.dumps(
-        [dict(record) for record in records],
-        ensure_ascii=False,
-        sort_keys=True,
-        default=str,
+    # Sort records by their serialized form to make checksum order-independent
+    serialized_records = sorted(
+        json.dumps(dict(record), ensure_ascii=False, sort_keys=True, default=str)
+        for record in records
     )
+    payload = "[" + ",".join(serialized_records) + "]"
     digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
     return f"sha256:{digest}"
 

--- a/src/kpubdata_builder/pipeline/context.py
+++ b/src/kpubdata_builder/pipeline/context.py
@@ -70,6 +70,8 @@ class BuildContext:
             ValueError: run_id에 안전하지 않은 문자가 포함된 경우.
         """
         started = started_at or _utc_now()
+        if started.tzinfo is None or started.utcoffset() is None:
+            raise ValueError("started_at must be timezone-aware")
         resolved_run_id = run_id or started.strftime("%Y%m%dT%H%M%S%fZ")
         _validate_run_id(resolved_run_id)
         return cls(

--- a/src/kpubdata_builder/publishers/huggingface.py
+++ b/src/kpubdata_builder/publishers/huggingface.py
@@ -5,7 +5,22 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+from ..errors import PublishError
 from .base import BasePublisher, PublishResult
+
+
+def _repo_path_for(path: Path, common_root: Path | None) -> str:
+    """파일 artifact를 레이아웃을 보존하는 repo 상대 경로로 매핑한다.
+
+    공통 상위 디렉터리(common_root) 기준 상대 경로를 사용해 중첩 구조를 유지하고,
+    근거가 없으면 basename으로 폴백한다.
+    """
+    if common_root is not None:
+        try:
+            return path.relative_to(common_root).as_posix()
+        except ValueError:
+            pass
+    return path.name
 
 
 class HuggingFacePublisher(BasePublisher):
@@ -40,6 +55,18 @@ class HuggingFacePublisher(BasePublisher):
         api = HfApi(token=token)
         count = 0
 
+        # 파일 artifact의 공통 상위 디렉터리를 기준으로 repo 내 경로를 정한다.
+        # bare filename으로 평탄화하면 중첩 디렉터리 레이아웃이 사라지고, 서로 다른
+        # 디렉터리의 동명 파일이 무경고로 덮어쓰기된다 (#170).
+        file_parents = [str(p.parent) for p in artifact_paths if not p.is_dir()]
+        common_root: Path | None
+        try:
+            common_root = Path(os.path.commonpath(file_parents)) if file_parents else None
+        except ValueError:
+            # 절대/상대 경로가 섞이는 등 공통 경로를 구할 수 없으면 basename으로 폴백.
+            common_root = None
+
+        seen_repo_paths: dict[str, Path] = {}
         for path in artifact_paths:
             if path.is_dir():
                 api.upload_folder(
@@ -49,9 +76,18 @@ class HuggingFacePublisher(BasePublisher):
                     commit_message="Update dataset via kpubdata-builder",
                 )
             else:
+                repo_path = _repo_path_for(path, common_root)
+                # 두 artifact가 같은 repo 경로로 매핑되면 한쪽이 묻히므로 명시적으로 실패.
+                prior = seen_repo_paths.get(repo_path)
+                if prior is not None and prior != path:
+                    raise PublishError(
+                        f"duplicate artifact target path {repo_path!r}: "
+                        f"{prior} and {path} would overwrite each other in {destination}"
+                    )
+                seen_repo_paths[repo_path] = path
                 api.upload_file(
                     path_or_fileobj=str(path),
-                    path_in_repo=path.name,
+                    path_in_repo=repo_path,
                     repo_id=destination,
                     repo_type="dataset",
                     commit_message="Update dataset via kpubdata-builder",

--- a/src/kpubdata_builder/snapshot.py
+++ b/src/kpubdata_builder/snapshot.py
@@ -51,7 +51,9 @@ class BuildSnapshot:
 def compute_records_checksum(records: Sequence[Mapping[str, JsonValue]]) -> str:
     """레코드의 재현 가능한 SHA-256 체크섬을 계산한다.
 
-    정렬 키 기반 JSON 직렬화로 키 순서 차이를 제거한다.
+    각 레코드를 정렬 키 기반으로 개별 직렬화한 뒤 직렬화된 문자열을 정렬해
+    레코드 키 순서뿐 아니라 레코드(행) 순서 차이도 제거한다. 동일한 데이터
+    집합은 API 반환 순서와 무관하게 같은 체크섬을 갖는다 (#165).
 
     매개변수:
         records: 체크섬을 계산할 레코드 시퀀스.
@@ -59,12 +61,11 @@ def compute_records_checksum(records: Sequence[Mapping[str, JsonValue]]) -> str:
     반환값:
         str: "sha256:" 접두사가 붙은 16진 해시.
     """
-    payload = json.dumps(
-        [dict(record) for record in records],
-        ensure_ascii=False,
-        sort_keys=True,
-        default=str,
+    serialized_records = sorted(
+        json.dumps(dict(record), ensure_ascii=False, sort_keys=True, default=str)
+        for record in records
     )
+    payload = "[" + ",".join(serialized_records) + "]"
     return f"sha256:{hashlib.sha256(payload.encode('utf-8')).hexdigest()}"
 
 

--- a/src/kpubdata_builder/spec/loader.py
+++ b/src/kpubdata_builder/spec/loader.py
@@ -133,23 +133,39 @@ def _parse_string_dict(value: object, *, field_name: str) -> dict[str, str]:
     return parsed
 
 
-def _validate_json_value(value: object, *, field_name: str) -> JsonValue:
-    """값이 JSON 프리미티브/컨테이너인지 재귀적으로 검증한다."""
+def _validate_json_value(
+    value: object, *, field_name: str, _ancestors: frozenset[int] = frozenset()
+) -> JsonValue:
+    """값이 JSON 프리미티브/컨테이너인지 재귀적으로 검증한다.
+
+    YAML anchor/alias로 만들어진 순환 구조(예: ``a: &x {self: *x}``)를 만나면
+    무한 재귀로 ``RecursionError`` crash가 발생할 수 있다. 현재 재귀 경로상의
+    컨테이너 ``id()``를 추적해 순환을 감지하면 ``ValueError``로 명확히 실패한다
+    (load_spec이 이를 SpecLoadError로 감싼다) (#169).
+    """
     if value is None or isinstance(value, (str, int, float, bool)):
         return value
-    if isinstance(value, list):
-        return [
-            _validate_json_value(item, field_name=f"{field_name}[{i}]")
-            for i, item in enumerate(value)
-        ]
-    if isinstance(value, dict):
+    if isinstance(value, (list, dict)):
+        marker = id(value)
+        if marker in _ancestors:
+            raise ValueError(f"{field_name} contains a circular reference")
+        child_ancestors = _ancestors | {marker}
+        if isinstance(value, list):
+            return [
+                _validate_json_value(
+                    item, field_name=f"{field_name}[{i}]", _ancestors=child_ancestors
+                )
+                for i, item in enumerate(value)
+            ]
         result: dict[str, JsonValue] = {}
         for k, v in cast(dict[object, object], value).items():
             if not isinstance(k, str):
                 raise TypeError(
                     f"{field_name} keys must be strings, got {type(k).__name__}"
                 )
-            result[k] = _validate_json_value(v, field_name=f"{field_name}.{k}")
+            result[k] = _validate_json_value(
+                v, field_name=f"{field_name}.{k}", _ancestors=child_ancestors
+            )
         return result
     raise TypeError(
         f"{field_name} contains non-JSON value of type {type(value).__name__}: {value!r}"

--- a/src/kpubdata_builder/spec/template.py
+++ b/src/kpubdata_builder/spec/template.py
@@ -70,6 +70,7 @@ def render_template(path: str | Path, params: dict[str, str]) -> str:
 
     def _substitute_in_value(value: object) -> object:
         if isinstance(value, str):
+
             def _replace(match: re.Match[str]) -> str:
                 name = match.group(1)
                 if name not in effective:

--- a/src/kpubdata_builder/spec/template.py
+++ b/src/kpubdata_builder/spec/template.py
@@ -64,21 +64,33 @@ def render_template(path: str | Path, params: dict[str, str]) -> str:
     meta = template_meta if isinstance(template_meta, dict) else {}
     effective = _effective_params(meta, params)
 
-    body_yaml = yaml.safe_dump(data, allow_unicode=True, sort_keys=False)
-
+    # Substitute in the data structure directly to avoid YAML structure corruption.
+    # Then re-dump so the output is valid YAML regardless of substitution values.
     missing: list[str] = []
 
-    def _replace(match: re.Match[str]) -> str:
-        name = match.group(1)
-        if name not in effective:
-            missing.append(name)
-            return match.group(0)
-        return effective[name]
+    def _substitute_in_value(value: object) -> object:
+        if isinstance(value, str):
+            def _replace(match: re.Match[str]) -> str:
+                name = match.group(1)
+                if name not in effective:
+                    missing.append(name)
+                    return match.group(0)
+                return effective[name]
 
-    rendered = _PLACEHOLDER.sub(_replace, body_yaml)
+            return _PLACEHOLDER.sub(_replace, value)
+        if isinstance(value, list):
+            return [_substitute_in_value(item) for item in value]
+        if isinstance(value, dict):
+            return {k: _substitute_in_value(v) for k, v in value.items()}
+        return value
+
+    substituted = _substitute_in_value(data)
+
     if missing:
         unique = ", ".join(sorted(set(missing)))
         raise SpecLoadError(f"Missing template parameter(s): {unique}")
+
+    rendered = yaml.safe_dump(substituted, allow_unicode=True, sort_keys=False)
     return rendered
 
 

--- a/src/kpubdata_builder/stages/bronze/persist.py
+++ b/src/kpubdata_builder/stages/bronze/persist.py
@@ -74,23 +74,40 @@ def persist_bronze_artifact(
 
     ensure_within(output_root, bronze_dir, label="bronze directory")
 
-    bronze_dir.mkdir(parents=True, exist_ok=True)
+    # Atomic write: write to temp dir, then rename to final location
+    import shutil
+    import tempfile
 
-    with records_path.open("w", encoding="utf-8") as f:
-        for record in artifact.raw_records:
-            f.write(json.dumps(record, ensure_ascii=False, sort_keys=True))
-            f.write("\n")
+    parent = bronze_dir.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    tmp_dir = Path(tempfile.mkdtemp(dir=parent, prefix=f".{artifact_id}_tmp_"))
+    try:
+        tmp_records = tmp_dir / "raw_records.jsonl"
+        tmp_metadata = tmp_dir / "metadata.json"
 
-    metadata = _metadata_for_artifact(
-        artifact,
-        records_path=records_path,
-        metadata_path=metadata_path,
-        bronze_dir=bronze_dir,
-    )
-    metadata_path.write_text(
-        json.dumps(metadata, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+        with tmp_records.open("w", encoding="utf-8") as f:
+            for record in artifact.raw_records:
+                f.write(json.dumps(record, ensure_ascii=False, sort_keys=True))
+                f.write("\n")
+
+        metadata = _metadata_for_artifact(
+            artifact,
+            records_path=records_path,
+            metadata_path=metadata_path,
+            bronze_dir=bronze_dir,
+        )
+        tmp_metadata.write_text(
+            json.dumps(metadata, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+        # Atomic rename (same filesystem)
+        if bronze_dir.exists():
+            shutil.rmtree(bronze_dir)
+        tmp_dir.rename(bronze_dir)
+    except BaseException:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise
 
     return BronzePersistResult(
         bronze_dir=bronze_dir,

--- a/src/kpubdata_builder/stages/gold/persist.py
+++ b/src/kpubdata_builder/stages/gold/persist.py
@@ -81,16 +81,30 @@ def persist_gold_package(
     gold_dir = output_root / run_id / "gold" / package.dataset_name
     ensure_within(output_root, gold_dir, label="gold directory")
 
-    gold_dir.mkdir(parents=True, exist_ok=True)
+    import shutil
+    import tempfile
+
+    gold_dir.parent.mkdir(parents=True, exist_ok=True)
 
     table_path = gold_dir / "table.parquet"
     package_path = gold_dir / "package.json"
 
-    package.table.write_parquet(table_path)
-    package_path.write_text(
-        json.dumps(_package_metadata(package), ensure_ascii=False, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+    # Atomic write: write to temp dir then rename
+    tmp_dir = Path(tempfile.mkdtemp(dir=gold_dir.parent, prefix=".gold_tmp_"))
+    try:
+        package.table.write_parquet(tmp_dir / "table.parquet")
+        (tmp_dir / "package.json").write_text(
+            json.dumps(_package_metadata(package), ensure_ascii=False, indent=2, sort_keys=True)
+            + "\n",
+            encoding="utf-8",
+        )
+
+        if gold_dir.exists():
+            shutil.rmtree(gold_dir)
+        tmp_dir.rename(gold_dir)
+    except BaseException:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise
 
     return GoldPersistResult(
         gold_dir=gold_dir,

--- a/src/kpubdata_builder/stages/gold/split.py
+++ b/src/kpubdata_builder/stages/gold/split.py
@@ -54,19 +54,23 @@ def _ratio_split(
 
 
 _MISSING_KEY_SENTINEL = "__missing__"
+_NULL_VALUE_SENTINEL = "__null__"
 
 
 def _key_split(records: Sequence[Record], key: str) -> dict[str, tuple[Record, ...]]:
     """컬럼 값에 따라 레코드를 그룹으로 분할한다(값 → 분할 이름).
 
-    키가 없는 레코드는 "__missing__" 버킷으로, 빈 문자열은 "" 버킷으로 분리한다.
+    키가 없는 레코드는 "__missing__" 버킷, None 값은 "__null__" 버킷,
+    빈 문자열은 "" 버킷으로 각각 분리한다.
     """
     grouped: dict[str, list[Record]] = {}
     for record in records:
         if key not in record:
             bucket = _MISSING_KEY_SENTINEL
+        elif record[key] is None:
+            bucket = _NULL_VALUE_SENTINEL
         else:
-            bucket = str(record[key]) if record[key] is not None else _MISSING_KEY_SENTINEL
+            bucket = str(record[key])
         grouped.setdefault(bucket, []).append(record)
     return {name: tuple(rows) for name, rows in grouped.items()}
 

--- a/src/kpubdata_builder/stages/gold/split.py
+++ b/src/kpubdata_builder/stages/gold/split.py
@@ -24,8 +24,11 @@ def _allocate_counts(total: int, ratios: dict[str, float], names: list[str]) -> 
     exact = {name: total * ratios[name] / ratio_sum for name in names}
     counts = {name: int(exact[name]) for name in names}
     remainder = total - sum(counts.values())
-    # 소수부가 큰 순서(동률이면 이름 순)로 잔여를 배분해 결정성을 보장한다.
-    by_fraction = sorted(names, key=lambda name: (exact[name] - counts[name], name), reverse=True)
+    # 소수부가 큰 순서(동률이면 이름 정순)로 잔여를 배분해 결정성을 보장한다.
+    by_fraction = sorted(
+        names,
+        key=lambda name: (-(exact[name] - counts[name]), name),
+    )
     for name in by_fraction[:remainder]:
         counts[name] += 1
     return counts
@@ -50,11 +53,20 @@ def _ratio_split(
     return result
 
 
+_MISSING_KEY_SENTINEL = "__missing__"
+
+
 def _key_split(records: Sequence[Record], key: str) -> dict[str, tuple[Record, ...]]:
-    """컬럼 값에 따라 레코드를 그룹으로 분할한다(값 → 분할 이름)."""
+    """컬럼 값에 따라 레코드를 그룹으로 분할한다(값 → 분할 이름).
+
+    키가 없는 레코드는 "__missing__" 버킷으로, 빈 문자열은 "" 버킷으로 분리한다.
+    """
     grouped: dict[str, list[Record]] = {}
     for record in records:
-        bucket = str(record.get(key, ""))
+        if key not in record:
+            bucket = _MISSING_KEY_SENTINEL
+        else:
+            bucket = str(record[key]) if record[key] is not None else _MISSING_KEY_SENTINEL
         grouped.setdefault(bucket, []).append(record)
     return {name: tuple(rows) for name, rows in grouped.items()}
 

--- a/src/kpubdata_builder/stages/silver/persist.py
+++ b/src/kpubdata_builder/stages/silver/persist.py
@@ -87,7 +87,10 @@ def persist_silver_dataset(
     silver_dir = output_root / run_id / "silver" / source_key_segment
     ensure_within(output_root, silver_dir, label="silver directory")
 
-    silver_dir.mkdir(parents=True, exist_ok=True)
+    import shutil
+    import tempfile
+
+    silver_dir.parent.mkdir(parents=True, exist_ok=True)
 
     table_path = silver_dir / "table.parquet"
     schema_path = silver_dir / "schema.json"
@@ -95,11 +98,21 @@ def persist_silver_dataset(
     preview_path = silver_dir / "preview.json"
     validation_path = silver_dir / "validation.json"
 
-    dataset.table.write_parquet(table_path)
-    _write_json(schema_path, asdict(dataset.schema))
-    _write_json(stats_path, asdict(dataset.statistics))
-    _write_json(preview_path, asdict(dataset.preview))
-    _write_json(validation_path, asdict(dataset.validation))
+    # Atomic write: write to temp dir then rename
+    tmp_dir = Path(tempfile.mkdtemp(dir=silver_dir.parent, prefix=".silver_tmp_"))
+    try:
+        dataset.table.write_parquet(tmp_dir / "table.parquet")
+        _write_json(tmp_dir / "schema.json", asdict(dataset.schema))
+        _write_json(tmp_dir / "stats.json", asdict(dataset.statistics))
+        _write_json(tmp_dir / "preview.json", asdict(dataset.preview))
+        _write_json(tmp_dir / "validation.json", asdict(dataset.validation))
+
+        if silver_dir.exists():
+            shutil.rmtree(silver_dir)
+        tmp_dir.rename(silver_dir)
+    except BaseException:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise
 
     return SilverPersistResult(
         silver_dir=silver_dir,

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -49,3 +49,29 @@ def test_load_spec_raises_for_missing_file(tmp_path: Path) -> None:
     # 존재하지 않는 파일 경로도 SpecLoadError로 처리되는지 확인한다.
     with pytest.raises(SpecLoadError):
         load_spec(tmp_path / "missing.yaml")
+
+
+def test_load_spec_rejects_circular_yaml_without_crash(tmp_path: Path) -> None:
+    # YAML anchor/alias로 만든 순환 구조는 RecursionError crash가 아니라
+    # SpecLoadError로 처리되어야 한다 (#169).
+    spec_path = tmp_path / "spec.yaml"
+    spec_path.write_text(
+        """
+dataset_id: dataset.sample
+title: Sample Dataset
+description: Sample description
+sources:
+  - provider: datago
+    dataset: air_quality
+    params: &p
+      self: *p
+exports:
+  - kind: jsonl
+    output_path: out/data.jsonl
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SpecLoadError, match="circular reference"):
+        load_spec(spec_path)

--- a/tests/unit/test_publishers.py
+++ b/tests/unit/test_publishers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -13,6 +15,7 @@ from kpubdata_builder.publishers import (
     LocalPublisher,
     PublishResult,
 )
+from kpubdata_builder.publishers.huggingface import HuggingFacePublisher
 
 
 def _make_artifacts(tmp_path: Path) -> tuple[Path, ...]:
@@ -91,3 +94,97 @@ class TestLocalPublisherFailurePolicy:
 
         with pytest.raises(PublishError, match="failed to copy"):
             LocalPublisher().publish((artifact,), destination=str(tmp_path / "registry"))
+
+
+def _install_fake_hf(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[dict[str, str]]]:
+    """huggingface_hub.HfApi를 가짜로 주입하고 업로드 호출을 기록한다."""
+    calls: dict[str, list[dict[str, str]]] = {"files": [], "folders": []}
+
+    class FakeHfApi:
+        def __init__(self, token: str | None = None) -> None:
+            self._token = token
+
+        def upload_file(
+            self,
+            *,
+            path_or_fileobj: str,
+            path_in_repo: str,
+            repo_id: str,
+            repo_type: str,
+            commit_message: str,
+        ) -> None:
+            calls["files"].append({"path_in_repo": path_in_repo, "src": path_or_fileobj})
+
+        def upload_folder(
+            self, *, folder_path: str, repo_id: str, repo_type: str, commit_message: str
+        ) -> None:
+            calls["folders"].append({"folder_path": folder_path})
+
+    fake_module = types.ModuleType("huggingface_hub")
+    fake_module.HfApi = FakeHfApi  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_module)
+    monkeypatch.setenv("HF_TOKEN", "test-token")
+    return calls
+
+
+class TestHuggingFacePublisher:
+    def test_requires_hf_token(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install_fake_hf(monkeypatch)
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        artifact = tmp_path / "data.parquet"
+        _ = artifact.write_text("x", encoding="utf-8")
+
+        with pytest.raises(RuntimeError, match="HF_TOKEN"):
+            HuggingFacePublisher().publish((artifact,), destination="org/ds")
+
+    def test_preserves_directory_layout_in_repo_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # 중첩 디렉터리 shard가 bare filename으로 평탄화되지 않고 상대 경로를 유지해야 한다 (#170).
+        calls = _install_fake_hf(monkeypatch)
+        (tmp_path / "data").mkdir()
+        readme = tmp_path / "README.md"
+        shard = tmp_path / "data" / "train.parquet"
+        _ = readme.write_text("# t\n", encoding="utf-8")
+        _ = shard.write_text("x", encoding="utf-8")
+
+        result = HuggingFacePublisher().publish((readme, shard), destination="org/ds")
+
+        repo_paths = {c["path_in_repo"] for c in calls["files"]}
+        assert repo_paths == {"README.md", "data/train.parquet"}
+        assert result.artifact_count == 2
+
+    def test_same_basename_different_dirs_do_not_collide(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # 동명 파일이라도 디렉터리 구조를 보존하면 서로 다른 repo 경로로 분리되어
+        # 무경고 덮어쓰기가 일어나지 않는다 (#170).
+        calls = _install_fake_hf(monkeypatch)
+        d1 = tmp_path / "a"
+        d2 = tmp_path / "b"
+        d1.mkdir()
+        d2.mkdir()
+        f1 = d1 / "data.parquet"
+        f2 = d2 / "data.parquet"
+        _ = f1.write_text("x", encoding="utf-8")
+        _ = f2.write_text("y", encoding="utf-8")
+
+        result = HuggingFacePublisher().publish((f1, f2), destination="org/ds")
+
+        repo_paths = {c["path_in_repo"] for c in calls["files"]}
+        assert repo_paths == {"a/data.parquet", "b/data.parquet"}
+        assert result.artifact_count == 2
+
+    def test_directory_artifacts_use_upload_folder(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls = _install_fake_hf(monkeypatch)
+        layout = tmp_path / "dataset"
+        layout.mkdir()
+        _ = (layout / "x.parquet").write_text("x", encoding="utf-8")
+
+        result = HuggingFacePublisher().publish((layout,), destination="org/ds")
+
+        assert len(calls["folders"]) == 1
+        assert calls["files"] == []
+        assert result.artifact_count == 1

--- a/tests/unit/test_snapshot.py
+++ b/tests/unit/test_snapshot.py
@@ -24,6 +24,18 @@ def test_checksum_is_reproducible_and_order_independent() -> None:
     assert a != compute_records_checksum([{"id": "2", "amount": 1000}])
 
 
+def test_checksum_is_record_order_independent() -> None:
+    """행(레코드) 순서가 달라도 같은 데이터면 동일 체크섬이어야 한다 (#165)."""
+    records = [{"id": "1", "amount": 1000}, {"id": "2", "amount": 2000}]
+    reversed_records = list(reversed(records))
+
+    assert compute_records_checksum(records) == compute_records_checksum(reversed_records)
+    # 데이터 자체가 달라지면 여전히 달라야 한다.
+    assert compute_records_checksum(records) != compute_records_checksum(
+        [{"id": "1", "amount": 1000}, {"id": "3", "amount": 2000}]
+    )
+
+
 def test_save_and_load_round_trip(tmp_path: Path) -> None:
     snapshot = BuildSnapshot(
         dataset_id="seoul_apt_trade",


### PR DESCRIPTION
## 개요

remote(upstream)에 열려 있던 **버그 이슈 일괄 해결** PR입니다. 기존 PR #163이 stale `origin/main` 기반이라 충돌로 닫혔던 문제를 바로잡아, **`upstream/main`에 리베이스**하고 회귀 이슈와 신규 버그까지 모두 반영했습니다.

총 **26개 버그 이슈** 해결 (`#146`–`#162`, `#164`–`#171`). 기능 이슈(#10, #41)는 범위에서 제외했습니다.

## 변경 요약

### 핵심 버그 (#146–#162)
- **#146/#165**: 체크섬을 레코드(행) 순서 무관하게 — 각 레코드를 개별 직렬화 후 정렬 (`provenance.py`, `snapshot.py`)
- **#147/#166**: 템플릿 치환을 YAML 텍스트가 아닌 **객체 트리**에서 수행 후 1회 dump (구조 파괴 방지)
- **#148**: split 잔여분 배분 tiebreaker를 이름 오름차순으로 (주석과 일치)
- **#149/#167**: key-based split이 missing key와 빈 문자열을 sentinel로 구분
- **#150**: 빈 Parquet이 스키마 타입을 보존 (모두 Utf8 방지)
- **#151**: CSV export가 스키마 외 필드도 유지 (무경고 데이터 손실 방지)
- **#152**: Markdown fallback이 전체 레코드에서 컬럼 수집
- **#153**: HF exporter 반환 계약 준수
- **#154**: `BuildContext.create`가 naive datetime 거부 (타임존 일관성)
- **#155/#156/#157/#164**: Bronze/Silver/Gold persist를 temp-dir + rename **원자적** 쓰기로
- **#158/#159/#168**: HF/Kaggle 업로드가 `copytree(dirs_exist_ok=True)`로 variant 하위 shard 포함
- **#160**: filter 파서가 비숫자 비교 시 문자열 비교로 폴백 (crash 방지)
- **#161**: 빈 CSV에서 ZeroDivisionError 방지
- **#162**: 무효 YYYYMM(202013 등) 검증

### 신규/회귀 버그
- **#169**: `_validate_json_value`가 순환 YAML anchor를 감지해 `SpecLoadError`로 처리 (RecursionError crash 방지)
- **#170**: `HuggingFacePublisher`가 공통 root 기준 상대 경로로 업로드해 디렉토리 구조 보존 + 동명 충돌 방지
- **#171**: 스케줄 워크플로(`publish-dataset.yml`)가 live 모드에서 `HF_TOKEN` 사전 확인 → late failure 대신 빠른 no-op

## 검증

- `pytest`: **308 passed** (회귀 테스트 추가: 행순서 독립 체크섬, 순환 YAML, HF 레이아웃 보존)
- `mypy src`: clean (66 files)
- `ruff check`: clean

## 비고

- PR #163을 대체합니다 (`upstream/main` 리베이스로 충돌 해소).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---
Closes #146, #147, #148, #149, #150, #151, #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #164, #165, #166, #167, #168, #169, #170, #171
