### PR TITLE
feat: add publish CLI command (#10)

### DIFF
--- a/src/kpubdata_builder/cli.py
+++ b/src/kpubdata_builder/cli.py
@@ -1,7 +1,7 @@
 """kpubdata-builder용 명령줄 진입점.
 
-이 모듈은 argparse 기반 CLI를 구성하고, validate/preview/build 명령의 진입점을
-제공한다.
+이 모듈은 argparse 기반 CLI를 구성하고, validate/preview/build/publish 명령의
+진입점을 제공한다.
 
 주요 함수:
     - build_parser: 하위 명령을 포함한 ArgumentParser 구성
@@ -18,8 +18,9 @@ from pathlib import Path
 from typing import cast
 
 from . import __version__
-from .errors import SpecLoadError, ValidationError
+from .errors import PublishError, SpecLoadError, ValidationError
 from .pipeline import preview_build, run_build
+from .publishers import PUBLISHER_REGISTRY
 from .spec import load_spec
 from .spec.validator import validate_spec
 from .stages.bronze.build import SourceClient
@@ -84,6 +85,28 @@ def build_parser() -> argparse.ArgumentParser:
         "--run-id",
         default=None,
         help="Run identifier (default: generated timestamp).",
+    )
+
+    publish_cmd = subparsers.add_parser(
+        "publish",
+        help="Publish build artifacts to a local or remote destination.",
+    )
+    publish_cmd.add_argument("spec", help="Path to the BuildSpec YAML file.")
+    publish_cmd.add_argument(
+        "--target",
+        choices=sorted(PUBLISHER_REGISTRY.keys()),
+        default="local",
+        help="Publish target (default: local).",
+    )
+    publish_cmd.add_argument(
+        "--destination",
+        required=True,
+        help="Local directory path (local) or HF repo id (huggingface).",
+    )
+    publish_cmd.add_argument(
+        "--artifacts-dir",
+        required=True,
+        help="Directory whose files will be published.",
     )
 
     return parser
@@ -222,6 +245,55 @@ def _run_preview(spec_path: str, *, limit: int) -> int:
     return 0
 
 
+def _run_publish(
+    spec_path: str, *, target: str, destination: str, artifacts_dir: str
+) -> int:
+    """BuildSpec을 로드·검증한 뒤 지정한 target에 산출물을 게시한다.
+
+    매개변수:
+        spec_path: 게시 기준 BuildSpec YAML 경로.
+        target: 게시 대상 식별자 (PUBLISHER_REGISTRY 키).
+        destination: 로컬 디렉터리 경로 또는 원격 repo id.
+        artifacts_dir: 게시할 파일이 있는 디렉터리.
+
+    반환값:
+        int: 성공 시 0, 로드/검증/게시 실패 시 1.
+    """
+    try:
+        spec = load_spec(Path(spec_path))
+        validate_spec(spec)
+    except SpecLoadError as exc:
+        print(f"error: failed to load spec: {exc}", file=sys.stderr)
+        return 1
+    except ValidationError as exc:
+        print("error: spec validation failed:", file=sys.stderr)
+        for problem in exc.problems:
+            print(f"  - {problem}", file=sys.stderr)
+        return 1
+
+    artifacts_path = Path(artifacts_dir)
+    if not artifacts_path.is_dir():
+        print(f"error: no artifacts found in {artifacts_dir}", file=sys.stderr)
+        return 1
+
+    paths = sorted(p for p in artifacts_path.rglob("*") if p.is_file())
+    if not paths:
+        print(f"error: no artifacts found in {artifacts_dir}", file=sys.stderr)
+        return 1
+
+    publisher = PUBLISHER_REGISTRY[target]
+    try:
+        result = publisher.publish(tuple(paths), destination=destination)
+    except (PublishError, RuntimeError) as exc:
+        print(f"error: publish failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"publish: {spec.dataset_id} -> {target}")
+    print(f"  target: {result.reference}")
+    print(f"  artifacts: {result.artifact_count}")
+    return 0
+
+
 def dispatch(args: argparse.Namespace) -> int:
     """파싱된 argparse 결과를 실제 명령 실행 함수로 전달한다.
 
@@ -243,6 +315,13 @@ def dispatch(args: argparse.Namespace) -> int:
         return _run_preview(args.spec, limit=args.limit)
     if command == "build":
         return _run_build(args.spec, output_dir=args.output_dir, run_id=args.run_id)
+    if command == "publish":
+        return _run_publish(
+            args.spec,
+            target=args.target,
+            destination=args.destination,
+            artifacts_dir=args.artifacts_dir,
+        )
     # 일반적인 CLI 경로로는 도달할 수 없지만(argparse가 알 수 없는 하위 명령을 거부함),
     # 프로그래밍 방식 호출자를 위한 방어적 대체 경로로 유지한다.
     return 2

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
 from kpubdata_builder import __version__
 from kpubdata_builder.cli import build_parser, main
+from kpubdata_builder.publishers.base import PublishResult
 
 VALID_SPEC_YAML = (
     """
@@ -136,3 +138,207 @@ def test_validate_fails_for_malformed_yaml(
 
     assert exit_code == 1
     assert "failed to load spec" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# publish 명령 테스트
+# ---------------------------------------------------------------------------
+
+
+def test_publish_local_end_to_end(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # --target local end-to-end: 파일이 destination 으로 복사되고 요약이 출력된다.
+    spec_path = tmp_path / "spec.yaml"
+    _ = spec_path.write_text(VALID_SPEC_YAML, encoding="utf-8")
+
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    (artifacts_dir / "a.parquet").write_bytes(b"parquet1")
+    (artifacts_dir / "b.parquet").write_bytes(b"parquet2")
+
+    dest_dir = tmp_path / "dest"
+
+    exit_code = main(
+        [
+            "publish",
+            str(spec_path),
+            "--target",
+            "local",
+            "--destination",
+            str(dest_dir),
+            "--artifacts-dir",
+            str(artifacts_dir),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert (dest_dir / "a.parquet").exists()
+    assert (dest_dir / "b.parquet").exists()
+    assert "publish: dataset.sample -> local" in captured.out
+    assert "artifacts: 2" in captured.out
+    assert captured.err == ""
+
+
+def test_publish_missing_artifacts_dir_returns_one(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # artifacts-dir 가 존재하지 않으면 exit 1 과 오류 메시지를 반환해야 한다.
+    spec_path = tmp_path / "spec.yaml"
+    _ = spec_path.write_text(VALID_SPEC_YAML, encoding="utf-8")
+
+    missing_dir = tmp_path / "no-such-dir"
+
+    exit_code = main(
+        [
+            "publish",
+            str(spec_path),
+            "--destination",
+            str(tmp_path / "dest"),
+            "--artifacts-dir",
+            str(missing_dir),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "no artifacts found" in captured.err
+
+
+def test_publish_empty_artifacts_dir_returns_one(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # artifacts-dir 가 비어 있으면 exit 1 과 오류 메시지를 반환해야 한다.
+    spec_path = tmp_path / "spec.yaml"
+    _ = spec_path.write_text(VALID_SPEC_YAML, encoding="utf-8")
+
+    artifacts_dir = tmp_path / "empty"
+    artifacts_dir.mkdir()
+
+    exit_code = main(
+        [
+            "publish",
+            str(spec_path),
+            "--destination",
+            str(tmp_path / "dest"),
+            "--artifacts-dir",
+            str(artifacts_dir),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "no artifacts found" in captured.err
+
+
+def test_publish_unknown_target_rejected_by_argparse(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # --target zzz は argparse が拒否して exit code 2 を返す.
+    spec_path = tmp_path / "spec.yaml"
+    _ = spec_path.write_text(VALID_SPEC_YAML, encoding="utf-8")
+
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    (artifacts_dir / "f.txt").write_text("x", encoding="utf-8")
+
+    exit_code = main(
+        [
+            "publish",
+            str(spec_path),
+            "--target",
+            "zzz",
+            "--destination",
+            str(tmp_path / "dest"),
+            "--artifacts-dir",
+            str(artifacts_dir),
+        ]
+    )
+
+    assert exit_code == 2
+
+
+def test_publish_huggingface_stub(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # HuggingFace publisher 를 stub 으로 교체하여 publish 가 올바른 인자로
+    # 호출되고 exit 0 을 반환하는지 검증한다.
+    spec_path = tmp_path / "spec.yaml"
+    _ = spec_path.write_text(VALID_SPEC_YAML, encoding="utf-8")
+
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    artifact_file = artifacts_dir / "data.parquet"
+    artifact_file.write_bytes(b"data")
+
+    fake_result = PublishResult(
+        publisher="huggingface",
+        reference="https://huggingface.co/datasets/org/dataset",
+        artifact_count=1,
+    )
+    stub = MagicMock()
+    stub.publish.return_value = fake_result
+
+    import kpubdata_builder.cli as cli_module
+
+    monkeypatch.setitem(cli_module.PUBLISHER_REGISTRY, "huggingface", stub)
+
+    exit_code = main(
+        [
+            "publish",
+            str(spec_path),
+            "--target",
+            "huggingface",
+            "--destination",
+            "org/dataset",
+            "--artifacts-dir",
+            str(artifacts_dir),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    stub.publish.assert_called_once_with(
+        (artifact_file,),
+        destination="org/dataset",
+    )
+    assert "publish: dataset.sample -> huggingface" in captured.out
+    assert "artifacts: 1" in captured.out
+
+
+def test_publish_publish_error_returns_one(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # publisher が PublishError を送出した場合は exit 1 と stderr エラーを返す.
+    # LocalPublisher の basename 衝突パスを使ってトリガーする.
+    spec_path = tmp_path / "spec.yaml"
+    _ = spec_path.write_text(VALID_SPEC_YAML, encoding="utf-8")
+
+    artifacts_dir = tmp_path / "artifacts"
+    sub_a = artifacts_dir / "a"
+    sub_b = artifacts_dir / "b"
+    sub_a.mkdir(parents=True)
+    sub_b.mkdir(parents=True)
+    # 서로 다른 하위 디렉터리에 같은 basename 파일 → LocalPublisher가 PublishError 발생
+    (sub_a / "data.parquet").write_bytes(b"1")
+    (sub_b / "data.parquet").write_bytes(b"2")
+
+    dest_dir = tmp_path / "dest"
+
+    exit_code = main(
+        [
+            "publish",
+            str(spec_path),
+            "--target",
+            "local",
+            "--destination",
+            str(dest_dir),
+            "--artifacts-dir",
+            str(artifacts_dir),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "publish failed" in captured.err


### PR DESCRIPTION
## 개요

`#10` [v0.2] Publish command — 빌드 산출물을 로컬 디렉터리 또는 Hugging Face Hub 같은 외부 대상에 게시하는 `publish` CLI 서브명령을 추가합니다.

기존 `PUBLISHER_REGISTRY`(local, huggingface)를 그대로 재사용하며 **BuildSpec 스키마는 변경하지 않습니다**.

## 인터페이스

```bash
kpubdata-builder publish <spec> \
    --target {local,huggingface} \
    --destination <path|repo_id> \
    --artifacts-dir <dir>
```

- `<spec>`: BuildSpec YAML 경로 (load + validate 수행, build/preview와 동일한 에러 처리)
- `--target`: `PUBLISHER_REGISTRY` 키에서 선택 (기본 `local`)
- `--destination`: 로컬 디렉터리 경로(local) 또는 HF repo id(huggingface) — 필수
- `--artifacts-dir`: 게시할 파일이 있는 디렉터리 — 필수

## 동작

1. spec 로드·검증 (실패 시 stderr + exit 1, 기존 명령과 동일한 메시지 형식)
2. `--artifacts-dir` 하위의 일반 파일을 **재귀적으로** 수집(경로 정렬로 결정적). 디렉터리 부재/빈 디렉터리면 exit 1
3. 선택한 publisher로 `publish(tuple(paths), destination=...)` 호출
4. `PublishError` / `RuntimeError`(예: `HF_TOKEN` 미설정)는 exit 1 + stderr 메시지로 표면화
5. 성공 시 `dataset_id -> target`, reference, artifact 개수 요약 출력

## 변경 파일

- `src/kpubdata_builder/cli.py`: `publish` 서브파서, `_run_publish()`, dispatch 분기, 모듈 docstring 업데이트
- `tests/unit/test_cli.py`: CLI 테스트 6개 (local end-to-end, 디렉터리 부재/빈, 잘못된 target 거부, huggingface stub 디스패치, PublishError 전파)

## 검증

- `pytest`: **308 passed**
- `mypy src`: clean (66 files)
- `ruff check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---
Closes #10
