### PR TITLE
[feat] add X-API-Key authentication to BuilderService

### DIFF
--- a/contract/builder-api.yaml
+++ b/contract/builder-api.yaml
@@ -13,6 +13,9 @@ servers:
   - url: http://localhost:8000
     description: 로컬 builder 개발 서버
 
+security:
+  - ApiKeyAuth: []
+
 paths:
   /version:
     get:
@@ -25,6 +28,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/VersionResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
 
   /validate:
     post:
@@ -49,6 +54,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ValidationError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
 
   /preview:
     post:
@@ -75,6 +82,8 @@ paths:
                 oneOf:
                   - $ref: "#/components/schemas/Error"
                   - $ref: "#/components/schemas/ValidationError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
 
   /build:
     post:
@@ -101,6 +110,8 @@ paths:
                 oneOf:
                   - $ref: "#/components/schemas/Error"
                   - $ref: "#/components/schemas/ValidationError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "502":
           description: >-
             하나 이상의 소스 fetch/stage 실패. upstream 소스 의존 실패이며 매니페스트는
@@ -129,6 +140,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "404":
           description: 해당 run을 찾을 수 없음
           content:
@@ -137,6 +150,23 @@ paths:
                 $ref: "#/components/schemas/Error"
 
 components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+      description: >-
