### PR TITLE
fix: 부동소수점 정밀도 보존 및 비유한(non-finite) JSON 거부 (#216, #217)

### DIFF
--- a/src/kpubdata_builder/exporters/huggingface.py
+++ b/src/kpubdata_builder/exporters/huggingface.py
@@ -52,8 +52,11 @@ def _write_data_file(artifact: ArtifactDataset, data_dir: Path, fmt: str) -> Pat
     if fmt == "parquet":
         records_to_dataframe(list(artifact.records)).write_parquet(data_path)
     else:
+        # allow_nan=False: NaN/Infinity는 비표준 JSON 토큰이 되므로 조용히 기록하지 않고
+        # ValueError로 실패시킨다 (#217).
         content = "\n".join(
-            json.dumps(record, ensure_ascii=False, sort_keys=True) for record in artifact.records
+            json.dumps(record, ensure_ascii=False, sort_keys=True, allow_nan=False)
+            for record in artifact.records
         )
         _ = data_path.write_text(f"{content}\n" if content else "", encoding="utf-8")
     return data_path
@@ -139,7 +142,13 @@ class HuggingFaceExporter(BaseExporter):
             _ = readme_path.write_text(_render_card(artifact), encoding="utf-8")
             infos_path = tmp_dir / "dataset_infos.json"
             _ = infos_path.write_text(
-                json.dumps(_dataset_infos(artifact), ensure_ascii=False, indent=2, sort_keys=True)
+                json.dumps(
+                    _dataset_infos(artifact),
+                    ensure_ascii=False,
+                    indent=2,
+                    sort_keys=True,
+                    allow_nan=False,
+                )
                 + "\n",
                 encoding="utf-8",
             )

--- a/src/kpubdata_builder/exporters/jsonl.py
+++ b/src/kpubdata_builder/exporters/jsonl.py
@@ -48,7 +48,9 @@ class JsonlExporter(BaseExporter):
         try:
             with destination.open("w", encoding="utf-8") as f:
                 for record in artifact.records:
-                    f.write(json.dumps(record, ensure_ascii=False, sort_keys=True))
+                    # allow_nan=False: NaN/Infinity는 비표준 JSON 토큰이 되므로 조용히
+                    # 기록하지 않고 ValueError로 실패시킨다 (#217).
+                    f.write(json.dumps(record, ensure_ascii=False, sort_keys=True, allow_nan=False))
                     f.write("\n")
         except OSError as exc:
             raise ExportError(f"Failed to export JSONL artifact to {destination}: {exc}") from exc

--- a/src/kpubdata_builder/stages/gold/persist.py
+++ b/src/kpubdata_builder/stages/gold/persist.py
@@ -95,8 +95,16 @@ def persist_gold_package(
     tmp_dir = Path(tempfile.mkdtemp(dir=gold_dir.parent, prefix=".gold_tmp_"))
     try:
         package.table.write_parquet(tmp_dir / "table.parquet")
+        # allow_nan=False: NaN/Infinity는 비표준 JSON 토큰이 되므로 조용히 기록하지 않고
+        # ValueError로 실패시킨다 (#217).
         (tmp_dir / "package.json").write_text(
-            json.dumps(_package_metadata(package), ensure_ascii=False, indent=2, sort_keys=True)
+            json.dumps(
+                _package_metadata(package),
+                ensure_ascii=False,
+                indent=2,
+                sort_keys=True,
+                allow_nan=False,
+            )
             + "\n",
             encoding="utf-8",
         )

--- a/src/kpubdata_builder/tabular/convert.py
+++ b/src/kpubdata_builder/tabular/convert.py
@@ -152,7 +152,10 @@ def records_to_dataframe(records: Sequence[dict[str, JsonValue]]) -> pl.DataFram
             "Use an explicit cast to keep these columns as strings or integers."
         )
 
-    return pl.DataFrame(list(records))
+    # infer_schema_length=None: 모든 레코드를 스캔해 dtype를 추론한다. 기본 추론 윈도우
+    # (앞쪽 일부 행)만 보면, 윈도우 밖에서 처음 등장하는 float가 Int64로 추론된 컬럼에서
+    # 조용히 정수로 잘려나간다 (#216).
+    return pl.DataFrame(list(records), infer_schema_length=None)
 
 
 def dataframe_to_records(df: pl.DataFrame) -> list[dict[str, JsonValue]]:

--- a/tests/unit/test_gold.py
+++ b/tests/unit/test_gold.py
@@ -75,6 +75,24 @@ class TestPersistGoldPackage:
         assert targets[0]["kind"] == "jsonl"
         assert meta["source_silver"] == "datago.apt_trade"
 
+    def test_rejects_non_finite_float_in_metadata(self, tmp_path: Path) -> None:
+        # export option에 실린 NaN/Infinity는 비표준 JSON 토큰이 되므로 조용히 기록하지
+        # 않고 ValueError로 실패시킨다 (bronze guard와 동일 계약) (#217).
+        package = build_gold_package(
+            _silver(({"id": "1"},)),
+            dataset_name="apt_trade",
+            exports=(
+                ExportTarget(
+                    kind="jsonl",
+                    output_path="data.jsonl",
+                    options={"threshold": float("nan")},
+                ),
+            ),
+        )
+
+        with pytest.raises(ValueError, match="Out of range float values"):
+            _ = persist_gold_package(package, output_root=tmp_path, run_id="run1")
+
     def test_rejects_unsafe_dataset_name(self, tmp_path: Path) -> None:
         package = build_gold_package(_silver(({"id": "1"},)), dataset_name="../escape")
 

--- a/tests/unit/test_huggingface_exporter.py
+++ b/tests/unit/test_huggingface_exporter.py
@@ -118,6 +118,18 @@ def test_reexport_with_format_change_removes_stale_shards(tmp_path: Path) -> Non
     assert shards == ["train-00000-of-00001.jsonl"]
 
 
+def test_jsonl_format_rejects_non_finite_float(tmp_path: Path) -> None:
+    # jsonl shard에 NaN/Infinity가 들어가면 비표준 JSON 토큰이 되므로 ValueError로
+    # 실패시킨다 (bronze guard와 동일 계약) (#217).
+    artifact = ArtifactDataset(records=({"v": float("inf")},))
+    target = ExportTarget(
+        kind="huggingface", output_path="hf/apt_trade", options={"format": "jsonl"}
+    )
+
+    with pytest.raises(ValueError, match="Out of range float values"):
+        HuggingFaceExporter().export(artifact, target, tmp_path)
+
+
 def test_registry_exposes_huggingface_exporter() -> None:
     # HF exporter가 kind "huggingface"로 레지스트리에 등록되어 있는지 확인한다.
     assert isinstance(EXPORTER_REGISTRY["huggingface"], HuggingFaceExporter)

--- a/tests/unit/test_jsonl_exporter.py
+++ b/tests/unit/test_jsonl_exporter.py
@@ -87,6 +87,17 @@ def test_returns_metadata_pointing_to_created_file(tmp_path: Path) -> None:
     assert result.format == "jsonl"
 
 
+def test_non_finite_float_is_rejected(tmp_path: Path) -> None:
+    # NaN/Infinity는 비표준 JSON 토큰(NaN/Infinity)이 되므로 조용히 기록하지 않고
+    # ValueError로 실패시킨다 (bronze guard와 동일 계약) (#217).
+    bad_record = cast(dict[str, JsonValue], {"v": float("nan")})
+    artifact = ArtifactDataset(records=(bad_record,))
+    target = ExportTarget(kind="jsonl", output_path="out/data.jsonl")
+
+    with pytest.raises(ValueError, match="Out of range float values"):
+        JsonlExporter().export(artifact, target, tmp_path)
+
+
 def test_non_serializable_value_surfaces_type_error(tmp_path: Path) -> None:
     # JsonValue 밖의 직렬화 불가 값(예: set)은 json.dumps에서 TypeError로 표면화된다.
     # write 실패의 OSError와 달리 ExportError로 감싸지 않는 경계를 명시적으로 고정한다.

--- a/tests/unit/test_tabular_helpers.py
+++ b/tests/unit/test_tabular_helpers.py
@@ -33,6 +33,17 @@ def test_records_to_dataframe_allows_numeric_mix_and_nulls() -> None:
     assert df.height == 3
 
 
+def test_records_to_dataframe_infers_float_beyond_default_window() -> None:
+    # 기본 추론 윈도우(앞쪽 행)를 넘어 처음 등장하는 float가 Int64로 잘려나가지 않고
+    # 전체 레코드를 스캔해 Float64로 추론되어 2.5가 보존되어야 한다 (#216).
+    records: list[dict[str, JsonValue]] = [{"b": 1}] * 150 + [{"b": 2.5}]
+
+    df = records_to_dataframe(records)
+
+    assert df.schema["b"] == pl.Float64
+    assert df["b"].to_list()[-1] == 2.5
+
+
 def test_records_to_dataframe_rejects_large_int_mixed_with_float() -> None:
     # 2^53을 넘는 정수가 float와 같은 컬럼에 있으면 f64 업캐스트로 반올림되므로 거부 (#198).
     records: list[dict[str, JsonValue]] = [{"v": 9007199254740993}, {"v": 2.5}]


### PR DESCRIPTION
Closes #216
Closes #217

## #216 — 스키마 추론 윈도우 이후 부동소수점 정밀도 손실 (HIGH)
\`records_to_dataframe\`는 Polars의 기본 \`infer_schema_length\` 윈도우(앞부분 행만)에 의존하고 있었습니다. 정수 컬럼으로 보이는 데이터에서 float 값이 해당 윈도우 *이후*에 처음 등장할 경우(예: \`[{"b": 1}] * 150 + [{"b": 2.5}]\`), 컬럼이 \`Int64\`로 추론되어 \`2.5\`가 \`2\`로 조용히 잘렸습니다.

수정: 전체 레코드 집합을 dtype 추론 대상으로 스캔하도록 \`infer_schema_length=None\`을 전달합니다. 이제 컬럼이 \`Float64\`로 올바르게 추론되어 \`2.5\`가 보존됩니다.

## #217 — 유효하지 않은 JSON 토큰(\`NaN\`/\`Infinity\`) 출력
JSONL 익스포터, Hugging Face 익스포터(jsonl 샤드 + \`dataset_infos.json\`), gold persist 경로에서 \`json.dumps(...)\`를 \`allow_nan=False\` 없이 호출하고 있었습니다. NaN/Infinity가 포함되면 많은 파서가 거부하는 비표준 JSON 토큰이 출력되었습니다.

수정: 기존 bronze persist 가드와 일관되게, 네 곳의 호출 지점 모두에 \`allow_nan=False\`를 추가합니다. 비유한(non-finite) 부동소수점은 이제 잘못된 JSON을 생성하는 대신 \`ValueError\`를 발생시킵니다.

## 검증
- #216 재현: 기본 추론 시 → \`Int64\`, 마지막 값 \`2\`; 수정 후 → \`Float64\`, 마지막 값 \`2.5\`.
- 회귀 테스트 추가:
  - \`test_records_to_dataframe_infers_float_beyond_default_window\` (#216)
  - \`test_non_finite_float_is_rejected\` (jsonl 익스포터, #217)
  - \`test_jsonl_format_rejects_non_finite_float\` (huggingface 익스포터, #217)
  - \`test_rejects_non_finite_float_in_metadata\` (gold persist, #217)
- \`ruff check .\` → 문제 없음; 변경 파일 \`ruff format --check\` 통과; \`mypy src\` → 문제 없음; \`pytest -q\` → 397개 통과.