### PR TITLE
fix(kaggle,persist): resolve remaining Kaggle pipeline & atomic persist issues (#176–#181)

### DIFF
--- a/src/kpubdata_builder/assembler.py
+++ b/src/kpubdata_builder/assembler.py
@@ -73,9 +73,18 @@ def assemble_artifact(
         raise AssemblyError(f"No source records available for dataset {spec.dataset_id}")
 
     statistics = {"record_count": len(merged_records)}
+
+    # spec의 핵심 식별 필드를 artifact metadata에 채워, Kaggle 같은 메타데이터 의존
+    # exporter가 "Dataset"/"unknown/dataset" 기본값으로 export되지 않게 한다 (#179).
+    # 명시적 spec.metadata 값이 우선하도록 setdefault를 사용한다.
+    metadata = dict(spec.metadata)
+    metadata.setdefault("title", spec.title)
+    metadata.setdefault("dataset_id", spec.dataset_id)
+    metadata.setdefault("description", spec.description)
+
     artifact = ArtifactDataset(
         records=tuple(merged_records),
-        metadata=dict(spec.metadata),
+        metadata=metadata,
         provenance=tuple(present_sources),
         statistics=statistics,
     )

--- a/src/kpubdata_builder/cli.py
+++ b/src/kpubdata_builder/cli.py
@@ -108,6 +108,11 @@ def build_parser() -> argparse.ArgumentParser:
         required=True,
         help="Directory whose files will be published.",
     )
+    publish_cmd.add_argument(
+        "--public",
+        action="store_true",
+        help="Create new datasets as public (kaggle only; default: private).",
+    )
 
     return parser
 
@@ -246,7 +251,12 @@ def _run_preview(spec_path: str, *, limit: int) -> int:
 
 
 def _run_publish(
-    spec_path: str, *, target: str, destination: str, artifacts_dir: str
+    spec_path: str,
+    *,
+    target: str,
+    destination: str,
+    artifacts_dir: str,
+    public: bool = False,
 ) -> int:
     """BuildSpec을 로드·검증한 뒤 지정한 target에 산출물을 게시한다.
 
@@ -255,6 +265,7 @@ def _run_publish(
         target: 게시 대상 식별자 (PUBLISHER_REGISTRY 키).
         destination: 로컬 디렉터리 경로 또는 원격 repo id.
         artifacts_dir: 게시할 파일이 있는 디렉터리.
+        public: kaggle 신규 데이터셋을 공개로 만들지 여부 (다른 target은 무시).
 
     반환값:
         int: 성공 시 0, 로드/검증/게시 실패 시 1.
@@ -276,14 +287,25 @@ def _run_publish(
         print(f"error: no artifacts found in {artifacts_dir}", file=sys.stderr)
         return 1
 
-    paths = sorted(p for p in artifacts_path.rglob("*") if p.is_file())
-    if not paths:
-        print(f"error: no artifacts found in {artifacts_dir}", file=sys.stderr)
-        return 1
-
     publisher = PUBLISHER_REGISTRY[target]
+
+    # 레이아웃 단위(Kaggle)는 디렉터리 자체를, 파일 단위(local/HF)는 개별 파일을
+    # 전달한다. 이렇게 publisher별 입력 계약 불일치를 해소한다 (#176).
+    paths: tuple[Path, ...]
+    if publisher.expects_directory:
+        paths = (artifacts_path,)
+    else:
+        paths = tuple(sorted(p for p in artifacts_path.rglob("*") if p.is_file()))
+        if not paths:
+            print(f"error: no artifacts found in {artifacts_dir}", file=sys.stderr)
+            return 1
+
+    publish_kwargs: dict[str, object] = {"destination": destination}
+    if target == "kaggle":
+        publish_kwargs["public"] = public
+
     try:
-        result = publisher.publish(tuple(paths), destination=destination)
+        result = publisher.publish(paths, **publish_kwargs)  # type: ignore[arg-type]
     except (PublishError, RuntimeError) as exc:
         print(f"error: publish failed: {exc}", file=sys.stderr)
         return 1
@@ -321,6 +343,7 @@ def dispatch(args: argparse.Namespace) -> int:
             target=args.target,
             destination=args.destination,
             artifacts_dir=args.artifacts_dir,
+            public=args.public,
         )
     # 일반적인 CLI 경로로는 도달할 수 없지만(argparse가 알 수 없는 하위 명령을 거부함),
     # 프로그래밍 방식 호출자를 위한 방어적 대체 경로로 유지한다.

--- a/src/kpubdata_builder/publishers/base.py
+++ b/src/kpubdata_builder/publishers/base.py
@@ -49,6 +49,16 @@ class BasePublisher(ABC):
     def name(self) -> str:
         """게시 도구 식별자를 반환한다."""
 
+    @property
+    def expects_directory(self) -> bool:
+        """publish가 개별 파일이 아닌 디렉터리(레이아웃)를 입력으로 기대하는지 여부.
+
+        기본값은 ``False``로, 호출자는 개별 파일 경로들을 전달한다. Kaggle처럼
+        ``dataset-metadata.json``이 포함된 디렉터리 단위를 요구하는 publisher는
+        이를 ``True``로 재정의한다 (#176).
+        """
+        return False
+
     @abstractmethod
     def publish(self, artifact_paths: tuple[Path, ...], *, destination: str) -> PublishResult:
         """생성된 산출물 경로를 지정한 destination에 게시한다.

--- a/src/kpubdata_builder/publishers/kaggle.py
+++ b/src/kpubdata_builder/publishers/kaggle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from ..errors import PublishError
@@ -15,12 +16,26 @@ class KagglePublisher(BasePublisher):
     def name(self) -> str:
         return "kaggle"
 
-    def publish(self, artifact_paths: tuple[Path, ...], *, destination: str) -> PublishResult:
+    @property
+    def expects_directory(self) -> bool:
+        # Kaggle API는 dataset-metadata.json이 포함된 디렉터리 단위로 업로드한다 (#176).
+        return True
+
+    def publish(
+        self,
+        artifact_paths: tuple[Path, ...],
+        *,
+        destination: str,
+        public: bool = False,
+    ) -> PublishResult:
         """Kaggle 데이터셋을 새 버전으로 업로드한다.
 
         Args:
             artifact_paths: dataset-metadata.json을 포함하는 디렉터리 경로.
-            destination: Kaggle dataset ID (e.g. "username/dataset-name").
+            destination: Kaggle dataset ID (e.g. "username/dataset-name"). 디렉터리의
+                ``dataset-metadata.json`` ``id``와 반드시 일치해야 한다.
+            public: 신규 데이터셋 생성 시 공개 여부. 안전을 위해 기본은 비공개이며,
+                의도적으로 공개하려면 명시적으로 ``True``를 전달한다 (#177).
         """
         try:
             from kaggle.api.kaggle_api_extended import KaggleApi  # type: ignore[import-not-found]
@@ -30,9 +45,13 @@ class KagglePublisher(BasePublisher):
             ) from exc
 
         api = KaggleApi()
-        api.authenticate()
-        count = 0
+        # 인증 실패 예외를 PublishError로 변환해 CLI raw traceback 노출을 막는다 (#178).
+        try:
+            api.authenticate()
+        except Exception as exc:
+            raise PublishError(f"Kaggle authentication failed: {exc}") from exc
 
+        count = 0
         for path in artifact_paths:
             if not path.is_dir():
                 raise PublishError(
@@ -40,11 +59,35 @@ class KagglePublisher(BasePublisher):
                     f"got file: {path}"
                 )
 
+            # 업로드 전 dataset-metadata.json을 검증해, 실제 업로드 대상(metadata id)이
+            # destination과 일치하는지 확인한다. Kaggle API는 metadata의 id로 대상을
+            # 결정하므로 불일치 시 엉뚱한 데이터셋이 생성/갱신될 수 있다 (#177).
+            metadata_path = path / "dataset-metadata.json"
+            if not metadata_path.is_file():
+                raise PublishError(f"KagglePublisher requires dataset-metadata.json in {path}")
+            try:
+                metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                raise PublishError(
+                    f"Failed to read dataset-metadata.json in {path}: {exc}"
+                ) from exc
+            metadata_id = metadata.get("id") if isinstance(metadata, dict) else None
+            if metadata_id != destination:
+                raise PublishError(
+                    f"dataset-metadata.json id {metadata_id!r} does not match "
+                    f"destination {destination!r}; they must be identical so the upload "
+                    "targets the intended dataset"
+                )
+
+            # dataset_list 실패를 삼키면 네트워크 오류 시 의도치 않게 신규(공개)
+            # 데이터셋을 생성할 수 있으므로 PublishError로 전파한다 (#177).
             try:
                 results = api.dataset_list(mine=True, search=destination.split("/")[-1])
-                dataset_exists = any(str(d) == destination for d in results)
-            except Exception:
-                dataset_exists = False
+            except Exception as exc:
+                raise PublishError(
+                    f"Failed to query existing Kaggle datasets for {destination}: {exc}"
+                ) from exc
+            dataset_exists = any(str(d) == destination for d in results)
 
             try:
                 if dataset_exists:
@@ -54,7 +97,7 @@ class KagglePublisher(BasePublisher):
                         dir_mode="zip",
                     )
                 else:
