### PR TITLE
docs: v0.4 Beyond-MVP ADR 초안 (0002-0006)

### DIFF
--- a/docs/adrs/0002-build-execution-model.md
+++ b/docs/adrs/0002-build-execution-model.md
@@ -1,0 +1,66 @@
+# ADR 0002 — Build 실행 모델: 동기 vs 비동기(job)
+
+- 상태: 제안됨(Proposed)
+- 관련 이슈: #308, #241, #209, kpubdata-studio#102
+- 관련 문서: [API_CONTRACT.md](../../API_CONTRACT.md), [BUILD_STATE.md](../../BUILD_STATE.md)
+
+## 배경
+
+현재 `POST /build`(`service/app.py:BuilderService.build`)는 **동기 실행**이다. 요청 스레드 안에서 Bronze→Silver→Gold 파이프라인을 모두 수행하고, 완료 후에야 `run_id`·`outcomes`·`manifest` 경로를 담아 200(성공) 또는 502(upstream 실패)를 반환한다.
+
+반면 문서와 소비자 기대는 비동기 모델을 전제한다.
+
+- `API_CONTRACT.md` §2/§8은 "실제 build와 publish는 비동기식으로 모델링하는 것을 기본값으로 둔다", `createBuild`는 "계약은 비동기 `POST /builds` 지향"이라고 서술한다.
+- Studio(`kpubdata-studio#102`)의 빌드 이력/상태 표시는 `run_id` 생성 후 상태를 폴링하는 흐름을 가정한다.
+
+이 동기 구현 ↔ 비동기 문서/기대 사이의 간극이 계약 드리프트(#241)의 핵심 원인이다.
+
+## 문제
+
+장시간 빌드(대형 소스, 다수 export)에서 동기 모델은 다음 한계가 있다.
+
+- HTTP 요청 타임아웃/프록시 버퍼링에 취약하다.
+- 진행 상태(단계별 진척) 노출이 불가능하다.
+- 취소/재시도 훅이 없다.
+- 클라이언트가 연결을 유지해야 하므로 UI 응답성이 떨어진다.
+
+## 결정 필요 사항
+
+1. `/build`를 **동기 유지**할지, **비동기 job 모델**로 전환할지, 또는 **양쪽 병행**할지.
+2. 비동기 채택 시 상태 머신 정의: `queued → running → succeeded | failed`(+ `cancelled`).
+3. 계약 형태: `POST /builds` → `202 Accepted` + `{run_id}`, 상태 폴링 `GET /builds/{run_id}`.
+4. 타임아웃/취소/동시성 상한 정책(#253의 `BoundedThreadingHTTPServer`와 정합).
+
+## 검토한 대안
+
+### 대안 A — 동기 유지(현행)
+- 장점: 구현 단순, 결정적, 현재 테스트 그대로 유효.
+- 단점: 장시간 빌드/진척 노출/취소 불가. 문서·Studio 기대와 불일치 지속.
+
+### 대안 B — 비동기 job 모델 전환
+- 장점: 장시간 빌드 대응, 진척/취소 가능, 문서·Studio와 정합.
+- 단점: 상태 저장소(→ ADR 0003) 필요, 워커/큐 도입으로 복잡도·운영부담 증가.
+
+### 대안 C — 하이브리드 (동기 기본 + 비동기 옵션)
+- `POST /build`(동기)는 소규모/CLI용으로 유지하고, `POST /builds`(비동기)를 신설.
+- 장점: 기존 계약 보존 + 확장. 단점: 두 경로 유지 비용.
+
+## 권고 (제안)
+
+**대안 C(하이브리드)를 v0.4 목표로 제안**한다. 단, 실제 job 실행 인프라(워커/큐)는 ADR 0003(영속 저장소) 확정에 의존하므로, v0.4에서는 다음 최소 단계를 우선한다.
+
+1. 상태 머신을 `BUILD_STATE.md`에 명문화(queued/running/succeeded/failed/cancelled).
+2. `POST /builds`(202+run_id) / `GET /builds/{run_id}`(상태) 계약을 `contract/builder-api.yaml`에 **선언만** 추가(구현 전, planned 표기).
+3. 동기 `POST /build`는 하위호환으로 유지.
+
+## 영향
+
+- `API_CONTRACT.md`의 "비동기 지향" 서술이 실제 계약과 일치하게 됨(#241 잔여 해소).
+- ADR 0003(영속 저장소)과 강하게 결합 — 상태를 어디에 보관할지 함께 결정해야 함.
+- Studio #102는 우선 동기 `/build` + `GET /builds` 목록으로 연동하고, 비동기 폴링은 후속 단계로 분리 가능.
+
+## 미해결 질문
+
+- 워커 실행 모델: 인프로세스 스레드풀 vs 별도 프로세스/큐?
+- 취소 시 부분 산출물(partial manifest) 처리 규약?
+- run_id 생성 주체(클라이언트 지정 허용 범위, 현재 `validate_path_segment`로 검증됨).

--- a/docs/adrs/0003-persistent-build-store.md
+++ b/docs/adrs/0003-persistent-build-store.md
@@ -1,0 +1,71 @@
+# ADR 0003 — 영속 Build 저장소: 파일시스템 스캔 대체
+
+- 상태: 제안됨(Proposed)
+- 관련 이슈: #309, #308, kpubdata-studio#102
+- 관련 문서: [ARCHITECTURE.md](../../ARCHITECTURE.md), [BUILD_STATE.md](../../BUILD_STATE.md)
+
+## 배경
+
+`GET /builds`(`BuilderService.list_builds`)는 현재 `output_root` 아래 디렉터리를 직접 스캔한다.
+
+```python
+candidates = heapq.nlargest(
+    limit,
+    (d for d in self._output_root.iterdir() if d.is_dir()),
+    key=lambda p: p.stat().st_mtime,
+)
+# 각 후보에서 manifest.json을 읽어 status/started_at/finished_at 조립
+```
+
+즉 빌드 이력의 **단일 진실원천이 파일시스템**이며, 목록 조회 시마다 디렉터리를 순회하고 각 `manifest.json`을 파싱한다.
+
+## 문제
+
+- **확장성**: 빌드 수 증가 시 `iterdir` + per-run `manifest.json` 파싱 비용이 선형 증가.
+- **일관성**: 빌드 진행 중(모델 전환 시)에는 manifest가 아직 없어 상태 표현 불가. 현재는 `manifest.json` 없는 디렉터리를 건너뛴다.
+- **동시성**: 여러 빌드/정리 작업이 동시에 디렉터리를 건드릴 때 경합.
+- **상태 표현 한계**: ADR 0002의 비동기 job 상태(`queued`/`running`)를 파일만으로 표현하기 어렵다.
+
+## 결정 필요 사항
+
+1. 빌드 메타데이터 인덱스의 저장 방식.
+2. 목록/조회/페이지네이션 계약.
+3. run_id 생성/충돌 정책(현재 `validate_path_segment`로 경로 안전성만 검증).
+4. 보존/정리(retention) 정책.
+
+## 검토한 대안
+
+### 대안 A — 현행 파일시스템 스캔 유지
+- 장점: 무의존성, 단순, 이미 동작. 소규모에서 충분.
+- 단점: 확장성·진행상태·동시성 한계(위 문제).
+
+### 대안 B — 경량 SQLite 인덱스
+- `builds` 테이블(run_id, status, started_at, finished_at, spec_digest, error)로 인덱싱.
+- 장점: 쿼리/페이지네이션/상태전이 자연스러움, 단일 파일 무서버, 트랜잭션.
+- 단점: manifest(파일)와 DB(인덱스) 이중 소스 → 동기화 규약 필요.
+
+### 대안 C — JSON 인덱스 파일(`_index.json`)
+- 장점: 의존성 없음, 사람이 읽기 쉬움.
+- 단점: 동시 쓰기 잠금 필요, 대규모에서 여전히 비효율.
+
+## 권고 (제안)
+
+**대안 B(SQLite 인덱스)를 제안**하되, **manifest.json을 여전히 per-run 정본으로 유지**하고 SQLite는 **파생 인덱스(캐시)**로 둔다.
+
+- 정본: `build/{run_id}/manifest.json` (감사·재현성, AGENTS.md '매니페스트 누락 금지' 준수).
+- 인덱스: `output_root/_builds.sqlite` — 빌드 생성/상태전이 시 갱신, 유실 시 스캔으로 재구축 가능(권위 없음).
+- `list_builds`는 인덱스를 우선 조회하고, 인덱스 부재 시 현행 스캔으로 폴백.
+
+이 설계는 ADR 0002의 비동기 상태(`queued`/`running`)를 manifest 없이도 표현할 수 있게 한다.
+
+## 영향
+
+- `list_builds` 구현이 인덱스 우선 + 스캔 폴백으로 변경.
+- 페이지네이션 계약(`?limit=`, 향후 `?cursor=`)을 `contract/builder-api.yaml`에 반영.
+- retention: run 수/디스크 상한 초과 시 오래된 run 정리 정책을 별도 이슈로 분해.
+
+## 미해결 질문
+
+- SQLite 도입이 '무의존성 지향'과 충돌하는가? (표준 라이브러리 `sqlite3`로 무외부의존 가능)
+- 인덱스와 manifest 불일치 시 조정(reconcile) 트리거 시점?
+- run_id를 서버 생성(예: ULID)으로 표준화할지, 클라이언트 지정 허용을 유지할지?

--- a/docs/adrs/0004-plugin-exporter-contract.md
+++ b/docs/adrs/0004-plugin-exporter-contract.md
@@ -1,0 +1,62 @@
+# ADR 0004 — Plugin Exporter API 계약 안정화
+
+- 상태: 제안됨(Proposed)
+- 관련 이슈: #311
+- 관련 문서: [EXPORT_MODEL.md](../../EXPORT_MODEL.md), [ARCHITECTURE.md](../../ARCHITECTURE.md)
+
+## 배경
+
+AGENTS.md는 "exporter는 플러그형으로 유지할 것"을 기본 규칙으로 규정한다. 현재 exporter는 `exporters/base.py`의 `BaseExporter`를 상속하고 `export()`를 구현하는 방식으로 추가된다. BuildSpec의 `ExportTarget.kind`가 exporter 레지스트리 키로 사용된다.
+
+## 문제
+
+플러그형이라는 목표에 비해 다음이 명문화되어 있지 않다.
+
+- **등록/발견(discovery)**: exporter가 어떻게 레지스트리에 등록되는가(내부 하드코딩 vs 동적 등록 vs entry points).
+- **계약 안정성**: `export()` 시그니처·반환 규약의 버저닝과 하위호환 보증 범위.
+- **실패 시맨틱**: 부분 출력/실패 시 manifest 반영 규약.
+- **서드파티 확장**: 외부 패키지가 exporter를 제공할 수 있는 공개 계약인가.
+
+## 결정 필요 사항
+
+1. Exporter 등록 메커니즘.
+2. `export()` 계약의 안정성 보증 및 버전 정책.
+3. 실패/부분출력 시맨틱과 manifest 통합 규약.
+4. 서드파티 exporter 지원 범위(공개 API vs 내부 확장점).
+
+## 검토한 대안
+
+### 대안 A — 내부 명시적 레지스트리(현행 유지)
+- kind→클래스 매핑을 코드 내부 dict로 유지.
+- 장점: 단순·결정적(AGENTS.md '결정적 동작 우선'과 정합), 발견 비용 0.
+- 단점: 서드파티가 코어 수정 없이 추가 불가.
+
+### 대안 B — Python entry points(`importlib.metadata`)
+- `kpubdata_builder.exporters` 그룹으로 외부 패키지가 exporter 등록.
+- 장점: 진정한 플러그인, 코어 수정 불필요.
+- 단점: 동적 발견 → 결정성/보안 검토 필요(신뢰 경계).
+
+### 대안 C — 하이브리드
+- 코어 exporter는 명시적 레지스트리, 확장은 명시적 opt-in 등록 API(`register_exporter`) 제공. entry points는 후속.
+
+## 권고 (제안)
+
+**대안 C(하이브리드)를 제안**한다.
+
+1. 코어 exporter(markdown/jsonl/parquet/csv/huggingface 등)는 명시적 레지스트리로 결정성 유지.
+2. 공개 등록 API `register_exporter(kind, factory)`를 노출해 확장 지점을 문서화.
+3. `export()` 계약을 EXPORT_MODEL.md에 안정 계약으로 명문화:
+   - 입력: 레코드/메타데이터, 출력 base_dir(경로 안전은 `_path_safety`가 강제).
+   - 반환: 생성된 `Artifact` 목록.
+   - 실패: 예외 규약 + 부분출력 금지(원자성) 또는 명시적 partial 표기.
+4. entry points 기반 자동 발견은 신뢰 경계 검토 후 후속 ADR로 분리.
+
+## 영향
+
+- `EXPORT_MODEL.md`에 exporter 계약 절 신설(현재 AGENTS.md의 간단 가이드를 정식 계약으로 승격).
+- 신규 exporter 추가 시 골든 테스트 요구(AGENTS.md 체크리스트)와 연결.
+
+## 미해결 질문
+
+- `export()`가 스트리밍(대용량)에 대응해야 하는가, 전량 메모리 로드로 충분한가?
+- exporter별 옵션 스키마 검증을 어디서 수행할지(validator vs exporter 내부)?

--- a/docs/adrs/0005-api-contract-single-source.md
+++ b/docs/adrs/0005-api-contract-single-source.md
@@ -1,0 +1,65 @@
+# ADR 0005 — API 계약 단일 소스 & 코드 생성 전략
+
+- 상태: 제안됨(Proposed)
+- 관련 이슈: #310, #209, #241, kpubdata-studio#85, kpubdata-studio#103
+- 관련 문서: [API_CONTRACT.md](../../API_CONTRACT.md), `contract/builder-api.yaml`
+
+## 배경
+
+Builder API는 세 곳에서 표현된다.
+
+1. 서버 라우팅: `service/app.py:dispatch`
+2. 계약 문서: `contract/builder-api.yaml`(OpenAPI) + `API_CONTRACT.md`
+3. 클라이언트: Studio `src/shared/lib/builderApi.ts`
+
+현재도 일부 정합 장치가 존재한다. `contract/builder-api.yaml`의 `info.version`과 코드의 `API_CONTRACT_VERSION`이 일치해야 하며 이를 `test_service_contract`가 강제한다(API_CONTRACT.md §8).
+
+## 문제
+
+버전 문자열 정합은 있으나, **엔드포인트/스키마 수준의 드리프트**는 자동으로 잡히지 않는다.
+
+- 이미 구현된 `GET /builds`(#250), `X-API-Key` 인증(#248)이 문서/계약에 반영되지 않을 수 있다(#241).
+- Studio 클라이언트는 응답을 `return parsed as T`로 캐스팅만 하고 런타임 검증이 없다(kpubdata-studio#103).
+- 세 표현이 수작업으로 유지되어 드리프트가 반복된다.
+
+## 결정 필요 사항
+
+1. 단일 진실원천(SSOT) 선정: `contract/builder-api.yaml`을 소스로 삼을지.
+2. 서버 라우트가 SSOT를 만족하는지 검증하는 계약 테스트 범위(버전 → 경로/스키마로 확장).
+3. Studio 타입/클라이언트 생성(codegen) 채택 여부.
+4. CI 게이트 배치.
+
+## 검토한 대안
+
+### 대안 A — 문서 우선(수작업) 유지
+- 장점: 단순. 단점: 드리프트 반복, 사람이 놓침.
+
+### 대안 B — OpenAPI를 SSOT로, 양방향 검증
+- 서버: 라우트/응답이 yaml 스키마를 만족하는지 스키마 대조 테스트.
+- 클라이언트: `openapi-typescript` 등으로 Studio 타입 생성 + zod 스키마 파생(#103과 결합).
+- 장점: 드리프트를 CI에서 차단, 3-레포 정합(#85).
+- 단점: 초기 도구 도입 비용, 생성물 관리.
+
+### 대안 C — 코드 우선(FastAPI 등으로 스키마 자동 생성)
+- 현재는 표준 라이브러리 `http.server` 기반이므로 프레임워크 교체가 선행되어야 함 → 범위 과대.
+
+## 권고 (제안)
+
+**대안 B를 제안**하되 점진 도입한다.
+
+1. **1단계(계약 테스트 확장)**: `test_service_contract`를 버전 일치 → **경로/메서드 커버리지 대조**까지 확장(yaml에 선언된 모든 operation이 `dispatch`에 존재하고 그 역도 성립). → #209 핵심.
+2. **2단계(문서 갱신)**: 구현된 `GET /builds`·인증을 yaml/API_CONTRACT.md에 반영(#241 잔여).
+3. **3단계(클라이언트 codegen)**: Studio에서 yaml→타입 생성 + zod 런타임 검증 도입(#103, #85). Builder는 yaml만 안정적으로 유지.
+
+프레임워크 교체(대안 C)는 채택하지 않는다 — 표준 라이브러리 기반의 결정성·무의존성을 유지한다.
+
+## 영향
+
+- `contract/builder-api.yaml`이 명시적 SSOT로 승격.
+- CI에 경로/스키마 대조 게이트 추가.
+- Studio 클라이언트 신뢰성 향상(#103)과 3-레포 계약 정합(#85)이 이 SSOT에 수렴.
+
+## 미해결 질문
+
+- 스키마 대조를 순수 파이썬(경량)으로 할지, `openapi-core` 등 검증 라이브러리를 도입할지?
+- codegen 산출물을 Studio 레포에 커밋할지, 빌드 타임 생성할지?

--- a/docs/adrs/0006-service-auth-and-deployment.md
+++ b/docs/adrs/0006-service-auth-and-deployment.md
@@ -1,0 +1,60 @@
+# ADR 0006 — 서비스 인증 & 배포(Docker) 스토리
+
+- 상태: 제안됨(Proposed)
+- 관련 이슈: #312, #237, #248, #253
+- 관련 문서: [API_CONTRACT.md](../../API_CONTRACT.md), [ARCHITECTURE.md](../../ARCHITECTURE.md)
+
+## 배경
+
+Builder HTTP 서비스는 구현되어 있다(#237 해결). `service/http.py`의 `BoundedThreadingHTTPServer`(동시성 상한, #253)와 `cli.py serve` 커맨드로 실제 서빙이 가능하다.
+
+인증도 **이미 부분 구현**되어 있다. `service/app.py`의 `_verify_api_key`가 `X-API-Key` 헤더를 `KPUBDATA_BUILDER_API_KEY` 환경변수와 `hmac.compare_digest`로 비교한다(#248). 환경변수 미설정 시 인증을 건너뛴다(로컬 개발 편의).
+
+## 문제
+
+운영(로컬 개발 이상)으로 가기 위한 다음이 정의되어 있지 않다.
+
+- **배포 아티팩트 부재**: Dockerfile/compose가 없어 재현 가능한 배포가 어렵다.
+- **CORS/오리진 정책**: Studio(브라우저)↔Builder 연동 시 오리진 정책이 명문화되지 않음.
+- **인증 정책 성숙도**: 단일 정적 API 키만 지원. 키 로테이션/다중 소비자/스코프는 미정.
+- **설정 표면**: 포트/바인드 주소/출력 루트/동시성 상한 등 운영 설정의 표준 규약 부재.
+
+## 결정 필요 사항
+
+1. 배포 아티팩트: Dockerfile(+ 선택적 compose)와 설정 규약(env/포트/볼륨).
+2. CORS/오리진 정책(Studio 연동 전제).
+3. 인증 모델의 목표 수준(정적 키 유지 vs 확장).
+
+## 검토한 대안
+
+### 인증
+- **A. 현행 정적 API 키 유지**: 단순, 신뢰 네트워크/단일 소비자에 충분. 로테이션/스코프 없음.
+- **B. 키 세트 + 스코프**: 다중 소비자·로테이션 지원. 복잡도 증가.
+- 권고: v0.4는 **A 유지 + 문서화**(프로덕션 배포 시 키 필수 명시), B는 후속.
+
+### 배포
+- **A. Dockerfile 단일 이미지**: `uv sync --no-sources`로 PyPI kpubdata 설치, `serve` 진입점. 권고.
+- **B. compose(빌더+스튜디오)**: 통합 데모/E2E에 유용. 후속 선택.
+
+### CORS
+- **A. 허용 오리진 환경변수(`KPUBDATA_BUILDER_ALLOWED_ORIGINS`)**: 기본은 동일 오리진/미설정 시 비허용. 권고.
+
+## 권고 (제안)
+
+v0.4 범위로 다음을 제안한다.
+
+1. **Dockerfile** 추가: `uv sync --no-sources` 기반, 진입점 `kpubdata-builder serve`, 설정은 env(`KPUBDATA_BUILDER_API_KEY`, 포트, 출력 루트)로 주입.
+2. **CORS 정책**을 허용 오리진 env로 도입하고 API_CONTRACT.md/README에 문서화.
+3. **인증**은 현행 정적 키 유지 + "프로덕션에서 키 필수" 운영 가이드 명문화(코드 주석 #248 내용을 문서로 승격).
+4. compose·키 로테이션·스코프는 별도 후속 이슈로 분해.
+
+## 영향
+
+- 신규 `Dockerfile`(+ 선택 `docker-compose.yml`), README '배포' 절 추가.
+- `service/app.py`/`http.py`에 CORS 헤더 처리 추가(구현은 후속 이슈).
+- Studio E2E(kpubdata-studio#104)가 컨테이너화된 Builder를 대상으로 실행 가능.
+
+## 미해결 질문
+
+- 이미지 베이스(경량 python-slim vs distroless)와 kpubdata 버전 핀 정합(#213)?
+- CORS를 서비스 계층에서 처리할지, 배포 시 리버스 프록시에 위임할지?

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,19 @@
+# Architecture Decision Records (ADR)
+
+KPubData Builder의 주요 설계 결정을 기록합니다. 각 ADR은 배경·문제·검토한 대안·권고·영향을 담으며, 상태(제안됨/승인됨/대체됨)를 표기합니다.
+
+| ADR | 제목 | 상태 | 관련 이슈 |
+| :--- | :--- | :--- | :--- |
+| [0001](./0001-builder-as-orchestrator.md) | 오케스트레이터로서의 Builder | 승인됨 | — |
+| [0002](./0002-build-execution-model.md) | Build 실행 모델: 동기 vs 비동기(job) | 제안됨 | #308 |
+| [0003](./0003-persistent-build-store.md) | 영속 Build 저장소: 파일시스템 스캔 대체 | 제안됨 | #309 |
+| [0004](./0004-plugin-exporter-contract.md) | Plugin Exporter API 계약 안정화 | 제안됨 | #311 |
+| [0005](./0005-api-contract-single-source.md) | API 계약 단일 소스 & 코드 생성 전략 | 제안됨 | #310 |
+| [0006](./0006-service-auth-and-deployment.md) | 서비스 인증 & 배포(Docker) 스토리 | 제안됨 | #312 |
+
+## 작성 규칙
+
+- 파일명: `NNNN-kebab-title.md` (4자리 일련번호).
+- 언어: 한국어(문서 정책).
+- 상태 흐름: `제안됨(Proposed) → 승인됨(Accepted) → (필요시) 대체됨(Superseded)`.
+- 이 목록은 v0.4 마일스톤(Beyond-MVP 통합, epic #313)의 설계 결정을 추적합니다.


### PR DESCRIPTION
## 개요
v0.4 통합 마일스톤(Beyond-MVP, epic #313)의 설계 결정을 ADR 초안으로 문서화합니다. **구현 변경 없음** — 문서만 추가합니다.

## 추가된 ADR (모두 '제안됨' 상태)
- `0002` Build 실행 모델: 동기 vs 비동기(job) — #308
- `0003` 영속 Build 저장소: 파일시스템 스캔 대체 — #309
- `0004` Plugin Exporter API 계약 안정화 — #311
- `0005` API 계약 단일 소스 & 코드 생성 전략 — #310
- `0006` 서비스 인증 & 배포(Docker) — #312
- `README.md` ADR 인덱스

## 코드 기준 반영 사항
초안 작성 전 실제 코드를 재검증하여 다음을 정확히 반영했습니다.
- 인증(`X-API-Key`, `KPUBDATA_BUILDER_API_KEY`)은 **이미 구현됨**(#248) → 0006은 배포/CORS로 스코프 조정
- 계약 버전 정합 테스트(`test_service_contract`)는 **이미 존재** → 0005는 경로/스키마 대조로 확장 제안
- `GET /builds`(list_builds)는 **파일시스템 스캔 기반**으로 구현됨 → 0003이 대체 설계 제시

## 성격
각 ADR은 배경·문제·검토한 대안·권고·미해결 질문을 담은 **의사결정 문서**이며, 승인 시 후속 구현 이슈로 분해됩니다.

관련: #308 #309 #310 #311 #312, epic #313