### PR TITLE
fix: resolve remaining correctness/robustness issues (#183–#196)

### DIFF
--- a/src/kpubdata_builder/errors.py
+++ b/src/kpubdata_builder/errors.py
@@ -56,13 +56,38 @@ class PublishError(BuildError):
     """산출물 게시(복사/업로드/등록)가 실패했음을 나타낸다."""
 
 
+class TabularError(BuildError):
+    """원시 레코드의 표 변환/정규화에서 데이터 무결성 문제가 발생했음을 나타낸다.
+
+    이질적(혼합 타입) 컬럼이나, 선언된 캐스팅이 값을 조용히 null로 만드는 손실
+    변환처럼, 조용히 데이터를 다시 쓰는 대신 명확히 실패해야 하는 경우에 쓴다.
+    """
+
+
+class DatasetValidationError(BuildError):
+    """조립된 데이터셋(Silver 등)이 검증을 통과하지 못했음을 나타낸다.
+
+    spec 검증(ValidationError)과 구분되며, 검증 실패한 데이터셋이 다운스트림
+    (Gold/패키징)으로 흘러가지 않도록 오케스트레이터가 소스를 실패 처리할 때 쓴다.
+
+    속성:
+        problems: 데이터셋 검증 단계에서 수집된 개별 위반 메시지 목록.
+    """
+
+    def __init__(self, problems: list[str]) -> None:
+        self.problems = problems
+        super().__init__(f"Dataset validation failed: {'; '.join(problems)}")
+
+
 __all__ = [
     "AssemblyError",
     "BuildError",
+    "DatasetValidationError",
     "ExecutionError",
     "ExportError",
     "ManifestError",
     "PublishError",
     "SpecLoadError",
+    "TabularError",
     "ValidationError",
 ]

--- a/src/kpubdata_builder/pipeline/orchestrator.py
+++ b/src/kpubdata_builder/pipeline/orchestrator.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+from ..errors import DatasetValidationError
 from ..manifest import (
     BuildManifest,
     SchemaSummary,
@@ -134,6 +135,10 @@ def _run_source_pipeline(
         )
 
         silver = build_silver_dataset(bronze)
+        # 검증에 실패한 Silver 데이터셋이 Gold/패키징으로 흘러가지 않도록 소스를
+        # 실패 처리한다. 검증은 더 이상 권고용이 아니라 게이트다 (#189).
+        if not silver.validation.ok:
+            raise DatasetValidationError(list(silver.validation.problems))
         silver_paths = persist_silver_dataset(
             silver, output_root=context.output_root, run_id=context.run_id
         )

--- a/src/kpubdata_builder/pipeline/preview.py
+++ b/src/kpubdata_builder/pipeline/preview.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from ..spec import BuildSpec, SourceRef
+from ..spec.validator import validate_spec
 from ..stages.bronze.build import SourceClient, build_bronze_artifact
 from ..stages.silver.build import build_silver_dataset
 from ..tabular import DEFAULT_PREVIEW_LIMIT, PreviewSlice, SchemaInfo
@@ -109,8 +110,12 @@ def preview_build(
 
     예외:
         ValueError: limit이 1보다 작은 경우.
+        ValidationError: spec이 최소 실행 요건을 충족하지 못한 경우. 유효하지 않은
+            spec을 부분 실행하거나 빈 결과로 돌려보내지 않고 빠르게 실패시켜
+            서비스 레이어와 동일하게 동작하도록 한다 (#193).
     """
     if limit < 1:
         raise ValueError(f"limit must be >= 1, got {limit}")
+    validate_spec(spec)
     previews = tuple(_preview_source(source, client=client, limit=limit) for source in spec.sources)
     return PreviewResult(previews=previews)

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -209,8 +209,15 @@ def dispatch(
         spec = _spec_from_body(body)
         if isinstance(spec, ServiceResponse):
             return spec
-        run_id_value = body.get("run_id") if body else None
-        run_id = run_id_value if isinstance(run_id_value, str) else None
+        run_id: str | None = None
+        if body is not None and "run_id" in body:
+            run_id_value = body["run_id"]
+            # run_id가 명시되면 비어있지 않은 문자열이어야 한다. 잘못된 타입을 조용히
+            # 자동 생성 run id로 떨어뜨리면 클라이언트가 의도한 run id와 실제 기록 위치가
+            # 달라지므로 400으로 거부한다 (#185).
+            if not isinstance(run_id_value, str) or not run_id_value.strip():
+                return ServiceResponse(400, {"error": "'run_id' must be a non-empty string"})
+            run_id = run_id_value
         return service.build(spec, run_id=run_id)
 
     if method == "GET" and path.startswith("/artifacts/"):

--- a/src/kpubdata_builder/service/http.py
+++ b/src/kpubdata_builder/service/http.py
@@ -13,9 +13,14 @@ from __future__ import annotations
 import json
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import cast
+from urllib.parse import urlsplit
 
 from ..spec import JsonValue
 from .app import BuilderService, dispatch
+
+# 단일 요청이 메모리를 고갈시키거나 단일 스레드 서버를 멈추게 하지 않도록 body 크기를
+# 제한한다. spec YAML 요청에 충분하면서도 남용을 막는 보수적 상한 (#186).
+_MAX_BODY_BYTES = 10 * 1024 * 1024  # 10 MiB
 
 
 def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
@@ -23,16 +28,35 @@ def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
 
     class _Handler(BaseHTTPRequestHandler):
         def _dispatch(self, method: str) -> None:
-            length = int(self.headers.get("Content-Length", 0) or 0)
+            try:
+                length = int(self.headers.get("Content-Length", 0) or 0)
+            except ValueError:
+                self._write(400, {"error": "invalid Content-Length header"})
+                return
+            if length < 0:
+                self._write(400, {"error": "invalid Content-Length header"})
+                return
+            # 선언된 길이가 상한을 넘으면 body를 읽지 않고 413으로 거부한다 (#186).
+            if length > _MAX_BODY_BYTES:
+                self._write(413, {"error": "request body too large"})
+                return
             raw = self.rfile.read(length) if length else b""
             body: dict[str, JsonValue] | None = None
             if raw:
                 try:
-                    body = cast(dict[str, JsonValue], json.loads(raw))
+                    parsed = cast(object, json.loads(raw))
                 except json.JSONDecodeError:
                     self._write(400, {"error": "invalid JSON body"})
                     return
-            response = dispatch(service, method, self.path, body)
+                # HTTP 어댑터는 임의의 JSON 최상위 타입을 받을 수 있지만, 서비스는
+                # 매핑(객체)만 다룬다. 스칼라/배열 body는 TypeError 대신 400으로 거부 (#183).
+                if not isinstance(parsed, dict):
+                    self._write(400, {"error": "JSON body must be an object"})
+                    return
+                body = cast(dict[str, JsonValue], parsed)
+            # 쿼리 스트링이 경로/run_id로 새지 않도록 path 컴포넌트만으로 라우팅한다 (#184).
+            path = urlsplit(self.path).path
+            response = dispatch(service, method, path, body)
             self._write(response.status_code, response.body)
 
         def _write(self, status_code: int, body: dict[str, JsonValue]) -> None:

--- a/src/kpubdata_builder/snapshot.py
+++ b/src/kpubdata_builder/snapshot.py
@@ -114,13 +114,31 @@ def load_snapshot(dataset_id: str, *, root: Path) -> BuildSnapshot | None:
     path = _snapshot_path(root, dataset_id)
     if not path.exists():
         return None
-    data = json.loads(path.read_text(encoding="utf-8"))
+    # 손상/잘린 스냅샷은 증분 빌드를 깨뜨리는 대신 "스냅샷 없음"으로 안전하게 저하시킨다.
+    # (None → has_data_changed가 True → 전체 재빌드) (#194).
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    required = ("dataset_id", "built_at", "data_checksum")
+    if any(key not in data for key in required):
+        return None
+    try:
+        record_count = int(data.get("record_count", 0))
+    except (TypeError, ValueError):
+        return None
+    source_params = data.get("source_params", {})
+    if not isinstance(source_params, dict):
+        return None
     return BuildSnapshot(
         dataset_id=str(data["dataset_id"]),
         built_at=str(data["built_at"]),
         data_checksum=str(data["data_checksum"]),
-        record_count=int(data.get("record_count", 0)),
-        source_params=dict(data.get("source_params", {})),
+        record_count=record_count,
+        source_params=dict(source_params),
     )
 
 

--- a/src/kpubdata_builder/spec/validator.py
+++ b/src/kpubdata_builder/spec/validator.py
@@ -10,6 +10,8 @@
 
 from __future__ import annotations
 
+import math
+
 from ..errors import ValidationError
 from ..exporters import EXPORTER_REGISTRY
 from .models import BuildSpec
@@ -36,6 +38,15 @@ def validate_spec(spec: BuildSpec) -> None:
         problems.append("description must be a non-empty string")
     if not spec.sources:
         problems.append("at least one source is required")
+    for i, source in enumerate(spec.sources):
+        # 빈 provider/dataset이나 공백 alias는 검증을 통과한 뒤 fetch/경로 처리에서
+        # 뒤늦게 실패하므로 여기서 막는다 (#191).
+        if not source.provider.strip():
+            problems.append(f"sources[{i}].provider must be a non-empty string")
+        if not source.dataset.strip():
+            problems.append(f"sources[{i}].dataset must be a non-empty string")
+        if source.alias and not source.alias.strip():
+            problems.append(f"sources[{i}].alias must not be blank when provided")
     if not spec.exports:
         problems.append("at least one export target is required")
     for i, export in enumerate(spec.exports):
@@ -66,11 +77,21 @@ def _split_problems(spec: BuildSpec) -> list[str]:
             problems.append("splits.ratios must define at least one split")
         if any(not name.strip() for name in split.ratios):
             problems.append("splits.ratios names must be non-empty strings")
-        if any(fraction <= 0 for fraction in split.ratios.values()):
+        # NaN/inf는 양수·합계 검사를 (NaN 비교가 항상 False라) 조용히 통과하므로,
+        # 다른 비율 검사보다 먼저 유한성을 확인한다 (#192).
+        non_finite = [
+            name for name, fraction in split.ratios.items() if not math.isfinite(fraction)
+        ]
+        if non_finite:
+            problems.append(
+                f"splits.ratios values must be finite numbers; non-finite: {sorted(non_finite)}"
+            )
+        elif any(fraction <= 0 for fraction in split.ratios.values()):
             problems.append("splits.ratios values must be positive")
-        total = sum(split.ratios.values())
-        if split.ratios and abs(total - 1.0) > 1e-6:
-            problems.append(f"splits.ratios must sum to 1.0 (got {total})")
+        else:
+            total = sum(split.ratios.values())
+            if split.ratios and abs(total - 1.0) > 1e-6:
+                problems.append(f"splits.ratios must sum to 1.0 (got {total})")
     elif split.mode == "key":
         if not split.key.strip():
             problems.append("splits.key must be a non-empty column name for key mode")

--- a/src/kpubdata_builder/stages/gold/card.py
+++ b/src/kpubdata_builder/stages/gold/card.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
+from datetime import date, datetime
 
 from ...spec import JsonValue
 
@@ -93,14 +94,22 @@ def build_dataset_card(
     )
 
 
-def _cell(value: JsonValue) -> str:
-    """Markdown 표 셀로 안전한 문자열을 만든다(파이프/개행 이스케이프)."""
+def _cell(value: object) -> str:
+    """Markdown 표 셀로 안전한 문자열을 만든다(파이프/개행 이스케이프).
+
+    sample_rows는 선언상 JsonValue지만, Silver 프리뷰에서 온 행은 date/datetime
+    같은 시간적 Python 객체를 포함할 수 있으므로 object를 받아 폭넓게 처리한다.
+    """
     if value is None:
         text = ""
     elif isinstance(value, bool):
         text = "true" if value else "false"
     elif isinstance(value, (str, int, float)):
         text = str(value)
+    elif isinstance(value, (date, datetime)):
+        # 시간적 Python 객체는 직접 JSON 인코딩하면 실패하므로 Silver 직렬화기와
+        # 동일하게 ISO 8601 문자열로 변환한다 (#195).
+        text = value.isoformat()
     else:
         text = json.dumps(value, ensure_ascii=False, sort_keys=True)
     return text.replace("\\", "\\\\").replace("|", "\\|").replace("\n", " ")

--- a/src/kpubdata_builder/stages/silver/build.py
+++ b/src/kpubdata_builder/stages/silver/build.py
@@ -38,7 +38,12 @@ def build_silver_dataset(
 
     반환값:
         SilverDataset: 정제 테이블과 스키마/통계/미리보기/검증 정보.
+
+    예외:
+        ValueError: preview_limit이 음수인 경우 (#190).
     """
+    if preview_limit < 0:
+        raise ValueError(f"preview_limit must be >= 0, got {preview_limit}")
     table = normalize_table(bronze, casts=casts)
     validation = validate_table(table, required_columns=required_columns)
     schema = build_schema(table)

--- a/src/kpubdata_builder/stages/silver/normalize.py
+++ b/src/kpubdata_builder/stages/silver/normalize.py
@@ -14,6 +14,7 @@ from collections.abc import Mapping
 
 import polars as pl
 
+from ...errors import TabularError
 from ...tabular.convert import records_to_dataframe
 from ...tabular.polars_helpers import DtypeSpec, cast_columns
 from ..bronze.models import BronzeArtifact
@@ -26,14 +27,30 @@ def normalize_table(
 ) -> pl.DataFrame:
     """Bronze raw records를 테이블로 변환하고 선언된 캐스팅만 적용한다.
 
+    선언된 캐스팅은 ``strict=False``로 적용되므로 변환에 실패한 값이 조용히 null이
+    될 수 있다. 그런 손실을 묻어두면 오염된 소스 값이 사라진 채 다운스트림 산출물이
+    빌드되므로, audit으로 null 증가를 감지해 어떤 컬럼에서 몇 개가 손실됐는지 명확한
+    에러로 표면화한다 (#188).
+
     매개변수:
         bronze: 원천 Bronze 산출물.
         casts: 컬럼별 dtype 캐스팅 규칙. None이면 캐스팅 없이 tabularize만 수행.
 
     반환값:
         pl.DataFrame: 정규화된 테이블.
+
+    예외:
+        TabularError: 선언된 캐스팅이 값을 null로 떨어뜨려 데이터가 손실된 경우.
     """
     table = records_to_dataframe(bronze.raw_records)
     if casts:
-        table = cast_columns(table, casts)
+        result = cast_columns(table, casts, audit=True)
+        if result.has_nulls_introduced:
+            details = "; ".join(
+                f"{report.column!r}: {report.nulls_introduced} value(s) -> null"
+                for report in result.reports
+                if report.nulls_introduced > 0
+            )
+            raise TabularError(f"declared cast dropped values to null (data loss): {details}")
+        table = result.df
     return table

--- a/src/kpubdata_builder/tabular/convert.py
+++ b/src/kpubdata_builder/tabular/convert.py
@@ -10,23 +10,67 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import cast
 
 import polars as pl
 
+from ..errors import TabularError
 from ..spec import JsonValue
+
+
+def _value_category(value: object) -> str:
+    """값을 호환 그룹으로 분류한다(혼합 타입 컬럼 감지용).
+
+    int/float는 수치로 함께 묶지만 bool은 별도로 둔다. JSON에서 의미가 다른 타입이
+    한 컬럼에 섞이면(예: 문자열과 숫자) Polars 자동 추론이 조용히 한쪽으로 강제
+    변환하므로, 그런 경우를 감지하기 위한 분류다.
+    """
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, (int, float)):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, Mapping):
+        return "mapping"
+    if isinstance(value, (list, tuple)):
+        return "list"
+    return type(value).__name__
 
 
 def records_to_dataframe(records: Sequence[dict[str, JsonValue]]) -> pl.DataFrame:
     """원시 레코드 매핑을 Polars DataFrame으로 변환한다.
+
+    Polars 자동 추론에만 의존하면 혼합 타입 컬럼이 검증 전에 조용히 강제 변환되어
+    원시 값이 바뀔 수 있다. 그래서 변환 전에 컬럼별로 호환되지 않는 타입이 섞였는지
+    먼저 감지하고, 발견되면 명확한 에러로 빠르게 실패한다 (#187).
 
     매개변수:
         records: JSON 호환 레코드 시퀀스.
 
     반환값:
         pl.DataFrame: 입력 레코드의 컬럼 구조를 반영한 DataFrame.
+
+    예외:
+        TabularError: 한 컬럼에 호환되지 않는 타입(예: 문자열+숫자)이 섞인 경우.
     """
+    categories: dict[str, set[str]] = {}
+    for record in records:
+        for key, value in record.items():
+            if value is None:
+                continue
+            categories.setdefault(key, set()).add(_value_category(value))
+
+    heterogeneous = {col: cats for col, cats in categories.items() if len(cats) > 1}
+    if heterogeneous:
+        details = "; ".join(
+            f"{col!r}: {', '.join(sorted(cats))}" for col, cats in sorted(heterogeneous.items())
+        )
+        raise TabularError(
+            f"heterogeneous column types detected (refusing to silently coerce): {details}"
+        )
+
     return pl.DataFrame(list(records))
 
 

--- a/src/kpubdata_builder/tabular/polars_engine.py
+++ b/src/kpubdata_builder/tabular/polars_engine.py
@@ -74,7 +74,13 @@ def generate_preview(df: pl.DataFrame, limit: int = DEFAULT_PREVIEW_LIMIT) -> Pr
 
     반환값:
         PreviewSlice: 상위 행과 전체 행 수.
+
+    예외:
+        ValueError: limit이 음수인 경우. 음수 limit은 df.head로 전달되면 "마지막
+            행을 제외한 전부"를 반환해 예상치 못한 큰 프리뷰를 만들기 때문이다 (#190).
     """
+    if limit < 0:
+        raise ValueError(f"preview limit must be >= 0, got {limit}")
     rows = tuple(dataframe_to_records(df.head(limit)))
     return PreviewSlice(rows=rows, total_rows=df.height)
 

--- a/tests/unit/test_dataset_card.py
+++ b/tests/unit/test_dataset_card.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import date, datetime
+
 from kpubdata_builder.stages.gold import (
     DatasetCard,
     build_dataset_card,
@@ -79,3 +81,17 @@ def test_render_handles_empty_schema_and_sample() -> None:
     assert "_No sample rows available._" in text
     assert "N/A" in text  # license 기본값
     assert "unversioned" in text  # version 기본값
+
+
+def test_render_serializes_temporal_sample_values() -> None:
+    # 샘플 행에 date/datetime이 있어도 크래시 없이 ISO 문자열로 렌더링된다 (#195).
+    card = build_dataset_card(
+        title="temporal",
+        fields=[("d", "Date", False), ("ts", "Datetime", False)],
+        sample_rows=[{"d": date(2025, 1, 2), "ts": datetime(2025, 1, 2, 12, 30, 0)}],
+    )
+
+    text = render_dataset_card(card)
+
+    assert "2025-01-02" in text
+    assert "2025-01-02T12:30:00" in text

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -191,6 +191,37 @@ def test_run_build_preserves_partial_artifacts_when_later_stage_fails(
     assert str(tmp_path / "run1" / "gold" / "datago.apt_trade" / "table.parquet") not in outputs
 
 
+def test_run_build_fails_source_when_silver_validation_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # 검증 실패한 Silver 데이터셋은 Gold로 흘러가지 않고 소스가 실패 처리되어야 한다 (#189).
+    import dataclasses
+
+    from kpubdata_builder.stages.silver import build_silver_dataset as real_build
+    from kpubdata_builder.stages.silver.models import ValidationResult
+
+    def _invalid_silver(*args: object, **kwargs: object) -> object:
+        dataset = real_build(*args, **kwargs)  # type: ignore[arg-type]
+        return dataclasses.replace(
+            dataset,
+            validation=ValidationResult(ok=False, problems=("synthetic validation failure",)),
+        )
+
+    monkeypatch.setattr(orchestrator, "build_silver_dataset", _invalid_silver)
+
+    spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
+    client = _FakeClient({"datago.apt_trade": [{"id": "1"}]})
+
+    result = run_build(spec, client=client, output_root=tmp_path, run_id="run1")
+
+    assert result.status == "failed"
+    outcome = result.outcomes[0]
+    assert outcome.status == "failed"
+    assert "synthetic validation failure" in (outcome.error or "")
+    # Gold 단계까지 가지 않는다.
+    assert "gold" not in outcome.stages_completed
+    assert not (tmp_path / "run1" / "gold" / "datago.apt_trade").exists()
+
 
 def test_run_build_writes_schema_summaries_to_manifest(tmp_path: Path) -> None:
     # 성공한 빌드의 manifest.json에 소스별 schema summary가 기록되는지 검증한다 (#11).

--- a/tests/unit/test_preview.py
+++ b/tests/unit/test_preview.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import builtins
 from collections.abc import Iterable
+from pathlib import Path
 
 import pytest
 
+from kpubdata_builder.errors import ValidationError
 from kpubdata_builder.pipeline import PreviewResult, preview_build
 from kpubdata_builder.spec import BuildSpec, ExportTarget, JsonValue, SourceRef
 from kpubdata_builder.tabular import PreviewSlice, SchemaInfo
@@ -66,14 +69,47 @@ def test_preview_build_returns_schema_and_sample() -> None:
     assert len(preview.preview.rows) == 3
 
 
-def test_preview_build_writes_no_files(tmp_path) -> None:  # type: ignore[no-untyped-def]
+def test_preview_build_writes_no_files(monkeypatch: pytest.MonkeyPatch) -> None:
+    # 이전 테스트는 preview_build에 전달되지도 않는 temp 디렉터리가 비었음을 확인해
+    # 사실상 항상 통과했다(#196). 실제 파일시스템 쓰기 경로를 가로채 preview_build가
+    # 어떤 쓰기도 하지 않음을 보장한다.
     spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
     client = _FakeClient({"datago.apt_trade": [{"id": "1"}]})
 
-    # preview_build은 output_root를 받지 않으므로 어떤 파일도 만들지 않는다.
-    preview_build(spec, client=client, limit=5)
+    real_open = builtins.open
 
-    assert list(tmp_path.iterdir()) == []
+    def _guard_open(file, mode="r", *args, **kwargs):  # type: ignore[no-untyped-def]
+        if any(flag in mode for flag in ("w", "a", "x", "+")):
+            raise AssertionError(f"unexpected file write during preview: {file!r} (mode={mode})")
+        return real_open(file, mode, *args, **kwargs)
+
+    def _boom(self: Path, *args: object, **kwargs: object) -> object:
+        raise AssertionError(f"unexpected filesystem write during preview: {self!r}")
+
+    monkeypatch.setattr(builtins, "open", _guard_open)
+    monkeypatch.setattr(Path, "write_text", _boom)
+    monkeypatch.setattr(Path, "write_bytes", _boom)
+    monkeypatch.setattr(Path, "mkdir", _boom)
+
+    # 쓰기 경로가 호출되면 AssertionError로 실패한다.
+    result = preview_build(spec, client=client, limit=5)
+
+    assert isinstance(result, PreviewResult)
+
+
+def test_preview_build_validates_spec(monkeypatch: pytest.MonkeyPatch) -> None:
+    # 유효하지 않은 spec은 부분 실행/빈 결과 대신 빠르게 실패해야 한다 (#193).
+    spec = BuildSpec(
+        dataset_id="apt_trade",
+        title="Apartment Trades",
+        description="seoul apartment trades",
+        sources=(SourceRef(provider="datago", dataset="apt_trade"),),
+        exports=(ExportTarget(kind="unsupported_kind", output_path="data.x"),),
+    )
+    client = _FakeClient({"datago.apt_trade": [{"id": "1"}]})
+
+    with pytest.raises(ValidationError):
+        preview_build(spec, client=client, limit=5)
 
 
 def test_preview_build_records_failure_for_missing_source() -> None:

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -169,6 +169,20 @@ class TestDispatch:
         )
         assert resp.status_code == 400
 
+    def test_build_rejects_non_string_run_id(self, tmp_path: Path) -> None:
+        # run_id가 문자열이 아니면 조용히 자동 생성 id로 떨어뜨리지 않고 400 (#185).
+        resp = dispatch(
+            _service(tmp_path), "POST", "/build", {"spec": VALID_SPEC_YAML, "run_id": 123}
+        )
+        assert resp.status_code == 400
+        assert "run_id" in str(resp.body.get("error", ""))
+
+    def test_build_rejects_blank_run_id(self, tmp_path: Path) -> None:
+        resp = dispatch(
+            _service(tmp_path), "POST", "/build", {"spec": VALID_SPEC_YAML, "run_id": "   "}
+        )
+        assert resp.status_code == 400
+
 
 class TestBuildFailureResponseCode:
     def test_failed_build_returns_502(self, tmp_path: Path) -> None:
@@ -223,6 +237,75 @@ class TestHttpAdapter:
         with pytest.raises(urllib.error.HTTPError) as exc_info:
             urllib.request.urlopen(f"{base_url}/nope", timeout=2.0)
         assert exc_info.value.code == 404
+
+    def test_non_object_json_body_returns_400(
+        self, http_server: tuple[str, HTTPServer, threading.Thread]
+    ) -> None:
+        # 유효하지만 객체가 아닌 JSON(스칼라)은 TypeError로 중단되지 않고 400 (#183).
+        base_url, _, _ = http_server
+        req = urllib.request.Request(
+            f"{base_url}/validate",
+            data=b"1",
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            urllib.request.urlopen(req, timeout=2.0)
+        assert exc_info.value.code == 400
+        body = cast(dict[str, object], json.loads(exc_info.value.read()))
+        assert "object" in str(body.get("error", ""))
+
+    def test_query_string_is_ignored_in_routing(
+        self, http_server: tuple[str, HTTPServer, threading.Thread]
+    ) -> None:
+        # 쿼리 스트링이 붙어도 경로 컴포넌트로만 라우팅된다 (#184).
+        base_url, _, _ = http_server
+        req = urllib.request.Request(
+            f"{base_url}/validate?x=1",
+            data=json.dumps({"spec": VALID_SPEC_YAML}).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=2.0) as response:
+            assert response.status == 200
+
+    def test_query_string_does_not_corrupt_run_id(
+        self, http_server: tuple[str, HTTPServer, threading.Thread]
+    ) -> None:
+        # /artifacts/<run_id>?download=1 의 쿼리가 run_id로 새지 않아야 한다 (#184).
+        base_url, _, _ = http_server
+        build_req = urllib.request.Request(
+            f"{base_url}/build",
+            data=json.dumps({"spec": VALID_SPEC_YAML, "run_id": "run1"}).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(build_req, timeout=2.0) as response:
+            assert response.status == 200
+        with urllib.request.urlopen(f"{base_url}/artifacts/run1?download=1", timeout=2.0) as resp:
+            assert resp.status == 200
+            body = cast(dict[str, object], json.loads(resp.read()))
+        assert body["run_id"] == "run1"
+
+    def test_oversized_body_returns_413(
+        self, http_server: tuple[str, HTTPServer, threading.Thread]
+    ) -> None:
+        # 선언된 Content-Length가 상한을 넘으면 body를 읽지 않고 413으로 거부 (#186).
+        import http.client
+
+        base_url, _, _ = http_server
+        host_port = base_url.removeprefix("http://")
+        host, port = host_port.split(":")
+        conn = http.client.HTTPConnection(host, int(port), timeout=2.0)
+        try:
+            conn.putrequest("POST", "/validate")
+            conn.putheader("Content-Type", "application/json")
+            conn.putheader("Content-Length", str(100 * 1024 * 1024))
+            conn.endheaders()  # body는 보내지 않는다 — 핸들러가 헤더만 보고 거부.
+            response = conn.getresponse()
+            assert response.status == 413
+        finally:
+            conn.close()
 
     def test_valid_post_validate_round_trips(
         self, http_server: tuple[str, HTTPServer, threading.Thread]

--- a/tests/unit/test_silver.py
+++ b/tests/unit/test_silver.py
@@ -92,6 +92,22 @@ class TestBuildSilverDataset:
 
         assert dataset.table.schema["amount"] == pl.Int64
 
+    def test_cast_data_loss_raises_instead_of_silently_nulling(self) -> None:
+        # 선언된 캐스팅이 값을 null로 떨어뜨리면 조용히 묻지 않고 TabularError로 실패 (#188).
+        from kpubdata_builder.errors import TabularError
+
+        bronze = _bronze(({"id": "1", "amount": "1000"}, {"id": "2", "amount": "oops"}))
+
+        with pytest.raises(TabularError, match="data loss"):
+            _ = build_silver_dataset(bronze, casts={"amount": "int"})
+
+    def test_rejects_negative_preview_limit(self) -> None:
+        # 음수 preview_limit은 df.head(-1)로 새지 않도록 일찍 거부한다 (#190).
+        bronze = _bronze(({"id": "1"},))
+
+        with pytest.raises(ValueError, match="preview_limit"):
+            _ = build_silver_dataset(bronze, preview_limit=-1)
+
 
 class TestPersistSilverDataset:
     def test_writes_parquet_and_json_sidecars(self, tmp_path: Path) -> None:

--- a/tests/unit/test_snapshot.py
+++ b/tests/unit/test_snapshot.py
@@ -55,6 +55,32 @@ def test_load_missing_snapshot_returns_none(tmp_path: Path) -> None:
     assert load_snapshot("never_built", root=tmp_path) is None
 
 
+def test_load_corrupt_snapshot_returns_none(tmp_path: Path) -> None:
+    # 잘린/비정상 JSON은 증분 빌드를 깨뜨리지 않고 "없음"으로 안전 저하 (#194).
+    path = tmp_path / ".kpubdata-builder/snapshots/seoul_apt_trade/snapshot.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _ = path.write_text('{"dataset_id": "seoul_apt_trade", trunc', encoding="utf-8")
+
+    assert load_snapshot("seoul_apt_trade", root=tmp_path) is None
+
+
+def test_load_snapshot_missing_required_keys_returns_none(tmp_path: Path) -> None:
+    # 형태가 어긋난(필수 키 누락) 스냅샷도 KeyError 대신 None으로 저하 (#194).
+    path = tmp_path / ".kpubdata-builder/snapshots/seoul_apt_trade/snapshot.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _ = path.write_text('{"dataset_id": "seoul_apt_trade"}', encoding="utf-8")
+
+    assert load_snapshot("seoul_apt_trade", root=tmp_path) is None
+
+
+def test_load_snapshot_non_object_returns_none(tmp_path: Path) -> None:
+    path = tmp_path / ".kpubdata-builder/snapshots/seoul_apt_trade/snapshot.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _ = path.write_text("[1, 2, 3]", encoding="utf-8")
+
+    assert load_snapshot("seoul_apt_trade", root=tmp_path) is None
+
+
 def test_save_rejects_unsafe_dataset_id(tmp_path: Path) -> None:
     snapshot = BuildSnapshot(dataset_id="../escape", built_at="t", data_checksum="sha256:x")
 

--- a/tests/unit/test_tabular_helpers.py
+++ b/tests/unit/test_tabular_helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import polars as pl
 import pytest
 
+from kpubdata_builder.errors import TabularError
 from kpubdata_builder.spec import JsonValue
 from kpubdata_builder.tabular import (
     CastReport,
@@ -13,6 +14,23 @@ from kpubdata_builder.tabular import (
     validate_required_columns,
 )
 from kpubdata_builder.tabular.convert import records_to_dataframe
+
+
+def test_records_to_dataframe_rejects_heterogeneous_column() -> None:
+    # 한 컬럼에 문자열+숫자가 섞이면 조용히 강제 변환하지 않고 명확히 실패한다 (#187).
+    records: list[dict[str, JsonValue]] = [{"v": 1}, {"v": "two"}]
+
+    with pytest.raises(TabularError, match="heterogeneous column types"):
+        _ = records_to_dataframe(records)
+
+
+def test_records_to_dataframe_allows_numeric_mix_and_nulls() -> None:
+    # int/float 혼합과 null은 호환으로 보고 통과시킨다(거짓 양성 방지) (#187).
+    records: list[dict[str, JsonValue]] = [{"v": 1}, {"v": 2.5}, {"v": None}]
+
+    df = records_to_dataframe(records)
+
+    assert df.height == 3
 
 
 def test_records_to_dataframe_converts_raw_records_without_mutating_input() -> None:

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from kpubdata_builder import ValidationError
-from kpubdata_builder.spec import BuildSpec, ExportTarget, SourceRef
+from kpubdata_builder.spec import BuildSpec, ExportTarget, SourceRef, SplitSpec
 from kpubdata_builder.spec.validator import validate_spec
 
 
@@ -139,3 +139,53 @@ def test_validate_spec_rejects_empty_metadata_key() -> None:
         validate_spec(spec)
 
     assert any("metadata keys" in p for p in exc_info.value.problems)
+
+
+def test_validate_spec_rejects_empty_source_provider_and_dataset() -> None:
+    # 빈 provider/dataset은 검증을 통과해 fetch 단계에서 뒤늦게 실패하므로 거부 (#191).
+    spec = BuildSpec(
+        dataset_id="dataset.sample",
+        title="Sample Dataset",
+        description="Sample description",
+        sources=(SourceRef(provider="  ", dataset=""),),
+        exports=_EXP,
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        validate_spec(spec)
+
+    problems = exc_info.value.problems
+    assert any("sources[0].provider" in p for p in problems)
+    assert any("sources[0].dataset" in p for p in problems)
+
+
+def test_validate_spec_rejects_blank_source_alias() -> None:
+    spec = BuildSpec(
+        dataset_id="dataset.sample",
+        title="Sample Dataset",
+        description="Sample description",
+        sources=(SourceRef(provider="datago", dataset="air_quality", alias="   "),),
+        exports=_EXP,
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        validate_spec(spec)
+
+    assert any("sources[0].alias" in p for p in exc_info.value.problems)
+
+
+def test_validate_spec_rejects_nan_split_ratio() -> None:
+    # NaN 비율은 양수/합계 검사를 조용히 통과하므로 유한성 검사로 막는다 (#192).
+    spec = BuildSpec(
+        dataset_id="dataset.sample",
+        title="Sample Dataset",
+        description="Sample description",
+        sources=_SRC,
+        exports=_EXP,
+        splits=SplitSpec(mode="ratio", ratios={"train": float("nan"), "test": 0.5}),
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        validate_spec(spec)
+
+    assert any("finite" in p for p in exc_info.value.problems)


### PR DESCRIPTION
## Summary

Resolves all 14 remaining open issues spanning the HTTP service layer, the tabular/Silver pipeline, spec validation, snapshots, and dataset cards. Every fix ships with a regression test.

### Service (HTTP)
| Issue | Fix |
|-------|-----|
| #183 | Reject non-object JSON bodies with **400** instead of crashing with `TypeError`. |
| #184 | Route on the URL **path component only** (`urlsplit`) — query strings no longer 404 or corrupt `run_id`. |
| #185 | Reject non-string / blank `run_id` with **400** instead of silently using a generated id. |
| #186 | Enforce a max request-body size (10 MiB) → **413**, read after the size check. |

### Tabular / Silver correctness
| Issue | Fix |
|-------|-----|
| #187 | `records_to_dataframe` detects heterogeneous (mixed-type) columns and fails fast with `TabularError` instead of letting Polars silently coerce. Numeric (int/float) mixes and nulls remain allowed. |
| #188 | `normalize_table` audits declared casts and raises `TabularError` when a cast drops values to null, instead of silently corrupting data. |
| #189 | The orchestrator fails the source when Silver `validation.ok` is false, so invalid datasets no longer flow forward to Gold/packaging. |
| #190 | Guard negative preview limits in `build_silver_dataset` / `generate_preview`. |

### Spec validation
| Issue | Fix |
|-------|-----|
| #191 | Validate per-source `provider`/`dataset` (non-empty) and `alias` (non-blank). |
| #192 | Reject non-finite (NaN/inf) split ratios via `math.isfinite` before the positivity/sum checks. |
| #193 | `preview_build` now validates the spec, matching the service layer (fail fast instead of empty/partial results). |

### Other
| Issue | Fix |
|-------|-----|
| #194 | `load_snapshot` degrades safely (returns `None`) on corrupt/malformed snapshots instead of raising. |
| #195 | Dataset-card `_cell` serializes `date`/`datetime` via `isoformat()`, mirroring Silver, so README rendering no longer crashes on temporal sample values. |
| #196 | Rewrite the tautological preview "writes no files" test to actually intercept filesystem writes during `preview_build`. |

New error types: `TabularError`, `DatasetValidationError`.

## Testing
- `ruff check` ✅ · `ruff format --check` ✅
- `mypy src` ✅ (no issues, 69 files)
- `pytest` ✅ **356 passed** (+19 new tests)

Closes #183
Closes #184
Closes #185
Closes #186
Closes #187
Closes #188
Closes #189
Closes #190
Closes #191
Closes #192
Closes #193
Closes #194
Closes #195
Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)