### PR TITLE
feat: GET /builds ?limit= query parameter (#252)

### DIFF
--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -18,6 +18,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
+from urllib.parse import parse_qs
 
 import yaml
 
@@ -248,6 +249,7 @@ def dispatch(
     method: str,
     path: str,
     body: Mapping[str, JsonValue] | None,
+    query: str = "",
 ) -> ServiceResponse:
     """(method, path)를 BuilderService 연산으로 라우팅한다."""
     if method == "GET" and path == "/version":
@@ -300,7 +302,19 @@ def dispatch(
 
     if method == "GET" and path == "/builds":
         limit = 50
-        if body is not None and "limit" in body:
+        # 표준 REST 스타일에 맞게 쿼리 파라미터(?limit=N)를 우선 지원한다 (#252).
+        # 기존 소비자 호환을 위해 body의 limit도 계속 받아들인다.
+        query_params = parse_qs(query)
+        if "limit" in query_params:
+            raw_limit = query_params["limit"][-1]
+            try:
+                query_limit = int(raw_limit)
+            except ValueError:
+                return ServiceResponse(400, {"error": "'limit' must be a positive integer"})
+            if query_limit < 1:
+                return ServiceResponse(400, {"error": "'limit' must be a positive integer"})
+            limit = query_limit
+        elif body is not None and "limit" in body:
             limit_value = body["limit"]
             if not isinstance(limit_value, int) or isinstance(limit_value, bool) or limit_value < 1:
                 return ServiceResponse(400, {"error": "'limit' must be a positive integer"})

--- a/src/kpubdata_builder/service/http.py
+++ b/src/kpubdata_builder/service/http.py
@@ -77,12 +77,14 @@ def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
                     self._write(400, {"error": "JSON body must be an object"})
                     return
                 body = cast(dict[str, JsonValue], parsed)
-            # 쿼리 스트링이 경로/run_id로 새지 않도록 path 컴포넌트만으로 라우팅한다 (#184).
-            path = urlsplit(self.path).path
+            # 쿼리 스트링이 경로/run_id로 새지 않도록 path 컴포넌트만으로 라우팅하고,
+            # 쿼리는 별도로 dispatch에 전달한다 (#252).
+            split = urlsplit(self.path)
+            path = split.path
             # dispatch()에서 예상치 못한 예외가 발생하면 연결을 끊는 대신 JSON 500을
             # 반환한다. 상세 정보는 서버 로그에만 기록하고 클라이언트에는 누설하지 않는다 (#218).
             try:
-                response = dispatch(service, method, path, body)
+                response = dispatch(service, method, path, body, query=split.query)
             except Exception:
                 _logger.error(
                     "Unhandled exception in dispatch: %s %s\n%s",

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -204,6 +204,24 @@ class TestListBuilds:
         assert resp.status_code == 400
         assert "limit" in str(resp.body.get("error", ""))
 
+    def test_dispatch_get_builds_query_limit(self, tmp_path: Path) -> None:
+        # ?limit=N 쿼리 파라미터를 지원해야 한다 (#252).
+        service = _service(tmp_path)
+        service.build(VALID_SPEC_YAML, run_id="run_q1")
+        service.build(VALID_SPEC_YAML, run_id="run_q2")
+        resp = dispatch(service, "GET", "/builds", None, query="limit=1")
+        assert resp.status_code == 200
+        builds = resp.body["builds"]
+        assert isinstance(builds, list)
+        assert len(builds) == 1
+
+    def test_dispatch_get_builds_query_limit_guard(self, tmp_path: Path) -> None:
+        # 쿼리 limit이 양의 정수가 아니면 400 (#252).
+        resp = dispatch(_service(tmp_path), "GET", "/builds", None, query="limit=0")
+        assert resp.status_code == 400
+        resp = dispatch(_service(tmp_path), "GET", "/builds", None, query="limit=abc")
+        assert resp.status_code == 400
+
 
 class TestDispatch:
     def test_routes_post_validate(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## 요약
- `dispatch`에 쿼리 문자열을 전달하고 `GET /builds`에서 `?limit=N`을 파싱 (표준 REST 시맨틱)
- 기존 body 기반 limit도 하위 호환을 위해 계속 지원 (쿼리 우선)

## 검증
- `ruff check` 통과
- 쿼리 limit/guard 유닛 테스트 추가, service+contract 테스트 46개 통과

Closes #252