### PR TITLE
ci: add lint/type/test quality gate and scripts/pipeline tests (#214, #238)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+# PR 머지 전 코드 품질 게이트: lint(ruff) + type check(mypy) + 테스트 매트릭스.
+# 데이터셋 발행 워크플로(publish-dataset.yml)와 분리된, 코드 품질 전용 CI다 (#214).
+#
+# --no-sources: [tool.uv.sources]의 editable ../kpubdata 오버라이드를 무시하고
+# pyproject의 버전 핀(>=0.5.0,<0.6, #213)대로 PyPI에서 kpubdata를 해석한다.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint & type check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --extra dev --no-sources
+
+      - name: Ruff (lint)
+        run: uv run ruff check .
+
+      - name: Ruff (format check)
+        run: uv run ruff format --check .
+
+      - name: mypy (type check)
+        run: uv run mypy src
+
+  test:
+    name: Tests (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --extra dev --no-sources --python ${{ matrix.python-version }}
+
+      - name: Run tests
+        run: uv run pytest

--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,4 @@ Thumbs.db
 # Environment
 .env
 .env.local
-.github/workflows/ci.yml
 staging/

--- a/tests/pipeline/test_fetch.py
+++ b/tests/pipeline/test_fetch.py
@@ -1,0 +1,211 @@
+"""Tests for scripts/pipeline/fetch.py — checkpoint/resume logic.
+
+These tests exercise pure logic only; no network calls are made.
+kpubdata.Client is fully mocked before module import.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Bootstrap: mock kpubdata before loading fetch.py, which does
+#   ``from kpubdata import Client`` at module level.
+# ---------------------------------------------------------------------------
+_kpubdata_mock = MagicMock()
+_kpubdata_mock.Client = MagicMock()
+sys.modules.setdefault("kpubdata", _kpubdata_mock)
+
+_FETCH_PATH = Path(__file__).parents[2] / "scripts" / "pipeline" / "fetch.py"
+
+
+def _load_fetch() -> Any:
+    spec = importlib.util.spec_from_file_location("_pipeline_fetch", _FETCH_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+fetch_mod = _load_fetch()
+fetch_records = fetch_mod.fetch_records
+FetchError = fetch_mod.FetchError
+_checkpoint_path = fetch_mod._checkpoint_path
+_save_checkpoint = fetch_mod._save_checkpoint
+_fetch_with_retry = fetch_mod._fetch_with_retry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeResult:
+    def __init__(self, items: list[dict[str, Any]]) -> None:
+        self.items = items
+
+
+class _FakeDataset:
+    """Returns successive batches on each call to list() / list_all()."""
+
+    def __init__(self, batches: list[list[dict[str, Any]]]) -> None:
+        self._batches = batches
+        self._call_count = 0
+
+    def list(self, **_params: Any) -> _FakeResult:
+        result = self._batches[self._call_count]
+        self._call_count += 1
+        return _FakeResult(result)
+
+    def list_all(self, **_params: Any) -> list[_FakeResult]:
+        result = self._batches[self._call_count]
+        self._call_count += 1
+        return [_FakeResult(result)]
+
+
+def _make_config(
+    fetch_params: list[dict[str, Any]],
+    *,
+    list_all: bool = False,
+) -> dict[str, Any]:
+    return {
+        "source": {
+            "provider": "datago",
+            "dataset": "air_quality",
+            "list_all": list_all,
+            "fetch_params": fetch_params,
+        }
+    }
+
+
+def _mock_client(dataset: _FakeDataset) -> MagicMock:
+    client = MagicMock()
+    client.dataset.return_value = dataset
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_records_returns_all_items() -> None:
+    """fetch_records aggregates items from all fetch_params."""
+    ds = _FakeDataset([[{"id": "1"}, {"id": "2"}], [{"id": "3"}]])
+    config = _make_config([{"year": 2022}, {"year": 2023}])
+
+    with patch.object(fetch_mod, "Client") as MockClient:
+        MockClient.from_env.return_value = _mock_client(ds)
+        records = fetch_records(config)
+
+    assert len(records) == 3
+    assert records[0]["id"] == "1"
+    assert records[2]["id"] == "3"
+
+
+def test_fetch_records_list_all_mode() -> None:
+    """list_all=True uses ds.list_all() instead of ds.list()."""
+    ds = _FakeDataset([[{"id": "a"}, {"id": "b"}]])
+    config = _make_config([{"year": 2022}], list_all=True)
+
+    with patch.object(fetch_mod, "Client") as MockClient:
+        MockClient.from_env.return_value = _mock_client(ds)
+        records = fetch_records(config)
+
+    assert [r["id"] for r in records] == ["a", "b"]
+
+
+def test_fetch_records_saves_checkpoint(tmp_path: Path) -> None:
+    """A checkpoint file is written after each successful fetch batch."""
+    ds = _FakeDataset([[{"id": "1"}], [{"id": "2"}]])
+    config = _make_config([{"year": 2022}, {"year": 2023}])
+
+    with patch.object(fetch_mod, "Client") as MockClient:
+        MockClient.from_env.return_value = _mock_client(ds)
+        fetch_records(config, checkpoint_dir=tmp_path)
+
+    cp = tmp_path / "fetch_checkpoint.json"
+    assert cp.exists()
+    data = json.loads(cp.read_text(encoding="utf-8"))
+    assert data["next_index"] == 2
+    assert len(data["records"]) == 2
+
+
+def test_fetch_records_resumes_from_checkpoint(tmp_path: Path) -> None:
+    """resume=True skips already-fetched batches using the checkpoint."""
+    # Pre-write a checkpoint: index 1 already done, 1 record cached.
+    cp = tmp_path / "fetch_checkpoint.json"
+    cp.write_text(
+        json.dumps({"next_index": 1, "records": [{"id": "cached"}]}),
+        encoding="utf-8",
+    )
+
+    # Only the second batch needs to be fetched.
+    ds = _FakeDataset([[{"id": "new"}]])
+    config = _make_config([{"year": 2022}, {"year": 2023}])
+
+    with patch.object(fetch_mod, "Client") as MockClient:
+        MockClient.from_env.return_value = _mock_client(ds)
+        records = fetch_records(config, checkpoint_dir=tmp_path, resume=True)
+
+    assert len(records) == 2
+    assert records[0]["id"] == "cached"
+    assert records[1]["id"] == "new"
+
+
+def test_fetch_records_no_checkpoint_when_dir_none() -> None:
+    """When checkpoint_dir is None, no checkpoint file is written."""
+    ds = _FakeDataset([[{"id": "x"}]])
+    config = _make_config([{"year": 2022}])
+
+    with patch.object(fetch_mod, "Client") as MockClient:
+        MockClient.from_env.return_value = _mock_client(ds)
+        records = fetch_records(config, checkpoint_dir=None)
+
+    assert records == [{"id": "x"}]
+
+
+def test_checkpoint_path_creates_directory(tmp_path: Path) -> None:
+    nested = tmp_path / "a" / "b"
+    path = _checkpoint_path(nested)
+    assert nested.is_dir()
+    assert path.name == "fetch_checkpoint.json"
+
+
+def test_save_checkpoint_writes_atomically(tmp_path: Path) -> None:
+    cp = tmp_path / "fetch_checkpoint.json"
+    _save_checkpoint(cp, next_index=3, records=[{"id": "r"}])
+    data = json.loads(cp.read_text(encoding="utf-8"))
+    assert data == {"next_index": 3, "records": [{"id": "r"}]}
+    # No .tmp file left behind
+    assert not (tmp_path / "fetch_checkpoint.tmp").exists()
+
+
+def test_fetch_with_retry_raises_fetch_error_after_exhaustion() -> None:
+    """Retryable errors raise FetchError after max_retries is exhausted."""
+    failing_ds = MagicMock()
+    failing_ds.list.side_effect = RuntimeError("503 service unavailable")
+
+    with pytest.raises(FetchError, match="retries"):
+        _fetch_with_retry(
+            failing_ds,
+            {"year": 2022},
+            max_retries=1,
+            base_delay=0.0,
+        )
+
+
+def test_fetch_with_retry_raises_immediately_for_non_retryable() -> None:
+    """Non-retryable errors propagate without waiting for max_retries."""
+    failing_ds = MagicMock()
+    failing_ds.list.side_effect = ValueError("bad input — not retryable")
+
+    with pytest.raises(ValueError, match="bad input"):
+        _fetch_with_retry(failing_ds, {}, max_retries=3, base_delay=0.0)

--- a/tests/pipeline/test_package.py
+++ b/tests/pipeline/test_package.py
@@ -1,0 +1,181 @@
+"""Tests for scripts/pipeline/package.py — parquet output and dataset card.
+
+Pure logic tests; no network calls.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+import pytest
+
+_PACKAGE_PATH = Path(__file__).parents[2] / "scripts" / "pipeline" / "package.py"
+
+
+def _load_package() -> Any:
+    spec = importlib.util.spec_from_file_location("scripts.pipeline.package", _PACKAGE_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault("scripts.pipeline.package", mod)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+package_mod = _load_package()
+write_parquet = package_mod.write_parquet
+generate_dataset_card = package_mod.generate_dataset_card
+_size_category = package_mod._size_category
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _minimal_config(hf_repo: str = "kpubdata/test-dataset") -> dict[str, Any]:
+    return {
+        "source": {"source_url": "https://www.data.go.kr"},
+        "output": {"hf_repo": hf_repo},
+        "card": {
+            "title": "Test Dataset",
+            "description": "A test dataset.",
+            "license": "cc-by-4.0",
+            "language": ["ko"],
+            "tags": ["korea", "test"],
+            "features": [{"name": "id", "description": "Record identifier"}],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# write_parquet
+# ---------------------------------------------------------------------------
+
+
+def test_write_parquet_creates_file(tmp_path: Path) -> None:
+    df = pl.DataFrame({"id": ["1", "2"], "value": [10, 20]})
+    out = tmp_path / "data" / "train.parquet"
+
+    result = write_parquet(df, out)
+
+    assert result == out
+    assert out.exists()
+    assert pl.read_parquet(out).equals(df)
+
+
+def test_write_parquet_creates_parent_dirs(tmp_path: Path) -> None:
+    df = pl.DataFrame({"x": [1]})
+    nested = tmp_path / "a" / "b" / "c" / "out.parquet"
+
+    write_parquet(df, nested)
+
+    assert nested.exists()
+
+
+def test_write_parquet_roundtrip_preserves_schema(tmp_path: Path) -> None:
+    df = pl.DataFrame({"name": ["Seoul"], "count": [42]})
+    out = tmp_path / "out.parquet"
+    write_parquet(df, out)
+
+    loaded = pl.read_parquet(out)
+    assert loaded.columns == df.columns
+    assert loaded["count"][0] == 42
+
+
+# ---------------------------------------------------------------------------
+# generate_dataset_card
+# ---------------------------------------------------------------------------
+
+
+def test_generate_dataset_card_creates_readme(tmp_path: Path) -> None:
+    df = pl.DataFrame({"id": ["1", "2"]})
+    config = _minimal_config()
+    out = tmp_path / "README.md"
+
+    result = generate_dataset_card(df, config, out)
+
+    assert result == out
+    assert out.exists()
+    content = out.read_text(encoding="utf-8")
+    assert "# Test Dataset" in content
+    assert "kpubdata/test-dataset" in content
+
+
+def test_generate_dataset_card_contains_frontmatter(tmp_path: Path) -> None:
+    df = pl.DataFrame({"id": ["1"]})
+    config = _minimal_config()
+    out = tmp_path / "README.md"
+
+    generate_dataset_card(df, config, out)
+
+    content = out.read_text(encoding="utf-8")
+    assert content.startswith("---")
+    assert "license: cc-by-4.0" in content
+    assert "- korea" in content
+
+
+def test_generate_dataset_card_with_variants(tmp_path: Path) -> None:
+    df = pl.DataFrame({"id": ["1"]})
+    config = _minimal_config()
+    out = tmp_path / "README.md"
+
+    generate_dataset_card(df, config, out, variant_names=["ko", "en"])
+
+    content = out.read_text(encoding="utf-8")
+    assert "config_name: ko" in content
+    assert "config_name: en" in content
+    assert "default_config_name: en" in content
+
+
+def test_generate_dataset_card_sample_table(tmp_path: Path) -> None:
+    df = pl.DataFrame({"id": ["r1", "r2", "r3", "r4", "r5", "r6"]})
+    config = _minimal_config()
+    out = tmp_path / "README.md"
+
+    generate_dataset_card(df, config, out)
+
+    content = out.read_text(encoding="utf-8")
+    # Sample table capped at 5 rows — r6 should not appear
+    assert "r5" in content
+    assert "r6" not in content
+
+
+def test_generate_dataset_card_stats_for_numeric(tmp_path: Path) -> None:
+    df = pl.DataFrame({"id": ["1", "2"], "count": [10, 20]})
+    config = _minimal_config()
+    out = tmp_path / "README.md"
+
+    generate_dataset_card(df, config, out)
+
+    content = out.read_text(encoding="utf-8")
+    assert "## Statistics" in content
+    assert "`count`" in content
+
+
+# ---------------------------------------------------------------------------
+# _size_category
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("n", "expected"),
+    [
+        (0, "n<1K"),
+        (999, "n<1K"),
+        (1_000, "1K<n<10K"),
+        (9_999, "1K<n<10K"),
+        (10_000, "10K<n<100K"),
+        (99_999, "10K<n<100K"),
+        (100_000, "100K<n<1M"),
+        (999_999, "100K<n<1M"),
+        (1_000_000, "1M<n<10M"),
+        (9_999_999, "1M<n<10M"),
+        (10_000_000, "n>10M"),
+    ],
+)
+def test_size_category(n: int, expected: str) -> None:
+    assert _size_category(n) == expected

--- a/tests/pipeline/test_publish.py
+++ b/tests/pipeline/test_publish.py
@@ -1,0 +1,251 @@
+"""Tests for scripts/pipeline/publish.py — upload logic (fully mocked, no network).
+
+All HuggingFace Hub and Kaggle calls are mocked via sys.modules stubs so
+these tests work without the optional publish extras installed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub optional dependencies before loading publish.py.
+# publish.py does lazy imports (inside functions), so we pre-populate
+# sys.modules with MagicMock stubs.
+# ---------------------------------------------------------------------------
+_hf_stub = MagicMock()
+sys.modules.setdefault("huggingface_hub", _hf_stub)
+
+_kaggle_stub = MagicMock()
+_kaggle_api_stub = MagicMock()
+_kaggle_api_extended_stub = MagicMock()
+sys.modules.setdefault("kaggle", _kaggle_stub)
+sys.modules.setdefault("kaggle.api", _kaggle_api_stub)
+sys.modules.setdefault("kaggle.api.kaggle_api_extended", _kaggle_api_extended_stub)
+
+_PUBLISH_PATH = Path(__file__).parents[2] / "scripts" / "pipeline" / "publish.py"
+
+
+def _load_publish() -> Any:
+    spec = importlib.util.spec_from_file_location("_pipeline_publish", _PUBLISH_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+publish_mod = _load_publish()
+upload_to_hf = publish_mod.upload_to_hf
+upload_to_kaggle = publish_mod.upload_to_kaggle
+_map_kaggle_license = publish_mod._map_kaggle_license
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _staging_dir(tmp_path: Path, *, with_data: bool = True) -> Path:
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    (staging / "README.md").write_text("# Test", encoding="utf-8")
+    if with_data:
+        data = staging / "data"
+        data.mkdir()
+        (data / "train.parquet").write_bytes(b"fake parquet bytes")
+    return staging
+
+
+def _kaggle_config(slug: str = "user/test-dataset") -> dict[str, Any]:
+    return {
+        "output": {"hf_repo": "kpubdata/test", "kaggle_slug": slug},
+        "card": {
+            "title": "Test Dataset",
+            "description": "A dataset for testing.",
+            "license": "cc-by-4.0",
+            "tags": ["korea", "test"],
+            "subtitle": "Testing the kaggle upload path",
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# upload_to_hf — dry_run
+# ---------------------------------------------------------------------------
+
+
+def test_upload_to_hf_dry_run_does_not_call_api(tmp_path: Path) -> None:
+    staging = _staging_dir(tmp_path)
+    _hf_stub.HfApi.reset_mock()
+
+    upload_to_hf(staging, "kpubdata/test", dry_run=True)
+
+    _hf_stub.HfApi.assert_not_called()
+
+
+def test_upload_to_hf_dry_run_logs_message(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    import logging
+
+    staging = _staging_dir(tmp_path)
+    with caplog.at_level(logging.INFO, logger="publish_to_hf.publish"):
+        upload_to_hf(staging, "kpubdata/test", dry_run=True)
+
+    assert any("DRY RUN" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# upload_to_hf — live (mocked HfApi via sys.modules stub)
+# ---------------------------------------------------------------------------
+
+
+def test_upload_to_hf_live_calls_create_and_upload(tmp_path: Path) -> None:
+    staging = _staging_dir(tmp_path)
+    mock_api_instance = MagicMock()
+    _hf_stub.HfApi.return_value = mock_api_instance
+
+    upload_to_hf(staging, "kpubdata/test-live", dry_run=False)
+
+    mock_api_instance.create_repo.assert_called_once_with(
+        repo_id="kpubdata/test-live", repo_type="dataset", exist_ok=True
+    )
+    mock_api_instance.upload_folder.assert_called_once()
+
+
+def test_upload_to_hf_copies_readme_and_data(tmp_path: Path) -> None:
+    """Verify README.md and data/ are present in the upload folder before cleanup."""
+    staging = _staging_dir(tmp_path)
+    found_files: list[list[str]] = []
+    mock_api_instance = MagicMock()
+
+    def _inspect_and_upload(**kwargs: Any) -> None:
+        # Called while upload dir still exists — record what's inside.
+        upload_dir = Path(kwargs["folder_path"])
+        found_files.append([str(p.relative_to(upload_dir)) for p in upload_dir.rglob("*")])
+
+    mock_api_instance.upload_folder.side_effect = _inspect_and_upload
+    _hf_stub.HfApi.return_value = mock_api_instance
+
+    upload_to_hf(staging, "kpubdata/test", dry_run=False)
+
+    assert len(found_files) == 1
+    flat = found_files[0]
+    assert "README.md" in flat
+    assert str(Path("data") / "train.parquet") in flat
+
+
+# ---------------------------------------------------------------------------
+# upload_to_kaggle — dry_run
+# ---------------------------------------------------------------------------
+
+
+def test_upload_to_kaggle_dry_run_does_not_authenticate(tmp_path: Path) -> None:
+    staging = _staging_dir(tmp_path)
+    config = _kaggle_config()
+    mock_api_instance = MagicMock()
+    _kaggle_api_extended_stub.KaggleApi.return_value = mock_api_instance
+
+    upload_to_kaggle(staging, config, dry_run=True)
+
+    mock_api_instance.authenticate.assert_not_called()
+
+
+def test_upload_to_kaggle_dry_run_logs_message(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    import logging
+
+    staging = _staging_dir(tmp_path)
+    config = _kaggle_config()
+
+    with caplog.at_level(logging.INFO, logger="publish_to_hf.publish"):
+        upload_to_kaggle(staging, config, dry_run=True)
+
+    assert any("DRY RUN" in r.message for r in caplog.records)
+
+
+def test_upload_to_kaggle_dry_run_cleans_up_upload_dir(tmp_path: Path) -> None:
+    staging = _staging_dir(tmp_path)
+    config = _kaggle_config()
+
+    upload_to_kaggle(staging, config, dry_run=True)
+
+    # The temp upload dir must not linger after dry_run
+    assert not (staging / ".kaggle_upload").exists()
+
+
+def test_upload_to_kaggle_dry_run_writes_metadata_json(tmp_path: Path) -> None:
+    """Metadata JSON content is correct (inspected before cleanup via mock)."""
+    staging = _staging_dir(tmp_path)
+    config = _kaggle_config("myorg/my-dataset")
+    written_metadata: list[dict[str, Any]] = []
+
+    # Intercept shutil.rmtree to capture the metadata before cleanup
+    import shutil as shutil_mod
+
+    original_rmtree = shutil_mod.rmtree
+
+    def _capture_and_remove(path: str, **kwargs: Any) -> None:
+        p = Path(path)
+        meta_file = p / "dataset-metadata.json"
+        if meta_file.exists():
+            written_metadata.append(json.loads(meta_file.read_text(encoding="utf-8")))
+        original_rmtree(path, **kwargs)
+
+    import unittest.mock as mock_mod
+
+    with mock_mod.patch.object(shutil_mod, "rmtree", side_effect=_capture_and_remove):
+        upload_to_kaggle(staging, config, dry_run=True)
+
+    assert len(written_metadata) == 1
+    md = written_metadata[0]
+    assert md["id"] == "myorg/my-dataset"
+    assert md["title"] == "Test Dataset"
+    assert "CC-BY-4.0" in md["licenses"][0]["name"]
+
+
+def test_upload_to_kaggle_no_slug_skips_gracefully(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    import logging
+
+    staging = _staging_dir(tmp_path)
+    config: dict[str, Any] = {
+        "output": {"hf_repo": "kpubdata/test"},  # no kaggle_slug
+        "card": {"title": "T", "description": "D", "license": "cc0-1.0", "tags": []},
+    }
+
+    with caplog.at_level(logging.ERROR, logger="publish_to_hf.publish"):
+        upload_to_kaggle(staging, config)
+
+    assert any("kaggle_slug" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# _map_kaggle_license
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("hf_license", "expected"),
+    [
+        ("cc-by-4.0", "CC-BY-4.0"),
+        ("cc0-1.0", "CC0-1.0"),
+        ("cc-by-sa-4.0", "CC-BY-SA-4.0"),
+        ("apache-2.0", "apache-2.0"),
+        ("mit", "other"),
+        ("odc-by", "ODC-BY-1.0"),
+        ("odbl", "ODbL-1.0"),
+        ("unknown-license", "other"),
+    ],
+)
+def test_map_kaggle_license(hf_license: str, expected: str) -> None:
+    assert _map_kaggle_license(hf_license) == expected

--- a/tests/pipeline/test_transform.py
+++ b/tests/pipeline/test_transform.py
@@ -1,0 +1,254 @@
+"""Tests for scripts/pipeline/transform.py — schema/validation logic.
+
+Pure logic tests; no network calls, no filesystem side-effects.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+import pytest
+
+_TRANSFORM_PATH = Path(__file__).parents[2] / "scripts" / "pipeline" / "transform.py"
+
+
+def _load_transform() -> Any:
+    spec = importlib.util.spec_from_file_location("scripts.pipeline.transform", _TRANSFORM_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault("scripts.pipeline.transform", mod)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+transform_mod = _load_transform()
+transform_records = transform_mod.transform_records
+validate_schema = transform_mod.validate_schema
+build_variant_dataframes = transform_mod.build_variant_dataframes
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _config(
+    column_mapping: dict[str, str],
+    *,
+    dtypes: dict[str, str] | None = None,
+    filters: list[str] | None = None,
+    derived: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "source": {"source_url": "https://example.com"},
+        "transform": {
+            "column_mapping": column_mapping,
+            "dtypes": dtypes or {},
+            "filters": filters or [],
+            "derived": derived or [],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# transform_records
+# ---------------------------------------------------------------------------
+
+
+def test_transform_basic_column_mapping() -> None:
+    records = [{"raw_id": "1", "raw_name": "Seoul"}, {"raw_id": "2", "raw_name": "Busan"}]
+    cfg = _config({"raw_id": "id", "raw_name": "name"})
+
+    df = transform_records(records, cfg)
+
+    assert df.columns == ["id", "name"]
+    assert df.height == 2
+    assert df["id"][0] == "1"
+    assert df["name"][1] == "Busan"
+
+
+def test_transform_missing_raw_key_becomes_none() -> None:
+    records = [{"raw_id": "1"}]  # raw_name absent
+    cfg = _config({"raw_id": "id", "raw_name": "name"})
+
+    df = transform_records(records, cfg)
+
+    assert df["name"][0] is None
+
+
+def test_transform_dtype_int_cast() -> None:
+    records = [{"amount": "1234"}, {"amount": None}, {"amount": "-"}]
+    cfg = _config({"amount": "amount"}, dtypes={"amount": "int"})
+
+    df = transform_records(records, cfg)
+
+    assert df["amount"].dtype == pl.Int64
+    assert df["amount"][0] == 1234
+    assert df["amount"][1] is None
+    assert df["amount"][2] is None  # null token
+
+
+def test_transform_dtype_int_comma() -> None:
+    records = [{"val": "1,234,567"}]
+    cfg = _config({"val": "val"}, dtypes={"val": "int_comma"})
+
+    df = transform_records(records, cfg)
+
+    assert df["val"][0] == 1234567
+
+
+def test_transform_dtype_float_cast() -> None:
+    records = [{"price": "3.14"}, {"price": "N/A"}]
+    cfg = _config({"price": "price"}, dtypes={"price": "float"})
+
+    df = transform_records(records, cfg)
+
+    assert df["price"].dtype == pl.Float64
+    assert abs(df["price"][0] - 3.14) < 1e-9
+    assert df["price"][1] is None
+
+
+def test_transform_filter_greater_than() -> None:
+    records = [{"amount": "100"}, {"amount": "200"}, {"amount": "50"}]
+    cfg = _config({"amount": "amount"}, dtypes={"amount": "int"}, filters=["amount > 100"])
+
+    df = transform_records(records, cfg)
+
+    assert df.height == 1
+    assert df["amount"][0] == 200
+
+
+def test_transform_filter_equal_string() -> None:
+    records = [{"city": "Seoul"}, {"city": "Busan"}, {"city": "Seoul"}]
+    cfg = _config({"city": "city"}, filters=["city == Seoul"])
+
+    df = transform_records(records, cfg)
+
+    assert df.height == 2
+
+
+def test_transform_filter_unknown_column_is_skipped() -> None:
+    """A filter referencing a nonexistent column is silently skipped."""
+    records = [{"x": "1"}]
+    cfg = _config({"x": "x"}, filters=["missing_col > 0"])
+
+    df = transform_records(records, cfg)
+    assert df.height == 1
+
+
+def test_transform_derived_concat_date() -> None:
+    records = [{"y": "2023", "m": "3", "d": "5"}]
+    cfg = _config(
+        {"y": "year", "m": "month", "d": "day"},
+        derived=[{"name": "date", "expr": "concat_date(year, month, day)", "dtype": "str"}],
+    )
+
+    df = transform_records(records, cfg)
+
+    assert "date" in df.columns
+    assert df["date"][0] == "2023-03-05"
+
+
+def test_transform_derived_format_expr() -> None:
+    records = [{"first": "Kim", "last": "Choe"}]
+    cfg = _config(
+        {"first": "first", "last": "last"},
+        derived=[{"name": "full", "expr": "format({} {}, first, last)", "dtype": "str"}],
+    )
+
+    df = transform_records(records, cfg)
+
+    assert df["full"][0] == "Kim Choe"
+
+
+# ---------------------------------------------------------------------------
+# validate_schema
+# ---------------------------------------------------------------------------
+
+
+def test_validate_schema_passes_for_exact_match() -> None:
+    df = pl.DataFrame({"id": ["1"], "name": ["Seoul"]})
+    cfg = _config({"raw_id": "id", "raw_name": "name"})
+
+    # Should not raise or call sys.exit
+    validate_schema(df, cfg)
+
+
+def test_validate_schema_fails_for_undeclared_column(monkeypatch: pytest.MonkeyPatch) -> None:
+    df = pl.DataFrame({"id": ["1"], "extra": ["oops"]})
+    cfg = _config({"raw_id": "id"})
+
+    with pytest.raises(SystemExit):
+        validate_schema(df, cfg)
+
+
+def test_validate_schema_fails_for_missing_column(monkeypatch: pytest.MonkeyPatch) -> None:
+    df = pl.DataFrame({"id": ["1"]})
+    cfg = _config({"raw_id": "id", "raw_name": "name"})
+
+    with pytest.raises(SystemExit):
+        validate_schema(df, cfg)
+
+
+def test_validate_schema_warns_for_all_null_column(caplog: pytest.LogCaptureFixture) -> None:
+    df = pl.DataFrame({"id": [None, None], "name": ["Seoul", "Busan"]})
+    cfg = _config({"raw_id": "id", "raw_name": "name"})
+
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="publish_to_hf.transform"):
+        validate_schema(df, cfg)
+
+    assert any("100%" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# build_variant_dataframes
+# ---------------------------------------------------------------------------
+
+
+def test_build_variant_dataframes_no_variants_returns_default() -> None:
+    df = pl.DataFrame({"id": ["1"]})
+    cfg: dict[str, Any] = {}
+
+    result = build_variant_dataframes(df, cfg)
+
+    assert list(result.keys()) == ["default"]
+    assert result["default"].equals(df)
+
+
+def test_build_variant_dataframes_column_rename() -> None:
+    df = pl.DataFrame({"id": ["1"], "name": ["Seoul"]})
+    cfg = {
+        "variants": {
+            "en": {"column_rename": {"name": "city_name"}},
+        }
+    }
+
+    result = build_variant_dataframes(df, cfg)
+
+    assert "en" in result
+    assert "city_name" in result["en"].columns
+    assert "name" not in result["en"].columns
+
+
+def test_build_variant_dataframes_multiple_variants_independent() -> None:
+    df = pl.DataFrame({"id": ["1"], "name": ["Seoul"]})
+    cfg = {
+        "variants": {
+            "ko": {},
+            "en": {"column_rename": {"name": "city"}},
+        }
+    }
+
+    result = build_variant_dataframes(df, cfg)
+
+    assert "ko" in result and "en" in result
+    # ko variant should keep original column name
+    assert "name" in result["ko"].columns
+    # en variant renamed
+    assert "city" in result["en"].columns


### PR DESCRIPTION
## Summary

- **#214 — CI quality gate**: Adds `.github/workflows/ci.yml` with pinned action SHAs (`actions/checkout@34e114…`, `astral-sh/setup-uv@d4b2f3…`), `permissions: { contents: read }`, ruff lint + `ruff format --check`, mypy type-check, and a 4-version Python matrix (3.10, 3.11, 3.12, 3.13) triggered on `pull_request` and `push` to `main`. Also removes the old `.gitignore` exclusion that had deferred this file.
- **#238 — Pipeline test coverage**: Adds `tests/pipeline/` with 62 tests covering `fetch.py` (checkpoint/resume, retry logic), `transform.py` (column mapping, dtype casts, filters, derived columns, schema validation), `package.py` (parquet roundtrip, dataset card generation, size categories), and `publish.py` (HF/Kaggle upload paths, dry-run, metadata). All tests are fully mocked — no network calls, no optional extras required.

## uv sync decision

Used `uv sync --no-sources` (not plain `uv sync`). The `[tool.uv.sources]` section pins `kpubdata` to an editable `../kpubdata` sibling path that doesn't exist in CI. The `--no-sources` flag ignores that override and resolves `kpubdata>=0.5.0,<0.6` from PyPI instead (#213).

## How verified

- `python3 -m pytest tests/pipeline/ -v` → **62 passed**
- `python3 -m ruff check tests/pipeline/ scripts/pipeline/ .github/workflows/` → clean
- `python3 -m ruff format --check tests/pipeline/ scripts/pipeline/ .github/workflows/` → clean
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → YAML valid

Closes #214
Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)