-                    api.dataset_create_new(folder=str(path), dir_mode="zip", public=True)
+                    api.dataset_create_new(folder=str(path), dir_mode="zip", public=public)
             except Exception as exc:
                 raise PublishError(
                     f"Failed to publish Kaggle dataset to {destination}: {exc}"

--- a/src/kpubdata_builder/stages/_atomic.py
+++ b/src/kpubdata_builder/stages/_atomic.py
@@ -1,0 +1,52 @@
+"""디렉터리 단위 원자적 교체 유틸 (#180).
+
+기존 디렉터리를 ``shutil.rmtree`` 후 ``rename``하면, 삭제와 rename 사이에서
+실패할 경우 기존 데이터도 신규 데이터도 남지 않아 데이터가 유실된다.
+
+이를 막기 위해 기존 디렉터리를 ``.old`` 백업으로 먼저 rename한 뒤 신규 디렉터리를
+제자리로 rename하고, 성공했을 때만 백업을 삭제한다. 두 rename은 동일 파일시스템
+에서 원자적이며, 신규 배치 단계에서 실패하면 백업을 원위치로 복구한다.
+
+주요 함수:
+    - atomic_replace_dir: tmp 디렉터리를 최종 경로로 원자적으로 교체
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+
+def atomic_replace_dir(tmp_dir: Path, final_dir: Path) -> None:
+    """``tmp_dir``를 ``final_dir`` 위치로 원자적으로 교체한다.
+
+    ``final_dir``가 없으면 단순 rename으로 끝낸다. 존재하면 기존 디렉터리를
+    고유한 ``.old`` 백업으로 rename → 신규 디렉터리 rename → 백업 삭제 순서로
+    교체하며, 신규 디렉터리 rename이 실패하면 백업을 복구한 뒤 예외를 전파한다.
+
+    매개변수:
+        tmp_dir: 최종 위치로 옮길 임시 디렉터리.
+        final_dir: 산출물이 놓일 최종 경로.
+    """
+    if not final_dir.exists():
+        tmp_dir.rename(final_dir)
+        return
+
+    # tmp_dir 이름(mkdtemp 기반)으로 백업 경로를 고유하게 만들어 이전 크래시가
+    # 남긴 stale 백업과 충돌하지 않게 한다.
+    backup = final_dir.with_name(f"{final_dir.name}.{tmp_dir.name}.old")
+    if backup.exists():
+        shutil.rmtree(backup, ignore_errors=True)
+
+    final_dir.rename(backup)  # 원자적: 기존 데이터를 백업으로 이동
+    try:
+        tmp_dir.rename(final_dir)  # 원자적: 신규 데이터를 제자리로
+    except BaseException:
+        # 신규 배치 실패 → 기존 데이터를 원위치로 복구한다.
+        if not final_dir.exists():
+            backup.rename(final_dir)
+        raise
+    shutil.rmtree(backup, ignore_errors=True)
+
+
+__all__ = ["atomic_replace_dir"]

--- a/src/kpubdata_builder/stages/bronze/persist.py
+++ b/src/kpubdata_builder/stages/bronze/persist.py
@@ -78,6 +78,8 @@ def persist_bronze_artifact(
     import shutil
     import tempfile
 
+    from .._atomic import atomic_replace_dir
+
     parent = bronze_dir.parent
     parent.mkdir(parents=True, exist_ok=True)
     tmp_dir = Path(tempfile.mkdtemp(dir=parent, prefix=f".{artifact_id}_tmp_"))
@@ -101,10 +103,8 @@ def persist_bronze_artifact(
             encoding="utf-8",
         )
 
-        # Atomic rename (same filesystem)
-        if bronze_dir.exists():
-            shutil.rmtree(bronze_dir)
-        tmp_dir.rename(bronze_dir)
+        # Atomic swap: 기존 디렉터리가 있어도 데이터 유실 없이 교체한다 (#180).
+        atomic_replace_dir(tmp_dir, bronze_dir)
     except BaseException:
         shutil.rmtree(tmp_dir, ignore_errors=True)
         raise

--- a/src/kpubdata_builder/stages/gold/persist.py
+++ b/src/kpubdata_builder/stages/gold/persist.py
@@ -84,6 +84,8 @@ def persist_gold_package(
     import shutil
     import tempfile
 
+    from .._atomic import atomic_replace_dir
+
     gold_dir.parent.mkdir(parents=True, exist_ok=True)
 
     table_path = gold_dir / "table.parquet"
@@ -99,9 +101,8 @@ def persist_gold_package(
             encoding="utf-8",
         )
 
-        if gold_dir.exists():
-            shutil.rmtree(gold_dir)
-        tmp_dir.rename(gold_dir)
+        # Atomic swap: 기존 디렉터리가 있어도 데이터 유실 없이 교체한다 (#180).
+        atomic_replace_dir(tmp_dir, gold_dir)
     except BaseException:
         shutil.rmtree(tmp_dir, ignore_errors=True)
         raise

--- a/src/kpubdata_builder/stages/silver/persist.py
+++ b/src/kpubdata_builder/stages/silver/persist.py
@@ -90,6 +90,8 @@ def persist_silver_dataset(
     import shutil
     import tempfile
 
+    from .._atomic import atomic_replace_dir
+
     silver_dir.parent.mkdir(parents=True, exist_ok=True)
 
     table_path = silver_dir / "table.parquet"
@@ -107,9 +109,8 @@ def persist_silver_dataset(
         _write_json(tmp_dir / "preview.json", asdict(dataset.preview))
         _write_json(tmp_dir / "validation.json", asdict(dataset.validation))
 
-        if silver_dir.exists():
-            shutil.rmtree(silver_dir)
-        tmp_dir.rename(silver_dir)
+        # Atomic swap: 기존 디렉터리가 있어도 데이터 유실 없이 교체한다 (#180).
+        atomic_replace_dir(tmp_dir, silver_dir)
     except BaseException:
         shutil.rmtree(tmp_dir, ignore_errors=True)
         raise

--- a/tests/unit/test_assembler.py
+++ b/tests/unit/test_assembler.py
@@ -30,6 +30,44 @@ def test_assemble_artifact_reports_missing_source_warning() -> None:
     assert result.warnings == ("Missing records for source: missing",)
 
 
+def test_assemble_artifact_injects_spec_core_metadata() -> None:
+    # spec의 title/dataset_id/description이 artifact metadata에 채워져야 한다 (#179).
+    spec = BuildSpec(
+        dataset_id="kpub/air",
+        title="Air Quality",
+        description="Hourly air quality",
+        sources=(SourceRef(provider="datago", dataset="air_quality", alias="present"),),
+        exports=(ExportTarget(kind="kaggle", output_path="out/data.csv"),),
+        metadata={"license": "CC0-1.0"},
+    )
+
+    result = assemble_artifact(spec, {"present": ({"id": "1"},)})
+
+    meta = result.artifact.metadata
+    assert meta["title"] == "Air Quality"
+    assert meta["dataset_id"] == "kpub/air"
+    assert meta["description"] == "Hourly air quality"
+    # 명시적 metadata 값은 보존된다.
+    assert meta["license"] == "CC0-1.0"
+
+
+def test_assemble_artifact_explicit_metadata_overrides_spec_fields() -> None:
+    # metadata에 동일 키가 있으면 spec 핵심 필드보다 우선한다 (#179).
+    spec = BuildSpec(
+        dataset_id="kpub/air",
+        title="Air Quality",
+        description="desc",
+        sources=(SourceRef(provider="datago", dataset="air_quality", alias="present"),),
+        exports=(ExportTarget(kind="kaggle", output_path="out/data.csv"),),
+        metadata={"title": "Override Title", "dataset_id": "kpub/override"},
+    )
+
+    result = assemble_artifact(spec, {"present": ({"id": "1"},)})
+
+    assert result.artifact.metadata["title"] == "Override Title"
+    assert result.artifact.metadata["dataset_id"] == "kpub/override"
+
+
 def test_assemble_artifact_raises_when_all_sources_missing() -> None:
     # 조립 가능한 레코드가 하나도 없으면 AssemblyError가 발생해야 한다.
     spec = BuildSpec(

--- a/tests/unit/test_atomic.py
+++ b/tests/unit/test_atomic.py
@@ -1,0 +1,67 @@
+"""디렉터리 원자적 교체 유틸 atomic_replace_dir 동작 검증 (#180)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kpubdata_builder.stages._atomic import atomic_replace_dir
+
+
+def _make_dir(parent: Path, name: str, content: str) -> Path:
+    d = parent / name
+    d.mkdir()
+    _ = (d / "data.txt").write_text(content, encoding="utf-8")
+    return d
+
+
+def test_replaces_into_empty_destination(tmp_path: Path) -> None:
+    tmp_dir = _make_dir(tmp_path, ".tmp_new", "new")
+    final_dir = tmp_path / "final"
+
+    atomic_replace_dir(tmp_dir, final_dir)
+
+    assert (final_dir / "data.txt").read_text(encoding="utf-8") == "new"
+    assert not tmp_dir.exists()
+
+
+def test_swaps_over_existing_destination(tmp_path: Path) -> None:
+    final_dir = _make_dir(tmp_path, "final", "old")
+    tmp_dir = _make_dir(tmp_path, ".tmp_new", "new")
+
+    atomic_replace_dir(tmp_dir, final_dir)
+
+    assert (final_dir / "data.txt").read_text(encoding="utf-8") == "new"
+    assert not tmp_dir.exists()
+    # 백업(.old)이 남지 않아야 한다.
+    leftovers = [p.name for p in tmp_path.iterdir() if p.name.endswith(".old")]
+    assert leftovers == []
+
+
+def test_restores_existing_data_when_swap_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # 신규 배치(rename) 실패 시 기존 데이터가 손실되지 않고 복구되어야 한다.
+    final_dir = _make_dir(tmp_path, "final", "old")
+    tmp_dir = _make_dir(tmp_path, ".tmp_new", "new")
+
+    original_rename = Path.rename
+    state = {"calls": 0}
+
+    def flaky_rename(self: Path, target: Path) -> Path:
+        # 첫 rename(기존→백업)은 통과, 두 번째 rename(tmp→final)에서 실패시킨다.
+        state["calls"] += 1
+        if state["calls"] == 2:
+            raise OSError("disk full")
+        return original_rename(self, target)
+
+    monkeypatch.setattr(Path, "rename", flaky_rename)
+
+    with pytest.raises(OSError, match="disk full"):
+        atomic_replace_dir(tmp_dir, final_dir)
+
+    monkeypatch.undo()
+    # 기존 데이터가 제자리로 복구되어 있어야 한다.
+    assert final_dir.exists()
+    assert (final_dir / "data.txt").read_text(encoding="utf-8") == "old"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -145,9 +145,7 @@ def test_validate_fails_for_malformed_yaml(
 # ---------------------------------------------------------------------------
 
 
-def test_publish_local_end_to_end(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
+def test_publish_local_end_to_end(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     # --target local end-to-end: 파일이 destination 으로 복사되고 요약이 출력된다.
     spec_path = tmp_path / "spec.yaml"
     _ = spec_path.write_text(VALID_SPEC_YAML, encoding="utf-8")
@@ -278,6 +276,8 @@ def test_publish_huggingface_stub(
         artifact_count=1,
     )
     stub = MagicMock()
+    # 실제 HuggingFacePublisher는 파일 단위 입력을 받으므로 stub도 동일하게 맞춘다.
+    stub.expects_directory = False
     stub.publish.return_value = fake_result
 
     import kpubdata_builder.cli as cli_module
@@ -342,3 +342,71 @@ def test_publish_publish_error_returns_one(
 
     assert exit_code == 1
     assert "publish failed" in captured.err
+
+
+def test_publish_kaggle_end_to_end(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # --target kaggle end-to-end: CLI가 dataset-metadata.json이 든 디렉터리 자체를
+    # KagglePublisher에 전달하고, fake API로 업로드가 호출되는지 검증한다 (#176, #181).
+    import json
+    import sys
+    import types
+
+    spec_path = tmp_path / "spec.yaml"
+    _ = spec_path.write_text(VALID_SPEC_YAML, encoding="utf-8")
+
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    (artifacts_dir / "data.csv").write_text("id\n1\n", encoding="utf-8")
+    (artifacts_dir / "dataset-metadata.json").write_text(
+        json.dumps({"id": "kpub/sample", "title": "Sample", "resources": []}),
+        encoding="utf-8",
+    )
+
+    calls: list[str] = []
+
+    class _FakeApi:
+        def authenticate(self) -> None:
+            calls.append("authenticate")
+
+        def dataset_list(self, *, mine: bool, search: str) -> list[str]:
+            del mine, search
+            return []
+
+        def dataset_create_new(self, *args: object, **kwargs: object) -> None:
+            del args
+            calls.append(f"create_new:public={kwargs.get('public')}")
+
+        def dataset_create_version(self, *args: object, **kwargs: object) -> None:
+            del args, kwargs
+            calls.append("create_version")
+
+    extended = types.ModuleType("kaggle.api.kaggle_api_extended")
+    extended.KaggleApi = lambda: _FakeApi()  # type: ignore[attr-defined]
+    api_pkg = types.ModuleType("kaggle.api")
+    kaggle_pkg = types.ModuleType("kaggle")
+    monkeypatch.setitem(sys.modules, "kaggle", kaggle_pkg)
+    monkeypatch.setitem(sys.modules, "kaggle.api", api_pkg)
+    monkeypatch.setitem(sys.modules, "kaggle.api.kaggle_api_extended", extended)
+
+    exit_code = main(
+        [
+            "publish",
+            str(spec_path),
+            "--target",
+            "kaggle",
+            "--destination",
+            "kpub/sample",
+            "--artifacts-dir",
+            str(artifacts_dir),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0, captured.err
+    assert "authenticate" in calls
+    # public 플래그를 주지 않았으므로 비공개로 생성되어야 한다.
+    assert "create_new:public=False" in calls
+    assert "publish: dataset.sample -> kaggle" in captured.out
+    assert "artifacts: 1" in captured.out

--- a/tests/unit/test_publishers.py
+++ b/tests/unit/test_publishers.py
@@ -219,6 +219,24 @@ class _FakeKaggleApi:
         self.calls.append("dataset_create_new")
 
 
+def _make_kaggle_dir(tmp_path: Path, dataset_id: str) -> Path:
+    """dataset-metadata.json과 데이터 파일이 있는 Kaggle 업로드 디렉터리를 만든다.
+
+    실제 Kaggle API는 dataset-metadata.json을 필수로 요구하므로, happy path
+    테스트도 빈 디렉터리가 아닌 실제 계약을 갖춘 디렉터리를 사용해야 한다 (#181).
+    """
+    import json
+
+    artifact_dir = tmp_path / "dataset"
+    artifact_dir.mkdir()
+    _ = (artifact_dir / "data.csv").write_text("id\n1\n", encoding="utf-8")
+    _ = (artifact_dir / "dataset-metadata.json").write_text(
+        json.dumps({"id": dataset_id, "title": "x", "resources": []}),
+        encoding="utf-8",
+    )
+    return artifact_dir
+
+
 def _inject_fake_kaggle(monkeypatch: pytest.MonkeyPatch, api: _FakeKaggleApi) -> None:
     """`kaggle.api.kaggle_api_extended.KaggleApi`를 가짜 모듈로 주입한다."""
     extended = types.ModuleType("kaggle.api.kaggle_api_extended")
@@ -240,8 +258,7 @@ class TestKagglePublisher:
     ) -> None:
         api = _FakeKaggleApi(existing=())
         _inject_fake_kaggle(monkeypatch, api)
-        artifact_dir = tmp_path / "dataset"
-        artifact_dir.mkdir()
+        artifact_dir = _make_kaggle_dir(tmp_path, "kpub/new")
 
         result = KagglePublisher().publish((artifact_dir,), destination="kpub/new")
 
@@ -254,8 +271,7 @@ class TestKagglePublisher:
     ) -> None:
         api = _FakeKaggleApi(existing=("kpub/existing",))
         _inject_fake_kaggle(monkeypatch, api)
-        artifact_dir = tmp_path / "dataset"
-        artifact_dir.mkdir()
+        artifact_dir = _make_kaggle_dir(tmp_path, "kpub/existing")
 
         result = KagglePublisher().publish((artifact_dir,), destination="kpub/existing")
 
@@ -277,23 +293,109 @@ class TestKagglePublisher:
     def test_missing_kaggle_package_raises_runtime_error(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # kaggle 모듈을 import 시 ImportError가 나도록 막아 RuntimeError를 유도한다.
-        for name in list(sys.modules):
+        # kaggle import만 ImportError로 막는다. sys.modules monkeypatch는 kaggle이
+        # 설치된 환경에서 spurious하게 동작하므로, __import__를 직접 가로챈다 (#181).
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _blocked_import(name: str, *args: object, **kwargs: object) -> object:
             if name == "kaggle" or name.startswith("kaggle."):
-                monkeypatch.setitem(sys.modules, name, None)
-        artifact_dir = tmp_path / "dataset"
-        artifact_dir.mkdir()
+                raise ImportError("No module named 'kaggle'")
+            return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(builtins, "__import__", _blocked_import)
+        artifact_dir = _make_kaggle_dir(tmp_path, "kpub/x")
 
         with pytest.raises(RuntimeError, match="kaggle is required"):
             KagglePublisher().publish((artifact_dir,), destination="kpub/x")
+
+    def test_rejects_metadata_id_mismatch(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # dataset-metadata.json의 id가 destination과 다르면 잘못된 대상 업로드를
+        # 막기 위해 PublishError를 던진다 (#177).
+        api = _FakeKaggleApi(existing=())
+        _inject_fake_kaggle(monkeypatch, api)
+        artifact_dir = _make_kaggle_dir(tmp_path, "kpub/declared")
+
+        with pytest.raises(PublishError, match="does not match destination"):
+            KagglePublisher().publish((artifact_dir,), destination="kpub/different")
+        assert "dataset_create_new" not in api.calls
+
+    def test_rejects_missing_metadata_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # dataset-metadata.json이 없는 디렉터리는 거부한다 (#181 happy path 회귀).
+        api = _FakeKaggleApi(existing=())
+        _inject_fake_kaggle(monkeypatch, api)
+        artifact_dir = tmp_path / "dataset"
+        artifact_dir.mkdir()
+
+        with pytest.raises(PublishError, match="requires dataset-metadata.json"):
+            KagglePublisher().publish((artifact_dir,), destination="kpub/x")
+
+    def test_authentication_failure_wrapped_in_publish_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # authenticate() 예외가 raw traceback 대신 PublishError로 변환되어야 한다 (#178).
+        class _AuthFailApi(_FakeKaggleApi):
+            def authenticate(self) -> None:
+                raise OSError("kaggle.json not found")
+
+        api = _AuthFailApi()
+        _inject_fake_kaggle(monkeypatch, api)
+        artifact_dir = _make_kaggle_dir(tmp_path, "kpub/x")
+
+        with pytest.raises(PublishError, match="Kaggle authentication failed"):
+            KagglePublisher().publish((artifact_dir,), destination="kpub/x")
+
+    def test_dataset_list_failure_wrapped_in_publish_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # dataset_list 실패를 삼켜 신규(공개) 데이터셋을 만들지 않고 전파한다 (#177).
+        class _ListFailApi(_FakeKaggleApi):
+            def dataset_list(self, *, mine: bool, search: str) -> list[str]:
+                del mine, search
+                raise ConnectionError("network down")
+
+        api = _ListFailApi()
+        _inject_fake_kaggle(monkeypatch, api)
+        artifact_dir = _make_kaggle_dir(tmp_path, "kpub/x")
+
+        with pytest.raises(PublishError, match="Failed to query existing Kaggle"):
+            KagglePublisher().publish((artifact_dir,), destination="kpub/x")
+        assert "dataset_create_new" not in api.calls
+
+    def test_new_dataset_defaults_to_private(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # public 인자를 주지 않으면 신규 데이터셋은 비공개로 생성되어야 한다 (#177).
+        class _RecordingApi(_FakeKaggleApi):
+            def __init__(self) -> None:
+                super().__init__(existing=())
+                self.public_arg: bool | None = None
+
+            def dataset_create_new(self, *args: object, **kwargs: object) -> None:
+                self.public_arg = bool(kwargs.get("public"))
+                self.calls.append("dataset_create_new")
+
+        api = _RecordingApi()
+        _inject_fake_kaggle(monkeypatch, api)
+        artifact_dir = _make_kaggle_dir(tmp_path, "kpub/new")
+
+        KagglePublisher().publish((artifact_dir,), destination="kpub/new")
+        assert api.public_arg is False
+
+        KagglePublisher().publish((artifact_dir,), destination="kpub/new", public=True)
+        assert api.public_arg is True
 
     def test_wraps_api_failure_in_publish_error(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         api = _FakeKaggleApi(existing=(), raise_on_create=True)
         _inject_fake_kaggle(monkeypatch, api)
-        artifact_dir = tmp_path / "dataset"
-        artifact_dir.mkdir()
+        artifact_dir = _make_kaggle_dir(tmp_path, "kpub/new")
 
         with pytest.raises(PublishError, match="Failed to publish Kaggle dataset"):
             KagglePublisher().publish((artifact_dir,), destination="kpub/new")


### PR DESCRIPTION
## Summary

Resolves all six remaining open issues, covering the Kaggle exporter→CLI→publisher pipeline and Medallion atomic persist.

| Issue | Fix |
|-------|-----|
| #176 | Unify the file-vs-directory contract. `BasePublisher.expects_directory` lets the CLI pass the artifacts **directory** to layout-style publishers (Kaggle) and individual **files** to file-style ones (local/HF). `publish --target kaggle` no longer always raises `PublishError`. |
| #177 | `KagglePublisher` validates `dataset-metadata.json` `id` == `destination`, propagates `dataset_list` failures as `PublishError` (no more silent new-public-dataset creation on network errors), and makes visibility configurable via `public` (CLI `--public`), defaulting to **private**. |
| #178 | `api.authenticate()` is wrapped → `PublishError`, so auth failures no longer escape CLI error handling as a raw traceback. |
| #179 | `assemble_artifact` injects spec core fields (`title`/`dataset_id`/`description`) into artifact metadata, so normal builds stop emitting invalid `"Dataset"`/`"unknown/dataset"` Kaggle metadata. Explicit `spec.metadata` still wins. |
| #180 | Atomic persist (bronze/silver/gold) now uses a shared `atomic_replace_dir` helper: rename existing→`.old`, rename new into place, delete backup, restore-on-failure — eliminating the rmtree-then-rename data-loss window on `run_id` reuse. |
| #181 | Kaggle tests use `dataset-metadata.json` fixtures, stub the import via `builtins.__import__` (robust even when `kaggle` is installed), and a CLI→Kaggle integration test is added. |

## Testing

- `ruff check` ✅ · `ruff format --check` (touched files) ✅
- `mypy src` ✅ (no issues, 69 files)
- `pytest` ✅ **337 passed**

Closes #176
Closes #177
Closes #178
Closes #179
Closes #180
Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)