+        서버에 KPUBDATA_BUILDER_API_KEY가 설정된 경우 필수. 미설정 시(로컬 개발 기본값)
+        인증 없이 모든 요청이 허용된다 (#248).
+
+  responses:
+    Unauthorized:
+      description: X-API-Key가 누락되었거나 서버에 설정된 키와 일치하지 않음
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+
   parameters:
     RunId:
       name: run_id

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -13,7 +13,9 @@ Studio 같은 외부 UI가 Builder를 호출할 수 있도록 validate/preview/b
 
 from __future__ import annotations
 
+import hmac
 import json
+import os
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -34,6 +36,24 @@ from ..tabular import DEFAULT_PREVIEW_LIMIT
 # (test_service_contract가 강제), 응답에 실어 Studio 같은 소비자가 하위 호환을
 # 협상할 수 있게 한다 (#209).
 API_CONTRACT_VERSION = "1.0.0"
+
+# 서버가 요구하는 API 키. 환경변수로만 주입하며, 미설정 시 인증을 건너뛴다(로컬 개발
+# 편의를 위한 기본값으로 CORS 기본 오리진 정책과 동일한 접근). /build가 비용이 큰
+# 외부 API 호출과 파일 시스템 쓰기를 유발하므로, 프로덕션 배포 시 반드시 설정해야
+# 한다 (#248).
+_API_KEY_ENV = "KPUBDATA_BUILDER_API_KEY"
+
+
+def _verify_api_key(api_key: str | None) -> bool:
+    """요청의 X-API-Key를 서버에 설정된 키와 비교한다 (#248).
+
+    KPUBDATA_BUILDER_API_KEY가 설정되지 않으면 인증을 건너뛴다. 설정된 경우
+    타이밍 공격을 막기 위해 hmac.compare_digest로 비교한다.
+    """
+    expected = os.environ.get(_API_KEY_ENV)
+    if not expected:
+        return True
+    return api_key is not None and hmac.compare_digest(api_key, expected)
 
 
 @dataclass(frozen=True)
@@ -250,8 +270,17 @@ def dispatch(
     path: str,
     body: Mapping[str, JsonValue] | None,
     query: str = "",
+    *,
+    api_key: str | None = None,
 ) -> ServiceResponse:
-    """(method, path)를 BuilderService 연산으로 라우팅한다."""
+    """(method, path)를 BuilderService 연산으로 라우팅한다.
+
+    라우팅 전에 X-API-Key를 검증한다 (#248). KPUBDATA_BUILDER_API_KEY가
+    설정되지 않으면 인증을 건너뛴다.
+    """
+    if not _verify_api_key(api_key):
+        return ServiceResponse(401, {"error": "unauthorized"})
+
     if method == "GET" and path == "/version":
         return service.version()
 

--- a/src/kpubdata_builder/service/http.py
+++ b/src/kpubdata_builder/service/http.py
@@ -90,7 +90,14 @@ def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
             # dispatch()에서 예상치 못한 예외가 발생하면 연결을 끊는 대신 JSON 500을
             # 반환한다. 상세 정보는 서버 로그에만 기록하고 클라이언트에는 누설하지 않는다 (#218).
             try:
-                response = dispatch(service, method, path, body, query=split.query)
+                response = dispatch(
+                    service,
+                    method,
+                    path,
+                    body,
+                    query=split.query,
+                    api_key=self.headers.get("X-API-Key"),
+                )
             except Exception:
                 _logger.error(
                     "Unhandled exception in dispatch: %s %s\n%s",
@@ -109,7 +116,7 @@ def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
             allow_origin = os.environ.get(_CORS_ALLOW_ORIGIN_ENV, _DEFAULT_CORS_ALLOW_ORIGIN)
             self.send_header("Access-Control-Allow-Origin", allow_origin)
             self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-            self.send_header("Access-Control-Allow-Headers", "Content-Type")
+            self.send_header("Access-Control-Allow-Headers", "Content-Type, X-API-Key")
             self.send_header("Access-Control-Max-Age", "86400")
 
         def _write(self, status_code: int, body: dict[str, JsonValue]) -> None:

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -283,6 +283,50 @@ class TestDispatch:
         assert "run_id" in str(resp.body.get("error", ""))
 
 
+class TestApiKeyAuth:
+    """API 키 인증(#248): X-API-Key 검증."""
+
+    def test_auth_skipped_when_env_unset(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # KPUBDATA_BUILDER_API_KEY 미설정 시 인증 없이 통과한다(로컬 개발 편의).
+        monkeypatch.delenv("KPUBDATA_BUILDER_API_KEY", raising=False)
+        resp = dispatch(_service(tmp_path), "GET", "/version", None)
+        assert resp.status_code == 200
+
+    def test_rejects_missing_api_key_when_configured(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("KPUBDATA_BUILDER_API_KEY", "secret")
+        resp = dispatch(_service(tmp_path), "GET", "/version", None)
+        assert resp.status_code == 401
+        assert resp.body == {"error": "unauthorized"}
+
+    def test_rejects_wrong_api_key_when_configured(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("KPUBDATA_BUILDER_API_KEY", "secret")
+        resp = dispatch(_service(tmp_path), "GET", "/version", None, api_key="wrong")
+        assert resp.status_code == 401
+
+    def test_accepts_matching_api_key(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("KPUBDATA_BUILDER_API_KEY", "secret")
+        resp = dispatch(_service(tmp_path), "GET", "/version", None, api_key="secret")
+        assert resp.status_code == 200
+
+    def test_build_route_requires_api_key_when_configured(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # /build처럼 비용이 큰 엔드포인트도 예외 없이 보호돼야 한다.
+        monkeypatch.setenv("KPUBDATA_BUILDER_API_KEY", "secret")
+        resp = dispatch(
+            _service(tmp_path), "POST", "/build", {"spec": VALID_SPEC_YAML, "run_id": "auth1"}
+        )
+        assert resp.status_code == 401
+
+
 class TestBuildFailureResponseCode:
     def test_failed_build_returns_502(self, tmp_path: Path) -> None:
         # 소스 fetch가 실패하면 status=failed + 502 — 매니페스트는 partial 정책으로 남는다.
@@ -448,7 +492,7 @@ class TestHttpAdapter:
             assert response.headers["Access-Control-Allow-Origin"] == "*"
             assert "POST" in response.headers["Access-Control-Allow-Methods"]
             assert "OPTIONS" in response.headers["Access-Control-Allow-Methods"]
-            assert response.headers["Access-Control-Allow-Headers"] == "Content-Type"
+            assert response.headers["Access-Control-Allow-Headers"] == "Content-Type, X-API-Key"
             assert response.headers["Access-Control-Max-Age"] == "86400"
 
     def test_response_includes_cors_header(
@@ -469,6 +513,29 @@ class TestHttpAdapter:
         base_url, _, _ = http_server
         with urllib.request.urlopen(f"{base_url}/version", timeout=2.0) as response:
             assert response.headers["Access-Control-Allow-Origin"] == "http://localhost:5173"
+
+    def test_missing_api_key_returns_401_when_configured(
+        self,
+        http_server: tuple[str, HTTPServer, threading.Thread],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # 어댑터가 X-API-Key 헤더를 dispatch로 전달해야 한다 (#248).
+        monkeypatch.setenv("KPUBDATA_BUILDER_API_KEY", "secret")
+        base_url, _, _ = http_server
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            urllib.request.urlopen(f"{base_url}/version", timeout=2.0)
+        assert exc_info.value.code == 401
+
+    def test_valid_api_key_header_is_accepted(
+        self,
+        http_server: tuple[str, HTTPServer, threading.Thread],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("KPUBDATA_BUILDER_API_KEY", "secret")
+        base_url, _, _ = http_server
+        req = urllib.request.Request(f"{base_url}/version", headers={"X-API-Key": "secret"})
+        with urllib.request.urlopen(req, timeout=2.0) as response:
+            assert response.status == 200
 
 
 class TestHttpRobustness:


### PR DESCRIPTION
## 요약
BuilderService의 dispatch()에 X-API-Key 기반 인증을 추가합니다. 요청의 X-API-Key 헤더를 KPUBDATA_BUILDER_API_KEY 환경변수 값과 타이밍 안전 비교(hmac.compare_digest)로 검증하고, 불일치·누락 시 401 unauthorized를 반환합니다. 환경변수가 설정되지 않으면 인증을 건너뛰어 로컬 개발 편의를 유지합니다. /build 등 외부 API 호출·파일시스템 쓰기를 유발하는 비용 큰 엔드포인트가 무인증으로 노출되던 문제(#248)를 해결합니다.

## 변경 내용
- service/app.py
 - _verify_api_key() 추가 — KPUBDATA_BUILDER_API_KEY 미설정 시 통과, 설정 시 hmac.compare_digest로 타이밍 공격 방지 비교
 - dispatch()에 키워드 전용 인자 api_key 추가, 라우팅 이전에 검증 → 실패 시 ServiceResponse(401, {"error": "unauthorized"}). 모든 엔드포인트(/version, /validate, /preview, /build, /builds/{run_id})에 일괄 적용
- service/http.py
 - HTTP 어댑터가 X-API-Key 요청 헤더를 읽어 dispatch(..., api_key=...)로 전달
 - CORS Access-Control-Allow-Headers에 X-API-Key 추가 (프리플라이트 대응)
- contract/builder-api.yaml
 - securitySchemes.ApiKeyAuth(apiKey / header / X-API-Key) 및 전역 security 선언
 - 재사용 responses.Unauthorized 추가, 모든 경로에 401 응답 문서화
- tests/unit/test_service.py
 - TestApiKeyAuth: 미설정 시 통과 / 키 누락·오키 거부 / 정키 허용 / /build 보호 검증
 - TestHttpAdapter: 어댑터의 헤더 전달(401) 및 정키 200, CORS 헤더 갱신 검증

## 관련 이슈
Closes #248 

## 검증
- [x] `uv run ruff check .` 통과
- [x] `uv run mypy` 통과 (해당 시)
- [x] 테스트 통과 (uv run pytest tests/unit/test_service.py) — TestApiKeyAuth 5건 및 어댑터 인증 2건 포함
- [x] 문서 변경 시 `mkdocs build --strict` 통과
- [x] manifest/골든 테스트 영향 없음 (인증 계층만 추가, 빌드 로직 무변경)

## 체크리스트
- [x] 기능 브랜치에서 작업했으며 `main`에 직접 push하지 않았다
- [x] 커밋 메시지를 영어로 작성했다
- [x] `kpubdata` provider 로직을 중복 구현하지 않았다
- [x] 필요한 단위/단계 인지형 테스트를 추가했다
- [x] 사용자 노출 기능 변경 시 문서를 분류해 갱신했다: OpenAPI 계약(builder-api.yaml)에 인증 스킴·401 응답 반영