### PR TITLE
Feat: Docker serve 이미지 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,29 @@
+# VCS / 에이전트 워크스페이스
+.git
+.gitignore
+.claude
+.github
+
+# Python 캐시·빌드 산물
+__pycache__
+**/__pycache__
+*.pyc
+.venv
+.mypy_cache
+.pytest_cache
+.ruff_cache
+*.egg-info
+build/
+dist/
+
+# 테스트는 배포 이미지에 넣지 않는다
+tests/
+
+# 프로젝트 메타·문서 중 빌드에 불필요한 것
+.omc
+docs/
+contract/
+
+# README/LICENSE는 이미지에 포함(아래 예외). 나머지 루트 문서는 제외.
+*.md
+!README.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,39 @@
+name: Docker
+
+# Dockerfile이 빌드 가능한 serve 이미지를 만드는지 검증한다 (#320, ADR 0006).
+# docker build 자체가 인수 기준 "빌드 성공 + serve 진입점 포함"을 증명한다.
+# uv sync --no-sources가 PyPI에서 kpubdata를 해석하므로 빌드 시 네트워크가 필요하다.
+
+on:
+  pull_request:
+    paths:
+      - "Dockerfile"
+      - "docker-entrypoint.sh"
+      - ".dockerignore"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "src/**"
+      - ".github/workflows/docker.yml"
+  push:
+    branches: [main]
+    paths:
+      - "Dockerfile"
+      - "docker-entrypoint.sh"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: docker build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Build serve image
+        run: docker build -t kpubdata-builder:ci .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# syntax=docker/dockerfile:1
+
+# KPubData Builder — serve 배포 이미지 (#320, ADR 0006).
+#
+# uv sync --no-sources: [tool.uv.sources]의 editable ../kpubdata 오버라이드를 무시하고
+# pyproject의 PyPI 핀(kpubdata>=0.5.0,<0.6, #213)대로 kpubdata를 설치한다. 진입점은
+# kpubdata-builder serve이며, 환경변수로 설정을 주입한다 (docker-entrypoint.sh).
+#
+# ADR 0006 결정: 컨테이너는 fail-closed로 동작한다. KPUBDATA_BUILDER_API_KEY 없이는
+# 기동하지 않는다 (docker-entrypoint.sh에서 강제). 베이스는 pragmatic한 python-slim
+# (ADR-0006 미해결 질문: distroless 대안은 후속).
+
+FROM python:3.12-slim
+
+# uv 바이너리를 Astral 공식 이미지에서 복사한다 (pip 설치 불필요).
+# 0.11.8 = 이 저장소의 uv.lock을 생성한 uv 버전.
+COPY --from=ghcr.io/astral-sh/uv:0.11.8 /uv /uvx /bin/
+
+# 가상환경을 고정 경로에 두고, 컴파일된 바이트코드와 함께 이미지 레이어로 캐싱.
+ENV UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1 \
+    UV_PROJECT_ENVIRONMENT=/app/.venv \
+    PATH=/app/.venv/bin:${PATH}
+
+WORKDIR /app
+
+# 매니페스트를 먼저 복사해 의존성 레이어를 캐시한다 (소스 변경 시에도 재사용).
+COPY pyproject.toml uv.lock ./
+COPY src/ ./src/
+COPY README.md LICENSE ./
+
+# --no-sources: editable ../kpubdata 무시, PyPI 핀 사용 (#213).
+# dev extra(mypy/pytest/ruff)는 배포 이미지에서 제외한다.
+RUN uv sync --no-sources
+
+# 빌드 산출물(아티팩트·매니페스트) 영속 볼륨의 기본 위치.
+RUN mkdir -p /data
+VOLUME /data
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# KPUBDATA_BUILDER_PORT(기본 8000)가 이 포트를 가리킨다.
+EXPOSE 8000
+
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -189,19 +189,48 @@ kpubdata-builder serve --host 0.0.0.0 --port 8000 --output-dir ./dist
 
 ### HTTP 서비스 배포 (Docker)
 
