### PR TITLE
docs: ADR 0004/0005 관련 이슈 번호 정정 (#310↔#311)

### DIFF
--- a/docs/adrs/0004-plugin-exporter-contract.md
+++ b/docs/adrs/0004-plugin-exporter-contract.md
@@ -1,7 +1,7 @@
 # ADR 0004 — Plugin Exporter API 계약 안정화
 
 - 상태: 승인됨(Accepted)
-- 관련 이슈: #311
+- 관련 이슈: #310
 - 관련 문서: [EXPORT_MODEL.md](../../EXPORT_MODEL.md), [ARCHITECTURE.md](../../ARCHITECTURE.md)
 
 ## 결정 (승인됨)

--- a/docs/adrs/0005-api-contract-single-source.md
+++ b/docs/adrs/0005-api-contract-single-source.md
@@ -1,7 +1,7 @@
 # ADR 0005 — API 계약 단일 소스 & 코드 생성 전략
 
 - 상태: 승인됨(Accepted)
-- 관련 이슈: #310, #209, #241, kpubdata-studio#85, kpubdata-studio#103
+- 관련 이슈: #311, #209, #241, kpubdata-studio#85, kpubdata-studio#103
 - 관련 문서: [API_CONTRACT.md](../../API_CONTRACT.md), `contract/builder-api.yaml`
 
 ## 결정 (승인됨)

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -7,8 +7,8 @@ KPubData Builder의 주요 설계 결정을 기록합니다. 각 ADR은 배경·
 | [0001](./0001-builder-as-orchestrator.md) | 오케스트레이터로서의 Builder | 승인됨 | — |
 | [0002](./0002-build-execution-model.md) | Build 실행 모델: 동기 vs 비동기(job) | 승인됨 | #308 |
 | [0003](./0003-persistent-build-store.md) | 영속 Build 저장소: 파일시스템 스캔 대체 | 승인됨 | #309 |
-| [0004](./0004-plugin-exporter-contract.md) | Plugin Exporter API 계약 안정화 | 승인됨 | #311 |
-| [0005](./0005-api-contract-single-source.md) | API 계약 단일 소스 & 코드 생성 전략 | 승인됨 | #310 |
+| [0004](./0004-plugin-exporter-contract.md) | Plugin Exporter API 계약 안정화 | 승인됨 | #310 |
+| [0005](./0005-api-contract-single-source.md) | API 계약 단일 소스 & 코드 생성 전략 | 승인됨 | #311 |
 | [0006](./0006-service-auth-and-deployment.md) | 서비스 인증 & 배포(Docker) 스토리 | 승인됨 | #312 |
 
 ## 작성 규칙


### PR DESCRIPTION
## 문제
ADR 문서와 README에서 관련 이슈 번호가 뒤바뀌어 있었습니다.

- 실제 **#310** = Plugin Exporter → **ADR 0004**
- 실제 **#311** = API 계약 단일 소스 → **ADR 0005**

## 수정
- `0004-plugin-exporter-contract.md` 관련 이슈: #311 → **#310**
- `0005-api-contract-single-source.md` 관련 이슈: #310 → **#311**
- `README.md` 상태표 동일 정정

(관련 이슈에 잘못 달린 결정 코멘트도 별도로 정정합니다.)