### PR TITLE
fix: remove deleted kr-building-name-normalizer from publish extra

### DIFF
--- a/docs/examples/seoul-apt-trade.md
+++ b/docs/examples/seoul-apt-trade.md
@@ -34,7 +34,7 @@ uv sync --extra dev --extra publish --extra docs
 pip install "kpubdata-builder[publish]"
 ```
 
-`publish` extra에는 `polars`, `huggingface-hub`, `xmltodict`, `kaggle`, `kr-building-name-normalizer`가 포함됩니다. 이 예제의 로컬 파일 생성에는 Polars와 Parquet 작성 의존성이 필요하고, 실제 Hugging Face 업로드를 할 때만 Hugging Face 인증이 필요합니다.
+`publish` extra에는 `huggingface-hub`, `xmltodict`, `kaggle`이 포함됩니다. 이 예제의 로컬 파일 생성에는 Polars와 Parquet 작성 의존성이 필요하고, 실제 Hugging Face 업로드를 할 때만 Hugging Face 인증이 필요합니다. 한국어 건물명 로마자 변환이 필요하면 `kr-building-name-normalizer`를 별도로 설치하세요.
 
 ## 사전 준비
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ docs = [
 ]
 parquet = ["pyarrow>=15,<18"]
 huggingface = ["huggingface-hub>=0.23,<1"]
-publish = ["huggingface-hub>=0.23,<1", "xmltodict>=0.13,<1", "kaggle>=1.6,<2", "kr-building-name-normalizer>=0.2.0,<1"]
+publish = ["huggingface-hub>=0.23,<1", "xmltodict>=0.13,<1", "kaggle>=1.6,<2"]
 dev = [
   "build>=1.2,<2",
   "mypy>=1.10,<2",

--- a/scripts/pipeline/transform.py
+++ b/scripts/pipeline/transform.py
@@ -201,7 +201,14 @@ def build_variant_dataframes(df: pl.DataFrame, config: dict[str, Any]) -> dict[s
 
         romanize_cols = opts.get("romanize_columns", [])
         if romanize_cols:
-            from kr_building_normalizer import romanize
+            try:
+                from kr_building_normalizer import romanize
+            except ImportError:
+                logger.warning(
+                    "kr-building-name-normalizer 미설치 — romanize_columns 건너뜀. "
+                    "pip install kr-building-name-normalizer 로 설치하세요."
+                )
+                romanize_cols = []
 
             for col in romanize_cols:
                 if col in variant_df.columns:

--- a/uv.lock
+++ b/uv.lock
@@ -573,12 +573,14 @@ requires-dist = [
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.2,<2" },
     { name = "httpx", specifier = ">=0.27,<1" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1,<2" },
+    { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5,<10" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10,<2" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.2,<3" },
     { name = "pandas-stubs", marker = "extra == 'dev'", specifier = ">=2.2,<3" },
     { name = "pydantic", marker = "extra == 'validation'", specifier = ">=2.7,<3" },
     { name = "pykrx", marker = "extra == 'dev'", specifier = ">=1.0.45,<2" },
     { name = "pykrx", marker = "extra == 'krx'", specifier = ">=1.0.45,<2" },
+    { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10,<11" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2,<9" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5,<6" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5,<1" },
@@ -586,11 +588,11 @@ requires-dist = [
     { name = "xmltodict", marker = "extra == 'dev'", specifier = ">=0.13,<1" },
     { name = "xmltodict", marker = "extra == 'xml'", specifier = ">=0.13,<1" },
 ]
-provides-extras = ["xml", "pandas", "krx", "validation", "mcp", "dev"]
+provides-extras = ["xml", "pandas", "krx", "validation", "mcp", "dev", "docs"]
 
 [[package]]
 name = "kpubdata-builder"
-version = "0.1.0a0"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "kpubdata" },
@@ -621,7 +623,6 @@ publish = [
     { name = "huggingface-hub" },
     { name = "kaggle", version = "1.7.4.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "kaggle", version = "1.8.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "kr-building-name-normalizer" },
     { name = "xmltodict" },
 ]
 
@@ -632,7 +633,6 @@ requires-dist = [
     { name = "huggingface-hub", marker = "extra == 'publish'", specifier = ">=0.23,<1" },
     { name = "kaggle", marker = "extra == 'publish'", specifier = ">=1.6,<2" },
     { name = "kpubdata", editable = "../kpubdata" },
-    { name = "kr-building-name-normalizer", marker = "extra == 'publish'", specifier = ">=0.2.0,<1" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6,<2" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9,<10" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10,<2" },
@@ -646,15 +646,6 @@ requires-dist = [
     { name = "xmltodict", marker = "extra == 'publish'", specifier = ">=0.13,<1" },
 ]
 provides-extras = ["docs", "parquet", "huggingface", "publish", "dev"]
-
-[[package]]
-name = "kr-building-name-normalizer"
-version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/07/0cfa4961e9c8e40d8b49cd1cf58119d97202736aff5875d91f5ae9cafc26/kr_building_name_normalizer-0.2.0.tar.gz", hash = "sha256:43ec9f93ed7d452823d4093c7446189656c7ac3e369510bf01ab3b065c626f10", size = 44364, upload-time = "2026-04-27T23:27:56.535Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/bc/0ae96e1ef074092e0e2b5b2752b7953b033cbef58315f722958649687eef/kr_building_name_normalizer-0.2.0-py3-none-any.whl", hash = "sha256:895d160eca4654174ec7dc957bfa1340a48f3835a945c551e925ce134678c13a", size = 15101, upload-time = "2026-04-27T23:27:55.36Z" },
-]
 
 [[package]]
 name = "librt"


### PR DESCRIPTION
## Summary

- `kr-building-name-normalizer` 패키지가 PyPI에서 삭제되어 모든 Scheduled CI 워크플로(Air Quality, Weather 등)가 `Install dependencies` 단계에서 실패하고 있었습니다.
- `publish` extra에서 해당 의존성을 제거하고, 사용처(`scripts/pipeline/transform.py`)에 `ImportError` 가드를 추가하여 패키지 미설치 시 경고와 함께 건너뛰도록 변경했습니다.

## Changes

- `pyproject.toml`: `publish` extra에서 `kr-building-name-normalizer>=0.2.0,<1` 제거
- `scripts/pipeline/transform.py`: `from kr_building_normalizer import romanize`에 `try/except ImportError` 가드 추가
- `uv.lock`: 의존성 재생성 (`kr-building-name-normalizer` 제거 반영)
- `docs/examples/seoul-apt-trade.md`: publish extra 설명 업데이트