### PR TITLE
fix: CORS headers and OPTIONS preflight (#254)

### DIFF
--- a/src/kpubdata_builder/service/http.py
+++ b/src/kpubdata_builder/service/http.py
@@ -94,11 +94,20 @@ def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
                 return
             self._write(response.status_code, response.body)
 
+        def _send_cors_headers(self) -> None:
+            # 로컬 개발 도구로서 Studio 등 브라우저 클라이언트의 크로스오리진 요청을
+            # 허용한다 (#254).
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+            self.send_header("Access-Control-Allow-Headers", "Content-Type")
+            self.send_header("Access-Control-Max-Age", "86400")
+
         def _write(self, status_code: int, body: dict[str, JsonValue]) -> None:
             payload = json.dumps(body, ensure_ascii=False, default=str).encode("utf-8")
             self.send_response(status_code)
             self.send_header("Content-Type", "application/json; charset=utf-8")
             self.send_header("Content-Length", str(len(payload)))
+            self._send_cors_headers()
             self.end_headers()
             _ = self.wfile.write(payload)
 
@@ -107,6 +116,13 @@ def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
 
         def do_POST(self) -> None:  # noqa: N802 - http.server 규약
             self._dispatch("POST")
+
+        def do_OPTIONS(self) -> None:  # noqa: N802 - http.server 규약
+            # CORS preflight 요청에 응답한다 (#254). body 없이 204로 허용 헤더만 반환한다.
+            self.send_response(204)
+            self.send_header("Content-Length", "0")
+            self._send_cors_headers()
+            self.end_headers()
 
         def log_message(self, format: str, *args: object) -> None:
             # 기본 stderr 접근 로그를 억제한다.

--- a/src/kpubdata_builder/service/http.py
+++ b/src/kpubdata_builder/service/http.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import traceback
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import cast
@@ -27,6 +28,11 @@ _MAX_BODY_BYTES = 10 * 1024 * 1024  # 10 MiB
 # 소켓 읽기 타임아웃(초). 느린 클라이언트/slowloris 공격이 스레드를 무한 점거하지 않도록
 # 한다 (#219). ThreadingHTTPServer를 사용하더라도 각 연결 스레드가 여기서 해제된다.
 _SOCKET_TIMEOUT_SECONDS = 30.0
+
+# CORS 허용 Origin. 기본값은 로컬 개발 편의를 위해 모든 오리진(`*`)이지만, 환경변수로
+# 특정 오리진(예: http://localhost:5173)만 허용하도록 제한할 수 있다 (#254 보안 강화).
+_CORS_ALLOW_ORIGIN_ENV = "KPUBDATA_BUILDER_CORS_ALLOW_ORIGIN"
+_DEFAULT_CORS_ALLOW_ORIGIN = "*"
 
 _logger = logging.getLogger(__name__)
 
@@ -96,8 +102,10 @@ def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
 
         def _send_cors_headers(self) -> None:
             # 로컬 개발 도구로서 Studio 등 브라우저 클라이언트의 크로스오리진 요청을
-            # 허용한다 (#254).
-            self.send_header("Access-Control-Allow-Origin", "*")
+            # 허용한다 (#254). 기본값은 `*`이며, 환경변수로 특정 오리진만
+            # 허용하도록 제한해 공격 표면을 줄일 수 있다.
+            allow_origin = os.environ.get(_CORS_ALLOW_ORIGIN_ENV, _DEFAULT_CORS_ALLOW_ORIGIN)
+            self.send_header("Access-Control-Allow-Origin", allow_origin)
             self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
             self.send_header("Access-Control-Allow-Headers", "Content-Type")
             self.send_header("Access-Control-Max-Age", "86400")

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -419,6 +419,25 @@ class TestHttpAdapter:
             body = cast(dict[str, object], json.loads(response.read()))
         assert body["status"] == "valid"
 
+    def test_options_preflight_returns_204_with_cors(
+        self, http_server: tuple[str, HTTPServer, threading.Thread]
+    ) -> None:
+        # CORS preflight(OPTIONS)가 204와 허용 헤더를 반환해야 한다 (#254).
+        base_url, _, _ = http_server
+        req = urllib.request.Request(f"{base_url}/build", method="OPTIONS")
+        with urllib.request.urlopen(req, timeout=2.0) as response:
+            assert response.status == 204
+            assert response.headers["Access-Control-Allow-Origin"] == "*"
+            assert "POST" in response.headers["Access-Control-Allow-Methods"]
+
+    def test_response_includes_cors_header(
+        self, http_server: tuple[str, HTTPServer, threading.Thread]
+    ) -> None:
+        # 일반 응답에도 CORS 헤더가 포함되어야 한다 (#254).
+        base_url, _, _ = http_server
+        with urllib.request.urlopen(f"{base_url}/version", timeout=2.0) as response:
+            assert response.headers["Access-Control-Allow-Origin"] == "*"
+
 
 class TestHttpRobustness:
     """#218 (JSON 500 handler) 과 #219 (DoS hardening) 검증."""

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -450,9 +450,7 @@ class TestHttpAdapter:
         monkeypatch.setenv("KPUBDATA_BUILDER_CORS_ALLOW_ORIGIN", "http://localhost:5173")
         base_url, _, _ = http_server
         with urllib.request.urlopen(f"{base_url}/version", timeout=2.0) as response:
-            assert (
-                response.headers["Access-Control-Allow-Origin"] == "http://localhost:5173"
-            )
+            assert response.headers["Access-Control-Allow-Origin"] == "http://localhost:5173"
 
 
 class TestHttpRobustness:

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -429,6 +429,9 @@ class TestHttpAdapter:
             assert response.status == 204
             assert response.headers["Access-Control-Allow-Origin"] == "*"
             assert "POST" in response.headers["Access-Control-Allow-Methods"]
+            assert "OPTIONS" in response.headers["Access-Control-Allow-Methods"]
+            assert response.headers["Access-Control-Allow-Headers"] == "Content-Type"
+            assert response.headers["Access-Control-Max-Age"] == "86400"
 
     def test_response_includes_cors_header(
         self, http_server: tuple[str, HTTPServer, threading.Thread]
@@ -437,6 +440,19 @@ class TestHttpAdapter:
         base_url, _, _ = http_server
         with urllib.request.urlopen(f"{base_url}/version", timeout=2.0) as response:
             assert response.headers["Access-Control-Allow-Origin"] == "*"
+
+    def test_cors_allow_origin_is_configurable(
+        self,
+        http_server: tuple[str, HTTPServer, threading.Thread],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # 환경변수로 허용 Origin을 특정 값으로 제한할 수 있어야 한다 (#254 보안 강화).
+        monkeypatch.setenv("KPUBDATA_BUILDER_CORS_ALLOW_ORIGIN", "http://localhost:5173")
+        base_url, _, _ = http_server
+        with urllib.request.urlopen(f"{base_url}/version", timeout=2.0) as response:
+            assert (
+                response.headers["Access-Control-Allow-Origin"] == "http://localhost:5173"
+            )
 
 
 class TestHttpRobustness:


### PR DESCRIPTION
## 요약
- 모든 응답에 `Access-Control-*` 헤더 추가
- `do_OPTIONS` 프리플라이트 핸들러 추가 (204 + 허용 헤더)
- Studio 등 브라우저 클라이언트의 크로스오리진 요청 허용

## 검증
- `ruff check` 통과
- CORS/OPTIONS 유닛 테스트 추가 및 통과

Closes #254