### PR TITLE
[B-003] executor: source_executor()에 @deprecated 데코레이터 적용 (#259)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   "kpubdata>=0.5.0,<0.6",
   "polars>=1.0,<2",
   "pyyaml>=6.0,<7",
+  "typing_extensions>=4.5",
 ]
 
 [project.scripts]

--- a/src/kpubdata_builder/executor.py
+++ b/src/kpubdata_builder/executor.py
@@ -14,6 +14,8 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from typing import Protocol
 
+from typing_extensions import deprecated
+
 from .artifact import ArtifactDataset
 from .errors import ExecutionError, ValidationError
 from .spec import BuildSpec, JsonValue, SourceRef
@@ -35,11 +37,12 @@ class ExecutionResult:
     errors: tuple[str, ...] = ()
 
 
+@deprecated("메달리온 파이프라인(pipeline/orchestrator)을 사용하세요.")
 def source_executor(spec: BuildSpec) -> ExecutionResult:
-    """선언된 소스를 실행하고 최소한의 조립 산출물 스텁을 반환한다.
+    """선언된 소스를 실행하고 최소한의 조립 산출물 스터빅을 반환한다.
 
     .. deprecated::
-        Use the Medallion pipeline (pipeline/orchestrator) instead.
+        메달리온 파이프라인(pipeline/orchestrator) 사용을 권장한다.
 
     현재 구현은 실제 네트워크 호출 대신 BuildSpec 검증과 provenance 구성에
     집중한다. 따라서 후속 단계가 기대하는 최소 ArtifactDataset을 안정적으로
@@ -55,13 +58,6 @@ def source_executor(spec: BuildSpec) -> ExecutionResult:
         ValidationError: 명세 검증 실패 시.
         ExecutionError: provenance 구성 중 예기치 않은 오류가 발생한 경우.
     """
-    import warnings
-
-    warnings.warn(
-        "source_executor() is deprecated. Use the Medallion pipeline instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
 
     try:
         validate_spec(spec)

--- a/uv.lock
+++ b/uv.lock
@@ -598,6 +598,7 @@ dependencies = [
     { name = "kpubdata" },
     { name = "polars" },
     { name = "pyyaml" },
+    { name = "typing-extensions" },
 ]
 
 [package.optional-dependencies]
@@ -643,6 +644,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0,<7" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5,<1" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
+    { name = "typing-extensions", specifier = ">=4.5" },
     { name = "xmltodict", marker = "extra == 'publish'", specifier = ">=0.13,<1" },
 ]
 provides-extras = ["docs", "parquet", "huggingface", "publish", "dev"]


### PR DESCRIPTION
## 요약

`source_executor()`의 인라인 `warnings.warn` 호출을 `typing_extensions.deprecated` 데코레이터로 교체합니다.

## 변경 내용

### pyproject.toml
- `typing_extensions>=4.5` 명시적 의존성 추가 (기존에는 kpubdata 경유 전이 의존성)

### executor.py
- `@deprecated("메달리온 파이프라인(pipeline/orchestrator)을 사용하세요.")` 데코레이터 추가
- 기존 인라인 `import warnings` / `warnings.warn(...)` 블록 제거 (데코레이터가 대체)

## 효과

- 타입 체커(mypy, pyright)가 `source_executor()` 호출 지점에서 경고 표시
- 런타임 `DeprecationWarning`은 데코레이터가 계속 발생시킴

## 검증

- `ruff check` 통과
- 기존 `test_executor.py` → 3/3 통과 (DeprecationWarning 경고 메시지 확인됨)

Closes #259