### PR TITLE
test: builder↔studio 계약(contract) 및 kpubdata 클라이언트 통합 커버리지 (#226)

### DIFF
--- a/contract/builder-api.yaml
+++ b/contract/builder-api.yaml
@@ -72,7 +72,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                oneOf:
+                  - $ref: "#/components/schemas/Error"
+                  - $ref: "#/components/schemas/ValidationError"
 
   /build:
     post:
@@ -96,7 +98,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                oneOf:
+                  - $ref: "#/components/schemas/Error"
+                  - $ref: "#/components/schemas/ValidationError"
         "502":
           description: >-
             하나 이상의 소스 fetch/stage 실패. upstream 소스 의존 실패이며 매니페스트는

--- a/contract/builder-api.yaml
+++ b/contract/builder-api.yaml
@@ -3,28 +3,30 @@ info:
   title: KPubData Builder Service API
   version: "1.0.0"
   description: >-
-    Builder 중심 서비스 계약. BuildSpec 검증, preview, build 실행, manifest/artifact
-    조회, publish 실행을 제공한다. CLI와 HTTP service mode가 동일한 도메인 계약을
-    공유한다. 본 문서는 API_CONTRACT.md의 기계 판독용(OpenAPI 3.1) 단일 소스이며,
-    Studio 같은 소비자가 타입 클라이언트를 생성하는 기준이 된다.
+    Builder 중심 서비스 계약. BuildSpec 검증, preview, build 실행, artifact 조회,
+    계약 버전 조회를 제공한다. CLI와 HTTP service mode(#36)가 동일한 도메인 계약을
+    공유한다. 본 문서는 BuilderService(service/app.py)의 dispatch 라우팅과 실제
+    wire 형태를 기계 판독용(OpenAPI 3.1) 단일 소스로 고정하며, Studio 같은 소비자가
+    타입 클라이언트를 생성하는 기준이 된다. 구현되지 않은 비동기/publish 엔드포인트는
+    드리프트를 막기 위해 계약에서 제거했다(#226).
 servers:
   - url: http://localhost:8000
     description: 로컬 builder 개발 서버
 
 paths:
-  /datasets:
+  /version:
     get:
-      operationId: listDatasets
-      summary: 사용 가능한 dataset/source 메타데이터 조회 (동기식)
+      operationId: getVersion
+      summary: Builder API 계약 버전 조회
       responses:
         "200":
-          description: dataset 카탈로그
+          description: 서비스/계약 버전
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DatasetCatalog"
+                $ref: "#/components/schemas/VersionResponse"
 
-  /spec/validate:
+  /validate:
     post:
       operationId: validateSpec
       summary: BuildSpec 검증 (동기식)
@@ -36,18 +38,22 @@ paths:
               $ref: "#/components/schemas/SpecRequest"
       responses:
         "200":
-          description: 검증 결과
+          description: 검증 통과
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ValidateResponse"
-        "422":
-          $ref: "#/components/responses/ErrorResponse"
+        "400":
+          description: spec 파싱 실패 또는 검증 실패
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationError"
 
   /preview:
     post:
       operationId: previewBuild
-      summary: 샘플 실행 및 export preview (동기식)
+      summary: 각 소스의 스키마와 샘플 행 산출 (파일 미기록, 동기식)
       requestBody:
         required: true
         content:
@@ -61,114 +67,80 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PreviewResponse"
-        "422":
-          $ref: "#/components/responses/ErrorResponse"
+        "400":
+          description: 잘못된 요청(spec 누락/검증 실패, limit 타입 오류 등)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
-  /builds:
+  /build:
     post:
       operationId: createBuild
-      summary: 새로운 build 실행 시작 (비동기식)
+      summary: 파이프라인 실행 및 결과 반환 (동기식)
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SpecRequest"
-      responses:
-        "202":
-          description: build 수락됨
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/BuildAccepted"
-        "422":
-          $ref: "#/components/responses/ErrorResponse"
-
-  /builds/{id}:
-    get:
-      operationId: getBuild
-      summary: build 상태 조회 (비동기식)
-      parameters:
-        - $ref: "#/components/parameters/BuildId"
+              $ref: "#/components/schemas/BuildRequest"
       responses:
         "200":
-          description: build 상태
+          description: 모든 소스 성공
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BuildStatus"
-        "404":
-          $ref: "#/components/responses/ErrorResponse"
-
-  /builds/{id}/manifest:
-    get:
-      operationId: getBuildManifest
-      summary: build manifest 조회 (manifested 이상 상태)
-      parameters:
-        - $ref: "#/components/parameters/BuildId"
-      responses:
-        "200":
-          description: manifest 본문
+                $ref: "#/components/schemas/BuildSuccessResponse"
+        "400":
+          description: 잘못된 요청(spec 누락/검증 실패, run_id 타입/경로 안전성 오류 등)
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ManifestResponse"
-        "404":
-          $ref: "#/components/responses/ErrorResponse"
+                $ref: "#/components/schemas/Error"
+        "502":
+          description: >-
+            하나 이상의 소스 fetch/stage 실패. upstream 소스 의존 실패이며 매니페스트는
+            partial 정책으로 남는다.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BuildFailureResponse"
 
-  /builds/{id}/artifacts:
+  /artifacts/{run_id}:
     get:
       operationId: listBuildArtifacts
-      summary: build artifact 목록 조회 (exported 이상 상태)
+      summary: 실행 워크스페이스의 산출물 파일 목록 조회
       parameters:
-        - $ref: "#/components/parameters/BuildId"
+        - $ref: "#/components/parameters/RunId"
       responses:
         "200":
-          description: artifact 목록
+          description: artifact 파일 목록
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ArtifactsResponse"
-        "404":
-          $ref: "#/components/responses/ErrorResponse"
-
-  /publish:
-    post:
-      operationId: publishArtifacts
-      summary: 이미 생성된 build artifact 게시 (비동기식)
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PublishRequest"
-      responses:
-        "202":
-          description: publish 수락됨
+        "400":
+          description: 경로 안전하지 않은 run_id
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PublishAccepted"
-        "422":
-          $ref: "#/components/responses/ErrorResponse"
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: 해당 run을 찾을 수 없음
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
 components:
   parameters:
-    BuildId:
-      name: id
+    RunId:
+      name: run_id
       in: path
       required: true
-      description: build 실행 식별자
+      description: build 실행 식별자(경로 안전한 단일 세그먼트)
       schema:
         type: string
-
-  responses:
-    ErrorResponse:
-      description: 표준 오류 응답
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/Error"
 
   schemas:
     Error:
@@ -176,191 +148,245 @@ components:
       required: [error]
       properties:
         error:
-          type: object
-          required: [code, message]
-          properties:
-            code:
-              type: string
-              description: 안정적인 기계 판독용 오류 코드
-            message:
-              type: string
-              description: 사람이 읽는 요약 메시지
-            details:
-              type: array
-              items:
-                type: object
-                properties:
-                  field:
-                    type: string
-                  reason:
-                    type: string
+          type: string
+          description: 사람이 읽는 오류 요약 메시지
 
-    BuildState:
-      type: string
-      enum: [draft, validated, running, exported, manifested, published, failed]
+    ValidationError:
+      type: object
+      description: >-
+        validate/build/preview의 spec 검증 실패 응답. SpecLoadError는
+        {status:"error", error}, ValidationError는 {status:"invalid", problems}로
+        나뉜다.
+      required: [status]
+      properties:
+        status:
+          type: string
+          enum: [error, invalid]
+        error:
+          type: string
+          description: status=error일 때의 파싱 오류 메시지
+        problems:
+          type: array
+          description: status=invalid일 때의 검증 문제 목록
+          items:
+            type: string
 
     BuildSpec:
       type: object
-      description: 선언적 빌드 명세. 세부 스키마는 spec 모델을 따른다.
+      description: >-
+        선언적 빌드 명세(snake_case). dataset_id/title/description/sources/exports는
+        필수, metadata/transforms/publish/splits는 선택. 세부 스키마는 spec 모델
+        (spec/models.py)을 따른다.
       additionalProperties: true
+      required: [dataset_id, title, description, sources, exports]
+      properties:
+        dataset_id:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        sources:
+          type: array
+          items:
+            $ref: "#/components/schemas/SourceRef"
+        exports:
+          type: array
+          items:
+            $ref: "#/components/schemas/ExportTarget"
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+
+    SourceRef:
+      type: object
+      required: [provider, dataset]
+      properties:
+        provider:
+          type: string
+        dataset:
+          type: string
+        params:
+          type: object
+          additionalProperties: true
+        alias:
+          type: string
+        normalization_mode:
+          type: string
+
+    ExportTarget:
+      type: object
+      required: [kind, output_path]
+      properties:
+        kind:
+          type: string
+        output_path:
+          type: string
+        options:
+          type: object
+          additionalProperties: true
 
     SpecRequest:
       type: object
       required: [spec]
       properties:
         spec:
-          $ref: "#/components/schemas/BuildSpec"
+          type: string
+          description: BuildSpec을 YAML로 직렬화한 문자열
 
     PreviewRequest:
       type: object
       required: [spec]
       properties:
         spec:
-          $ref: "#/components/schemas/BuildSpec"
+          type: string
+          description: BuildSpec을 YAML로 직렬화한 문자열
         limit:
           type: integer
           minimum: 1
           default: 5
 
-    DatasetCatalog:
+    BuildRequest:
       type: object
-      required: [datasets]
+      required: [spec]
       properties:
-        datasets:
-          type: array
-          items:
-            type: object
-            required: [provider, dataset]
-            properties:
-              provider:
-                type: string
-              dataset:
-                type: string
-              supports_preview:
-                type: boolean
-              supported_exports:
-                type: array
-                items:
-                  type: string
+        spec:
+          type: string
+          description: BuildSpec을 YAML로 직렬화한 문자열
+        run_id:
+          type: string
+          description: 명시 시 비어있지 않은 경로 안전한 단일 세그먼트여야 한다
+
+    VersionResponse:
+      type: object
+      required: [service, api_version]
+      properties:
+        service:
+          type: string
+        api_version:
+          type: string
 
     ValidateResponse:
       type: object
-      required: [valid]
+      required: [status, dataset_id, api_version]
       properties:
-        valid:
-          type: boolean
-        issues:
-          type: array
-          items:
-            type: string
+        status:
+          type: string
+          enum: [valid]
+        dataset_id:
+          type: string
+        api_version:
+          type: string
 
     PreviewResponse:
       type: object
-      required: [records, schema]
+      required: [dataset_id, previews]
       properties:
-        stage:
+        dataset_id:
           type: string
-        records:
+        previews:
+          type: array
+          items:
+            $ref: "#/components/schemas/SourcePreview"
+
+    SourcePreview:
+      type: object
+      required: [source_key, status, schema, sample, total_rows]
+      properties:
+        source_key:
+          type: string
+        status:
+          type: string
+        error:
+          type: [string, "null"]
+        schema:
+          type: array
+          items:
+            type: object
+            required: [name, dtype, nullable, unique_count]
+            properties:
+              name:
+                type: string
+              dtype:
+                type: string
+              nullable:
+                type: boolean
+              unique_count:
+                type: integer
+        sample:
           type: array
           items:
             type: object
             additionalProperties: true
-        schema:
-          type: object
-          additionalProperties:
-            type: string
-        export_preview:
-          type: object
-          properties:
-            format:
-              type: string
-            artifact_path:
-              type: string
-
-    BuildAccepted:
-      type: object
-      required: [build_id, state]
-      properties:
-        build_id:
-          type: string
-        state:
-          $ref: "#/components/schemas/BuildState"
-        status_url:
-          type: string
-
-    BuildStatus:
-      type: object
-      required: [build_id, state]
-      properties:
-        build_id:
-          type: string
-        dataset:
-          type: string
-        state:
-          $ref: "#/components/schemas/BuildState"
-        started_at:
-          type: string
-          format: date-time
-        updated_at:
-          type: string
-          format: date-time
-
-    Artifact:
-      type: object
-      required: [path, format]
-      properties:
-        path:
-          type: string
-        format:
-          type: string
-        size_bytes:
+        total_rows:
           type: integer
 
-    ManifestResponse:
+    BuildOutcome:
       type: object
-      required: [build_id, manifest]
+      required: [source_key, status, stages_completed, error]
       properties:
-        build_id:
+        source_key:
           type: string
-        state:
-          $ref: "#/components/schemas/BuildState"
+        status:
+          type: string
+          enum: [ok, failed]
+        stages_completed:
+          type: array
+          items:
+            type: string
+        error:
+          type: [string, "null"]
+
+    BuildSuccessResponse:
+      type: object
+      required: [status, run_id, outcomes, manifest, api_version]
+      properties:
+        status:
+          type: string
+          enum: [ok]
+        run_id:
+          type: string
+        outcomes:
+          type: array
+          items:
+            $ref: "#/components/schemas/BuildOutcome"
         manifest:
-          type: object
-          additionalProperties: true
+          type: string
+          description: 기록된 manifest.json의 경로
+        api_version:
+          type: string
+
+    BuildFailureResponse:
+      type: object
+      required: [status, run_id, outcomes, manifest, api_version, error]
+      properties:
+        status:
+          type: string
+          enum: [failed]
+        run_id:
+          type: string
+        outcomes:
+          type: array
+          items:
+            $ref: "#/components/schemas/BuildOutcome"
+        manifest:
+          type: string
+          description: partial 정책으로 남은 manifest.json의 경로
+        api_version:
+          type: string
+        error:
+          type: string
+          description: 첫 번째 실패 outcome의 error에서 파생된 human-readable 요약 (#226)
 
     ArtifactsResponse:
       type: object
-      required: [build_id, artifacts]
+      required: [run_id, files]
       properties:
-        build_id:
+        run_id:
           type: string
-        artifacts:
+        files:
           type: array
           items:
-            $ref: "#/components/schemas/Artifact"
-
-    PublishRequest:
-      type: object
-      required: [build_id, target]
-      properties:
-        build_id:
-          type: string
-        target:
-          type: object
-          required: [kind]
-          properties:
-            kind:
-              type: string
-            repository:
-              type: string
-
-    PublishAccepted:
-      type: object
-      required: [publish_id, build_id, state]
-      properties:
-        publish_id:
-          type: string
-        build_id:
-          type: string
-        state:
-          type: string
+            type: string
+            description: run 디렉터리 기준 상대 파일 경로

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -151,16 +151,22 @@ class BuilderService:
             for outcome in result.outcomes
         ]
         status_code = 200 if result.status == "ok" else 502
-        return ServiceResponse(
-            status_code,
-            {
-                "status": result.status,
-                "run_id": result.context.run_id,
-                "outcomes": outcomes,
-                "manifest": str(result.manifest_path),
-                "api_version": API_CONTRACT_VERSION,
-            },
-        )
+        body: dict[str, JsonValue] = {
+            "status": result.status,
+            "run_id": result.context.run_id,
+            "outcomes": outcomes,
+            "manifest": str(result.manifest_path),
+            "api_version": API_CONTRACT_VERSION,
+        }
+        # 실패한 빌드는 첫 번째 실패 outcome의 error를 최상위 `error` 요약으로 노출해,
+        # Studio 같은 소비자가 outcomes 배열을 파싱하지 않고도 사람이 읽을 수 있는
+        # 사유를 즉시 표면화할 수 있게 한다 (#226).
+        if result.status != "ok":
+            first_error = next(
+                (o.error for o in result.outcomes if o.status != "ok" and o.error), None
+            )
+            body["error"] = first_error or "build failed"
+        return ServiceResponse(status_code, body)
 
     def artifacts(self, run_id: str) -> ServiceResponse:
         """실행 워크스페이스의 산출물 파일 목록을 반환한다."""

--- a/tests/integration/test_kpubdata_client_protocol.py
+++ b/tests/integration/test_kpubdata_client_protocol.py
@@ -11,6 +11,7 @@ builder의 Bronze 단계는 kpubdata 호환 클라이언트에 다음 구조 계
 
 from __future__ import annotations
 
+import typing
 from collections.abc import Iterable
 
 import pytest
@@ -66,30 +67,31 @@ class TestRealKpubdataClientConformance:
         client_cls = getattr(kpubdata, "Client", None)
         assert client_cls is not None, "kpubdata.Client must exist"
 
-        # Client.dataset(source_key)가 존재해야 한다.
+        # Client.dataset(source_key)가 존재해야 한다 — 런타임 구조 계약.
         assert hasattr(client_cls, "dataset"), "kpubdata.Client must expose .dataset()"
         assert callable(client_cls.dataset)
 
         # dataset(...)이 반환하는 타입에 .list(**params)가 있어야 한다.
-        dataset_cls = client_cls.dataset.__annotations__.get("return")
-        if isinstance(dataset_cls, str):
-            # 문자열 어노테이션이면 client 모듈 네임스페이스에서 해석한다.
-            import inspect
-
-            module = inspect.getmodule(client_cls)
-            assert module is not None
-            dataset_cls = getattr(module, dataset_cls, None)
-        assert dataset_cls is not None, "Client.dataset return type must be resolvable"
+        # get_type_hints로 forward ref를 안전하게 해석하고, 어노테이션이 없으면
+        # return-type 심층 검사를 건너뛴다 (런타임 구조 계약은 이미 위에서 확인).
+        try:
+            dataset_hints = typing.get_type_hints(client_cls.dataset)
+        except Exception:
+            dataset_hints = {}
+        dataset_cls = dataset_hints.get("return")
+        if dataset_cls is None:
+            # 어노테이션이 없거나 해석 불가 — return-type 심층 검사 생략.
+            return
         assert hasattr(dataset_cls, "list"), "Dataset must expose .list()"
         assert callable(dataset_cls.list)
 
         # list(...)이 반환하는 타입에 .items가 있어야 한다(builder가 소비하는 속성).
-        list_return = dataset_cls.list.__annotations__.get("return")
-        if isinstance(list_return, str):
-            import inspect
-
-            module = inspect.getmodule(dataset_cls)
-            assert module is not None
-            list_return = getattr(module, list_return, None)
-        assert list_return is not None, "Dataset.list return type must be resolvable"
+        try:
+            list_hints = typing.get_type_hints(dataset_cls.list)
+        except Exception:
+            list_hints = {}
+        list_return = list_hints.get("return")
+        if list_return is None:
+            # 어노테이션이 없거나 해석 불가 — return-type 심층 검사 생략.
+            return
         assert hasattr(list_return, "items"), "list() result must expose .items"

--- a/tests/integration/test_kpubdata_client_protocol.py
+++ b/tests/integration/test_kpubdata_client_protocol.py
@@ -1,0 +1,95 @@
+"""kpubdata SourceClient Protocol 적합성 테스트 (#226).
+
+builder의 Bronze 단계는 kpubdata 호환 클라이언트에 다음 구조 계약을 요구한다:
+
+    client.dataset(source_key).list(**params).items -> Iterable[dict]
+
+이 테스트는 (1) 임의 객체가 Protocol을 구조적으로 만족할 수 있음을 고정하고,
+(2) 실제 kpubdata 패키지가 설치돼 있으면 kpubdata.Client가 같은 구조 계약을
+만족하는지(메서드/속성 존재 수준에서) 확인한다. 네트워크 호출은 하지 않는다.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import pytest
+
+from kpubdata_builder.spec import JsonValue
+from kpubdata_builder.stages.bronze.build import SourceClient
+
+
+class _ConformingResult:
+    @property
+    def items(self) -> Iterable[dict[str, JsonValue]]:
+        return [{"id": "1"}]
+
+
+class _ConformingDataset:
+    def list(self, **params: JsonValue) -> _ConformingResult:
+        return _ConformingResult()
+
+
+class _ConformingClient:
+    def dataset(self, source_key: str) -> _ConformingDataset:
+        return _ConformingDataset()
+
+
+class TestProtocolIsSatisfiable:
+    def test_in_memory_client_satisfies_protocol(self) -> None:
+        # SourceClient는 runtime_checkable이 아닐 수 있으므로, mypy(정적)와 별개로
+        # 구조적 적합성을 런타임에서 호출 경로로 확인한다.
+        client: SourceClient = _ConformingClient()
+        dataset = client.dataset("datago.air_quality")
+        result = dataset.list(region="seoul")
+        items = list(result.items)
+        assert items == [{"id": "1"}]
+
+    def test_protocol_call_chain_shapes(self) -> None:
+        client = _ConformingClient()
+        # builder가 호출하는 정확한 경로: dataset(key).list(**params).items.
+        assert hasattr(client, "dataset")
+        dataset = client.dataset("k")
+        assert hasattr(dataset, "list")
+        result = dataset.list()
+        assert hasattr(result, "items")
+        for record in result.items:
+            assert isinstance(record, dict)
+
+
+class TestRealKpubdataClientConformance:
+    def test_real_client_structurally_conforms(self) -> None:
+        # 실제 kpubdata 패키지가 import 가능할 때만 실행. 네트워크 호출은 없다 —
+        # 클래스/메서드 시그니처 수준의 구조 적합성만 확인한다.
+        kpubdata = pytest.importorskip("kpubdata")
+
+        client_cls = getattr(kpubdata, "Client", None)
+        assert client_cls is not None, "kpubdata.Client must exist"
+
+        # Client.dataset(source_key)가 존재해야 한다.
+        assert hasattr(client_cls, "dataset"), "kpubdata.Client must expose .dataset()"
+        assert callable(client_cls.dataset)
+
+        # dataset(...)이 반환하는 타입에 .list(**params)가 있어야 한다.
+        dataset_cls = client_cls.dataset.__annotations__.get("return")
+        if isinstance(dataset_cls, str):
+            # 문자열 어노테이션이면 client 모듈 네임스페이스에서 해석한다.
+            import inspect
+
+            module = inspect.getmodule(client_cls)
+            assert module is not None
+            dataset_cls = getattr(module, dataset_cls, None)
+        assert dataset_cls is not None, "Client.dataset return type must be resolvable"
+        assert hasattr(dataset_cls, "list"), "Dataset must expose .list()"
+        assert callable(dataset_cls.list)
+
+        # list(...)이 반환하는 타입에 .items가 있어야 한다(builder가 소비하는 속성).
+        list_return = dataset_cls.list.__annotations__.get("return")
+        if isinstance(list_return, str):
+            import inspect
+
+            module = inspect.getmodule(dataset_cls)
+            assert module is not None
+            list_return = getattr(module, list_return, None)
+        assert list_return is not None, "Dataset.list return type must be resolvable"
+        assert hasattr(list_return, "items"), "list() result must expose .items"

--- a/tests/integration/test_studio_contract.py
+++ b/tests/integration/test_studio_contract.py
@@ -1,0 +1,195 @@
+"""Studio↔Builder 계약 통합 테스트 (#226).
+
+Studio 같은 외부 UI가 직렬화하는 spec(snake_case 매핑)을 실제 BuilderService에
+dispatch 레이어를 통해 흘려보내고, Studio가 의존하는 실제 wire 응답 형태를 고정한다.
+
+검증 대상 엔드포인트:
+    - POST /validate (200)
+    - POST /build SUCCESS (200)
+    - POST /build FAILURE (502)
+    - GET  /artifacts/{run_id} (200)
+
+데이터는 in-test fake source client(dataset(key).list(**params).items)로 공급한다.
+실제 네트워크 호출은 하지 않는다.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+import yaml
+
+from kpubdata_builder.service import API_CONTRACT_VERSION, BuilderService, dispatch
+from kpubdata_builder.spec import JsonValue
+
+
+class _FakeResult:
+    """SourceClient Protocol의 DatasetResult 부분(items)을 만족하는 fake."""
+
+    def __init__(self, items: list[dict[str, JsonValue]]) -> None:
+        self._items = items
+
+    @property
+    def items(self) -> Iterable[dict[str, JsonValue]]:
+        return self._items
+
+
+class _FakeDataset:
+    """dataset(key).list(**params) 부분을 만족하는 fake."""
+
+    def __init__(self, items: list[dict[str, JsonValue]]) -> None:
+        self._items = items
+
+    def list(self, **params: JsonValue) -> _FakeResult:
+        return _FakeResult(self._items)
+
+
+class _FakeClient:
+    """builder가 의존하는 SourceClient Protocol을 구조적으로 만족하는 fake."""
+
+    def __init__(self, data: dict[str, list[dict[str, JsonValue]]]) -> None:
+        self._data = data
+
+    def dataset(self, source_key: str) -> _FakeDataset:
+        if source_key not in self._data:
+            raise KeyError(f"unknown source: {source_key}")
+        return _FakeDataset(self._data[source_key])
+
+
+def _studio_spec(*, dataset_value: str = "air_quality") -> dict[str, JsonValue]:
+    """Studio가 직렬화하는 형태의 spec 매핑을 만든다(snake_case).
+
+    sources/exports/metadata와 선택 필드(params, alias, options)를 포함해
+    Studio가 보내는 wire 형태를 의도적으로 그대로 재현한다.
+    """
+    return {
+        "dataset_id": "dataset.studio_sample",
+        "title": "Studio Sample Dataset",
+        "description": "A dataset assembled via the Studio UI.",
+        "sources": [
+            {
+                "provider": "datago",
+                "dataset": dataset_value,
+                "params": {"region": "seoul", "year": 2024},
+                "alias": "aq",
+            }
+        ],
+        "exports": [
+            {
+                "kind": "jsonl",
+                "output_path": "out/data.jsonl",
+                "options": {"ensure_ascii": False},
+            }
+        ],
+        "metadata": {"owner": "studio", "license": "CC-BY-4.0"},
+    }
+
+
+def _serialize(spec: dict[str, JsonValue]) -> str:
+    """Studio 직렬화 spec 매핑을 builder가 받는 wire 형태(YAML 문자열)로 변환한다."""
+    return yaml.safe_dump(spec, sort_keys=False, allow_unicode=True)
+
+
+def _service(tmp_path: Path) -> BuilderService:
+    client = _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}, {"id": "2", "v": 20}]})
+    return BuilderService(output_root=tmp_path, client_factory=lambda: client)
+
+
+class TestValidateContract:
+    def test_validate_returns_valid_envelope(self, tmp_path: Path) -> None:
+        spec_yaml = _serialize(_studio_spec())
+        resp = dispatch(_service(tmp_path), "POST", "/validate", {"spec": spec_yaml})
+
+        assert resp.status_code == 200
+        assert resp.body == {
+            "status": "valid",
+            "dataset_id": "dataset.studio_sample",
+            "api_version": API_CONTRACT_VERSION,
+        }
+
+
+class TestBuildSuccessContract:
+    def test_build_success_envelope(self, tmp_path: Path) -> None:
+        spec_yaml = _serialize(_studio_spec())
+        resp = dispatch(
+            _service(tmp_path),
+            "POST",
+            "/build",
+            {"spec": spec_yaml, "run_id": "studio-run"},
+        )
+
+        assert resp.status_code == 200
+        body = resp.body
+        # 최상위 wire 형태 고정: status/manifest/outcomes/run_id/api_version.
+        assert body["status"] == "ok"
+        assert body["run_id"] == "studio-run"
+        assert body["api_version"] == API_CONTRACT_VERSION
+        assert isinstance(body["manifest"], str)
+        assert body["manifest"].endswith("manifest.json")
+
+        outcomes = body["outcomes"]
+        assert isinstance(outcomes, list)
+        assert len(outcomes) == 1
+        outcome = outcomes[0]
+        assert isinstance(outcome, dict)
+        # alias가 주어지면 outcome의 source_key는 alias가 된다(provider.dataset 대신).
+        assert outcome["source_key"] == "aq"
+        assert outcome["status"] == "ok"
+        assert outcome["error"] is None
+        assert isinstance(outcome["stages_completed"], list)
+
+        # manifest 파일이 실제로 기록되었는지 확인.
+        assert (tmp_path / "studio-run" / "manifest.json").exists()
+
+
+class TestBuildFailureContract:
+    def test_build_failure_envelope(self, tmp_path: Path) -> None:
+        # 존재하지 않는 소스를 가리키게 해서 fetch 실패를 유도한다.
+        failing_spec = _studio_spec(dataset_value="missing")
+        spec_yaml = _serialize(failing_spec)
+        resp = dispatch(
+            _service(tmp_path),
+            "POST",
+            "/build",
+            {"spec": spec_yaml, "run_id": "studio-fail"},
+        )
+
+        assert resp.status_code == 502
+        body = resp.body
+        assert body["status"] == "failed"
+        assert body["run_id"] == "studio-fail"
+        assert body["api_version"] == API_CONTRACT_VERSION
+
+        outcomes = body["outcomes"]
+        assert isinstance(outcomes, list)
+        assert len(outcomes) == 1
+        outcome = outcomes[0]
+        assert isinstance(outcome, dict)
+        # fetch는 provider.dataset(datago.missing)로 시도하지만, outcome의 source_key는
+        # alias("aq")로 태깅된다(_output_source_key 정책).
+        assert outcome["source_key"] == "aq"
+        assert outcome["status"] == "failed"
+        assert isinstance(outcome["error"], str)
+        assert outcome["error"]
+
+        # #226: 최상위 human-readable error 요약은 첫 실패 outcome의 error에서 파생된다.
+        assert isinstance(body["error"], str)
+        assert body["error"] == outcome["error"]
+
+
+class TestArtifactsContract:
+    def test_artifacts_lists_files_after_build(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        spec_yaml = _serialize(_studio_spec())
+        dispatch(service, "POST", "/build", {"spec": spec_yaml, "run_id": "studio-art"})
+
+        resp = dispatch(service, "GET", "/artifacts/studio-art", None)
+
+        assert resp.status_code == 200
+        body = resp.body
+        assert body["run_id"] == "studio-art"
+        files = body["files"]
+        assert isinstance(files, list)
+        assert all(isinstance(f, str) for f in files)
+        assert any("manifest.json" in f for f in files)

--- a/tests/unit/test_service_contract.py
+++ b/tests/unit/test_service_contract.py
@@ -1,8 +1,9 @@
-"""Builder Service Contract(#63) OpenAPI 스펙의 구조 검증.
+"""Builder Service Contract(#63, #226) OpenAPI 스펙의 구조 검증.
 
-설치된 OpenAPI validator가 없으므로, 계약이 OpenAPI 3.1이고 API_CONTRACT.md의
-8개 엔드포인트와 표준 오류 스키마를 모두 담는지 구조적으로 검증한다. 실행 중인
-builder dev server 대비 계약 테스트는 service mode(#36) 도입 후 확장한다.
+설치된 OpenAPI validator가 없으므로, 계약이 OpenAPI 3.1이고 BuilderService
+(service/app.py)가 실제로 구현한 동기 라우트와 wire 형태를 모두 담는지 구조적으로
+검증한다. 계약은 이제 구현된 엔드포인트만 기술하며(#226), 한쪽만 바뀌는 조용한
+드리프트를 막기 위해 구현 라우트 ↔ 계약 operationId 매핑을 명시적으로 고정한다.
 """
 
 from __future__ import annotations
@@ -14,16 +15,14 @@ import yaml
 
 _CONTRACT_PATH = Path(__file__).parents[2] / "contract" / "builder-api.yaml"
 
-# (path, method) 형태의 계약 필수 오퍼레이션.
+# (path, method) 형태의 계약 필수 오퍼레이션. BuilderService.dispatch가 실제로
+# 라우팅하는 동기 엔드포인트와 1:1로 대응한다.
 _REQUIRED_OPERATIONS = [
-    ("/datasets", "get"),
-    ("/spec/validate", "post"),
+    ("/version", "get"),
+    ("/validate", "post"),
     ("/preview", "post"),
-    ("/builds", "post"),
-    ("/builds/{id}", "get"),
-    ("/builds/{id}/manifest", "get"),
-    ("/builds/{id}/artifacts", "get"),
-    ("/publish", "post"),
+    ("/build", "post"),
+    ("/artifacts/{run_id}", "get"),
 ]
 
 
@@ -67,23 +66,10 @@ def test_operation_ids_are_unique() -> None:
 def test_defines_standard_error_schema() -> None:
     schemas = _load_contract()["components"]["schemas"]
 
+    # 실제 구현은 단순한 {"error": "<message>"} 형태를 사용한다(#226).
     assert "Error" in schemas
-    error_props = schemas["Error"]["properties"]["error"]["properties"]
-    assert {"code", "message", "details"} <= set(error_props)
-
-
-def test_build_state_enum_matches_contract() -> None:
-    schemas = _load_contract()["components"]["schemas"]
-
-    assert set(schemas["BuildState"]["enum"]) == {
-        "draft",
-        "validated",
-        "running",
-        "exported",
-        "manifested",
-        "published",
-        "failed",
-    }
+    assert "error" in schemas["Error"]["properties"]
+    assert schemas["Error"]["properties"]["error"]["type"] == "string"
 
 
 def test_service_api_version_matches_contract() -> None:
@@ -93,21 +79,14 @@ def test_service_api_version_matches_contract() -> None:
     assert str(_load_contract()["info"]["version"]) == API_CONTRACT_VERSION
 
 
-# 현재 BuilderService가 구현한 동기 라우트 → 계약 operationId 매핑.
-# 구현 경로 이름은 계약과 다르다(예: POST /validate vs 계약의 /spec/validate).
-# 이 매핑이 그 차이를 명시적으로 고정해, 한쪽만 바뀌는 조용한 드리프트를 막는다 (#209).
+# 계약이 기술하는 모든 오퍼레이션은 BuilderService에 실제로 구현돼 있어야 한다.
+# 구현 경로 이름은 계약과 1:1로 일치한다(#226: aspirational 비동기/publish 라우트 제거).
 _IMPLEMENTED_OPERATIONS = {
+    "getVersion",  # GET /version
     "validateSpec",  # POST /validate
     "previewBuild",  # POST /preview
-    "createBuild",  # POST /build (동기; 계약은 비동기 POST /builds 지향)
+    "createBuild",  # POST /build
     "listBuildArtifacts",  # GET /artifacts/{run_id}
-}
-# 아직 builder service에 구현되지 않은(계약상 존재하는) 오퍼레이션.
-_PLANNED_OPERATIONS = {
-    "listDatasets",
-    "getBuild",
-    "getBuildManifest",
-    "publishArtifacts",
 }
 
 
@@ -121,14 +100,26 @@ def _contract_operation_ids() -> set[str]:
     }
 
 
-def test_implemented_and_planned_cover_all_contract_operations() -> None:
-    # 구현됨 + 계획됨의 합집합이 계약의 모든 오퍼레이션을 빠짐없이 덮어야 한다.
-    # 계약에 새 오퍼레이션이 추가되면 이 테스트가 깨져 분류를 강제한다 (#209).
-    contract_ops = _contract_operation_ids()
+def test_contract_operations_match_implementation() -> None:
+    # 계약의 오퍼레이션 집합이 구현된 동기 라우트 집합과 정확히 일치해야 한다.
+    # 계약에 미구현 오퍼레이션이 추가되거나 라우트가 사라지면 이 테스트가 깨진다 (#226).
+    assert _contract_operation_ids() == _IMPLEMENTED_OPERATIONS
 
-    assert contract_ops >= _IMPLEMENTED_OPERATIONS
-    assert contract_ops >= _PLANNED_OPERATIONS
-    assert contract_ops == _IMPLEMENTED_OPERATIONS | _PLANNED_OPERATIONS
+
+def test_build_responses_pin_wire_status_codes() -> None:
+    # POST /build의 실제 상태 코드(200 성공, 502 부분 실패)를 계약이 고정해야 한다 (#226).
+    build = _load_contract()["paths"]["/build"]["post"]["responses"]
+    assert "200" in build
+    assert "502" in build
+    assert "400" in build
+
+
+def test_build_failure_response_includes_error_summary() -> None:
+    # 502 응답이 human-readable error 요약을 포함하는 것을 계약 수준에서 고정 (#226).
+    schemas = _load_contract()["components"]["schemas"]
+    failure = schemas["BuildFailureResponse"]
+    assert "error" in failure["properties"]
+    assert "error" in failure["required"]
 
 
 def test_referenced_schemas_resolve() -> None:


### PR DESCRIPTION
Closes #226.

## 추가/변경 내용

### 계약 통합 테스트 (우선순위 1)
\`tests/integration/test_studio_contract.py\`는 Studio 스타일의 직렬화된 스펙(snake_case \`dataset_id\`/\`title\`/\`description\`/\`sources:[{provider,dataset,params,alias}]\`/\`exports:[{kind,output_path,options}]\`/\`metadata\`)을 구성하고, 빌더가 받아들이는 와이어 포맷(\`{"spec": "<yaml>"}\`)으로 직렬화한 뒤, 인테스트 가짜 소스 클라이언트(\`dataset(key).list(**params).items\`)를 사용하는 \`dispatch\` 레이어를 통해 실제 \`BuilderService\`에 전달합니다. 다음 실제 와이어 형태를 고정합니다:
- \`POST /validate\` → 200 \`{status:"valid", dataset_id, api_version}\`
- \`POST /build\` 성공 → 200 \`{status:"ok", manifest, outcomes, run_id, api_version}\`
- \`POST /build\` 실패 → 502 \`{status:"failed", outcomes:[{source_key,status,error,...}], error, ...}\`
- \`GET /artifacts/{run_id}\` → 200 \`{files:[...], run_id}\`

실제 \`alias\` → 결과 \`source_key\` 매핑도 고정합니다(alias가 결과에서 \`provider.dataset\`을 재정의).

### kpubdata 클라이언트 프로토콜(Protocol) 테스트 (우선순위 2)
\`tests/integration/test_kpubdata_client_protocol.py\`는 \`SourceClient\` 프로토콜(\`dataset(source_key).list(**params).items\` → dict의 이터러블)이 인메모리 적합 클라이언트를 통해 충족될 수 있음을 검증하고, \`importorskip("kpubdata")\`로 가드된 구조적 적합성 검사를 수행하여 실제 \`kpubdata.Client\`가 계약(\`Client.dataset(...) -> Dataset.list(**kwargs) -> RecordBatch.items\`)과 일치하는지 확인합니다. 실시간 네트워크 호출 없음.

### 계약 YAML 동기화 (우선순위 3)
\`contract/builder-api.yaml\`을 실제 구현된 라우트(\`/version\`, \`/validate\`, \`/preview\`, \`/build\`, \`/artifacts/{run_id}\`), 실제 상태 코드(400, not 422; 부분 빌드 실패 시 502; 누락된 실행 시 404), 실제 요청/응답 바디(\`spec\`은 YAML 문자열, snake_case \`BuildSpec\`/\`SourceRef\`/\`ExportTarget\`, 빌드 성공/실패/결과 봉투)와 일치하도록 재작성했습니다. 구현되지 않은 비동기/게시 엔드포인트(\`/builds\`, \`/spec/validate\`, \`/publish\` 등)를 제거하여 묵시적 드리프트를 방지합니다. \`tests/unit/test_service_contract.py\`는 동기화된 계약을 검증하도록 업데이트되었습니다(필수 작업, 상태 코드 고정, 오류 요약 존재, \`$ref\` 해결).

### 선택적 응답 개선 (우선순위 4) — 포함
\`service/app.py\`: \`/build\` 실패(502) 응답에 최상위 사람이 읽을 수 있는 \`error\` 요약 문자열을 추가합니다. 첫 번째 실패한 결과의 \`error\`에서 파생되어 클라이언트가 \`outcomes\` 배열을 파싱하지 않고도 이유를 표시할 수 있습니다. 저위험: 기존 502 테스트는 \`status\`/\`status_code\`만 검증하므로 영향 없음; 새 계약 테스트와 \`test_service_contract.py\`가 새 필드를 고정합니다.

미뤄진 항목 없음.

## 검증 방법
- \`ruff check .\` → 문제 없음
- 수정된 파일에 대해 \`ruff format --check\` → 문제 없음
- \`mypy src\` → 70개 소스 파일에서 문제 없음
- \`pytest -q\` → 401개 통과 (이전 393개; 새 테스트 +8개)