### PR TITLE
docs: 절차형 순서도 시작/종료 터미네이터 표준화

### DIFF
--- a/ALGORITHM.md
+++ b/ALGORITHM.md
@@ -25,8 +25,8 @@ def run_build(
 
 ```mermaid
 flowchart TD
-    A[run_build 진입] --> B[1. validate_spec: fail-fast 검증]
-    B -->|ValidationError| Z[failed 종료]
+    A([run_build 진입]) --> B[1. validate_spec: fail-fast 검증]
+    B -->|ValidationError| Z([failed 종료])
     B -->|통과| C[2. BuildContext.create<br/>run workspace 준비]
     C --> D{3. 각 source 순회}
     D --> E[per-source 파이프라인<br/>Bronze to Silver to Gold]
@@ -36,7 +36,7 @@ flowchart TD
     G --> D
     D -->|모든 source 완료| H[4. 상태 판정<br/>errors 있으면 failed]
     H --> I[5. BuildManifest 조립 + 기록]
-    I --> J[BuildResult 반환]
+    I --> J([BuildResult 반환])
 ```
 
 의사코드:
@@ -101,15 +101,17 @@ build/{run_id}/
 
 ```mermaid
 flowchart LR
-    B1["build_bronze_artifact<br/>source_key=provider.dataset"] --> B2[_retag_bronze_artifact]
+    Start([source 파이프라인 시작]) --> B1["build_bronze_artifact<br/>source_key=provider.dataset"]
+    B1 --> B2[_retag_bronze_artifact]
     B2 --> B3[persist_bronze_artifact]
     B3 --> S1["build_silver_dataset"]
     S1 --> S2{validation.ok?}
-    S2 -->|No| SX[DatasetValidationError<br/>중단]
+    S2 -->|No| SX([DatasetValidationError<br/>중단])
     S2 -->|Yes| S3[persist_silver_dataset]
     S3 --> G1["build_gold_package<br/>exports/splits 반영"]
     G1 --> G2[persist_gold_package]
     G2 --> G3[build/render dataset_card<br/>gold README.md 기록]
+    G3 --> End([source 완료])
 ```
 
 1. **Bronze — 원시 수집/스냅샷**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,13 +139,13 @@ gitGraph
 
 ```mermaid
 flowchart TD
-    Start[이슈 확인 및 선택] --> Branch[새 브랜치 만들기]
+    Start([시작: 이슈 확인 및 선택]) --> Branch[새 브랜치 만들기]
     Branch --> Coding[코드 수정 및 테스트]
     Coding --> Commit[변경 사항 커밋]
     Commit --> Push[내 GitHub에 올리기]
     Push --> PR[Pull Request 생성]
     PR --> Review[코드 리뷰 및 수정]
-    Review --> Merge[main에 합치기]
+    Review --> Merge([완료: main에 합치기])
 ```
 
 1.  **브랜치 생성**: `git checkout -b feat/issue-번호-설명`

--- a/EXPORT_MODEL.md
+++ b/EXPORT_MODEL.md
@@ -121,11 +121,13 @@ sequenceDiagram
 
 ```mermaid
 flowchart TD
-    S1[Step 1: BaseExporter 상속받기] --> S2[Step 2: name 속성 구현]
+    Start([시작]) --> S1[Step 1: BaseExporter 상속받기]
+    S1 --> S2[Step 2: name 속성 구현]
     S2 --> S3[Step 3: export 메서드 구현]
     S3 --> S4[Step 4: ExportResult 반환]
     S4 --> S5[Step 5: 레지스트리에 등록]
     S5 --> S6[Step 6: 테스트 코드 추가]
+    S6 --> End([완료])
 ```
 
 ### Step 1: BaseExporter 상속받기


### PR DESCRIPTION
## 요약

절차/분기형 다이어그램(진짜 순서도)에 **시작/종료 터미네이터(스타디움 기호)** 와 분기(마름모) 규약을 일관되게 적용합니다. 구조도(계층·의존 관계도, 파일 트리, 엔터티 관계도)는 순서도가 아니므로 **변경하지 않습니다.**

## 변경 사항
- `ALGORITHM.md` — `run_build` 진입/종료 노드를 터미네이터로, source 파이프라인에 명시적 시작/종료 추가
- `CONTRIBUTING.md` — 기여 절차 흐름 시작/종료 터미네이터
- `EXPORT_MODEL.md` — Exporter 튜토리얼 흐름 시작/종료 터미네이터

## 유지(변환 제외)
- Medallion 파이프라인 흐름도, `EXPORT_MODEL.md §5`(개념 비교도), `DOMAIN_MODEL.md`(엔터티 관계), `AGENTS.md`/구조도류

## 검증
- mermaid-cli 렌더 정상
- `mkdocs build --strict` 통과 (exit 0)