### PR TITLE
perf(service): use heapq.nlargest in list_builds to avoid full sort

### DIFF
--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -13,6 +13,7 @@ Studio 같은 외부 UI가 Builder를 호출할 수 있도록 validate/preview/b
 
 from __future__ import annotations
 
+import heapq
 import hmac
 import json
 import os
@@ -218,13 +219,13 @@ class BuilderService:
         if not self._output_root.exists():
             return ServiceResponse(200, {"builds": []})
 
-        candidates = sorted(
+        candidates = heapq.nlargest(
+            limit,
             (d for d in self._output_root.iterdir() if d.is_dir()),
             key=lambda p: p.stat().st_mtime,
-            reverse=True,
         )
         builds: list[JsonValue] = []
-        for run_dir in candidates[:limit]:
+        for run_dir in candidates:
             manifest_path = run_dir / "manifest.json"
             if not manifest_path.exists():
                 continue


### PR DESCRIPTION
## Summary
- `list_builds()`가 `output_root` 아래 모든 디렉터리를 메모리에 올려 `sorted()`로 전체 정렬한 뒤 `[:limit]`로 자르던 것을, `heapq.nlargest(limit, ...)`로 교체해 O(n log n) 전체 정렬 대신 O(n log limit) 부분 선택만 수행하도록 변경했습니다.
- 이슈에서 제안한 "단기" 해결책을 적용한 것으로, 동작(반환되는 build 목록/정렬 순서)은 동일하게 유지됩니다. 중기(메타데이터 인덱스)·장기(retention 정책) 해결책은 별도 이슈로 남겨둡니다.

## Test plan
- [x] `python -m pytest tests/unit/test_service.py -q` — 45 passed
- [x] `python -m ruff check src/kpubdata_builder/service/app.py` — All checks passed

Fixes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)