### PR TITLE
[B-002] silver: validate_table에 dtype 검증 추가 (#258)

### DIFF
--- a/src/kpubdata_builder/stages/silver/build.py
+++ b/src/kpubdata_builder/stages/silver/build.py
@@ -26,6 +26,7 @@ def build_silver_dataset(
     *,
     required_columns: Sequence[str] = (),
     casts: Mapping[str, DtypeSpec] | None = None,
+    column_dtypes: Mapping[str, DtypeSpec] | None = None,
     preview_limit: int = DEFAULT_PREVIEW_LIMIT,
 ) -> SilverDataset:
     """Bronze 산출물을 Silver 데이터셋으로 변환한다.
@@ -34,6 +35,8 @@ def build_silver_dataset(
         bronze: 원천 Bronze 산출물.
         required_columns: 검증에 사용할 필수 컬럼 목록.
         casts: 정규화 시 적용할 컬럼별 dtype 캐스팅 규칙.
+        column_dtypes: 검증에 사용할 코럼별 기대 dtype 규칙. 키는 코럼명,
+            값은 DtypeSpec(str | pl.DataType | type[pl.DataType]).
         preview_limit: 미리보기에 포함할 최대 행 수.
 
     반환값:
@@ -45,7 +48,9 @@ def build_silver_dataset(
     if preview_limit < 0:
         raise ValueError(f"preview_limit must be >= 0, got {preview_limit}")
     table = normalize_table(bronze, casts=casts)
-    validation = validate_table(table, required_columns=required_columns)
+    validation = validate_table(
+        table, required_columns=required_columns, column_dtypes=column_dtypes
+    )
     schema = build_schema(table)
     statistics = build_statistics(table)
     preview = build_preview(table, limit=preview_limit)

--- a/src/kpubdata_builder/stages/silver/validate.py
+++ b/src/kpubdata_builder/stages/silver/validate.py
@@ -1,6 +1,6 @@
 """Silver 스키마 검증 (#46).
 
-정규화된 테이블이 선언된 스키마 요건(필수 컬럼 존재)을 충족하는지 검사한다.
+정규화된 테이블이 선언된 스키마 요건(필수 코럼 존재, 코럼 dtype 일치)을 충족하는지 검사한다.
 
 주요 함수:
     - validate_table: pl.DataFrame → ValidationResult
@@ -8,10 +8,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 
 import polars as pl
 
+from ...tabular.polars_helpers import DtypeSpec, _resolve_dtype
 from .models import ValidationResult
 
 
@@ -19,12 +20,16 @@ def validate_table(
     table: pl.DataFrame,
     *,
     required_columns: Sequence[str] = (),
+    column_dtypes: Mapping[str, DtypeSpec] | None = None,
 ) -> ValidationResult:
-    """필수 컬럼 존재 여부를 검증한다.
+    """필수 코럼 존재 여부와 선언된 dtype 일치를 검증한다.
 
     매개변수:
         table: 검증할 테이블.
-        required_columns: 반드시 존재해야 하는 컬럼 목록.
+        required_columns: 반드시 존재해야 하는 코럼 목록.
+        column_dtypes: 코럼별 기대 dtype. 키는 코럼명,
+            값은 DtypeSpec(str | pl.DataType | type[pl.DataType]).
+            코럼이 없으면 해당 코럼에 대한 dtype 문제를 등록한다.
 
     반환값:
         ValidationResult: 통과 여부와 위반 메시지.
@@ -33,4 +38,14 @@ def validate_table(
     missing = [column for column in required_columns if column not in table.columns]
     if missing:
         problems.append(f"missing required columns: {', '.join(missing)}")
+    for column, expected_spec in (column_dtypes or {}).items():
+        if column not in table.columns:
+            problems.append(f"column {column!r} not found; cannot validate dtype")
+            continue
+        expected = _resolve_dtype(expected_spec)
+        actual = table.schema[column]
+        if actual != expected:
+            problems.append(
+                f"column {column!r}: expected dtype {expected}, got {actual}"
+            )
     return ValidationResult(ok=not problems, problems=tuple(problems))

--- a/src/kpubdata_builder/stages/silver/validate.py
+++ b/src/kpubdata_builder/stages/silver/validate.py
@@ -45,7 +45,5 @@ def validate_table(
         expected = _resolve_dtype(expected_spec)
         actual = table.schema[column]
         if actual != expected:
-            problems.append(
-                f"column {column!r}: expected dtype {expected}, got {actual}"
-            )
+            problems.append(f"column {column!r}: expected dtype {expected}, got {actual}")
     return ValidationResult(ok=not problems, problems=tuple(problems))

--- a/tests/unit/test_silver.py
+++ b/tests/unit/test_silver.py
@@ -78,6 +78,36 @@ class TestBuildSilverDataset:
         assert dataset.validation.ok is False
         assert any("amount" in problem for problem in dataset.validation.problems)
 
+    def test_validation_passes_when_dtype_matches(self) -> None:
+        bronze = _bronze(({"id": "1", "amount": 1000},))
+
+        dataset = build_silver_dataset(
+            bronze, casts={"amount": "int"}, column_dtypes={"amount": "int"}
+        )
+
+        assert dataset.validation.ok is True
+        assert dataset.validation.problems == ()
+
+    def test_validation_fails_when_dtype_mismatches(self) -> None:
+        bronze = _bronze(({"id": "1", "amount": 1000},))
+
+        # amount는 바로 읽으면 Int64; Float64를 요구하면 실패해야 한다
+        dataset = build_silver_dataset(
+            bronze, column_dtypes={"amount": "float"}
+        )
+
+        assert dataset.validation.ok is False
+        assert any("amount" in p for p in dataset.validation.problems)
+
+    def test_validation_reports_missing_column_for_dtype_spec(self) -> None:
+        bronze = _bronze(({"id": "1"},))
+
+        # 'amount' 코럼이 없으면 dtype 검증 실패 메시지를 포함해야 한다
+        dataset = build_silver_dataset(bronze, column_dtypes={"amount": "int"})
+
+        assert dataset.validation.ok is False
+        assert any("amount" in p for p in dataset.validation.problems)
+
     def test_preview_respects_limit(self) -> None:
         records = tuple({"n": i} for i in range(10))
         dataset = build_silver_dataset(_bronze(records), preview_limit=3)

--- a/tests/unit/test_silver.py
+++ b/tests/unit/test_silver.py
@@ -92,9 +92,7 @@ class TestBuildSilverDataset:
         bronze = _bronze(({"id": "1", "amount": 1000},))
 
         # amount는 바로 읽으면 Int64; Float64를 요구하면 실패해야 한다
-        dataset = build_silver_dataset(
-            bronze, column_dtypes={"amount": "float"}
-        )
+        dataset = build_silver_dataset(bronze, column_dtypes={"amount": "float"})
 
         assert dataset.validation.ok is False
         assert any("amount" in p for p in dataset.validation.problems)


### PR DESCRIPTION
## 요약

Silver 단계 검증 함수 `validate_table`에 컬럼 dtype 일치 검증 기능을 추가합니다.

## 변경 내용

### validate.py
- `column_dtypes: Mapping[str, DtypeSpec] | None = None` 파라미터 추가
- 컬럼이 없으면 "cannot validate dtype" 문제 등록
- 컬럼 실제 dtype과 선언 dtype이 다르면 "expected / got" 문제 등록

### build.py
- `column_dtypes` 파라미터를 `build_silver_dataset`에 추가하고 `validate_table`에 전달

### test_silver.py
- `test_validation_passes_when_dtype_matches`: 캐스팅 후 dtype 일치 → ok
- `test_validation_fails_when_dtype_mismatches`: dtype 불일치 → 검증 실패
- `test_validation_reports_missing_column_for_dtype_spec`: dtype 대상 컬럼 없음 → 문제 등록

## 검증

- `ruff check` 통과
- `mypy` 통과
- `pytest tests/unit/test_silver.py` → 16/16 통과

Closes #258