### PR TITLE
fix: 익스포터 원자적 쓰기(atomic write), 임시 디렉토리 정리, 백업 복원 (#220, #222, #224)

### DIFF
--- a/src/kpubdata_builder/exporters/csv.py
+++ b/src/kpubdata_builder/exporters/csv.py
@@ -8,9 +8,12 @@ exporter를 제공한다. 컬럼은 artifact.schema가 있으면 그 순서를, 
 
 from __future__ import annotations
 
+import contextlib
 import csv
 import io
 import json
+import os
+import tempfile
 from pathlib import Path
 
 from ..artifact import ArtifactDataset
@@ -91,7 +94,15 @@ class CsvExporter(BaseExporter):
         content = buffer.getvalue()
 
         try:
-            _ = destination.write_text(content, encoding="utf-8")
+            fd, tmp_name = tempfile.mkstemp(dir=destination.parent, suffix=".tmp")
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    f.write(content)
+                os.replace(tmp_name, destination)
+            except BaseException:
+                with contextlib.suppress(OSError):
+                    os.unlink(tmp_name)
+                raise
         except OSError as exc:
             raise ExportError(f"Failed to export CSV artifact to {destination}: {exc}") from exc
 

--- a/src/kpubdata_builder/exporters/huggingface.py
+++ b/src/kpubdata_builder/exporters/huggingface.py
@@ -147,9 +147,12 @@ class HuggingFaceExporter(BaseExporter):
         except ExportError:
             shutil.rmtree(tmp_dir, ignore_errors=True)
             raise
-        except BaseException as exc:
+        except Exception as exc:
             shutil.rmtree(tmp_dir, ignore_errors=True)
             raise ExportError(f"Failed to export Hugging Face layout to {hf_dir}: {exc}") from exc
+        except BaseException:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            raise
 
         # HF exporter returns the layout directory (not a single file) since it
         # produces multiple files. Consumers should use output_path as a directory.

--- a/src/kpubdata_builder/exporters/huggingface.py
+++ b/src/kpubdata_builder/exporters/huggingface.py
@@ -20,7 +20,6 @@ import shutil
 import tempfile
 from pathlib import Path
 
-import polars as pl
 import yaml
 
 from ..artifact import ArtifactDataset
@@ -145,7 +144,10 @@ class HuggingFaceExporter(BaseExporter):
             )
             total_size = sum(path.stat().st_size for path in (data_path, readme_path, infos_path))
             atomic_replace_dir(tmp_dir, hf_dir)
-        except (OSError, pl.exceptions.PolarsError) as exc:
+        except ExportError:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            raise
+        except BaseException as exc:
             shutil.rmtree(tmp_dir, ignore_errors=True)
             raise ExportError(f"Failed to export Hugging Face layout to {hf_dir}: {exc}") from exc
 

--- a/src/kpubdata_builder/exporters/jsonl.py
+++ b/src/kpubdata_builder/exporters/jsonl.py
@@ -6,7 +6,10 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
+import os
+import tempfile
 from pathlib import Path
 
 from ..artifact import ArtifactDataset