-> **Dockerfile과 docker-compose는 ADR 0006 (#312) 후속 작업으로 계획 중입니다.**
+`Dockerfile`과 `docker-entrypoint.sh`은 `uv sync --no-sources`로 PyPI `kpubdata`를
+설치해 `kpubdata-builder serve`를 실행하는 재현 가능한 이미지를 만듭니다 (#320,
+ADR 0006). 설정은 환경변수로 주입합니다 — `docker-entrypoint.sh`가 이를 serve CLI
+플래그로 변환합니다.
 
-현재는 다음과 같이 서비스를 실행할 수 있습니다:
+**컨테이너 환경변수**:
+
+| 변수 | 설명 | 기본값 | 필수 |
+| :--- | :--- | :--- | :--- |
+| `KPUBDATA_BUILDER_API_KEY` | `X-API-Key` 인증 키 | 없음 | **필수** (fail-closed) |
+| `KPUBDATA_BUILDER_PORT` | 바인딩 포트 | `8000` | 선택 |
+| `KPUBDATA_BUILDER_OUTPUT_DIR` | 실행 워크스페이스 루트 | `/data` | 선택 |
+| `KPUBDATA_BUILDER_HOST` | 바인딩 호스트 | `0.0.0.0` | 선택 |
+| `KPUBDATA_BUILDER_DEV` | `1`이면 API 키 없이 기동 (로컬 개발 전용) | 미설정 | 선택 |
+
+> **fail-closed (ADR 0006)**: 컨테이너는 `KPUBDATA_BUILDER_API_KEY`가 없으면 기동을
+> 거부합니다. `service/app.py`의 "키 미설정 = 인증 생략" 동작은 로컬 개발 편의 전용이며
+> 컨테이너로 누출되지 않습니다. 로컬에서 인증 없이 띄우려면 `KPUBDATA_BUILDER_DEV=1`을
+> 명시하세요.
 
 ```bash
-# 로컬 개발 환경
-export KPUBDATA_BUILDER_API_KEY="dev-key"
-kpubdata-builder serve --host 127.0.0.1 --port 8000
+# 이미지 빌드
+docker build -t kpubdata-builder:latest .
 
-# 프로덕션 환경 (API 키 필수)
-export KPUBDATA_BUILDER_API_KEY="${PROD_API_KEY}"
-kpubdata-builder serve --host 0.0.0.0 --port 8000 --output-dir /data/builds
+# 실행 — API 키 필수 (fail-closed). 빌드 산출물은 /data 볼륨에 영속화.
+docker run --rm -p 8000:8000 \
+  -e KPUBDATA_BUILDER_API_KEY="${API_KEY}" \
+  -v kpubdata-builder-data:/data \
+  kpubdata-builder:latest
+
+# 헬스 체크: 계약 버전 확인
+curl -s -H "X-API-Key: ${API_KEY}" http://localhost:8000/version
+# {"service": "kpubdata-builder", "api_version": "1.0.0"}
+
+# 로컬 개발 — 인증 생략 (dev-mode)
+docker run --rm -p 8000:8000 -e KPUBDATA_BUILDER_DEV=1 kpubdata-builder:latest
 ```
+
+`kpubdata`는 `uv sync --no-sources`로 PyPI에서 설치되므로, 빌드 시 형제 디렉터리
+(`../kpubdata`)가 필요하지 않습니다 (버전 핀 정책은 [CONTRIBUTING.md](./CONTRIBUTING.md)
+참고). Parquet/Hugging Face export 등의 선택 의존성이 필요하면 Dockerfile의
+`uv sync` 라인에 `--extra parquet --extra huggingface`를 추가하세요.
 
 ### API 인증
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# KPubData Builder 컨테이너 진입점 (#320, ADR 0006).
+#
+# 환경변수를 `serve` CLI 플래그로 변환한다. 핵심은 ADR 0006의 fail-closed 정책을
+# 컨테이너 경계에서 강제하는 것 — service/app.py의 "키 미설정 = 인증 생략" 동작은
+# 로컬 개발 편의 전용이며 컨테이너로 누출되지 않아야 한다. 따라서 API 키가 없으면
+# (명시적 dev 플래그가 없는 한) 기동을 거부한다.
+set -eu
+
+if [ -z "${KPUBDATA_BUILDER_API_KEY:-}" ] && [ "${KPUBDATA_BUILDER_DEV:-0}" != "1" ]; then
+  echo "kpubdata-builder: KPUBDATA_BUILDER_API_KEY is required (fail-closed, ADR 0006)." >&2
+  echo "  set KPUBDATA_BUILDER_API_KEY=<secret>, or KPUBDATA_BUILDER_DEV=1 for" >&2
+  echo "  unauthenticated local use." >&2
+  exit 1
+fi
+
+exec kpubdata-builder serve \
+  --host "${KPUBDATA_BUILDER_HOST:-0.0.0.0}" \
+  --port "${KPUBDATA_BUILDER_PORT:-8000}" \
+  --output-dir "${KPUBDATA_BUILDER_OUTPUT_DIR:-/data}"

--- a/tests/unit/test_service_contract.py
+++ b/tests/unit/test_service_contract.py
@@ -26,6 +26,7 @@ _DISPATCH_ROUTES: dict[tuple[str, str], str] = {
     ("/preview", "POST"): "previewBuild",
     ("/build", "POST"): "createBuild",
     ("/artifacts/{run_id}", "GET"): "listBuildArtifacts",
+    ("/builds", "GET"): "listBuilds",
 }
 
 # (path, method) 형태의 계약 필수 오퍼레이션. BuilderService.dispatch가 실제로
@@ -275,6 +276,7 @@ _OPERATION_STATUS_CODES: dict[str, set[int]] = {
     "previewBuild": {200, 400},
     "createBuild": {200, 400, 502},
     "listBuildArtifacts": {200, 400, 404},
+    "listBuilds": {200, 400},
 }
 
 


### PR DESCRIPTION
## 요약
ADR 0005 미해결 질문 #1(스키마 대조를 순수 파이썬으로 할지)을 "순수 파이썬 경량"
방향으로 마무리합니다. 기존 계약 테스트(#317/#319)가 YAML 선언과 라우팅 목록의
*정적* 일치만 보던 것과 달리, 실제 `dispatch()` 응답 본문이 OpenAPI 스키마에
부합하는지(wire-level conformance)를 무의존 validator로 검증해 app.py↔계약 드리프트를
CI에서 차단합니다.

## 변경 내용
ADR 0006에 따라 Builder serve 이미지를 추가합니다.
- `Dockerfile`: python:3.12-slim + uv. `uv sync --no-sources`가 editable
  ../kpubdata 오버라이드를 무시하고 PyPI 핀(kpubdata>=0.5.0,<0.6, #213)으로
  설치하므로 빌드 시 형제 디렉터리가 불필요. dev extra 제외.
- `docker-entrypoint.sh`: `KPUBDATA_BUILDER_{HOST,PORT,OUTPUT_DIR}`을 serve
  플래그로 변환. **fail-closed** — `KPUBDATA_BUILDER_API_KEY` 없으면 기동 거부,
  `KPUBDATA_BUILDER_DEV=1`로만 우회(로컬 개발용).
- `.dockerignore`, `.github/workflows/docker.yml`(docker build CI 게이트).
- README: "Docker 계획 중" placeholder → 실제 빌드/실행 예제 + env 표.

## 관련 이슈
Closes #320

## 검증 (로컬)
- `docker build` 성공 (kpubdata==0.5.0 PyPI 해석, dev 툴 제외 12패키지)
- API 키 주입: 정상 키→200, 무키→401, `/version` OK
- fail-closed: 키 없으면 exit 1; `DEV=1` → 200
- env 주입: PORT/OUTPUT_DIR/HOST 정상 반영

## 체크리스트
- [x] `uv run ruff check .` / `format --check .` / `mypy src` 통과
- [x] `uv run pytest` 523 passed
- [x] `docker build` 성공 + serve 기동 + env/fail-closed 검증

## 참고
upstream/main의 #318+#319가 #317 없이 머지돼 contract 테스트 2개가 빨간 상태였습니다.
본 PR의 CI를 녹색으로 유지하기 위해 `/builds` 라우트 맵 2줄을 채웠습니다(#209과 동일 수정).
어느 쪽이 먼저 머지되든 나머지는 trivial rebase입니다.