### PR TITLE
feat(kaggle): complete Kaggle exporter/publisher (#41, supersedes #145)

### DIFF
--- a/src/kpubdata_builder/exporters/__init__.py
+++ b/src/kpubdata_builder/exporters/__init__.py
@@ -14,6 +14,7 @@ from .base import BaseExporter, ExportResult, ensure_output_dir
 from .csv import CsvExporter
 from .huggingface import HuggingFaceExporter
 from .jsonl import JsonlExporter
+from .kaggle import KaggleExporter
 from .markdown import MarkdownExporter
 from .parquet import ParquetExporter
 from .registry import (
@@ -29,6 +30,7 @@ register_exporter(CsvExporter(), override=True)
 register_exporter(HuggingFaceExporter(), override=True)
 register_exporter(JsonlExporter(), override=True)
 register_exporter(MarkdownExporter(), override=True)
+register_exporter(KaggleExporter(), override=True)
 register_exporter(ParquetExporter(), override=True)
 
 __all__ = [
@@ -39,6 +41,7 @@ __all__ = [
     "ExportResult",
     "HuggingFaceExporter",
     "JsonlExporter",
+    "KaggleExporter",
     "MarkdownExporter",
     "ParquetExporter",
     "ensure_output_dir",

--- a/src/kpubdata_builder/exporters/kaggle.py
+++ b/src/kpubdata_builder/exporters/kaggle.py
@@ -1,0 +1,69 @@
+"""Kaggle 호환 데이터셋 디렉터리를 생성하는 exporter.
+
+출력 구조::
+    {output_dir}/{output_path}       ← CSV 데이터 파일
+    {output_dir}/dataset-metadata.json  ← Kaggle 메타데이터
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from pathlib import Path
+
+from ..artifact import ArtifactDataset
+from ..errors import ExportError
+from ..spec import ExportTarget
+from .base import BaseExporter, ExportResult, ensure_output_dir
+
+
+class KaggleExporter(BaseExporter):
+    """Kaggle 형식(CSV + dataset-metadata.json)으로 내보내는 exporter."""
+
+    @property
+    def name(self) -> str:
+        return "kaggle"
+
+    def export(
+        self, artifact: ArtifactDataset, target: ExportTarget, output_dir: Path
+    ) -> ExportResult:
+        destination = ensure_output_dir(output_dir, target.output_path)
+
+        if not artifact.records:
+            content = ""
+        else:
+            fieldnames = list(artifact.records[0].keys())
+            buf = io.StringIO()
+            writer = csv.DictWriter(buf, fieldnames=fieldnames, extrasaction="ignore")
+            writer.writeheader()
+            for record in artifact.records:
+                writer.writerow(record)
+            content = buf.getvalue()
+
+        try:
+            _ = destination.write_text(content, encoding="utf-8")
+        except OSError as exc:
+            raise ExportError(f"Failed to export Kaggle artifact to {destination}: {exc}") from exc
+
+        metadata_path = destination.parent / "dataset-metadata.json"
+        dataset_id = artifact.metadata.get("dataset_id", "unknown/dataset")
+        metadata = {
+            "title": artifact.metadata.get("title", "Dataset"),
+            "id": dataset_id,
+            "licenses": [{"name": "CC-BY-4.0"}],
+            "resources": [{"path": destination.name, "description": "Main dataset file"}],
+        }
+        try:
+            metadata_path.write_text(
+                json.dumps(metadata, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            raise ExportError(f"Failed to write Kaggle metadata to {metadata_path}: {exc}") from exc
+
+        return ExportResult(
+            output_path=destination,
+            file_size=destination.stat().st_size,
+            format=self.name,
+        )

--- a/src/kpubdata_builder/exporters/kaggle.py
+++ b/src/kpubdata_builder/exporters/kaggle.py
@@ -11,11 +11,13 @@ import csv
 import io
 import json
 from pathlib import Path
+from typing import Any
 
 from ..artifact import ArtifactDataset
 from ..errors import ExportError
 from ..spec import ExportTarget
 from .base import BaseExporter, ExportResult, ensure_output_dir
+from .csv import _format_cell, _resolve_columns
 
 
 class KaggleExporter(BaseExporter):
@@ -29,17 +31,15 @@ class KaggleExporter(BaseExporter):
         self, artifact: ArtifactDataset, target: ExportTarget, output_dir: Path
     ) -> ExportResult:
         destination = ensure_output_dir(output_dir, target.output_path)
+        columns = _resolve_columns(artifact)
 
-        if not artifact.records:
-            content = ""
-        else:
-            fieldnames = list(artifact.records[0].keys())
-            buf = io.StringIO()
-            writer = csv.DictWriter(buf, fieldnames=fieldnames, extrasaction="ignore")
-            writer.writeheader()
+        buffer = io.StringIO()
+        if columns:
+            writer = csv.writer(buffer, lineterminator="\n")
+            writer.writerow(columns)
             for record in artifact.records:
-                writer.writerow(record)
-            content = buf.getvalue()
+                writer.writerow([_format_cell(record.get(column)) for column in columns])
+        content = buffer.getvalue()
 
         try:
             _ = destination.write_text(content, encoding="utf-8")
@@ -47,13 +47,30 @@ class KaggleExporter(BaseExporter):
             raise ExportError(f"Failed to export Kaggle artifact to {destination}: {exc}") from exc
 
         metadata_path = destination.parent / "dataset-metadata.json"
-        dataset_id = artifact.metadata.get("dataset_id", "unknown/dataset")
-        metadata = {
-            "title": artifact.metadata.get("title", "Dataset"),
-            "id": dataset_id,
-            "licenses": [{"name": "CC-BY-4.0"}],
-            "resources": [{"path": destination.name, "description": "Main dataset file"}],
-        }
+        resource = {"path": destination.name, "description": "Main dataset file"}
+        metadata: dict[str, Any]
+
+        if metadata_path.exists():
+            try:
+                metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                raise ExportError(
+                    f"Failed to read existing Kaggle metadata at {metadata_path}: {exc}"
+                ) from exc
+            resources = metadata.setdefault("resources", [])
+            if not any(
+                isinstance(entry, dict) and entry.get("path") == resource["path"]
+                for entry in resources
+            ):
+                resources.append(resource)
+        else:
+            metadata = {
+                "title": artifact.metadata.get("title", "Dataset"),
+                "id": artifact.metadata.get("dataset_id", "unknown/dataset"),
+                "licenses": [{"name": artifact.metadata.get("license", "CC-BY-4.0")}],
+                "resources": [resource],
+            }
+
         try:
             metadata_path.write_text(
                 json.dumps(metadata, ensure_ascii=False, indent=2) + "\n",

--- a/src/kpubdata_builder/publishers/__init__.py
+++ b/src/kpubdata_builder/publishers/__init__.py
@@ -15,17 +15,20 @@ from __future__ import annotations
 
 from .base import BasePublisher, PublishResult
 from .huggingface import HuggingFacePublisher
+from .kaggle import KagglePublisher
 from .local import LocalPublisher
 
 PUBLISHER_REGISTRY: dict[str, BasePublisher] = {
     "local": LocalPublisher(),
     "huggingface": HuggingFacePublisher(),
+    "kaggle": KagglePublisher(),
 }
 
 __all__ = [
     "PUBLISHER_REGISTRY",
     "BasePublisher",
     "HuggingFacePublisher",
+    "KagglePublisher",
     "LocalPublisher",
     "PublishResult",
 ]

--- a/src/kpubdata_builder/publishers/kaggle.py
+++ b/src/kpubdata_builder/publishers/kaggle.py
@@ -1,0 +1,52 @@
+"""Kaggle API를 통해 데이터셋을 퍼블리시하는 publisher."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .base import BasePublisher, PublishResult
+
+
+class KagglePublisher(BasePublisher):
+    """Kaggle API로 dataset-metadata.json이 있는 디렉터리를 업로드한다."""
+
+    @property
+    def name(self) -> str:
+        return "kaggle"
+
+    def publish(self, artifact_paths: tuple[Path, ...], *, destination: str) -> PublishResult:
+        """Kaggle 데이터셋을 새 버전으로 업로드한다.
+
+        Args:
+            artifact_paths: dataset-metadata.json을 포함하는 디렉터리 경로.
+            destination: Kaggle dataset ID (e.g. "username/dataset-name").
+        """
+        try:
+            from kaggle.api.kaggle_api_extended import KaggleApi  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise RuntimeError(
+                "kaggle is required for Kaggle publishing. Install it with: pip install kaggle"
+            ) from exc
+
+        api = KaggleApi()
+        api.authenticate()
+        count = 0
+
+        for path in artifact_paths:
+            if not path.is_dir():
+                raise RuntimeError(
+                    f"KagglePublisher expects a directory with dataset-metadata.json, "
+                    f"got file: {path}"
+                )
+            api.dataset_create_version(
+                str(path),
+                version_notes="Update via kpubdata-builder",
+                dir_mode="zip",
+            )
+            count += 1
+
+        return PublishResult(
+            publisher=self.name,
+            reference=f"https://www.kaggle.com/datasets/{destination}",
+            artifact_count=count,
+        )

--- a/src/kpubdata_builder/publishers/kaggle.py
+++ b/src/kpubdata_builder/publishers/kaggle.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from ..errors import PublishError
 from .base import BasePublisher, PublishResult
 
 
@@ -34,15 +35,30 @@ class KagglePublisher(BasePublisher):
 
         for path in artifact_paths:
             if not path.is_dir():
-                raise RuntimeError(
+                raise PublishError(
                     f"KagglePublisher expects a directory with dataset-metadata.json, "
                     f"got file: {path}"
                 )
-            api.dataset_create_version(
-                str(path),
-                version_notes="Update via kpubdata-builder",
-                dir_mode="zip",
-            )
+
+            try:
+                results = api.dataset_list(mine=True, search=destination.split("/")[-1])
+                dataset_exists = any(str(d) == destination for d in results)
+            except Exception:
+                dataset_exists = False
+
+            try:
+                if dataset_exists:
+                    api.dataset_create_version(
+                        str(path),
+                        version_notes="Update via kpubdata-builder",
+                        dir_mode="zip",
+                    )
+                else:
+                    api.dataset_create_new(folder=str(path), dir_mode="zip", public=True)
+            except Exception as exc:
+                raise PublishError(
+                    f"Failed to publish Kaggle dataset to {destination}: {exc}"
+                ) from exc
             count += 1
 
         return PublishResult(

--- a/tests/unit/test_kaggle_exporter.py
+++ b/tests/unit/test_kaggle_exporter.py
@@ -1,0 +1,124 @@
+"""KaggleExporter의 출력 규칙을 테스트로 고정한다.
+
+CSV 본문은 CsvExporter와 동일하게 schema 우선 컬럼 순서를 따라야 하고,
+dataset-metadata.json은 title/id/licenses/resources를 담아야 한다. 라이선스
+오버라이드, 기존 메타데이터 병합, I/O 실패 정책을 회귀 테스트로 못 박는다.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from kpubdata_builder import ArtifactDataset, ExportError
+from kpubdata_builder.exporters import EXPORTER_REGISTRY, KaggleExporter
+from kpubdata_builder.spec import ExportTarget
+
+
+def _read_rows(path: Path) -> list[list[str]]:
+    return list(csv.reader(io.StringIO(path.read_text(encoding="utf-8"))))
+
+
+def _read_metadata(directory: Path) -> dict[str, object]:
+    raw = (directory / "dataset-metadata.json").read_text(encoding="utf-8")
+    return json.loads(raw)
+
+
+def test_writes_csv_following_schema_and_valid_metadata(tmp_path: Path) -> None:
+    # CSV 헤더는 schema 순서를 따르고, 메타데이터 json은 유효해야 한다.
+    artifact = ArtifactDataset(
+        records=({"b": "2", "a": "1"}, {"a": "3", "b": "4"}),
+        schema={"a": "str", "b": "str"},
+        metadata={"title": "Air Quality", "dataset_id": "kpub/air"},
+    )
+    target = ExportTarget(kind="kaggle", output_path="out/data.csv")
+
+    result = KaggleExporter().export(artifact, target, tmp_path)
+
+    assert _read_rows(result.output_path) == [["a", "b"], ["1", "2"], ["3", "4"]]
+
+    metadata = _read_metadata(result.output_path.parent)
+    assert metadata["title"] == "Air Quality"
+    assert metadata["id"] == "kpub/air"
+    assert metadata["licenses"] == [{"name": "CC-BY-4.0"}]
+    assert metadata["resources"] == [{"path": "data.csv", "description": "Main dataset file"}]
+
+
+def test_empty_records_with_schema_writes_header_only(tmp_path: Path) -> None:
+    # schema는 있고 records가 없으면 헤더 한 줄만 기록한다.
+    artifact = ArtifactDataset(records=(), schema={"id": "str", "name": "str"})
+    target = ExportTarget(kind="kaggle", output_path="out/data.csv")
+
+    result = KaggleExporter().export(artifact, target, tmp_path)
+
+    assert result.output_path.read_text(encoding="utf-8") == "id,name\n"
+
+
+def test_license_override_from_metadata(tmp_path: Path) -> None:
+    # metadata.license가 있으면 그 값이 licenses name으로 반영된다.
+    artifact = ArtifactDataset(
+        records=({"id": "1"},),
+        schema={"id": "str"},
+        metadata={"license": "CC0-1.0", "title": "X", "dataset_id": "kpub/x"},
+    )
+    target = ExportTarget(kind="kaggle", output_path="out/data.csv")
+
+    result = KaggleExporter().export(artifact, target, tmp_path)
+
+    metadata = _read_metadata(result.output_path.parent)
+    assert metadata["licenses"] == [{"name": "CC0-1.0"}]
+
+
+def test_registry_exposes_kaggle_exporter() -> None:
+    # Kaggle exporter가 kind 문자열 "kaggle"로 레지스트리에 등록되어 있는지 확인한다.
+    assert isinstance(EXPORTER_REGISTRY["kaggle"], KaggleExporter)
+
+
+def test_merges_resource_into_existing_metadata(tmp_path: Path) -> None:
+    # 같은 디렉터리에 두 번 내보내면 resources에 두 경로가 모두 누적된다.
+    target_one = ExportTarget(kind="kaggle", output_path="out/first.csv")
+    target_two = ExportTarget(kind="kaggle", output_path="out/second.csv")
+    artifact = ArtifactDataset(
+        records=({"id": "1"},),
+        schema={"id": "str"},
+        metadata={"title": "First", "dataset_id": "kpub/first"},
+    )
+
+    first = KaggleExporter().export(artifact, target_one, tmp_path)
+    KaggleExporter().export(
+        ArtifactDataset(
+            records=({"id": "2"},),
+            schema={"id": "str"},
+            metadata={"title": "Second", "dataset_id": "kpub/second"},
+        ),
+        target_two,
+        tmp_path,
+    )
+
+    metadata = _read_metadata(first.output_path.parent)
+    # 첫 writer의 title/id를 유지하고 새 resource만 추가한다.
+    assert metadata["title"] == "First"
+    assert metadata["id"] == "kpub/first"
+    paths = {entry["path"] for entry in metadata["resources"]}  # type: ignore[index, union-attr]
+    assert paths == {"first.csv", "second.csv"}
+
+
+def test_wraps_io_failure_in_export_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # 파일 쓰기 실패가 ExportError로 래핑되는지 확인한다.
+    artifact = ArtifactDataset(records=({"id": "1"},), schema={"id": "str"})
+    target = ExportTarget(kind="kaggle", output_path="out/data.csv")
+
+    def raise_io_error(self: Path, data: str, *, encoding: str) -> int:
+        del self, data, encoding
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "write_text", raise_io_error)
+
+    with pytest.raises(ExportError):
+        KaggleExporter().export(artifact, target, tmp_path)

--- a/tests/unit/test_publishers.py
+++ b/tests/unit/test_publishers.py
@@ -12,6 +12,7 @@ from kpubdata_builder.errors import PublishError
 from kpubdata_builder.publishers import (
     PUBLISHER_REGISTRY,
     BasePublisher,
+    KagglePublisher,
     LocalPublisher,
     PublishResult,
 )
@@ -188,3 +189,111 @@ class TestHuggingFacePublisher:
         assert len(calls["folders"]) == 1
         assert calls["files"] == []
         assert result.artifact_count == 1
+
+
+class _FakeKaggleApi:
+    """Kaggle API 더블: 호출을 기록하고 dataset 존재 여부를 흉내낸다."""
+
+    def __init__(self, existing: tuple[str, ...] = (), raise_on_create: bool = False) -> None:
+        self._existing = existing
+        self._raise_on_create = raise_on_create
+        self.calls: list[str] = []
+
+    def authenticate(self) -> None:
+        self.calls.append("authenticate")
+
+    def dataset_list(self, *, mine: bool, search: str) -> list[str]:
+        del mine, search
+        return list(self._existing)
+
+    def dataset_create_version(self, *args: object, **kwargs: object) -> None:
+        del args, kwargs
+        if self._raise_on_create:
+            raise RuntimeError("kaggle boom")
+        self.calls.append("dataset_create_version")
+
+    def dataset_create_new(self, *args: object, **kwargs: object) -> None:
+        del args, kwargs
+        if self._raise_on_create:
+            raise RuntimeError("kaggle boom")
+        self.calls.append("dataset_create_new")
+
+
+def _inject_fake_kaggle(monkeypatch: pytest.MonkeyPatch, api: _FakeKaggleApi) -> None:
+    """`kaggle.api.kaggle_api_extended.KaggleApi`를 가짜 모듈로 주입한다."""
+    extended = types.ModuleType("kaggle.api.kaggle_api_extended")
+    extended.KaggleApi = lambda: api  # type: ignore[attr-defined]
+    api_pkg = types.ModuleType("kaggle.api")
+    kaggle_pkg = types.ModuleType("kaggle")
+    monkeypatch.setitem(sys.modules, "kaggle", kaggle_pkg)
+    monkeypatch.setitem(sys.modules, "kaggle.api", api_pkg)
+    monkeypatch.setitem(sys.modules, "kaggle.api.kaggle_api_extended", extended)
+
+
+class TestKagglePublisher:
+    def test_registered_in_publisher_registry(self) -> None:
+        assert "kaggle" in PUBLISHER_REGISTRY
+        assert isinstance(PUBLISHER_REGISTRY["kaggle"], KagglePublisher)
+
+    def test_publish_new_dataset_calls_create_new(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        api = _FakeKaggleApi(existing=())
+        _inject_fake_kaggle(monkeypatch, api)
+        artifact_dir = tmp_path / "dataset"
+        artifact_dir.mkdir()
+
+        result = KagglePublisher().publish((artifact_dir,), destination="kpub/new")
+
+        assert "dataset_create_new" in api.calls
+        assert "dataset_create_version" not in api.calls
+        assert result.artifact_count == 1
+
+    def test_publish_existing_dataset_calls_create_version(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        api = _FakeKaggleApi(existing=("kpub/existing",))
+        _inject_fake_kaggle(monkeypatch, api)
+        artifact_dir = tmp_path / "dataset"
+        artifact_dir.mkdir()
+
+        result = KagglePublisher().publish((artifact_dir,), destination="kpub/existing")
+
+        assert "dataset_create_version" in api.calls
+        assert "dataset_create_new" not in api.calls
+        assert result.artifact_count == 1
+
+    def test_rejects_non_directory_artifact(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        api = _FakeKaggleApi()
+        _inject_fake_kaggle(monkeypatch, api)
+        artifact = tmp_path / "data.csv"
+        _ = artifact.write_text("id\n1\n", encoding="utf-8")
+
+        with pytest.raises(PublishError, match="expects a directory"):
+            KagglePublisher().publish((artifact,), destination="kpub/x")
+
+    def test_missing_kaggle_package_raises_runtime_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # kaggle 모듈을 import 시 ImportError가 나도록 막아 RuntimeError를 유도한다.
+        for name in list(sys.modules):
+            if name == "kaggle" or name.startswith("kaggle."):
+                monkeypatch.setitem(sys.modules, name, None)
+        artifact_dir = tmp_path / "dataset"
+        artifact_dir.mkdir()
+
+        with pytest.raises(RuntimeError, match="kaggle is required"):
+            KagglePublisher().publish((artifact_dir,), destination="kpub/x")
+
+    def test_wraps_api_failure_in_publish_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        api = _FakeKaggleApi(existing=(), raise_on_create=True)
+        _inject_fake_kaggle(monkeypatch, api)
+        artifact_dir = tmp_path / "dataset"
+        artifact_dir.mkdir()
+
+        with pytest.raises(PublishError, match="Failed to publish Kaggle dataset"):
+            KagglePublisher().publish((artifact_dir,), destination="kpub/new")


### PR DESCRIPTION
## 개요

`#41` [v0.3] Kaggle dataset exporter/publisher를 완성합니다. 기존 PR #145의 스켈레톤을 `upstream/main`에 리베이스한 뒤, 리뷰에서 발견된 갈등/누락 항목을 모두 보완하고 테스트를 추가했습니다. **PR #145를 대체합니다.**

## 보완 내용 (리뷰 지적 사항 해결)

### Exporter (`exporters/kaggle.py`)
- **스키마 우선 컬럼 순서**: 첫 레코드 키 대신 `csv._resolve_columns`/`_format_cell`를 재사용 → `CsvExporter`와 동일한 출력, 스키마 컬럼 누락 없음. 스키마가 있고 레코드가 비면 **헤더만 있는 CSV** 생성.
- **라이선스 오버라이드**: `artifact.metadata['license']` 반영 (기존 `CC-BY-4.0` 하드코딩 제거).
- **기존 `dataset-metadata.json` 병합**: 덮어쓰지 않고 `resources`에 항목 추가. 읽기 실패는 `ExportError`로 감쌈.

### Publisher (`publishers/kaggle.py`)
- **레지스트리 등록**: `PUBLISHER_REGISTRY`에 `"kaggle"` 추가 (이름으로 조회 가능).
- **`PublishError` 계약 준수**: 비-디렉터리 경로 및 Kaggle API 실패를 `PublishError`로 (SDK 미설치만 `RuntimeError` 유지).
- **최초 게시 fallback**: 데이터셋이 없으면 `dataset_create_new`, 있으면 `dataset_create_version`.

## 테스트

신규 12개:
- `tests/unit/test_kaggle_exporter.py` (6): 스키마 순서 CSV+메타데이터, 헤더-only, 라이선스 오버라이드, 레지스트리 등록, 메타데이터 병합, IO 실패→`ExportError`
- `tests/unit/test_publishers.py` (6): 레지스트리 등록, 신규/기존 데이터셋 분기, 비-디렉터리→`PublishError`, SDK 미설치→`RuntimeError`, API 실패→`PublishError`

## 검증

- `pytest`: **314 passed**
- `mypy src`: clean (68 files)
- `ruff check`: clean

## 비고

- PR #145를 대체합니다 (#145 닫기 권장).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---
Closes #41
