### PR TITLE
fix: pin typing_extensions upper bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "kpubdata>=0.5.0,<0.6",
   "polars>=1.0,<2",
   "pyyaml>=6.0,<7",
-  "typing_extensions>=4.5",
+  "typing_extensions>=4.5,<5",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## 요약
- `typing_extensions>=4.5` 의존성에 상한(`<5`)을 추가해 예기치 않은 메이저 업그레이드 방지

## 참고
- 로컬 개발용 editable checkout을 유지하기 위해 uv.lock의 무관한 드리프트는 커밋하지 않음