### PR TITLE
fix(#246,#250): replace warnings.warn with logger.error; add GET /builds history API

### DIFF
--- a/src/kpubdata_builder/pipeline/orchestrator.py
+++ b/src/kpubdata_builder/pipeline/orchestrator.py
@@ -16,7 +16,7 @@ Export 단계 연결은 stage-aware exporter 도입(#28/v0.2) 시점으로 연�
 
 from __future__ import annotations
 
-import warnings
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -42,6 +42,8 @@ from ..stages.gold.persist import persist_gold_package
 from ..stages.silver.build import build_silver_dataset
 from ..stages.silver.persist import persist_silver_dataset
 from .context import BuildContext
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -194,9 +196,11 @@ def _run_source_pipeline(
         if isinstance(exc, (ValidationError, DatasetValidationError)):
             error_msg = str(exc)
         else:
-            warnings.warn(
-                f"source pipeline failed for {output_key!r}: {exc}",
-                stacklevel=2,
+            logger.error(
+                "source pipeline failed for %r: %s",
+                output_key,
+                exc,
+                exc_info=exc,
             )
             error_msg = f"pipeline failed for source {output_key!r}"
         return SourceBuildOutcome(

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -13,6 +13,7 @@ Studio 같은 외부 UI가 Builder를 호출할 수 있도록 validate/preview/b
 
 from __future__ import annotations
 
+import json
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -187,6 +188,39 @@ class BuilderService:
         )
         return ServiceResponse(200, {"run_id": run_id, "files": list(files)})
 
+    def list_builds(self, *, limit: int = 50) -> ServiceResponse:
+        """실행 이력 목록을 최신 수정 시각 기준으로 내림차순 반환한다.
+
+        output_root 아래의 디렉터리를 스캔해 manifest.json이 있는 실행만
+        포함한다. Studio 같은 소비자가 빌드 이력 목록을 표시하는 데 쓰인다 (#250).
+        """
+        if not self._output_root.exists():
+            return ServiceResponse(200, {"builds": []})
+
+        candidates = sorted(
+            (d for d in self._output_root.iterdir() if d.is_dir()),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+        builds: list[JsonValue] = []
+        for run_dir in candidates[:limit]:
+            manifest_path = run_dir / "manifest.json"
+            if not manifest_path.exists():
+                continue
+            try:
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                continue
+            builds.append(
+                {
+                    "run_id": run_dir.name,
+                    "status": "failed" if manifest.get("errors") else "ok",
+                    "started_at": manifest.get("started_at"),
+                    "finished_at": manifest.get("finished_at"),
+                }
+            )
+        return ServiceResponse(200, {"builds": builds})
+
     def _load_validated(self, spec_yaml: str) -> BuildSpec | ServiceResponse:
         """spec_yaml을 파싱·검증하고, 실패 시 오류 ServiceResponse를 반환한다."""
         try:
@@ -263,6 +297,15 @@ def dispatch(
     if method == "GET" and path.startswith("/artifacts/"):
         run_id = path[len("/artifacts/") :]
         return service.artifacts(run_id)
+
+    if method == "GET" and path == "/builds":
+        limit = 50
+        if body is not None and "limit" in body:
+            limit_value = body["limit"]
+            if not isinstance(limit_value, int) or isinstance(limit_value, bool) or limit_value < 1:
+                return ServiceResponse(400, {"error": "'limit' must be a positive integer"})
+            limit = limit_value
+        return service.list_builds(limit=limit)
 
     return ServiceResponse(404, {"error": f"not found: {method} {path}"})
 

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -169,9 +169,12 @@ def test_run_build_card_uses_alias_as_source_identity(tmp_path: Path) -> None:
 
 
 def test_run_build_redacts_path_from_unexpected_exception(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     # #225: 예상치 못한 예외(OS 오류 등)의 절대 경로가 클라이언트에 노출되지 않아야 한다.
+    # #246: 상세 정보는 warnings.warn이 아닌 logger.error로 기록해야 한다.
     spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
     client = _FakeClient({"datago.apt_trade": [{"id": "1"}]})
 
@@ -180,18 +183,17 @@ def test_run_build_redacts_path_from_unexpected_exception(
 
     monkeypatch.setattr(orchestrator, "build_gold_package", _fail_with_path)
 
-    import warnings
+    import logging
 
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
+    with caplog.at_level(logging.ERROR, logger="kpubdata_builder.pipeline.orchestrator"):
         result = run_build(spec, client=client, output_root=tmp_path, run_id="run1")
 
     outcome = result.outcomes[0]
     assert outcome.status == "failed"
     # 클라이언트에게 돌아가는 error 메시지에는 절대 경로가 없어야 한다.
     assert "/absolute/path" not in (outcome.error or "")
-    # 상세 정보는 서버 경고에만 기록된다.
-    assert any("/absolute/path" in str(w.message) for w in caught)
+    # 상세 정보는 logger.error로만 기록된다 (#246).
+    assert any("/absolute/path" in r.getMessage() for r in caplog.records)
 
 
 def test_run_build_records_failure_when_source_missing(tmp_path: Path) -> None:

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -166,6 +166,45 @@ class TestArtifacts:
         assert resp.status_code == 404
 
 
+class TestListBuilds:
+    def test_empty_when_no_runs(self, tmp_path: Path) -> None:
+        resp = _service(tmp_path).list_builds()
+        assert resp.status_code == 200
+        assert resp.body["builds"] == []
+
+    def test_lists_run_after_build(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        service.build(VALID_SPEC_YAML, run_id="run1")
+
+        resp = service.list_builds()
+        assert resp.status_code == 200
+        builds = resp.body["builds"]
+        assert isinstance(builds, list)
+        assert len(builds) == 1
+        assert builds[0]["run_id"] == "run1"  # type: ignore[index]
+        assert builds[0]["status"] == "ok"  # type: ignore[index]
+
+    def test_skips_dirs_without_manifest(self, tmp_path: Path) -> None:
+        (tmp_path / "no-manifest-dir").mkdir()
+        resp = _service(tmp_path).list_builds()
+        assert resp.status_code == 200
+        assert resp.body["builds"] == []
+
+    def test_dispatch_get_builds_returns_200(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        service.build(VALID_SPEC_YAML, run_id="run2")
+        resp = dispatch(service, "GET", "/builds", None)
+        assert resp.status_code == 200
+        builds = resp.body["builds"]
+        assert isinstance(builds, list)
+        assert any(b["run_id"] == "run2" for b in builds)  # type: ignore[index,union-attr]
+
+    def test_dispatch_limit_guard(self, tmp_path: Path) -> None:
+        resp = dispatch(_service(tmp_path), "GET", "/builds", {"limit": 0})
+        assert resp.status_code == 400
+        assert "limit" in str(resp.body.get("error", ""))
+
+
 class TestDispatch:
     def test_routes_post_validate(self, tmp_path: Path) -> None:
         resp = dispatch(_service(tmp_path), "POST", "/validate", {"spec": VALID_SPEC_YAML})


### PR DESCRIPTION
## Summary

- **#246 (P2)**: `orchestrator.py` used `warnings.warn()` to report pipeline failures, which is suppressed by warning filters and de-duplicated silently. Replaced with `logging.getLogger(__name__)` + `logger.error(..., exc_info=exc)` so failures are always captured in structured logs regardless of filter configuration.
- **#250 (P3)**: Added `BuilderService.list_builds(limit=50)` that scans `output_root` for subdirectories containing `manifest.json`, returning them sorted by mtime (newest first). Wired `GET /builds` route in `dispatch()` with a `limit` integer guard.

## Changes

- `src/kpubdata_builder/pipeline/orchestrator.py`: swap `import warnings` + `warnings.warn()` for `logging` module + `logger.error()` with `exc_info`
- `src/kpubdata_builder/service/app.py`: add `list_builds()` method and `GET /builds` dispatch route
- `tests/unit/test_pipeline.py`: update `test_run_build_redacts_path_from_unexpected_exception` to use `caplog` instead of `warnings.catch_warnings`
- `tests/unit/test_service.py`: add `TestListBuilds` (5 cases covering empty state, post-build listing, dirs without manifest, dispatch routing, limit guard)

## Test plan

- [x] `pytest -q` → 495 passed, 0 failed
- [x] `mypy src` → Success, no issues in 70 source files
- [x] `ruff check` + `ruff format --check` → All checks passed on modified files

Closes #246
Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>