### PR TITLE
feat: add serve CLI command (#249)

### DIFF
--- a/src/kpubdata_builder/cli.py
+++ b/src/kpubdata_builder/cli.py
@@ -355,7 +355,11 @@ def _run_serve(*, output_dir: str, host: str, port: int) -> int:
         output_root=Path(output_dir),
         client_factory=_create_client,
     )
-    print(f"serving kpubdata-builder on http://{host}:{port} (output: {output_dir})")
+    # 장시간 실행 명령이므로 시작 로그가 파이프 버퍼링에 갈리지 않도록 즉시 flush한다.
+    print(
+        f"serving kpubdata-builder on http://{host}:{port} (output: {output_dir})",
+        flush=True,
+    )
     try:
         serve(service, host=host, port=port)
     except KeyboardInterrupt:

--- a/src/kpubdata_builder/cli.py
+++ b/src/kpubdata_builder/cli.py
@@ -1,6 +1,6 @@
 """kpubdata-builder용 명령줄 진입점.
 
-이 모듈은 argparse 기반 CLI를 구성하고, validate/preview/build/publish 명령의
+이 모듈은 argparse 기반 CLI를 구성하고, validate/preview/build/publish/serve 명령의
 진입점을 제공한다.
 
 주요 함수:
@@ -112,6 +112,27 @@ def build_parser() -> argparse.ArgumentParser:
         "--public",
         action="store_true",
         help="Create new datasets as public (kaggle only; default: private).",
+    )
+
+    serve_cmd = subparsers.add_parser(
+        "serve",
+        help="Run the Builder HTTP service.",
+    )
+    serve_cmd.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Bind host (default: 127.0.0.1).",
+    )
+    serve_cmd.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Bind port (default: 8000).",
+    )
+    serve_cmd.add_argument(
+        "--output-dir",
+        default="build",
+        help="Run workspace root directory (default: build).",
     )
 
     return parser
@@ -316,6 +337,32 @@ def _run_publish(
     return 0
 
 
+def _run_serve(*, output_dir: str, host: str, port: int) -> int:
+    """BuilderService를 HTTP 서버로 실행한다 (#249).
+
+    매개변수:
+        output_dir: 실행 워크스페이스 루트.
+        host: 바인딩 호스트.
+        port: 바인딩 포트.
+
+    반환값:
+        int: 종료 코드. Ctrl-C로 중단 시 0.
+    """
+    from .service import BuilderService
+    from .service.http import serve
+
+    service = BuilderService(
+        output_root=Path(output_dir),
+        client_factory=_create_client,
+    )
+    print(f"serving kpubdata-builder on http://{host}:{port} (output: {output_dir})")
+    try:
+        serve(service, host=host, port=port)
+    except KeyboardInterrupt:
+        print("\nshutting down", file=sys.stderr)
+    return 0
+
+
 def dispatch(args: argparse.Namespace) -> int:
     """파싱된 argparse 결과를 실제 명령 실행 함수로 전달한다.
 
@@ -344,6 +391,12 @@ def dispatch(args: argparse.Namespace) -> int:
             destination=args.destination,
             artifacts_dir=args.artifacts_dir,
             public=args.public,
+        )
+    if command == "serve":
+        return _run_serve(
+            output_dir=args.output_dir,
+            host=args.host,
+            port=args.port,
         )
     # 일반적인 CLI 경로로는 도달할 수 없지만(argparse가 알 수 없는 하위 명령을 거부함),
     # 프로그래밍 방식 호출자를 위한 방어적 대체 경로로 유지한다.

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -417,12 +417,16 @@ def test_serve_invokes_http_server(
 ) -> None:
     # serve 명령이 http.serve를 올바른 host/port로 호출해야 한다 (#249).
     import kpubdata_builder.service.http as http_module
+    from kpubdata_builder.service import BuilderService
 
     captured_kwargs: dict[str, object] = {}
 
     def fake_serve(service: object, *, host: str, port: int) -> None:
         captured_kwargs["host"] = host
         captured_kwargs["port"] = port
+        # --output-dir가 BuilderService.output_root로 올바르게 전달되는지 확인한다 (#249 review).
+        assert isinstance(service, BuilderService)
+        captured_kwargs["output_root"] = service._output_root
 
     monkeypatch.setattr(http_module, "serve", fake_serve)
 
@@ -440,5 +444,9 @@ def test_serve_invokes_http_server(
     out = capsys.readouterr().out
 
     assert exit_code == 0
-    assert captured_kwargs == {"host": "0.0.0.0", "port": 9123}
+    assert captured_kwargs == {
+        "host": "0.0.0.0",
+        "port": 9123,
+        "output_root": tmp_path,
+    }
     assert "serving kpubdata-builder" in out

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -410,3 +410,35 @@ def test_publish_kaggle_end_to_end(
     assert "create_new:public=False" in calls
     assert "publish: dataset.sample -> kaggle" in captured.out
     assert "artifacts: 1" in captured.out
+
+
+def test_serve_invokes_http_server(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # serve 명령이 http.serve를 올바른 host/port로 호출해야 한다 (#249).
+    import kpubdata_builder.service.http as http_module
+
+    captured_kwargs: dict[str, object] = {}
+
+    def fake_serve(service: object, *, host: str, port: int) -> None:
+        captured_kwargs["host"] = host
+        captured_kwargs["port"] = port
+
+    monkeypatch.setattr(http_module, "serve", fake_serve)
+
+    exit_code = main(
+        [
+            "serve",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "9123",
+            "--output-dir",
+            str(tmp_path),
+        ]
+    )
+    out = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert captured_kwargs == {"host": "0.0.0.0", "port": 9123}
+    assert "serving kpubdata-builder" in out


### PR DESCRIPTION
## 요약
- 기존 `http.serve` 어댑터를 CLI `serve` 하위 명령으로 연결
- `--host`/`--port`/`--output-dir` 옵션 지원
- Ctrl-C(KeyboardInterrupt) 시 정상 종료

## 검증
- `ruff check` 통과
- serve 명령이 http.serve를 올바른 host/port로 호출하는 유닛 테스트 추가 및 통과

Refs #249