### PR TITLE
fix(gold): restore splits fields dropped by B-005 rebase

### DIFF
--- a/src/kpubdata_builder/stages/gold/models.py
+++ b/src/kpubdata_builder/stages/gold/models.py
@@ -46,3 +46,4 @@ class GoldPackage:
     export_plan: ExportPlan
     source_silver: str
     metadata: dict[str, str] = field(default_factory=dict)
+    splits: dict[str, pl.DataFrame] | None = None

--- a/src/kpubdata_builder/stages/gold/persist.py
+++ b/src/kpubdata_builder/stages/gold/persist.py
@@ -11,7 +11,7 @@ parquet으로, 패키지 메타데이터는 결정적 JSON으로 기록한다.
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import cast
 
@@ -33,6 +33,7 @@ class GoldPersistResult:
     gold_dir: Path
     table_path: Path
     package_path: Path
+    splits_paths: dict[str, Path] = field(default_factory=dict)
 
 
 def _package_metadata(package: GoldPackage) -> dict[str, JsonValue]:
@@ -114,14 +115,28 @@ def persist_gold_package(
             encoding="utf-8",
         )
 
+        # splits 처리: package.splits가 있으면 splits/ 서브디렉토리에 각 분할을 parquet로 기록
+        if package.splits is not None:
+            (tmp_dir / "splits").mkdir(exist_ok=True)
+            for split_name, split_df in package.splits.items():
+                validate_path_segment(split_name, field_name="split_name")
+                split_df.write_parquet(tmp_dir / "splits" / f"{split_name}.parquet")
+
         # Atomic swap: 기존 디렉터리가 있어도 데이터 유실 없이 교체한다 (#180).
         atomic_replace_dir(tmp_dir, gold_dir)
     except BaseException:
         shutil.rmtree(tmp_dir, ignore_errors=True)
         raise
 
+    # splits_paths 결과 구성
+    splits_paths: dict[str, Path] = {}
+    if package.splits is not None:
+        for split_name in package.splits:
+            splits_paths[split_name] = gold_dir / "splits" / f"{split_name}.parquet"
+
     return GoldPersistResult(
         gold_dir=gold_dir,
         table_path=table_path,
         package_path=package_path,
+        splits_paths=splits_paths,
     )


### PR DESCRIPTION
## 원인

B-005(#268) rebase 수정 과정에서 `gold/models.py`를 B-004(#270) 머지 이전의
`origin/main` 버전으로 복원했습니다. 이로 인해 B-004가 추가한 아래 항목들이
최종 main에서 누락됐습니다.

## 누락됐던 항목

- `GoldPackage.splits: dict[str, pl.DataFrame] | None = None`
- `GoldPersistResult.splits_paths: dict[str, Path]`
- `persist_gold_package()` 내 splits/ 서브디렉터리 원자적 기록 로직

## 증상

```
TypeError: GoldPackage.__init__() got an unexpected keyword argument 'splits'
```
→ `build_gold_package()`가 `splits=` 키워드를 전달하지만 `GoldPackage`에 필드 없음
→ mypy 4개 오류, pytest 23개 실패

## 수정

- `models.py`: `GoldPackage`에 `splits` 필드 추가
- `persist.py`: `GoldPersistResult`에 `splits_paths` 필드 추가, splits 기록 로직 복원

Closes #260 (B-004 완전 통합)