@@ -46,10 +49,17 @@ class JsonlExporter(BaseExporter):
         """
         destination = ensure_output_dir(output_dir, target.output_path)
         try:
-            with destination.open("w", encoding="utf-8") as f:
-                for record in artifact.records:
-                    f.write(json.dumps(record, ensure_ascii=False, sort_keys=True))
-                    f.write("\n")
+            fd, tmp_name = tempfile.mkstemp(dir=destination.parent, suffix=".tmp")
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    for record in artifact.records:
+                        f.write(json.dumps(record, ensure_ascii=False, sort_keys=True))
+                        f.write("\n")
+                os.replace(tmp_name, destination)
+            except BaseException:
+                with contextlib.suppress(OSError):
+                    os.unlink(tmp_name)
+                raise
         except OSError as exc:
             raise ExportError(f"Failed to export JSONL artifact to {destination}: {exc}") from exc
 

--- a/src/kpubdata_builder/exporters/kaggle.py
+++ b/src/kpubdata_builder/exporters/kaggle.py
@@ -7,9 +7,12 @@
 
 from __future__ import annotations
 
+import contextlib
 import csv
 import io
 import json
+import os
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -42,7 +45,15 @@ class KaggleExporter(BaseExporter):
         content = buffer.getvalue()
 
         try:
-            _ = destination.write_text(content, encoding="utf-8")
+            fd, tmp_name = tempfile.mkstemp(dir=destination.parent, suffix=".tmp")
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    f.write(content)
+                os.replace(tmp_name, destination)
+            except BaseException:
+                with contextlib.suppress(OSError):
+                    os.unlink(tmp_name)
+                raise
         except OSError as exc:
             raise ExportError(f"Failed to export Kaggle artifact to {destination}: {exc}") from exc
 
@@ -78,10 +89,15 @@ class KaggleExporter(BaseExporter):
         metadata["licenses"] = [{"name": artifact.metadata.get("license", "CC-BY-4.0")}]
 
         try:
-            metadata_path.write_text(
-                json.dumps(metadata, ensure_ascii=False, indent=2) + "\n",
-                encoding="utf-8",
-            )
+            fd, tmp_meta = tempfile.mkstemp(dir=metadata_path.parent, suffix=".tmp")
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    f.write(json.dumps(metadata, ensure_ascii=False, indent=2) + "\n")
+                os.replace(tmp_meta, metadata_path)
+            except BaseException:
+                with contextlib.suppress(OSError):
+                    os.unlink(tmp_meta)
+                raise
         except OSError as exc:
             raise ExportError(f"Failed to write Kaggle metadata to {metadata_path}: {exc}") from exc
 

--- a/src/kpubdata_builder/exporters/markdown.py
+++ b/src/kpubdata_builder/exporters/markdown.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import contextlib
+import os
+import tempfile
 from pathlib import Path
 
 from ..artifact import ArtifactDataset
@@ -27,7 +30,15 @@ class MarkdownExporter(BaseExporter):
         destination = ensure_output_dir(output_dir, target.output_path)
         content = _render_markdown(artifact)
         try:
-            _ = destination.write_text(content, encoding="utf-8")
+            fd, tmp_name = tempfile.mkstemp(dir=destination.parent, suffix=".tmp")
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    f.write(content)
+                os.replace(tmp_name, destination)
+            except BaseException:
+                with contextlib.suppress(OSError):
+                    os.unlink(tmp_name)
+                raise
         except OSError as exc:
             raise ExportError(
                 f"Failed to export Markdown artifact to {destination}: {exc}"

--- a/src/kpubdata_builder/exporters/parquet.py
+++ b/src/kpubdata_builder/exporters/parquet.py
@@ -7,6 +7,9 @@
 
 from __future__ import annotations
 
+import contextlib
+import os
+import tempfile
 from pathlib import Path
 
 import polars as pl
@@ -40,9 +43,7 @@ def _build_frame(artifact: ArtifactDataset) -> pl.DataFrame:
             "bool": pl.Boolean,
             "Boolean": pl.Boolean,
         }
-        schema = {
-            name: _TYPE_MAP.get(dtype, pl.Utf8) for name, dtype in artifact.schema.items()
-        }
+        schema = {name: _TYPE_MAP.get(dtype, pl.Utf8) for name, dtype in artifact.schema.items()}
         return pl.DataFrame(schema=schema)
     return pl.DataFrame()
 
@@ -79,7 +80,16 @@ class ParquetExporter(BaseExporter):
         destination = ensure_output_dir(output_dir, target.output_path)
         frame = _build_frame(artifact)
         try:
-            frame.write_parquet(destination)
+            fd, tmp_name = tempfile.mkstemp(dir=destination.parent, suffix=".tmp")
+            os.close(fd)
+            tmp_path = Path(tmp_name)
+            try:
+                frame.write_parquet(tmp_path)
+                os.replace(tmp_name, destination)
+            except BaseException:
+                with contextlib.suppress(OSError):
+                    os.unlink(tmp_name)
+                raise
         except (OSError, pl.exceptions.PolarsError) as exc:
             raise ExportError(f"Failed to export Parquet artifact to {destination}: {exc}") from exc
 

--- a/src/kpubdata_builder/stages/_atomic.py
+++ b/src/kpubdata_builder/stages/_atomic.py
@@ -43,8 +43,10 @@ def atomic_replace_dir(tmp_dir: Path, final_dir: Path) -> None:
         tmp_dir.rename(final_dir)  # 원자적: 신규 데이터를 제자리로
     except BaseException:
         # 신규 배치 실패 → 기존 데이터를 원위치로 복구한다.
-        if not final_dir.exists():
-            backup.rename(final_dir)
+        # partial final_dir이 남아 있으면 제거한 뒤 백업을 원위치로 되돌린다.
+        if final_dir.exists():
+            shutil.rmtree(final_dir, ignore_errors=True)
+        backup.rename(final_dir)
         raise
     shutil.rmtree(backup, ignore_errors=True)
 

--- a/tests/unit/test_atomic.py
+++ b/tests/unit/test_atomic.py
@@ -65,3 +65,34 @@ def test_restores_existing_data_when_swap_fails(
     # 기존 데이터가 제자리로 복구되어 있어야 한다.
     assert final_dir.exists()
     assert (final_dir / "data.txt").read_text(encoding="utf-8") == "old"
+
+
+def test_restores_backup_even_when_final_dir_partially_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # tmp→final rename 실패 후 final_dir가 이미 존재하더라도 backup을 복구해야 한다 (#224).
+    # 실제 OS에서는 rename 실패 후 final_dir가 생기진 않지만, 방어 코드가 올바른지 검증한다.
+    final_dir = _make_dir(tmp_path, "final", "old")
+    tmp_dir = _make_dir(tmp_path, ".tmp_new", "new")
+
+    original_rename = Path.rename
+    state = {"calls": 0}
+
+    def flaky_rename(self: Path, target: Path) -> Path:
+        state["calls"] += 1
+        if state["calls"] == 2:
+            # rename 실패를 시뮬레이션하기 전에 final_dir를 빈 디렉터리로 만들어
+            # "부분 배치" 상황을 재현한다.
+            target.mkdir(exist_ok=True)
+            raise OSError("partial rename failure")
+        return original_rename(self, target)
+
+    monkeypatch.setattr(Path, "rename", flaky_rename)
+
+    with pytest.raises(OSError, match="partial rename failure"):
+        atomic_replace_dir(tmp_dir, final_dir)
+
+    monkeypatch.undo()
+    # final_dir는 백업에서 복구된 원본 데이터를 담고 있어야 한다.
+    assert final_dir.exists()
+    assert (final_dir / "data.txt").read_text(encoding="utf-8") == "old"

--- a/tests/unit/test_csv_exporter.py
+++ b/tests/unit/test_csv_exporter.py
@@ -136,14 +136,15 @@ def test_registry_exposes_csv_exporter() -> None:
 
 def test_wraps_io_failure_in_export_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # 파일 쓰기 실패가 ExportError로 래핑되는지 확인한다.
+    import os
+
     artifact = ArtifactDataset(records=({"id": "1"},), schema={"id": "str"})
     target = ExportTarget(kind="csv", output_path="out/data.csv")
 
-    def raise_io_error(self: Path, data: str, *, encoding: str) -> int:
-        del self, data, encoding
+    def raise_on_replace(src: str, dst: object) -> None:
         raise OSError("permission denied")
 
-    monkeypatch.setattr(Path, "write_text", raise_io_error)
+    monkeypatch.setattr(os, "replace", raise_on_replace)
 
     with pytest.raises(ExportError):
         CsvExporter().export(artifact, target, tmp_path)

--- a/tests/unit/test_exporters.py
+++ b/tests/unit/test_exporters.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -20,14 +21,12 @@ def test_jsonl_exporter_raises_export_error_on_io_failure(
     artifact = ArtifactDataset(records=({"id": "1"},), provenance=("datago.air_quality",))
     target = ExportTarget(kind="jsonl", output_path="out/data.jsonl")
 
-    _orig_open = Path.open
+    _orig_replace = os.replace
 
-    def raise_on_open(self: Path, *args: object, **kwargs: object) -> object:
-        if "data.jsonl" in str(self):
-            raise OSError("permission denied")
-        return _orig_open(self, *args, **kwargs)  # type: ignore[arg-type]
+    def raise_on_replace(src: str, dst: str) -> None:
+        raise OSError("permission denied")
 
-    monkeypatch.setattr(Path, "open", raise_on_open)
+    monkeypatch.setattr(os, "replace", raise_on_replace)
 
     with pytest.raises(ExportError):
         JsonlExporter().export(artifact, target, tmp_path)
@@ -40,11 +39,12 @@ def test_markdown_exporter_raises_export_error_on_io_failure(
     artifact = ArtifactDataset(records=({"id": "1"},), provenance=("datago.air_quality",))
     target = ExportTarget(kind="markdown", output_path="out/README.md")
 
-    def raise_io_error(self: Path, data: str, *, encoding: str) -> int:
-        del self, data, encoding
+    _orig_replace = os.replace
+
+    def raise_on_replace(src: str, dst: str) -> None:
         raise OSError("permission denied")
 
-    monkeypatch.setattr(Path, "write_text", raise_io_error)
+    monkeypatch.setattr(os, "replace", raise_on_replace)
 
     with pytest.raises(ExportError):
         MarkdownExporter().export(artifact, target, tmp_path)
@@ -70,3 +70,38 @@ def test_markdown_exporter_returns_export_metadata(tmp_path: Path) -> None:
     assert result.output_path == tmp_path / "out/README.md"
     assert result.file_size > 0
     assert result.format == "markdown"
+
+
+@pytest.mark.parametrize(
+    "exporter_cls,output_path",
+    [
+        ("JsonlExporter", "out/data.jsonl"),
+        ("MarkdownExporter", "out/README.md"),
+    ],
+)
+def test_exporter_leaves_no_temp_file_on_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exporter_cls: str,
+    output_path: str,
+) -> None:
+    # 쓰기 실패 시 임시 파일(.tmp)이 남지 않아야 한다 (#220).
+    from kpubdata_builder.exporters import JsonlExporter, MarkdownExporter  # noqa: F401
+
+    cls = JsonlExporter if exporter_cls == "JsonlExporter" else MarkdownExporter
+    artifact = ArtifactDataset(records=({"id": "1"},), provenance=("datago.air_quality",))
+    target = ExportTarget(kind="jsonl", output_path=output_path)
+
+    def raise_on_replace(src: str, dst: str) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(os, "replace", raise_on_replace)
+
+    with pytest.raises(ExportError):
+        cls().export(artifact, target, tmp_path)
+
+    # 임시 파일이 남아 있으면 안 된다.
+    out_dir = tmp_path / "out"
+    if out_dir.exists():
+        leftovers = [p.name for p in out_dir.iterdir() if p.suffix == ".tmp"]
+        assert leftovers == [], f"Temp files leaked: {leftovers}"

--- a/tests/unit/test_exporters.py
+++ b/tests/unit/test_exporters.py
@@ -90,7 +90,8 @@ def test_exporter_leaves_no_temp_file_on_failure(
 
     cls = JsonlExporter if exporter_cls == "JsonlExporter" else MarkdownExporter
     artifact = ArtifactDataset(records=({"id": "1"},), provenance=("datago.air_quality",))
-    target = ExportTarget(kind="jsonl", output_path=output_path)
+    kind = "jsonl" if exporter_cls == "JsonlExporter" else "markdown"
+    target = ExportTarget(kind=kind, output_path=output_path)
 
     def raise_on_replace(src: str, dst: str) -> None:
         raise OSError("disk full")

--- a/tests/unit/test_huggingface_exporter.py
+++ b/tests/unit/test_huggingface_exporter.py
@@ -121,3 +121,28 @@ def test_reexport_with_format_change_removes_stale_shards(tmp_path: Path) -> Non
 def test_registry_exposes_huggingface_exporter() -> None:
     # HF exporter가 kind "huggingface"로 레지스트리에 등록되어 있는지 확인한다.
     assert isinstance(EXPORTER_REGISTRY["huggingface"], HuggingFaceExporter)
+
+
+def test_failing_export_leaves_no_temp_dir_behind(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # TabularError(또는 다른 예외)가 발생해도 .hf_tmp_* 임시 디렉터리가 남지 않아야 한다 (#222).
+    import kpubdata_builder.exporters.huggingface as hf_module
+    from kpubdata_builder.errors import TabularError
+
+    target = ExportTarget(kind="huggingface", output_path="hf/apt_trade")
+
+    def raise_tabular_error(records: object) -> None:
+        raise TabularError("혼합 타입 컬럼")
+
+    # huggingface 모듈에서 직접 import한 records_to_dataframe을 교체해야 패치가 적용된다.
+    monkeypatch.setattr(hf_module, "records_to_dataframe", raise_tabular_error)
+
+    with pytest.raises(ExportError):
+        HuggingFaceExporter().export(_artifact(), target, tmp_path)
+
+    # 임시 디렉터리(.hf_tmp_*)가 남아 있으면 안 된다.
+    hf_parent = tmp_path / "hf"
+    if hf_parent.exists():
+        leaked = [p for p in hf_parent.iterdir() if p.name.startswith(".hf_tmp_")]
+        assert leaked == [], f"Temp dirs leaked: {leaked}"

--- a/tests/unit/test_kaggle_exporter.py
+++ b/tests/unit/test_kaggle_exporter.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import csv
 import io
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -141,11 +142,10 @@ def test_wraps_io_failure_in_export_error(tmp_path: Path, monkeypatch: pytest.Mo
     artifact = ArtifactDataset(records=({"id": "1"},), schema={"id": "str"})
     target = ExportTarget(kind="kaggle", output_path="out/data.csv")
 
-    def raise_io_error(self: Path, data: str, *, encoding: str) -> int:
-        del self, data, encoding
+    def raise_on_replace(src: str, dst: str) -> None:
         raise OSError("permission denied")
 
-    monkeypatch.setattr(Path, "write_text", raise_io_error)
+    monkeypatch.setattr(os, "replace", raise_on_replace)
 
     with pytest.raises(ExportError):
         KaggleExporter().export(artifact, target, tmp_path)


### PR DESCRIPTION
## 요약

- **Closes #220** — 5개의 익스포터(csv, jsonl, parquet, markdown, kaggle)가 최종 경로에 직접 쓰고 있었습니다. 쓰기 중 크래시가 발생하면 잘린 파일이 남을 수 있었습니다. 각각을 \`stages/gold/persist.py\` 및 \`stages/bronze/persist.py\`에서 이미 사용 중인 패턴과 동일하게, 같은 디렉토리 내 \`tempfile.mkstemp\` + \`os.replace\`를 통해 쓰도록 변환했습니다. 임시 파일은 실패 시 \`contextlib.suppress(OSError)\`를 통해 정리됩니다.

- **Closes #222** — \`HuggingFaceExporter\`의 정리 핸들러가 \`(OSError, pl.exceptions.PolarsError)\`만 잡고 있었습니다. \`records_to_dataframe\`에서 발생하는 \`TabularError\`는 잡히지 않아 \`.hf_tmp_*\` 디렉토리가 누출되었습니다. \`except BaseException\` + rmtree + 재발생(\`ExportError\`로 변환)으로 교체하여 어떤 예외 유형도 임시 디렉토리를 누출할 수 없도록 합니다.

- **Closes #224** — \`atomic_replace_dir\`의 복구 경로에 \`if not final_dir.exists(): backup.rename(final_dir)\`가 있었습니다. \`tmp_dir.rename(final_dir)\`이 실패했지만 일부 파일시스템에서 부분적으로 \`final_dir\`이 나타난 경우, 이 조건이 복원을 건너뛰어 백업을 \`.old\`로 고아 상태로 남겼습니다. 부분적인 \`final_dir\`을 무조건 \`shutil.rmtree\`로 제거한 후 항상 \`backup.rename(final_dir)\`을 호출하고 예외를 재발생시키도록 수정했습니다.

## 검증 방법

- \`ruff check .\` — 모든 검사 통과
- 수정된 파일에 대해 \`ruff format --check\` — 모두 포맷 정상
- \`mypy src\` — 70개 소스 파일에서 문제 없음
- \`pytest -q\` — 397개 통과, 경고 4개 (새 회귀 테스트 3개 추가: \`test_failing_export_leaves_no_temp_dir_behind\`, \`test_restores_backup_even_when_final_dir_partially_present\`, \`test_exporter_leaves_no_temp_file_on_failure\`)