### PR TITLE
feat: 런타임 wire-level 응답 conformance 검증 추가

### DIFF
--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -278,6 +278,13 @@ BuildSpec을 실행 전에 검증합니다. body의 `spec` 키에 YAML 문자열
 (`test_service_contract`가 강제). 소비자는 `GET /version`으로 계약 버전을 먼저
 확인할 수 있고, `POST /validate`·`POST /build` 응답에도 `api_version`이 실립니다.
 
+버전 문자열 일치 외에, `test_service_contract`의 **`TestResponseConformance`** 는
+실제 `dispatch()` 응답 본문이 선언된 OpenAPI 스키마에 부합하는지(wire-level
+conformance) 순수 파이썬 validator(`tests/unit/_openapi.py`)로 검증합니다
+(#209, ADR-0005 미해결 질문 #1). app.py 응답에서 필수 필드가 빠지거나 타입이
+바뀌되 YAML이 갱신되지 않는 드리프트를 CI에서 차단합니다. 정적 경로/상태코드
+대조(#317, #319)가 *선언* 일치를 본다면, 이 검사는 *실제 wire* 일치를 봅니다.
+
 | 계약 operationId | 상태 | 현재 구현 경로 |
 | :--- | :--- | :--- |
 | `validateSpec` | 구현됨 | `POST /validate` (동기) |

--- a/tests/unit/_openapi.py
+++ b/tests/unit/_openapi.py
@@ -1,0 +1,210 @@
+"""순수 파이썬 OpenAPI 3.1 JSON Schema 부분집합 validator (#209, ADR-0005).
+
+외부 의존성(`openapi-core`, `jsonschema`) 없이 `contract/builder-api.yaml`의 응답
+스키마 부분집합을 검증한다. ADR-0005의 "무외부의존·stdlib 결정성" 원칙을 지키면서
+미해결 질문 #1(스키마 대조를 순수 파이썬 경량으로 할지, 검증 라이브러리를 도입할지)을
+"순수 파이썬 경량" 방향으로 마무리한다.
+
+정적 계약 검증(경로/상태코드/operationId 대조 — #317, #319)이 YAML의 *선언*과
+`dispatch`의 *라우팅 목록*이 일치하는지 본다면, 이 validator는 한 단계 더 나아가
+**실제 dispatch 응답 본문이 선언된 스키마에 부합하는지**(wire-level conformance)를
+검증한다. app.py가 응답에서 필수 필드를 빼거나 타입을 바꾸되 YAML을 갱신하지
+않으면, 정적 검사는 잡지 못하지만 이 검사가 잡는다 — 이것이 ADR-0005가 막고자 하는
+드리프트의 실체다.
+
+지원 키워드(이 계약이 사용하는 부분집합만):
+    - ``$ref`` (``#/components/schemas/Name`` 형태의 로컬 참조만)
+    - ``type`` (단일 문자열 또는 null 포함 합집합: ``[string, "null"]``)
+    - ``required``, ``properties``
+    - ``additionalProperties`` (``true`` | ``false`` | 스키마)
+    - ``items`` (array)
+    - ``enum``
+    - ``oneOf`` (적어도 한 분기가 통과하면 유효 — conformance 게이트는 실제 드리프트를
+      잡는 것이 목적이므로, 여러 분기에 동시에 맞더라도 거짓 양성을 피하기 위해 관대하게
+      해석한다)
+    - ``minimum`` (정수/숫자 하한)
+
+알 수 없는 키워드는 무시한다(전방 호환). 추가 선택 필드는 기본 허용하므로, 응답에
+새 선택 필드가 더해지는 *부가적* 변화는 통과시키고, 필수 필드 누락·타입 변경 같은
+*구조적 회귀*만 실패시킨다.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# OpenAPI/JSON Schema 문서와 JSON 값은 모두 임의 중첩 구조다. 테스트 보조 모듈이므로
+# 정확한 재귀 별칭 대신 Any를 쓴다(mypy는 src/만 검사하므로 여기엔 영향 없음).
+Schema = dict[str, Any]
+Json = Any
+
+
+def resolve_ref(contract: Schema, ref: str) -> Schema:
+    """``#/components/schemas/Name`` 형태의 로컬 $ref를 실제 스키마로 해석한다.
+
+    외부/원격 참조는 이 계약에서 쓰지 않으므로 거부한다.
+    """
+    if not ref.startswith("#/"):
+        raise ValueError(f"unsupported $ref (only local '#/' allowed): {ref}")
+    node: Any = contract
+    for part in ref.lstrip("#/").split("/"):
+        if not isinstance(node, dict) or part not in node:
+            raise ValueError(f"unresolved $ref: {ref}")
+        node = node[part]
+    if not isinstance(node, dict):
+        raise ValueError(f"$ref target is not a mapping: {ref}")
+    return node
+
+
+def _matches_type(value: Json, type_name: str) -> bool:
+    if type_name == "object":
+        return isinstance(value, dict)
+    if type_name == "array":
+        return isinstance(value, list)
+    if type_name == "string":
+        return isinstance(value, str)
+    if type_name == "integer":
+        # bool은 int의 하위 타입이지만 JSON integer 의미가 아니므로 제외한다.
+        return isinstance(value, int) and not isinstance(value, bool)
+    if type_name == "boolean":
+        return isinstance(value, bool)
+    if type_name == "null":
+        return value is None
+    if type_name == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    return False
+
+
+def _type_names(schema: Schema) -> list[str]:
+    raw = schema.get("type")
+    if isinstance(raw, str):
+        return [raw]
+    if isinstance(raw, list):
+        return [str(item) for item in raw]
+    return []
+
+
+def validate(value: Json, schema: Schema, contract: Schema, path: str = "$") -> list[str]:
+    """``value``가 ``schema``를 만족하는지 검증하고 위반 목록을 반환한다.
+
+    반환값이 빈 리스트면 유효하다. 각 위반은 사람이 읽을 수 있는 문자열이며,
+    ``path``(기본 ``$``)는 JSON 문서 내 위치를 가리킨다.
+    """
+    # $ref가 있으면 다른 키워드와 함께 쓰이지 않으므로(OpenAPI 규칙) 해석 후 위임한다.
+    ref = schema.get("$ref")
+    if isinstance(ref, str):
+        return validate(value, resolve_ref(contract, ref), contract, path)
+
+    errors: list[str] = []
+
+    # oneOf: 적어도 한 분기가 통과하면 유효(관대한 해석 — 의도는 위 모듈 docstring 참고).
+    one_of = schema.get("oneOf")
+    if isinstance(one_of, list):
+        passing = [
+            branch
+            for branch in one_of
+            if isinstance(branch, dict) and not validate(value, branch, contract, path)
+        ]
+        if not passing:
+            errors.append(f"{path}: value matched no oneOf branch")
+        return errors
+
+    if "enum" in schema and value not in schema["enum"]:
+        errors.append(f"{path}: {value!r} not in enum {schema['enum']!r}")
+
+    type_names = _type_names(schema)
+    if type_names and not any(_matches_type(value, name) for name in type_names):
+        errors.append(f"{path}: expected type {type_names}, got {type(value).__name__}")
+        # 타입 자체가 다르면 하위 구조를 더 검사해 봐야 의미가 없다.
+        return errors
+
+    if "object" in type_names and isinstance(value, dict):
+        errors.extend(_validate_object(value, schema, contract, path))
+    elif "array" in type_names and isinstance(value, list):
+        item_schema = schema.get("items")
+        if isinstance(item_schema, dict):
+            for index, item in enumerate(value):
+                errors.extend(validate(item, item_schema, contract, f"{path}[{index}]"))
+
+    if (
+        "minimum" in schema
+        and isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and value < schema["minimum"]
+    ):
+        errors.append(f"{path}: {value} < minimum {schema['minimum']}")
+
+    return errors
+
+
+def _validate_object(
+    value: dict[str, Json], schema: Schema, contract: Schema, path: str
+) -> list[str]:
+    errors: list[str] = []
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        properties = {}
+
+    for key in schema.get("required", []):
+        if key not in value:
+            errors.append(f"{path}: missing required property {key!r}")
+
+    for key, sub in value.items():
+        child_path = f"{path}.{key}"
+        prop_schema = properties.get(key)
+        if isinstance(prop_schema, dict):
+            errors.extend(validate(sub, prop_schema, contract, child_path))
+            continue
+        # 선언되지 않은 프로퍼티 → additionalProperties 정책으로 판정.
+        addl = schema.get("additionalProperties", True)
+        if addl is False:
+            errors.append(f"{child_path}: extra property not allowed")
+        elif isinstance(addl, dict):
+            errors.extend(validate(sub, addl, contract, child_path))
+        # True / 생략 → 추가 프로퍼티 허용(부가적 변화 허용).
+    return errors
+
+
+def _normalize_path(contract: Schema, path: str) -> str:
+    """구체적 경로(예: ``/artifacts/run-1``)를 템플릿(``/artifacts/{run_id}``)에 맞춘다."""
+    paths = contract.get("paths")
+    if not isinstance(paths, dict):
+        return path
+    if path in paths:
+        return path
+    path_parts = path.split("/")
+    for template in paths:
+        tmpl_parts = template.split("/")
+        if len(tmpl_parts) != len(path_parts):
+            continue
+        # 길이가 같음은 위에서 continue로 보장했으므로 strict=True가 안전하다.
+        if all(
+            tp.startswith("{") or tp == pp for tp, pp in zip(tmpl_parts, path_parts, strict=True)
+        ):
+            return template
+    return path
+
+
+def response_schema(contract: Schema, path: str, method: str, status_code: int) -> Schema | None:
+    """``(path, method, status_code)``에 대응하는 응답 JSON 스키마를 반환한다.
+
+    경로 템플릿 정규화와 ``content/application/json`` 추출을 담당한다.
+    해당 상태 코드가 계약에 선언되어 있지 않으면 ``None``을 반환한다.
+    """
+    paths = contract.get("paths")
+    if not isinstance(paths, dict):
+        return None
+    norm = _normalize_path(contract, path)
+    operation = paths.get(norm)
+    if not isinstance(operation, dict):
+        return None
+    responses = operation.get(method.lower())
+    if not isinstance(responses, dict):
+        return None
+    response = responses.get("responses", {}).get(str(status_code))
+    if not isinstance(response, dict):
+        return None
+    content = response.get("content", {})
+    app_json = content.get("application/json")
+    schema = app_json.get("schema") if isinstance(app_json, dict) else None
+    return schema if isinstance(schema, dict) else None

--- a/tests/unit/test_openapi_validator.py
+++ b/tests/unit/test_openapi_validator.py
@@ -1,0 +1,202 @@
+"""``tests/unit/_openapi.py`` 순수 파이썬 validator의 단위 테스트 (#209, ADR-0005).
+
+validator 자체가 드리프트를 잡아내는지(필수 필드 누락·타입 변경) 증명한다.
+conformance 게이트의 가치는 이 검증기가 "유효 응답은 통과시키고, 회귀 응답은
+실패시키는지"에 달려 있으므로, 합격/불합격 경계를 명시적으로 고정한다.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from ._openapi import resolve_ref, response_schema, validate
+
+_CONTRACT_PATH = Path(__file__).parents[2] / "contract" / "builder-api.yaml"
+
+
+def _contract() -> dict[str, Any]:
+    return yaml.safe_load(_CONTRACT_PATH.read_text(encoding="utf-8"))
+
+
+# --- type / required / enum / minimum 경계 -------------------------------------
+
+
+def test_accepts_object_with_all_required_fields() -> None:
+    schema: dict[str, Any] = {
+        "type": "object",
+        "required": ["status", "api_version"],
+        "properties": {"status": {"type": "string"}, "api_version": {"type": "string"}},
+    }
+    assert validate({"status": "valid", "api_version": "1.0.0"}, schema, {}) == []
+
+
+def test_rejects_missing_required_field() -> None:
+    schema: dict[str, Any] = {
+        "type": "object",
+        "required": ["status", "api_version"],
+        "properties": {"status": {"type": "string"}, "api_version": {"type": "string"}},
+    }
+    errors = validate({"status": "valid"}, schema, {})
+    assert any("api_version" in e for e in errors)
+
+
+def test_rejects_wrong_value_type() -> None:
+    schema: dict[str, Any] = {"type": "object", "properties": {"n": {"type": "integer"}}}
+    errors = validate({"n": "not-an-int"}, schema, {})
+    assert errors and any("integer" in e for e in errors)
+
+
+def test_integer_does_not_accept_bool() -> None:
+    # bool은 int의 하위 타입이지만 JSON integer가 아니다.
+    schema: dict[str, Any] = {"type": "integer"}
+    assert validate(True, schema, {})  # True/False는 integer로 거부
+
+
+def test_nullable_union_accepts_string_and_null() -> None:
+    schema: dict[str, Any] = {"type": ["string", "null"]}
+    assert validate(None, schema, {}) == []
+    assert validate("ok", schema, {}) == []
+    assert validate(7, schema, {})  # 정수는 거부
+
+
+def test_enum_rejects_out_of_range_value() -> None:
+    schema: dict[str, Any] = {"type": "string", "enum": ["ok", "failed"]}
+    assert validate("ok", schema, {}) == []
+    assert validate("pending", schema, {})  # enum 밖
+
+
+def test_minimum_rejects_below_bound() -> None:
+    schema: dict[str, Any] = {"type": "integer", "minimum": 1}
+    assert validate(1, schema, {}) == []
+    assert validate(0, schema, {})
+
+
+# --- 구조적 키워드: $ref / oneOf / additionalProperties / items -----------------
+
+
+def test_ref_resolves_local_schema() -> None:
+    contract: dict[str, Any] = {
+        "components": {"schemas": {"Foo": {"type": "object", "required": ["x"]}}}
+    }
+    assert validate({"x": 1}, {"$ref": "#/components/schemas/Foo"}, contract) == []
+    assert validate({}, {"$ref": "#/components/schemas/Foo"}, contract)  # x 누락
+
+
+def test_ref_raises_on_unresolved_target() -> None:
+    with pytest.raises(ValueError):
+        resolve_ref({"components": {"schemas": {}}}, "#/components/schemas/Missing")
+
+
+def test_oneof_accepts_when_at_least_one_branch_matches() -> None:
+    contract: dict[str, Any] = {
+        "components": {
+            "schemas": {
+                "Error": {"type": "object", "required": ["error"]},
+                "ValidationError": {"type": "object", "required": ["status"]},
+            }
+        }
+    }
+    schema: dict[str, Any] = {
+        "oneOf": [
+            {"$ref": "#/components/schemas/Error"},
+            {"$ref": "#/components/schemas/ValidationError"},
+        ]
+    }
+    # Error 형태와 ValidationError 형태 각각이 한 분기에 맞는다.
+    assert validate({"error": "boom"}, schema, contract) == []
+    assert validate({"status": "invalid"}, schema, contract) == []
+    # 어느 쪽도 아니면 실패.
+    assert validate({"unexpected": 1}, schema, contract)
+
+
+def test_additional_properties_schema_validates_extras() -> None:
+    schema: dict[str, Any] = {
+        "type": "object",
+        "properties": {"known": {"type": "string"}},
+        "additionalProperties": {"type": "string"},
+    }
+    assert validate({"known": "a", "extra": "b"}, schema, {}) == []
+    # 추가 프로퍼티가 문자열이 아니면 거부.
+    assert validate({"known": "a", "extra": 5}, schema, {})
+
+
+def test_additional_properties_false_rejects_extras() -> None:
+    schema: dict[str, Any] = {
+        "type": "object",
+        "properties": {"known": {"type": "string"}},
+        "additionalProperties": False,
+    }
+    assert validate({"known": "a"}, schema, {}) == []
+    assert validate({"known": "a", "extra": "b"}, schema, {})
+
+
+def test_additional_properties_omitted_allows_extras() -> None:
+    # 응답에 새 선택 필드가 더해지는 부가적 변화는 통과시킨다(전방 호환).
+    schema: dict[str, Any] = {
+        "type": "object",
+        "required": ["status"],
+        "properties": {"status": {"type": "string"}},
+    }
+    assert validate({"status": "ok", "future_field": 123}, schema, {}) == []
+
+
+def test_array_items_are_each_validated() -> None:
+    schema: dict[str, Any] = {"type": "array", "items": {"type": "integer"}}
+    assert validate([1, 2, 3], schema, {}) == []
+    errors = validate([1, "x", 3], schema, {})
+    assert any("$[1]" in e for e in errors)
+
+
+# --- response_schema 조회 / 경로 정규화 ----------------------------------------
+
+
+def test_response_schema_returns_declared_schema() -> None:
+    contract = _contract()
+    schema = response_schema(contract, "/version", "GET", 200)
+    assert schema is not None
+    assert validate({"service": "kpubdata-builder", "api_version": "1.0.0"}, schema, contract) == []
+
+
+def test_response_schema_none_for_undeclared_status() -> None:
+    contract = _contract()
+    assert response_schema(contract, "/version", "GET", 500) is None
+
+
+def test_response_schema_normalizes_path_template() -> None:
+    # /artifacts/{run_id} 템플릿을 구체적 run_id로 조회한다.
+    contract = _contract()
+    assert response_schema(contract, "/artifacts/any-run-id", "GET", 200) is not None
+    assert response_schema(contract, "/artifacts/any-run-id", "GET", 404) is not None
+
+
+# --- 게이트 가치 증명: 실제 계약 스키마로 회귀 잡기 ----------------------------
+
+
+def test_gate_catches_required_field_drift() -> None:
+    """app.py가 BuildSuccessResponse에서 run_id를 빼먹는 회귀를 게이트가 잡는다."""
+    contract = _contract()
+    schema = response_schema(contract, "/build", "POST", 200)
+    assert schema is not None
+    good = {
+        "status": "ok",
+        "run_id": "r1",
+        "outcomes": [],
+        "manifest": "/p/manifest.json",
+        "api_version": "1.0.0",
+    }
+    assert validate(good, schema, contract) == []
+    drifted = dict(good)
+    del drifted["run_id"]
+    assert validate(drifted, schema, contract)
+
+
+def test_gate_catches_type_drift() -> None:
+    """api_version이 문자열에서 정수로 바뀌는 회귀도 잡는다."""
+    contract = _contract()
+    schema = response_schema(contract, "/version", "GET", 200)
+    assert schema is not None
+    assert validate({"service": "kpubdata-builder", "api_version": 1}, schema, contract)

--- a/tests/unit/test_service_contract.py
+++ b/tests/unit/test_service_contract.py
@@ -1,4 +1,4 @@
-"""Builder Service Contract(#63, #226, #317, #319) OpenAPI 스펙의 구조 검증.
+"""Builder Service Contract(#63, #226, #317, #319, #209) OpenAPI 스펙의 구조·런타임 검증.
 
 설치된 OpenAPI validator가 없으므로, 계약이 OpenAPI 3.1이고 BuilderService
 (service/app.py)가 실제로 구현한 동기 라우트와 wire 형태를 모두 담는지 구조적으로
@@ -6,14 +6,27 @@
 드리프트를 막기 위해 구현 라우트 ↔ 계약 operationId 매핑을 명시적으로 고정한다(#317).
 또한 YAML 계약과 실제 dispatch 구현 간의 양방향 일치성을 검증하며(#317),
 상태 코드와 응답 스키마 검증으로 범위를 확장한다(#319).
+
+구조 검증(위)은 YAML의 *선언*과 dispatch의 *라우팅 목록*이 일치하는지 본다(#317, #319).
+``TestResponseConformance``(#209, ADR-0005)는 한 단계 더 나아가 **실제 dispatch 응답
+본문이 선언된 스키마에 부합하는지**(wire-level conformance)를 순수 파이썬
+validator(``_openapi.py``)로 검증한다 — #319의 정적 스키마 검사가 "스키마가 required를
+선언했는가"만 보듯, app.py 응답에서 필수 필드가 빠지거나 타입이 바뀌어도 선언부가
+그대로면 정적 검사는 통과하지만 이 런타임 검사는 잡는다.
 """
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, cast
 
 import yaml
+
+from kpubdata_builder.service import BuilderService, ServiceResponse, dispatch
+from kpubdata_builder.spec import JsonValue
+
+from ._openapi import response_schema, validate
 
 _CONTRACT_PATH = Path(__file__).parents[2] / "contract" / "builder-api.yaml"
 
@@ -26,6 +39,7 @@ _DISPATCH_ROUTES: dict[tuple[str, str], str] = {
     ("/preview", "POST"): "previewBuild",
     ("/build", "POST"): "createBuild",
     ("/artifacts/{run_id}", "GET"): "listBuildArtifacts",
+    ("/builds", "GET"): "listBuilds",
 }
 
 # (path, method) 형태의 계약 필수 오퍼레이션. BuilderService.dispatch가 실제로
@@ -36,6 +50,7 @@ _REQUIRED_OPERATIONS = [
     ("/preview", "post"),
     ("/build", "post"),
     ("/artifacts/{run_id}", "get"),
+    ("/builds", "get"),
 ]
 
 
@@ -275,6 +290,7 @@ _OPERATION_STATUS_CODES: dict[str, set[int]] = {
     "previewBuild": {200, 400},
     "createBuild": {200, 400, 502},
     "listBuildArtifacts": {200, 400, 404},
+    "listBuilds": {200, 400},
 }
 
 
@@ -395,3 +411,182 @@ def test_response_schemas_have_required_fields() -> None:
                     f"{method} {path} (operationId: {operation_id})의 "
                     f"200 응답 스키마에 필수 필드가 너무 적습니다: {required_fields}"
                 )
+
+
+# ---------------------------------------------------------------------------
+# 런타임 wire-level conformance (#209, ADR-0005)
+#
+# 정적 검증(위)은 계약 YAML과 dispatch 라우팅 목록이 일치하는지 본다. 아래 테스트들은
+# 실제 dispatch()를 호출해 반환된 JSON 본문이 선언된 응답 스키마에 부합하는지 검증한다.
+# 외부 의존 없이 순수 파이썬 validator(_openapi.py)를 쓰며, 이것이 ADR-0005 미해결 질문
+# #1(스키마 대조를 순수 파이썬 경량으로 할지)을 "순수 파이썬 경량" 방향으로 마무리한다.
+#
+# #319의 test_response_schemas_have_required_fields는 스키마가 required를 *선언했는지*만
+# 본다. app.py가 실제 응답에서 필수 필드를 빼거나 타입을 바꿔도 선언부가 그대로면 그 정적
+# 검사는 통과한다 — 이 런타임 검사가 그 wire 드리프트를 잡는다. 계약에 선언된 6개 오퍼레이션
+# 모두(/version, /validate, /preview, /build, /artifacts, /builds)를 성공+오류 상태 코드에
+# 걸쳐 검증한다.
+# ---------------------------------------------------------------------------
+
+_CONFORM_SPEC_YAML = (
+    "dataset_id: dataset.conform\n"
+    "title: Conform Sample\n"
+    "description: runtime conformance fixture\n"
+    "sources:\n"
+    "  - provider: datago\n"
+    "    dataset: air_quality\n"
+    "exports:\n"
+    "  - kind: jsonl\n"
+    "    output_path: out/data.jsonl\n"
+)
+
+# fetch를 실패시켜 502 경로를 만들기 위한 spec: fake client가 모르는 소스.
+_FAILING_SPEC_YAML = _CONFORM_SPEC_YAML.replace("dataset: air_quality\n", "dataset: missing\n")
+
+# 파싱은 통과하지만 validate_spec에서 미지원 exporter kind로 실패하는 spec.
+_INVALID_SPEC_YAML = _CONFORM_SPEC_YAML.replace("kind: jsonl", "kind: unsupported_format")
+
+
+class _FakeResult:
+    def __init__(self, items: list[dict[str, JsonValue]]) -> None:
+        self._items = items
+
+    @property
+    def items(self) -> Iterable[dict[str, JsonValue]]:
+        return self._items
+
+
+class _FakeDataset:
+    def __init__(self, items: list[dict[str, JsonValue]]) -> None:
+        self._items = items
+
+    def list(self, **params: JsonValue) -> _FakeResult:
+        return _FakeResult(self._items)
+
+
+class _FakeClient:
+    def __init__(self, data: dict[str, list[dict[str, JsonValue]]]) -> None:
+        self._data = data
+
+    def dataset(self, source_key: str) -> _FakeDataset:
+        if source_key not in self._data:
+            raise KeyError(f"unknown source: {source_key}")
+        return _FakeDataset(self._data[source_key])
+
+
+def _conform_service(tmp_path: Path) -> BuilderService:
+    client = _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}, {"id": "2", "v": 20}]})
+    return BuilderService(output_root=tmp_path, client_factory=lambda: client)
+
+
+def _assert_conforms(resp: ServiceResponse, path: str, method: str) -> None:
+    """실제 dispatch 응답이 계약 스키마에 부합하는지(상태 코드 선언 + 본문 형태) 검증."""
+    contract = _load_contract()
+    schema = response_schema(contract, path, method, resp.status_code)
+    assert schema is not None, (
+        f"{method} {path}: status {resp.status_code} is not declared in the contract"
+    )
+    errors = validate(resp.body, schema, contract)
+    assert not errors, (
+        f"{method} {path} {resp.status_code} response drifts from contract:\n  "
+        + "\n  ".join(errors)
+    )
+
+
+class TestResponseConformance:
+    """선언된 각 오퍼레이션의 실제 wire 응답이 OpenAPI 스키마에 부합하는지 고정."""
+
+    def test_version_200(self, tmp_path: Path) -> None:
+        resp = dispatch(_conform_service(tmp_path), "GET", "/version", None)
+        assert resp.status_code == 200
+        _assert_conforms(resp, "/version", "GET")
+
+    def test_validate_200(self, tmp_path: Path) -> None:
+        resp = dispatch(
+            _conform_service(tmp_path), "POST", "/validate", {"spec": _CONFORM_SPEC_YAML}
+        )
+        assert resp.status_code == 200
+        _assert_conforms(resp, "/validate", "POST")
+
+    def test_validate_400_invalid_spec(self, tmp_path: Path) -> None:
+        resp = dispatch(
+            _conform_service(tmp_path), "POST", "/validate", {"spec": _INVALID_SPEC_YAML}
+        )
+        assert resp.status_code == 400
+        # 미지원 exporter → {"status": "invalid", "problems": [...]}
+        _assert_conforms(resp, "/validate", "POST")
+
+    def test_preview_200(self, tmp_path: Path) -> None:
+        resp = dispatch(
+            _conform_service(tmp_path), "POST", "/preview", {"spec": _CONFORM_SPEC_YAML, "limit": 2}
+        )
+        assert resp.status_code == 200
+        _assert_conforms(resp, "/preview", "POST")
+
+    def test_preview_400_bad_limit(self, tmp_path: Path) -> None:
+        # 400 응답은 oneOf(Error | ValidationError) — limit 오류는 Error 형태.
+        resp = dispatch(
+            _conform_service(tmp_path), "POST", "/preview", {"spec": _CONFORM_SPEC_YAML, "limit": 0}
+        )
+        assert resp.status_code == 400
+        _assert_conforms(resp, "/preview", "POST")
+
+    def test_build_200_success(self, tmp_path: Path) -> None:
+        resp = dispatch(
+            _conform_service(tmp_path),
+            "POST",
+            "/build",
+            {"spec": _CONFORM_SPEC_YAML, "run_id": "conform-ok"},
+        )
+        assert resp.status_code == 200
+        _assert_conforms(resp, "/build", "POST")
+
+    def test_build_502_failure(self, tmp_path: Path) -> None:
+        resp = dispatch(
+            _conform_service(tmp_path),
+            "POST",
+            "/build",
+            {"spec": _FAILING_SPEC_YAML, "run_id": "conform-fail"},
+        )
+        assert resp.status_code == 502
+        _assert_conforms(resp, "/build", "POST")
+
+    def test_build_400_bad_run_id(self, tmp_path: Path) -> None:
+        # 400 응답은 oneOf(Error | ValidationError) — run_id 타입 오류는 Error 형태.
+        resp = dispatch(
+            _conform_service(tmp_path),
+            "POST",
+            "/build",
+            {"spec": _CONFORM_SPEC_YAML, "run_id": 123},
+        )
+        assert resp.status_code == 400
+        _assert_conforms(resp, "/build", "POST")
+
+    def test_artifacts_200_after_build(self, tmp_path: Path) -> None:
+        service = _conform_service(tmp_path)
+        dispatch(service, "POST", "/build", {"spec": _CONFORM_SPEC_YAML, "run_id": "conform-art"})
+        resp = dispatch(service, "GET", "/artifacts/conform-art", None)
+        assert resp.status_code == 200
+        _assert_conforms(resp, "/artifacts/{run_id}", "GET")
+
+    def test_artifacts_404_missing(self, tmp_path: Path) -> None:
+        resp = dispatch(_conform_service(tmp_path), "GET", "/artifacts/nope", None)
+        assert resp.status_code == 404
+        _assert_conforms(resp, "/artifacts/{run_id}", "GET")
+
+    def test_builds_200_empty(self, tmp_path: Path) -> None:
+        resp = dispatch(_conform_service(tmp_path), "GET", "/builds", None, query="")
+        assert resp.status_code == 200
+        _assert_conforms(resp, "/builds", "GET")
+
+    def test_builds_200_after_build(self, tmp_path: Path) -> None:
+        service = _conform_service(tmp_path)
+        dispatch(service, "POST", "/build", {"spec": _CONFORM_SPEC_YAML, "run_id": "conform-list"})
+        resp = dispatch(service, "GET", "/builds", None, query="")
+        assert resp.status_code == 200
+        _assert_conforms(resp, "/builds", "GET")
+
+    def test_builds_400_bad_limit(self, tmp_path: Path) -> None:
+        resp = dispatch(_conform_service(tmp_path), "GET", "/builds", None, query="limit=0")
+        assert resp.status_code == 400
+        _assert_conforms(resp, "/builds", "GET")


### PR DESCRIPTION
## 요약
ADR-0005 미해결 질문 #1 "스키마 대조를 순수 파이썬 경량으로 할지, 검증 라이브러리를
도입할지"를 **순수 파이썬 경량** 방향으로 마무리합니다(무외부의존 원칙 유지).

기존 계약 테스트(#317/#319)는 모두 *정적*입니다 — YAML 선언과 하드코딩된 dispatch
라우트/상태코드 맵을 비교하고, 응답 스키마가 required를 *선언했는지*만 봅니다.
실제 dispatch()를 돌려 반환된 JSON이 스키마에 부합하는지는 검사하지 않습니다.
따라서 app.py 응답에서 필수 필드를 빼거나 타입을 바꿔도 YAML이 그대로면 아무 테스트도
wire 드리프트를 잡지 못합니다 — ADR-0005가 CI에서 막고자 하는 것이 정확히 이것입니다.

## 변경 내용
- `tests/unit/_openapi.py`: 무의존 OpenAPI 3.1 스키마 부분집합 validator
  ($ref, type/null 합집합, required/properties, additionalProperties, items, enum,
  oneOf-관대형, minimum). 부가적 변화는 통과, 구조적 회귀만 실패.
- `tests/unit/test_openapi_validator.py`: validator 단위 테스트 + 게이트가
  required/타입 드리프트를 잡는지 증명.
- `TestResponseConformance`: 선언된 6개 오퍼레이션(/version, /validate, /preview,
  /build, /artifacts, /builds)의 실제 dispatch 응답을 성공·오류 상태코드에 걸쳐 검증.

## 부가 수정 (#317 잔여분)
upstream/main에서 #318(YAML에 /builds 추가)과 #319(라우트 맵)이 #317 없이 머지돼
`test_all_yaml_operations_implemented_in_dispatch`,
`test_declared_status_codes_match_implementation` 2개가 **빨간색**이었습니다.
`_DISPATCH_ROUTES`/`_OPERATION_STATUS_CODES`에 /builds를 추가(#317의 조각)해 녹색으로
복구했고, 이로써 conformance가 /builds까지 커버합니다.

## 관련 이슈
Closes #209 

## 검증
- [x] `uv run ruff check .` 통과
- [x] `uv run ruff format --check .` 통과
- [x] `uv run mypy src` 통과
- [x] `uv run pytest` 555 passed