### PR TITLE
fix(service): HTTP 서버 JSON 500 핸들러 및 DoS 강화 (#218, #219)

### DIFF
--- a/src/kpubdata_builder/service/http.py
+++ b/src/kpubdata_builder/service/http.py
@@ -51,7 +51,19 @@ def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
             if length > _MAX_BODY_BYTES:
                 self._write(413, {"error": "request body too large"})
                 return
-            raw = self.rfile.read(length) if length else b""
+            # body 읽기: 타임아웃이나 불완전한 읽기는 dropped connection 대신
+            # JSON 400으로 처리한다 (#219).
+            if length:
+                try:
+                    raw = self.rfile.read(length)
+                except TimeoutError:
+                    self._write(400, {"error": "request body read timed out"})
+                    return
+                if len(raw) < length:
+                    self._write(400, {"error": "incomplete request body"})
+                    return
+            else:
+                raw = b""
             body: dict[str, JsonValue] | None = None
             if raw:
                 try:

--- a/src/kpubdata_builder/service/http.py
+++ b/src/kpubdata_builder/service/http.py
@@ -11,7 +11,9 @@
 from __future__ import annotations
 
 import json
-from http.server import BaseHTTPRequestHandler, HTTPServer
+import logging
+import traceback
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import cast
 from urllib.parse import urlsplit
 
@@ -22,11 +24,20 @@ from .app import BuilderService, dispatch
 # 제한한다. spec YAML 요청에 충분하면서도 남용을 막는 보수적 상한 (#186).
 _MAX_BODY_BYTES = 10 * 1024 * 1024  # 10 MiB
 
+# 소켓 읽기 타임아웃(초). 느린 클라이언트/slowloris 공격이 스레드를 무한 점거하지 않도록
+# 한다 (#219). ThreadingHTTPServer를 사용하더라도 각 연결 스레드가 여기서 해제된다.
+_SOCKET_TIMEOUT_SECONDS = 30.0
+
+_logger = logging.getLogger(__name__)
+
 
 def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
     """주어진 BuilderService에 바인딩된 요청 핸들러 클래스를 생성한다."""
 
     class _Handler(BaseHTTPRequestHandler):
+        # BaseHTTPRequestHandler.timeout이 설정되면 소켓에 적용된다 (#219).
+        timeout = _SOCKET_TIMEOUT_SECONDS
+
         def _dispatch(self, method: str) -> None:
             try:
                 length = int(self.headers.get("Content-Length", 0) or 0)
@@ -56,7 +67,19 @@ def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
                 body = cast(dict[str, JsonValue], parsed)
             # 쿼리 스트링이 경로/run_id로 새지 않도록 path 컴포넌트만으로 라우팅한다 (#184).
             path = urlsplit(self.path).path
-            response = dispatch(service, method, path, body)
+            # dispatch()에서 예상치 못한 예외가 발생하면 연결을 끊는 대신 JSON 500을
+            # 반환한다. 상세 정보는 서버 로그에만 기록하고 클라이언트에는 누설하지 않는다 (#218).
+            try:
+                response = dispatch(service, method, path, body)
+            except Exception:
+                _logger.error(
+                    "Unhandled exception in dispatch: %s %s\n%s",
+                    method,
+                    path,
+                    traceback.format_exc(),
+                )
+                self._write(500, {"error": "internal server error"})
+                return
             self._write(response.status_code, response.body)
 
         def _write(self, status_code: int, body: dict[str, JsonValue]) -> None:
@@ -83,12 +106,15 @@ def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
 def serve(service: BuilderService, *, host: str = "127.0.0.1", port: int = 8000) -> None:
     """BuilderService를 블로킹 HTTP 서버로 제공한다.
 
+    단일 스레드 HTTPServer 대신 ThreadingHTTPServer를 사용하여 느린 클라이언트가
+    서버 전체를 멈추지 않도록 한다 (#219).
+
     매개변수:
         service: 노출할 BuilderService.
         host: 바인딩 호스트.
         port: 바인딩 포트.
     """
-    server = HTTPServer((host, port), make_handler(service))
+    server = ThreadingHTTPServer((host, port), make_handler(service))
     try:
         server.serve_forever()
     finally:

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -367,3 +367,95 @@ class TestHttpAdapter:
             assert response.status == 200
             body = cast(dict[str, object], json.loads(response.read()))
         assert body["status"] == "valid"
+
+
+class TestHttpRobustness:
+    """#218 (JSON 500 handler) 과 #219 (DoS hardening) 검증."""
+
+    def test_dispatch_exception_returns_json_500(
+        self, tmp_path: Path, http_server: tuple[str, HTTPServer, threading.Thread]
+    ) -> None:
+        # dispatch()에서 예외가 발생해도 연결이 끊기지 않고 JSON 500이 반환돼야 한다 (#218).
+        # 패치로 dispatch를 교체해 인위적으로 예외를 발생시킨다.
+        import unittest.mock
+
+        base_url, _, _ = http_server
+
+        with unittest.mock.patch(
+            "kpubdata_builder.service.http.dispatch",
+            side_effect=RuntimeError("boom"),
+        ):
+            req = urllib.request.Request(
+                f"{base_url}/validate",
+                data=json.dumps({"spec": VALID_SPEC_YAML}).encode("utf-8"),
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with pytest.raises(urllib.error.HTTPError) as exc_info:
+                urllib.request.urlopen(req, timeout=2.0)
+        assert exc_info.value.code == 500
+        body = cast(dict[str, object], json.loads(exc_info.value.read()))
+        assert body.get("error") == "internal server error"
+        # 내부 예외 메시지("boom")가 클라이언트에 누설되지 않아야 한다.
+        assert "boom" not in json.dumps(body)
+
+    def test_make_handler_has_socket_timeout(self, tmp_path: Path) -> None:
+        # 핸들러 클래스에 timeout이 설정돼 있어야 느린 클라이언트가 스레드를 무한 점거하지
+        # 않는다 (#219). BaseHTTPRequestHandler.timeout 이 None이면 무제한이다.
+        from kpubdata_builder.service.http import _SOCKET_TIMEOUT_SECONDS, make_handler
+
+        handler_cls = make_handler(_service(tmp_path))
+        assert handler_cls.timeout is not None
+        assert handler_cls.timeout == _SOCKET_TIMEOUT_SECONDS
+        assert handler_cls.timeout > 0
+
+    def test_serve_uses_threading_http_server(self, tmp_path: Path) -> None:
+        # serve()가 ThreadingHTTPServer를 사용해야 느린 클라이언트가 서버 전체를
+        # 멈추지 않는다 (#219).
+        import contextlib
+        import unittest.mock
+        from http.server import ThreadingHTTPServer
+
+        from kpubdata_builder.service.http import serve
+
+        created_servers: list[object] = []
+        original_init = ThreadingHTTPServer.__init__
+
+        def capturing_init(self: object, *args: object, **kwargs: object) -> None:
+            created_servers.append(self)
+            original_init(self, *args, **kwargs)  # type: ignore[misc]
+
+        with (
+            unittest.mock.patch.object(ThreadingHTTPServer, "__init__", capturing_init),
+            unittest.mock.patch.object(
+                ThreadingHTTPServer, "serve_forever", side_effect=KeyboardInterrupt
+            ),
+            unittest.mock.patch.object(ThreadingHTTPServer, "server_close"),
+            contextlib.suppress(KeyboardInterrupt),
+        ):
+            serve(_service(tmp_path), host="127.0.0.1", port=0)
+
+        assert len(created_servers) == 1
+        assert isinstance(created_servers[0], ThreadingHTTPServer)
+
+    def test_oversized_body_content_length_returns_413_http(
+        self, http_server: tuple[str, HTTPServer, threading.Thread]
+    ) -> None:
+        # Content-Length가 _MAX_BODY_BYTES를 넘으면 body를 읽지 않고 413으로 거부 (#219).
+        import http.client
+
+        base_url, _, _ = http_server
+        host_port = base_url.removeprefix("http://")
+        host, port = host_port.split(":")
+        conn = http.client.HTTPConnection(host, int(port), timeout=2.0)
+        try:
+            conn.putrequest("POST", "/validate")
+            conn.putheader("Content-Type", "application/json")
+            conn.putheader("Content-Length", str(20 * 1024 * 1024))  # 20 MiB > 10 MiB 상한
+            conn.endheaders()  # body는 보내지 않는다 — 핸들러가 헤더만 보고 거부.
+            response = conn.getresponse()
+            assert response.status == 413
+            resp_body = cast(dict[str, object], json.loads(response.read()))
+            assert "too large" in str(resp_body.get("error", ""))
+        finally:
+            conn.close()

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -459,3 +459,57 @@ class TestHttpRobustness:
             assert "too large" in str(resp_body.get("error", ""))
         finally:
             conn.close()
+
+    def test_body_read_timeout_returns_json_400(self, tmp_path: Path) -> None:
+        # rfile.read()가 TimeoutError를 던지면 연결 끊김이 아닌 JSON 400이어야 한다 (#219).
+        import io
+
+        handler_cls = make_handler(_service(tmp_path))
+
+        captured: list[tuple[int, dict[str, object]]] = []
+
+        class _PatchedHandler(handler_cls):  # type: ignore[valid-type]
+            def _write(self, status_code: int, body: dict[str, object]) -> None:  # type: ignore[override]
+                captured.append((status_code, body))
+
+        slow_rfile = io.BytesIO(b"")
+
+        def _timeout_read(n: int) -> bytes:
+            raise TimeoutError("timed out")
+
+        slow_rfile.read = _timeout_read  # type: ignore[method-assign]
+
+        h = object.__new__(_PatchedHandler)
+        h.rfile = slow_rfile
+        h.headers = {"Content-Length": "10"}  # type: ignore[assignment]
+        h._dispatch("POST")
+
+        assert len(captured) == 1
+        status, body = captured[0]
+        assert status == 400
+        assert "timed out" in str(body.get("error", ""))
+
+    def test_truncated_body_returns_json_400(self, tmp_path: Path) -> None:
+        # Content-Length보다 짧은 body(EOF)는 연결 끊김이 아닌 JSON 400이어야 한다 (#219).
+        import io
+
+        handler_cls = make_handler(_service(tmp_path))
+
+        captured: list[tuple[int, dict[str, object]]] = []
+
+        class _PatchedHandler(handler_cls):  # type: ignore[valid-type]
+            def _write(self, status_code: int, body: dict[str, object]) -> None:  # type: ignore[override]
+                captured.append((status_code, body))
+
+        # Content-Length는 10이지만 실제로는 5바이트만 전달.
+        truncated_rfile = io.BytesIO(b"hello")
+
+        h = object.__new__(_PatchedHandler)
+        h.rfile = truncated_rfile
+        h.headers = {"Content-Length": "10"}  # type: ignore[assignment]
+        h._dispatch("POST")
+
+        assert len(captured) == 1
+        status, body = captured[0]
+        assert status == 400
+        assert "incomplete" in str(body.get("error", ""))


### PR DESCRIPTION
## 요약

- **Closes #218**: \`_Handler._dispatch\` 내부의 \`dispatch()\` 호출을 \`try/except Exception\`으로 감쌉니다. 예기치 않은 예외가 발생할 경우 트레이스백과 함께 연결이 끊기는 대신, HTTP 500과 함께 구조화된 JSON \`{"error": "internal server error"}\`를 반환합니다. 오류 세부 정보는 \`logging.error\`를 통해 서버 측에 기록(메서드, 경로, 전체 트레이스백 포함)되며 클라이언트에는 노출되지 않습니다.
- **Closes #219**: \`serve()\`를 \`HTTPServer\`에서 \`ThreadingHTTPServer\`(표준 라이브러리, 새 의존성 없음)로 전환하여 느리거나 지연된 클라이언트 연결이 전체 서버를 차단하지 않도록 합니다. 핸들러에 클래스 수준 \`timeout\` 속성인 \`_SOCKET_TIMEOUT_SECONDS = 30.0\`을 추가합니다. \`BaseHTTPRequestHandler\`가 이를 각 연결 소켓에 적용하여 30초 후 유휴/슬로우로리스 클라이언트로부터 스레드를 해제합니다. \`Content-Length\` 초과 요청에 대한 413 거부(#186)는 이미 구현되어 있으며 DoS 강화 커버리지의 일환으로 재검증됩니다.

## 검증 방법

- 변경 파일에 대해 \`ruff check\` 및 \`ruff format --check\` 통과.
- \`mypy src\` — 70개 소스 파일 문제 없음.
- \`pytest -q\` — **397개 통과** (실패 없음).
- \`TestHttpRobustness\` 테스트 4개 추가:
  - \`test_dispatch_exception_returns_json_500\` — \`dispatch\`에서 예외 발생 시 HTTP 500 JSON 바디 반환 및 내부 메시지 미노출 검증.
  - \`test_make_handler_has_socket_timeout\` — \`handler_cls.timeout == _SOCKET_TIMEOUT_SECONDS > 0\` 검증.
  - \`test_serve_uses_threading_http_server\` — \`ThreadingHTTPServer.__init__\`을 패치하여 \`serve()\`가 해당 클래스를 인스턴스화함을 확인.
  - \`test_oversized_body_content_length_returns_413_http\` — 원시 \`HTTPConnection\`을 통한 종단 간 413 검증 (DoS 강화 스모크 테스트).