### PR TITLE
fix(security): CSV 수식 삽입(formula-injection) 이스케이프 및 CI 강화 (#221, #223)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,14 +21,14 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
       - run: pip install mkdocs-material
       - run: mkdocs build
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
         with:
           path: site
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4

--- a/.github/workflows/publish-dataset.yml
+++ b/.github/workflows/publish-dataset.yml
@@ -39,15 +39,18 @@ on:
         type: string
         default: "--local-only"
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
 
       - name: Install dependencies
         run: uv sync --extra dev --extra publish --no-sources

--- a/.github/workflows/scheduled-air-quality.yml
+++ b/.github/workflows/scheduled-air-quality.yml
@@ -12,4 +12,6 @@ jobs:
     with:
       mode: ""
       config: scripts/configs/air_quality.yaml
-    secrets: inherit
+    secrets:
+      KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/.github/workflows/scheduled-dur.yml
+++ b/.github/workflows/scheduled-dur.yml
@@ -12,60 +12,78 @@ jobs:
     with:
       mode: ""
       config: scripts/configs/dur_usjnt_taboo.yaml
-    secrets: inherit
+    secrets:
+      KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   dur-pregnancy-taboo:
     uses: ./.github/workflows/publish-dataset.yml
     with:
       mode: ""
       config: scripts/configs/dur_pregnancy_taboo.yaml
-    secrets: inherit
+    secrets:
+      KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   dur-age-taboo:
     uses: ./.github/workflows/publish-dataset.yml
     with:
       mode: ""
       config: scripts/configs/dur_age_taboo.yaml
-    secrets: inherit
+    secrets:
+      KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   dur-older-adult-caution:
     uses: ./.github/workflows/publish-dataset.yml
     with:
       mode: ""
       config: scripts/configs/dur_older_adult_caution.yaml
-    secrets: inherit
+    secrets:
+      KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   dur-dosage-caution:
     uses: ./.github/workflows/publish-dataset.yml
     with:
       mode: ""
       config: scripts/configs/dur_dosage_caution.yaml
-    secrets: inherit
+    secrets:
+      KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   dur-medication-period-caution:
     uses: ./.github/workflows/publish-dataset.yml
     with:
       mode: ""
       config: scripts/configs/dur_medication_period_caution.yaml
-    secrets: inherit
+    secrets:
+      KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   dur-efficacy-duplication:
     uses: ./.github/workflows/publish-dataset.yml
     with:
       mode: ""
       config: scripts/configs/dur_efficacy_duplication.yaml
-    secrets: inherit
+    secrets:
+      KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   dur-product-info:
     uses: ./.github/workflows/publish-dataset.yml
     with:
       mode: ""
       config: scripts/configs/dur_product_info.yaml
-    secrets: inherit
+    secrets:
+      KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   dur-er-tablet-split-caution:
     uses: ./.github/workflows/publish-dataset.yml
     with:
       mode: ""
       config: scripts/configs/dur_er_tablet_split_caution.yaml
-    secrets: inherit
+    secrets:
+      KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/.github/workflows/scheduled-real-estate.yml
+++ b/.github/workflows/scheduled-real-estate.yml
@@ -12,11 +12,15 @@ jobs:
     with:
       mode: ""
       config: scripts/configs/seoul_apartment_trades.yaml
-    secrets: inherit
+    secrets:
+      KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   apt-rent:
     uses: ./.github/workflows/publish-dataset.yml
     with:
       mode: ""
       config: scripts/configs/seoul_apartment_rent.yaml
-    secrets: inherit
+    secrets:
+      KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/.github/workflows/scheduled-tourism.yml
+++ b/.github/workflows/scheduled-tourism.yml
@@ -12,25 +12,33 @@ jobs:
     with:
       mode: ""
       config: scripts/configs/tour_kor_area.yaml
-    secrets: inherit
+    secrets:
+      KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   tour-location:
     uses: ./.github/workflows/publish-dataset.yml
     with:
       mode: ""
       config: scripts/configs/tour_kor_location.yaml
-    secrets: inherit
+    secrets:
+      KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   tour-keyword:
     uses: ./.github/workflows/publish-dataset.yml
     with:
       mode: ""
       config: scripts/configs/tour_kor_keyword.yaml
-    secrets: inherit
+    secrets:
+      KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   tour-festival:
     uses: ./.github/workflows/publish-dataset.yml
     with:
       mode: ""
       config: scripts/configs/tour_kor_festival.yaml
-    secrets: inherit
+    secrets:
+      KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/.github/workflows/scheduled-weather.yml
+++ b/.github/workflows/scheduled-weather.yml
@@ -12,11 +12,15 @@ jobs:
     with:
       mode: ""
       config: scripts/configs/weather_village_fcst.yaml
-    secrets: inherit
+    secrets:
+      KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   ultra-short-term:
     uses: ./.github/workflows/publish-dataset.yml
     with:
       mode: ""
       config: scripts/configs/weather_ultra_srt_ncst.yaml
-    secrets: inherit
+    secrets:
+      KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/src/kpubdata_builder/exporters/csv.py
+++ b/src/kpubdata_builder/exporters/csv.py
@@ -35,18 +35,32 @@ def _resolve_columns(artifact: ArtifactDataset) -> list[str]:
     return list(columns.keys())
 
 
+_FORMULA_TRIGGER_CHARS = frozenset("=+-@\t\r")
+"""스프레드시트가 수식으로 해석하는 선두 문자 집합 (CWE-1236)."""
+
+
 def _format_cell(value: JsonValue) -> str:
     """단일 셀 값을 CSV 문자열로 변환한다.
 
     None은 빈 문자열, bool은 소문자 JSON 표기, 중첩 list/dict는 결정적 JSON
     문자열로 직렬화한다. 그 외 스칼라는 str()로 변환한다.
+
+    문자열이 스프레드시트 수식 트리거 문자(``=``, ``+``, ``-``, ``@``,
+    탭, 캐리지 리턴)로 시작하면 앞에 홑따옴표 ``'``를 붙여 수식 실행을
+    막는다(CSV 인젝션 대응, CWE-1236).  숫자·bool·None 등 비문자열 값은
+    변경하지 않는다.
     """
     if value is None:
         return ""
     if isinstance(value, bool):
         return "true" if value else "false"
-    if isinstance(value, (str, int, float)):
+    if isinstance(value, (int, float)):
         return str(value)
+    if isinstance(value, str):
+        text = value
+        if text and text[0] in _FORMULA_TRIGGER_CHARS:
+            text = "'" + text
+        return text
     return json.dumps(value, ensure_ascii=False, sort_keys=True)
 
 

--- a/src/kpubdata_builder/exporters/csv.py
+++ b/src/kpubdata_builder/exporters/csv.py
@@ -35,8 +35,9 @@ def _resolve_columns(artifact: ArtifactDataset) -> list[str]:
     return list(columns.keys())
 
 
+# 스프레드시트가 수식으로 해석하는 선두 문자 집합.
+# 셀 값이 이 문자로 시작하면 앞에 홑따옴표를 붙여 수식 실행을 막는다 (CSV 인젝션 대응, CWE-1236).
 _FORMULA_TRIGGER_CHARS = frozenset("=+-@\t\r")
-"""스프레드시트가 수식으로 해석하는 선두 문자 집합 (CWE-1236)."""
 
 
 def _format_cell(value: JsonValue) -> str:

--- a/tests/unit/test_csv_exporter.py
+++ b/tests/unit/test_csv_exporter.py
@@ -129,6 +129,69 @@ def test_returns_metadata_pointing_to_created_file(tmp_path: Path) -> None:
     assert result.format == "csv"
 
 
+def test_formula_injection_trigger_chars_are_prefixed(tmp_path: Path) -> None:
+    # 수식 트리거 문자(=, +, -, @, 탭)로 시작하는 문자열은 홑따옴표 접두사가
+    # 붙어야 한다 (CWE-1236).  캐리지리턴(\r)은 CSV round-trip이 불안정하므로
+    # 별도 test_formula_injection_cr_prefix 에서 raw 파일 내용으로 검증한다.
+    trigger_values = ["=CMD", "+SUM()", "-1+1", "@SUM", "\tTAB"]
+    artifact = ArtifactDataset(
+        records=tuple({"v": val} for val in trigger_values),
+        schema={"v": "str"},
+    )
+    target = ExportTarget(kind="csv", output_path="out/data.csv")
+
+    result = CsvExporter().export(artifact, target, tmp_path)
+
+    rows = _read_rows(result.output_path)
+    data_rows = rows[1:]  # 헤더 제외
+    for i, val in enumerate(trigger_values):
+        assert data_rows[i][0] == "'" + val, f"트리거 값 {val!r}에 접두사가 없음"
+
+
+def test_formula_injection_cr_prefix(tmp_path: Path) -> None:
+    # 캐리지리턴(\r)으로 시작하는 문자열도 홑따옴표 접두사가 붙어야 한다.
+    # csv.reader round-trip은 \r을 불안정하게 처리하므로 raw 파일 내용으로 검증한다.
+    artifact = ArtifactDataset(records=({"v": "\rCR"},), schema={"v": "str"})
+    target = ExportTarget(kind="csv", output_path="out/data.csv")
+
+    result = CsvExporter().export(artifact, target, tmp_path)
+
+    raw = result.output_path.read_bytes()
+    # 홑따옴표가 \r 앞에 붙으면 파일 내에 b"'\r" 시퀀스가 나타난다.
+    assert b"'\r" in raw, "캐리지리턴 앞에 홑따옴표 접두사가 없음"
+
+
+def test_formula_injection_normal_strings_unchanged(tmp_path: Path) -> None:
+    # 트리거 문자로 시작하지 않는 일반 문자열은 그대로 유지되어야 한다.
+    normal_values = ["hello", "world", "1234", "", "한글", "abc=def"]
+    artifact = ArtifactDataset(
+        records=tuple({"v": val} for val in normal_values),
+        schema={"v": "str"},
+    )
+    target = ExportTarget(kind="csv", output_path="out/data.csv")
+
+    result = CsvExporter().export(artifact, target, tmp_path)
+
+    rows = _read_rows(result.output_path)
+    data_rows = rows[1:]
+    for i, val in enumerate(normal_values):
+        assert data_rows[i][0] == val, f"일반 값 {val!r}이 변경됨"
+
+
+def test_formula_injection_numeric_values_unchanged(tmp_path: Path) -> None:
+    # 숫자(int/float)는 트리거 문자 검사를 거치지 않고 str()로 변환되어야 한다.
+    artifact = ArtifactDataset(
+        records=({"i": -1, "f": -3.14},),
+        schema={"i": "int", "f": "float"},
+    )
+    target = ExportTarget(kind="csv", output_path="out/data.csv")
+
+    result = CsvExporter().export(artifact, target, tmp_path)
+
+    rows = _read_rows(result.output_path)
+    assert rows[1] == ["-1", "-3.14"]
+
+
 def test_registry_exposes_csv_exporter() -> None:
     # CSV exporter가 kind 문자열 "csv"로 레지스트리에 등록되어 있는지 확인한다.
     assert isinstance(EXPORTER_REGISTRY["csv"], CsvExporter)

--- a/tests/unit/test_kaggle_exporter.py
+++ b/tests/unit/test_kaggle_exporter.py
@@ -73,6 +73,21 @@ def test_license_override_from_metadata(tmp_path: Path) -> None:
     assert metadata["licenses"] == [{"name": "CC0-1.0"}]
 
 
+def test_formula_injection_trigger_chars_prefixed_in_kaggle(tmp_path: Path) -> None:
+    # KaggleExporter도 _format_cell을 공유하므로 수식 트리거 값에 접두사가 붙어야 한다.
+    artifact = ArtifactDataset(
+        records=({"cmd": '=HYPERLINK("evil.com")'},),
+        schema={"cmd": "str"},
+        metadata={"title": "T", "dataset_id": "kpub/t"},
+    )
+    target = ExportTarget(kind="kaggle", output_path="out/data.csv")
+
+    result = KaggleExporter().export(artifact, target, tmp_path)
+
+    rows = _read_rows(result.output_path)
+    assert rows[1][0] == '\'=HYPERLINK("evil.com")'
+
+
 def test_registry_exposes_kaggle_exporter() -> None:
     # Kaggle exporter가 kind 문자열 "kaggle"로 레지스트리에 등록되어 있는지 확인한다.
     assert isinstance(EXPORTER_REGISTRY["kaggle"], KaggleExporter)


### PR DESCRIPTION
## 요약

- Closes #221 — CSV 수식 삽입(formula injection, CWE-1236): \`exporters/csv.py\`의 \`_format_cell\`이 이제 \`=\`, \`+\`, \`-\`, \`@\`, 탭(\`\t\`), 캐리지 리턴(\`\r\`)으로 시작하는 문자열 셀 앞에 작은따옴표 \`'\`를 붙입니다. 이는 스프레드시트 안전을 위한 표준 완화 방법입니다. 숫자, bool, None 셀은 변경되지 않습니다. \`exporters/kaggle.py\`는 \`_format_cell\`을 공유하므로 동일한 보호가 자동으로 적용됩니다.
- Closes #223 — CI/워크플로우 강화:
  - 5개의 \`scheduled-*.yml\` 워크플로우가 이제 \`secrets: inherit\` 대신 \`KPUBDATA_DATAGO_API_KEY\`와 \`HF_TOKEN\`만 명시적으로 전달하여 시크릿 노출 범위를 \`publish-dataset.yml\`에서 실제로 선언한 항목으로 제한합니다.
  - \`publish-dataset.yml\`에 최상위 \`permissions: contents: read\` 블록을 추가합니다(\`docs.yml\`의 기존 형식과 일치).
  - \`publish-dataset.yml\` 및 \`docs.yml\`의 서드파티 액션 참조를 전체 커밋 SHA로 고정:
    - \`actions/checkout@v4\` → \`@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4\`
    - \`astral-sh/setup-uv@v5\` → \`@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5\`
    - \`actions/setup-python@v5\` → \`@a26af69be951a213d495a4c3e4e4022e16d87065  # v5\`
    - \`actions/upload-pages-artifact@v3\` → \`@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3\`
    - \`actions/deploy-pages@v4\` → \`@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4\`
  - 참고: SHA는 작성 시점에 \`gh api repos/<owner>/<repo>/commits/<tag>\`를 통해 확인되었으며, 5개 모두 성공적으로 확인되었습니다.

## 검증 방법

- 수정된 Python 파일에 대해 \`ruff check\` 및 \`ruff format --check\` 통과.
- \`mypy src\` — 오류 0개 (70개 소스 파일).
- \`pytest -q\` — **398개 통과**, 기존 비권장 경고 4개, 실패 0개.
- 새 테스트 항목: 각 트리거 문자(\`=\`, \`+\`, \`-\`, \`@\`, \`\t\`, \`\r\`), 일반 문자열 미변경, 숫자 값 미변경, \`KaggleExporter\` 경로(공유 \`_format_cell\` 사용).
- YAML 검증: \`python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"\` — 모든 파일 정상 파싱.