### PR TITLE
docs: 도메인 모델 엔티티 관계도를 mermaid erDiagram으로 추가

### DIFF
--- a/DOMAIN_MODEL.md
+++ b/DOMAIN_MODEL.md
@@ -177,57 +177,57 @@ erDiagram
     BUILDMANIFEST ||--|{ PHYSICALFILE : "records as outputs"
 
     BUILDSPEC {
-        string dataset_id PK
-        string title
-        string description
-        tuple transforms
-        dict metadata
+        String dataset_id PK
+        String title
+        String description
+        Tuple transforms
+        Dict metadata
         bool publish
     }
     SOURCEREF {
-        string provider
-        string dataset
-        dict params
-        string alias
-        string normalization_mode
+        String provider
+        String dataset
+        Dict params
+        String alias
+        String normalization_mode
     }
     SPLITSPEC {
-        string mode
-        dict ratios
-        string key
+        String mode
+        Dict ratios
+        String key
         int seed
     }
     ARTIFACTDATASET {
-        list records
-        dict schema
-        dict provenance
-        dict statistics
+        List records
+        Dict schema
+        Dict provenance
+        Dict statistics
     }
     EXPORTTARGET {
-        string kind
-        string output_path
-        dict options
+        String kind
+        String output_path
+        Dict options
     }
     BUILDMANIFEST {
-        string build_id PK
-        datetime started_at
-        datetime finished_at
-        string schema_version
-        tuple inputs
-        tuple outputs
-        tuple warnings
-        tuple errors
-        dict row_counts
-        dict schema_summaries
-        tuple provenance
-        string build_environment
-        string inputs_fingerprint
-    }
-    PHYSICALFILE {
-        string path PK
-        string kind
+        String build_id PK
+        DateTime started_at
+        DateTime finished_at
+        String schema_version
+        Tuple inputs
+        Tuple outputs
+        Tuple warnings
+        Tuple errors
+        Dict row_counts
+        Dict schema_summaries
+        Tuple provenance
+        BuildEnvironment build_environment
+        String inputs_fingerprint
     }
 ```
+
+> **참고**: `BuildSpec`의 `sources`(SourceRef)·`exports`(ExportTarget)·`splits`(SplitSpec) 필드는
+> 값 속성이 아니라 다른 엔티티를 참조하는 관계이므로, 속성 목록 대신 관계선(edge)으로 표현했습니다.
+> 각 엔티티의 전체 필드 정의와 제네릭 타입 표기는 파일 상단의 `classDiagram`을 참조하세요.
 
 > 위 다이어그램의 텍스트 버전은 아래와 같습니다.
 

--- a/DOMAIN_MODEL.md
+++ b/DOMAIN_MODEL.md
@@ -165,6 +165,72 @@ flowchart LR
 
 ## 엔티티 관계도
 
+```mermaid
+erDiagram
+    BUILDSPEC ||--|{ SOURCEREF : "defines (1..N)"
+    BUILDSPEC ||--|{ EXPORTTARGET : "defines (1..N)"
+    BUILDSPEC ||--o| SPLITSPEC : "defines (0..1)"
+    BUILDSPEC ||--|| BUILDMANIFEST : "records result"
+    SOURCEREF }|--|| ARTIFACTDATASET : "populates"
+    ARTIFACTDATASET ||--|{ EXPORTTARGET : "formatted by"
+    EXPORTTARGET ||--|{ PHYSICALFILE : "writes"
+    BUILDMANIFEST ||--|{ PHYSICALFILE : "records as outputs"
+
+    BUILDSPEC {
+        string dataset_id PK
+        string title
+        string description
+        tuple transforms
+        dict metadata
+        bool publish
+    }
+    SOURCEREF {
+        string provider
+        string dataset
+        dict params
+        string alias
+        string normalization_mode
+    }
+    SPLITSPEC {
+        string mode
+        dict ratios
+        string key
+        int seed
+    }
+    ARTIFACTDATASET {
+        list records
+        dict schema
+        dict provenance
+        dict statistics
+    }
+    EXPORTTARGET {
+        string kind
+        string output_path
+        dict options
+    }
+    BUILDMANIFEST {
+        string build_id PK
+        datetime started_at
+        datetime finished_at
+        string schema_version
+        tuple inputs
+        tuple outputs
+        tuple warnings
+        tuple errors
+        dict row_counts
+        dict schema_summaries
+        tuple provenance
+        string build_environment
+        string inputs_fingerprint
+    }
+    PHYSICALFILE {
+        string path PK
+        string kind
+    }
+```
+
+> 위 다이어그램의 텍스트 버전은 아래와 같습니다.
+
 ```text
 [BuildSpec] (레시피)
     |


### PR DESCRIPTION
## 요약

`DOMAIN_MODEL.md`의 "엔티티 관계도"를 ASCII 트리에서 mermaid `erDiagram`으로 변환합니다.

## 변경 사항

- 카디널리티를 명시한 `erDiagram` 추가 (예: `BuildSpec ||--|{ SourceRef`, `||--o| SplitSpec` 등)
- 각 엔티티의 주요 속성(필드) 포함 — 파일 상단의 `classDiagram`과 일치
- 기존 텍스트 트리는 fallback으로 유지 (저장소의 mermaid + text 컨벤션 준수)

## 관계

- `BuildSpec` 1 : N `SourceRef` (1..N)
- `BuildSpec` 1 : N `ExportTarget` (1..N)
- `BuildSpec` 1 : 0..1 `SplitSpec`
- `BuildSpec` 1 : 1 `BuildManifest`
- `SourceRef` N : 1 `ArtifactDataset` (populates)
- `ArtifactDataset` 1 : N `ExportTarget` (formatted by)
- `ExportTarget` / `BuildManifest` → `PhysicalFile`

## 검증

- `@mermaid-js/mermaid-cli`로 문서 내 4개 다이어그램 모두 정상 렌더링 확인
