### PR TITLE
docs: fix broken mermaid diagrams

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ uv sync --extra dev --extra publish --no-sources
 우리는 `main` 브랜치에 직접 코드를 올리지 않습니다. 반드시 새로운 브랜치를 만들어 작업한 뒤 **Pull Request (PR)**를 통해 합칩니다.
 
 ```mermaid
-gitgraph
+gitGraph
     commit id: "initial"
     branch feat/issue-3-csv-exporter
     checkout feat/issue-3-csv-exporter

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 ```mermaid
 flowchart LR
     BS[BuildSpec] --> B[Bronze: raw fetch]
-    B --> S[Silver: tabularize/validate\n(Polars)]
+    B --> S["Silver: tabularize/validate<br/>(Polars)"]
     S --> G[Gold: package]
     G --> E[Export]
     E --> M[Manifest]


### PR DESCRIPTION
## 요약
- README.md, CONTRIBUTING.md의 렌더링되지 않던 mermaid 다이어그램 수정
- 특수문자 포함 노드 라벨을 따옴표 처리하고 `gitGraph` 대소문자 교정

## 검증
- 전역 설치된 `mmdc`(mermaid CLI)로 모든 mermaid 블록 렌더링 성공 확인