### PR TITLE
[fix] bound ThreadingHTTPServer concurrency to prevent DoS

### DIFF
--- a/src/kpubdata_builder/service/http.py
+++ b/src/kpubdata_builder/service/http.py
@@ -14,8 +14,10 @@ import json
 import logging
 import os
 import traceback
+from concurrent.futures import ThreadPoolExecutor
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import cast
+from socket import socket as _socket
+from typing import Any, cast
 from urllib.parse import urlsplit
 
 from ..spec import JsonValue
@@ -28,6 +30,11 @@ _MAX_BODY_BYTES = 10 * 1024 * 1024  # 10 MiB
 # 소켓 읽기 타임아웃(초). 느린 클라이언트/slowloris 공격이 스레드를 무한 점거하지 않도록
 # 한다 (#219). ThreadingHTTPServer를 사용하더라도 각 연결 스레드가 여기서 해제된다.
 _SOCKET_TIMEOUT_SECONDS = 30.0
+
+# 동시에 요청을 처리할 수 있는 최대 스레드 수. ThreadingHTTPServer는 연결마다 새
+# 스레드(스레드당 스택 ~8MB)를 무제한으로 만들기 때문에, 수백~수천 개의 동시 연결만으로
+# 메모리가 고갈될 수 있다 (#253). 고정 크기 스레드 풀로 상한을 둔다.
+_DEFAULT_MAX_WORKERS = 10
 
 # CORS 허용 Origin. 기본값은 로컬 개발 편의를 위해 모든 오리진(`*`)이지만, 환경변수로
 # 특정 오리진(예: http://localhost:5173)만 허용하도록 제한할 수 있다 (#254 보안 강화).
@@ -141,22 +148,66 @@ def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
     return _Handler
 
 
