### PR TITLE
docs: build.py, huggingface.py 영어 docstring 한국어 전환

### DIFF
--- a/src/kpubdata_builder/build.py
+++ b/src/kpubdata_builder/build.py
@@ -1,4 +1,4 @@
-"""Build orchestration: connect source execution, assembly, export, and manifest."""
+"""빌드 오케스트레이션: 소스 실행, 조립, 내보내기, 매니페스트를 연결한다."""
 
 from __future__ import annotations
 
@@ -22,7 +22,7 @@ MANIFEST_FILENAME = "manifest.json"
 
 @dataclass(frozen=True)
 class BuildResult:
-    """Outcome of a build run: produced files and manifest location."""
+    """빌드 실행 결과: 생성된 파일 목록과 매니페스트 경로를 담는다."""
 
     artifact_paths: tuple[Path, ...]
     manifest_path: Path
@@ -37,11 +37,11 @@ def execute_build(
     exporters: Mapping[str, BaseExporter] = EXPORTER_REGISTRY,
     build_id: str | None = None,
 ) -> BuildResult:
-    """Run the full build pipeline for a validated spec.
+    """검증된 스펙을 기반으로 전체 빌드 파이프라인을 실행한다.
 
-    Steps: validate -> fetch sources -> assemble -> export -> write manifest.
-    The client is injected so tests can supply a fake without network access.
-    A manifest is always written, recording inputs, outputs, and warnings.
+    실행 순서: 스펙 검증 → 소스 수집 → 조립 → 내보내기 → 매니페스트 기록.
+    client는 주입 방식으로 전달돼 테스트에서 네트워크 없이 가짜 구현체를 사용할 수 있다.
+    매니페스트는 항상 기록되며 입력 소스, 출력 파일, 경고를 포함한다.
     """
     validate_spec(spec)
 

--- a/src/kpubdata_builder/publishers/huggingface.py
+++ b/src/kpubdata_builder/publishers/huggingface.py
@@ -1,4 +1,4 @@
-"""Hugging Face Hub publisher — uploads artifacts to a HF dataset repo."""
+"""Hugging Face Hub 게시자 — artifact를 HF 데이터셋 레포지토리에 업로드한다."""
 
 from __future__ import annotations
 
@@ -24,18 +24,18 @@ def _repo_path_for(path: Path, common_root: Path | None) -> str:
 
 
 class HuggingFacePublisher(BasePublisher):
-    """Upload artifact files to a Hugging Face Hub dataset repository."""
+    """Hugging Face Hub 데이터셋 레포지토리에 artifact 파일을 업로드한다."""
 
     @property
     def name(self) -> str:
         return "huggingface"
 
     def publish(self, artifact_paths: tuple[Path, ...], *, destination: str) -> PublishResult:
-        """Publish artifacts to a HuggingFace dataset repo.
+        """artifact를 HuggingFace 데이터셋 레포지토리에 게시한다.
 
-        Args:
-            artifact_paths: Files/directories to upload.
-            destination: HF repo ID (e.g. "kpubdata/air-quality").
+        매개변수:
+            artifact_paths: 업로드할 파일 또는 디렉토리 목록.
+            destination: HF 레포지토리 ID (예: "kpubdata/air-quality").
         """
         try:
             from huggingface_hub import HfApi  # type: ignore[import-not-found]


### PR DESCRIPTION
## 개요

AGENTS.md 언어 정책: "코드(변수명, 함수명, 주석, docstring)는 한국어 우선으로 작성한다."

`build.py`와 `publishers/huggingface.py`의 영어 docstring을 한국어로 일괄 전환합니다.

## 변경 파일

**build.py:**
- 모듈 docstring
- `BuildResult` 클래스 docstring
- `execute_build()` 함수 docstring

**publishers/huggingface.py:**
- 모듈 docstring
- `HuggingFacePublisher` 클래스 docstring
- `publish()` 메서드 docstring (Args 섹션 포함)

## 테스트

```
495 passed, 4 warnings
```

Closes #257