-def serve(service: BuilderService, *, host: str = "127.0.0.1", port: int = 8000) -> None:
+class BoundedThreadingHTTPServer(ThreadingHTTPServer):
+    """동시 처리 스레드 수가 제한된 ThreadingHTTPServer (#253).
+
+    ThreadingHTTPServer는 연결마다 새 스레드를 무제한으로 생성해, 악의적이거나
+    비정상적인 클라이언트가 다수의 동시 연결을 열면 스레드/메모리 고갈로 서비스가
+    중단될 수 있다. 요청 처리를 고정 크기 ThreadPoolExecutor에 위임해 동시
+    처리량에 상한을 둔다.
+    """
+
+    daemon_threads = True
+
+    def __init__(
+        self,
+        *args: Any,
+        max_workers: int = _DEFAULT_MAX_WORKERS,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._executor = ThreadPoolExecutor(
+            max_workers=max_workers, thread_name_prefix="kpubdata-http"
+        )
+
+    def process_request(
+        self, request: _socket | tuple[bytes, _socket], client_address: Any
+    ) -> None:
+        # 새 스레드를 직접 만드는 대신 고정 크기 풀에 위임한다. 풀이 가득 차면
+        # 초과 요청은 스레드를 점유하지 않고 풀 큐에서 대기한다.
+        self._executor.submit(self.process_request_thread, request, client_address)
+
+    def server_close(self) -> None:
+        super().server_close()
+        self._executor.shutdown(wait=False, cancel_futures=True)
+
+
+def serve(
+    service: BuilderService,
+    *,
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    max_workers: int = _DEFAULT_MAX_WORKERS,
+) -> None:
     """BuilderService를 블로킹 HTTP 서버로 제공한다.
 
-    단일 스레드 HTTPServer 대신 ThreadingHTTPServer를 사용하여 느린 클라이언트가
-    서버 전체를 멈추지 않도록 한다 (#219).
+    단일 스레드 HTTPServer 대신 BoundedThreadingHTTPServer를 사용하여 느린
+    클라이언트가 서버 전체를 멈추지 않으면서도 (#219), 동시 처리 스레드 수에
+    상한을 두어 DoS를 방지한다 (#253).
 
     매개변수:
         service: 노출할 BuilderService.
         host: 바인딩 호스트.
         port: 바인딩 포트.
+        max_workers: 동시에 요청을 처리할 최대 스레드 수.
     """
-    server = ThreadingHTTPServer((host, port), make_handler(service))
+    server = BoundedThreadingHTTPServer(
+        (host, port), make_handler(service), max_workers=max_workers
+    )
     try:
         server.serve_forever()
     finally:
         server.server_close()
 
 
-__all__ = ["make_handler", "serve"]
+__all__ = ["BoundedThreadingHTTPServer", "make_handler", "serve"]

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -511,14 +511,14 @@ class TestHttpRobustness:
         assert handler_cls.timeout == _SOCKET_TIMEOUT_SECONDS
         assert handler_cls.timeout > 0
 
-    def test_serve_uses_threading_http_server(self, tmp_path: Path) -> None:
-        # serve()가 ThreadingHTTPServer를 사용해야 느린 클라이언트가 서버 전체를
-        # 멈추지 않는다 (#219).
+    def test_serve_uses_bounded_threading_http_server(self, tmp_path: Path) -> None:
+        # serve()가 BoundedThreadingHTTPServer를 사용해야 느린 클라이언트가 서버
+        # 전체를 멈추지 않으면서도(#219) 동시 처리 스레드 수에 상한이 걸린다 (#253).
         import contextlib
         import unittest.mock
         from http.server import ThreadingHTTPServer
 
-        from kpubdata_builder.service.http import serve
+        from kpubdata_builder.service.http import BoundedThreadingHTTPServer, serve
 
         created_servers: list[object] = []
         original_init = ThreadingHTTPServer.__init__
@@ -538,7 +538,87 @@ class TestHttpRobustness:
             serve(_service(tmp_path), host="127.0.0.1", port=0)
 
         assert len(created_servers) == 1
-        assert isinstance(created_servers[0], ThreadingHTTPServer)
+        assert isinstance(created_servers[0], BoundedThreadingHTTPServer)
+
+    def test_serve_passes_max_workers_to_executor(self, tmp_path: Path) -> None:
+        from kpubdata_builder.service.http import BoundedThreadingHTTPServer, make_handler
+
+        server = BoundedThreadingHTTPServer(
+            ("127.0.0.1", 0), make_handler(_service(tmp_path)), max_workers=3
+        )
+        try:
+            assert server._executor._max_workers == 3
+        finally:
+            server.server_close()
+
+    def test_bounded_server_limits_concurrent_processing(self, tmp_path: Path) -> None:
+        # 동시 처리 스레드 수가 max_workers로 상한이 걸려야 한다 (#253): 워커 수보다
+        # 많은 클라이언트가 동시에 접속해도 실제 동시 처리량은 max_workers를 넘지 않는다.
+        import time
+        import unittest.mock
+
+        from kpubdata_builder.service.app import ServiceResponse
+        from kpubdata_builder.service.http import BoundedThreadingHTTPServer, make_handler
+
+        max_workers = 2
+        num_clients = 4
+        server = BoundedThreadingHTTPServer(
+            ("127.0.0.1", 0), make_handler(_service(tmp_path)), max_workers=max_workers
+        )
+        server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+        server_thread.start()
+        base_url = f"http://{server.server_address[0]}:{server.server_address[1]}"
+
+        lock = threading.Lock()
+        concurrent_count = 0
+        max_seen = 0
+        release = threading.Event()
+
+        def _slow_dispatch(*args: object, **kwargs: object) -> ServiceResponse:
+            nonlocal concurrent_count, max_seen
+            with lock:
+                concurrent_count += 1
+                max_seen = max(max_seen, concurrent_count)
+            release.wait(timeout=5.0)
+            with lock:
+                concurrent_count -= 1
+            return ServiceResponse(200, {"service": "kpubdata-builder", "api_version": "1.0.0"})
+
+        results: list[int] = []
+
+        def _get() -> None:
+            with urllib.request.urlopen(f"{base_url}/version", timeout=5.0) as resp:
+                results.append(resp.status)
+
+        try:
+            with unittest.mock.patch(
+                "kpubdata_builder.service.http.dispatch", side_effect=_slow_dispatch
+            ):
+                client_threads = [threading.Thread(target=_get) for _ in range(num_clients)]
+                for t in client_threads:
+                    t.start()
+
+                # 워커 풀이 상한(max_workers)까지 채워질 때까지 능동적으로 대기한다.
+                deadline = time.monotonic() + 5.0
+                while time.monotonic() < deadline:
+                    with lock:
+                        if concurrent_count >= max_workers:
+                            break
+                    time.sleep(0.02)
+
+                with lock:
+                    observed = max_seen
+
+                release.set()
+                for t in client_threads:
+                    t.join(timeout=5.0)
+        finally:
+            server.shutdown()
+            server.server_close()
+            server_thread.join(timeout=1.0)
+
+        assert observed == max_workers
+        assert len(results) == num_clients
 
     def test_oversized_body_content_length_returns_413_http(
         self, http_server: tuple[str, HTTPServer, threading.Thread]


### PR DESCRIPTION
## 요약
ThreadingHTTPServer는 연결마다 새 스레드(스택 ~8MB)를 무제한 생성하므로, 클라이언트가 수백~수천 개의 동시 연결을 열면 서버 메모리가 고갈될 수 있습니다. 요청 처리를 고정 크기 ThreadPoolExecutor에 위임하는 BoundedThreadingHTTPServer를 추가해 동시 처리 스레드 수에 상한을 둡니다(기본 10, serve(max_workers=...)로 조정 가능).

## 변경 내용
- service/http.py
 - BoundedThreadingHTTPServer 추가 — ThreadingHTTPServer를 상속하되, 스레드를 직접 생성하지 않고 process_request()를 오버라이드해 고정 크기 ThreadPoolExecutor(thread_name_prefix="kpubdata-http")에 process_request_thread를 submit. 풀이 가득 차면 초과 요청은 스레드를 점유하지 않고 큐에서 대기
 - daemon_threads = True 설정, server_close()에서 executor를 shutdown(wait=False, cancel_futures=True)로 정리
 - _DEFAULT_MAX_WORKERS = 10 상수 추가
 - serve()에 max_workers 키워드 인자 추가, ThreadingHTTPServer → BoundedThreadingHTTPServer 사용으로 교체
 - __all__에 BoundedThreadingHTTPServer 추가
- tests/unit/test_service.py
 - test_serve_uses_threading_http_server → test_serve_uses_bounded_threading_http_server로 갱신(serve()가 bounded 서버를 쓰는지 검증)
 - test_serve_passes_max_workers_to_executor — max_workers가 executor에 전달되는지 검증
 - test_bounded_server_limits_concurrent_processing — dispatch를 느린 핸들러로 패치, 워커 수보다 많은 클라이언트를 동시 접속시켜 실제 동시 처리량이 max_workers를 넘지 않음을 검증

기존 소켓 타임아웃(#219)·body 크기 제한(#186) 완화 장치는 그대로 유지되며, 이번 변경은 그 위에 동시 스레드 개수 상한을 추가합니다.

## 관련 이슈
Closes #253 

## 검증
- [x] `uv run ruff check .` 통과
- [x] `uv run mypy` 통과 (해당 시)
- [x] 테스트 통과 (uv run pytest tests/unit/test_service.py) — TestHttpRobustness의 bounded 서버/max_workers/동시성 상한 테스트 3건 포함
- [x] 문서 변경 시 mkdocs build --strict 통과 (해당 없음 — 코드/테스트만 변경)
- [x] manifest/골든 테스트 영향 없음 (서버 동시성 계층만 변경, 빌드 로직 무변경)

## 체크리스트
- [x] 기능 브랜치에서 작업했으며 `main`에 직접 push하지 않았다
- [x] 커밋 메시지를 영어로 작성했다
- [x] `kpubdata` provider 로직을 중복 구현하지 않았다
- [x] 필요한 단위/단계 인지형 테스트를 추가했다 (bounded 서버 사용·max_workers 전달·동시성 상한)
- [x] 사용자 노출 기능 변경 시 문서를 분류해 갱신했다 (내부 서버 동작 변경, 사용자 노출 계약 변화 없음 — 해당 없음)
