### PR TITLE
feat: 버전 호환성 정책 및 강화

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ uv sync --extra dev --extra publish --no-sources
 
 #### 핀 범위(`>=0.5.0,<0.6`)를 이렇게 설정한 이유
 
-`kpubdata-builder`는 `kpubdata` 0.5.x의 API(`Client.dataset(...).list` 등)에 의존합니다. 0.6 이상은 호환성 정책이 확정되지 않아 현재로서는 허용하지 않습니다. 호환 정책이 확정되면 상한을 올릴 예정입니다 (관련 이슈: #213).
+`kpubdata-builder`는 `kpubdata` 0.5.x의 API(`Client.dataset(...).list` 등)에 의존합니다. 0.6 이상은 호환성 정책이 확정되지 않아 현재로서는 허용하지 않습니다. 호환 정책이 확정되면 상한을 올릴 예정입니다 (관련 이슈: #213, 자세한 내용은 [ADR 0007](adrs/0007-kpubdata-version-compatibility-policy.md) 참조).
 
 #### 요약
 

--- a/docs/adrs/0007-kpubdata-version-compatibility-policy.md
+++ b/docs/adrs/0007-kpubdata-version-compatibility-policy.md
@@ -1,0 +1,120 @@
+# ADR 0007 — kpubdata 버전 호환성 정책 및 핀 강화
+
+- 상태: 승인됨(Accepted)
+- 관련 이슈: #213, kpubdata#233
+- 관련 문서: [CONTRIBUTING.md](../CONTRIBUTING.md) §3-1, [pyproject.toml](../../pyproject.toml)
+
+## 결정 (승인됨)
+
+**권고안을 채택한다.**
+
+1. `pyproject.toml`의 kpubdata 종속성을 `>=0.1.0a0`에서 `>=0.5.0,<0.6`으로 명시적으로 핀한다.
+2. CI에 하한(lower-bound) 테스트 잡을 추가하여, 선언된 최소 버전에서 테스트 스위트가 통과하는지 강제한다.
+3. 호환성 정책을 문서화하여, 상위 버전(kpubdata 0.6+)에 대한 업그레이드 경로와 검증 절차를 명확히 한다.
+
+## 배경
+
+`kpubdata-builder`는 `kpubdata` 라이브러리의 0.5.x 시리즈 API에 의존한다:
+
+- `Client.dataset(...).list` — 데이터셋 메타데이터 조회
+- `RecordBatch` 필드 구조 — 레코드 배치의 표준화된 스키마
+- 기타 0.5.x 도입된 계약 메서드
+
+그러나 `pyproject.toml`의 종속성 선언이 `kpubdata >=0.1.0a0`으로 되어 있어, 사실상 모든 버전을 허용하고 있었다. 이는 clean install 시 0.1.x~0.4.x 버전이 설치되면 런타임 에러가 발생하는 상황을 초래했다.
+
+## 문제
+
+1. **하한 미준수**: 선언된 최소 버전(0.1.0a0)이 실제 요구되는 API(0.5.x)보다 낮아, 의존성 해석 시 호환되지 않는 버전이 설치될 수 있다.
+2. **CI 검증 부재**: 하한 버전에서 테스트가 수행되지 않아, 실제 호환성이 검증되지 않았다.
+3. **상한 미정의**: 0.6+ 버전의 호환성 정책이 확정되지 않아, 의도치 않은 주요 버전이 설치되는 것을 막지 못했다.
+4. **문서 누락**: 종속성 핀의 의미와 업그레이드 절차가 문서화되지 않아, 기여자가 의도를 파악하기 어려웠다.
+
+## 결정 필요 사항
+
+1. 하한 버전을 실제 필요한 API 버전(0.5.0)으로 올릴 것인가?
+2. 상한 버전을 둘 것인가? 둔다면 어떤 형식(직역, compatible release)인가?
+3. CI에서 하한 버전을 테스트할 것인가?
+4. 호환성 정책을 어디에 어떻게 문서화할 것인가?
+
+## 검토한 대안
+
+### 대안 A — 하한만 설정 (`>=0.5.0`)
+- 장점: 명시적 하한, 유연한 상한
+- 단점: 0.6+ breaking change가 자동으로 설치되어 런타임 에러 위험
+
+### 대안 B — Compatible Release (`~=0.5.0`)
+- 장점: PEP 440 표준, 명시적 의미(0.5.x만 허용)
+- 단점: 문법이 less explicit, CI에서 하한 추출이 어려울 수 있음
+
+### 대안 C — 명시적 하한/상한 (`>=0.5.0,<0.6`)
+- 장점: 의도가 가장 명확, CI 스크립트에서 파싱 용이
+- 단점: 상한 변경 시 수동 갱신 필요 (하지만 이는 의도된 것: 의식적 업그레이드 강제)
+
+### 대안 D — 하한 테스트 방식
+
+**D-1. 전체 lowest-direct resolution**
+```bash
+uv pip install --resolution=lowest-direct
+```
+- 단점: 다른 종속성(예: `pyyaml>=6.0,<7`)이 하한으로 해석되어 빌드 실패
+
+**D-2. kpubdata만 하한으로 고정**
+```bash
+uv sync --no-sources && uv pip install "kpubdata==$floor" --no-deps
+```
+- 장점: 다른 종속성은 정상 해석, kpubdata만 하한 테스트
+- 단점: 두 단계 필요 (정상 해석 후 kpubdata만 재설치)
+
+## 권고 (제안)
+
+**대안 C(명시적 핀 `>=0.5.0,<0.6`)와 대안 D-2(CI 하한 테스트)를 조합하여 채택한다.**
+
+### 1. pyproject.toml 수정
+```toml
+dependencies = [
+  # Builder depends on the 0.5.x kpubdata API (Client.dataset(...).list, etc.).
+  # The old >=0.1.0a0 floor accepted any release and broke on clean installs that
+  # resolved an older kpubdata; pin to the 0.5 line until a compat policy lands (#213).
+  "kpubdata>=0.5.0,<0.6",
+  ...
+]
+```
+
+### 2. CI 하한 테스트 잡 추가 (`.github/workflows/ci.yml`)
+```yaml
+min-deps:
+  name: Minimum kpubdata floor
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@...
+    - name: Install uv
+      uses: astral-sh/setup-uv@...
+    - name: Install dependencies (normal resolution)
+      run: uv sync --extra dev --no-sources
+    - name: Pin kpubdata to its declared floor
+      run: |
+        floor=$(sed -n 's/.*kpubdata>=\([0-9][0-9.]*\).*/\1/p' pyproject.toml | head -1)
+        echo "Pinning kpubdata to declared floor: $floor"
+        test -n "$floor" || { echo "could not extract kpubdata floor from pyproject.toml"; exit 1; }
+        uv pip install "kpubdata==$floor" --no-deps
+    - name: Run tests at the floor
+      run: uv run --no-sync pytest
+```
+
+### 3. 문서화 ([CONTRIBUTING.md](../../CONTRIBUTING.md) §3-1 확장)
+- 로컬 개발과 CI/배포 환경의 의존성 해석 차이를 명시
+- 핀 범위(`>=0.5.0,<0.6`)의 의미와 이슈 #213 링크를 추가
+- 하한 테스트 잡의 목적과 절차를 설명
+
+## 영향
+
+- **빌드**: clean install 시 최소 0.5.0이 보장되어 런타임 에러 방지
+- **CI**: 매 PR/merge마다 하한 버전에서 테스트가 수행되어 실제 호환성 검증
+- **문서**: 기여자가 종속성 정책과 업그레이드 절차를 명확히 이해
+- **관련 이슈**: kpubdata#233(cross-repo compatibility matrix)와 연계하여, 상위 버전 업그레이드 시 ADR 갱신 절차 확립 필요
+
+## 미해결 질문
+
+- **kpubdata 0.6+ 호환성**: 0.6이 호환 가능한 breaking change 없는 minor 업그레이드인지, 신규 ADR/테스트로 검증 후 상한을 `<0.7`으로 올릴 것인가?
+- **자동 상한 관리**: pyproject.toml에서 상한을 CI/CD가 자동 갱신할 것인가? (현재는 수동 갱신으로 의도적 업그레이드 강제)
+- **Cross-repo compatibility matrix**: kpubdata#233의 compatibility matrix가 확정되면, 이 ADR을 어떻게 연동/갱신할 것인가?

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -10,6 +10,7 @@ KPubData Builder의 주요 설계 결정을 기록합니다. 각 ADR은 배경·
 | [0004](./0004-plugin-exporter-contract.md) | Plugin Exporter API 계약 안정화 | 승인됨 | #310 |
 | [0005](./0005-api-contract-single-source.md) | API 계약 단일 소스 & 코드 생성 전략 | 승인됨 | #311 |
 | [0006](./0006-service-auth-and-deployment.md) | 서비스 인증 & 배포(Docker) 스토리 | 승인됨 | #312 |
+| [0007](./0007-kpubdata-version-compatibility-policy.md) | kpubdata 버전 호환성 정책 및 핀 강화 | 승인됨 | #213 |
 
 ## 작성 규칙
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,12 @@ nav:
       - 변경 이력: CHANGELOG.md
   - ADR:
       - Builder as Orchestrator: adrs/0001-builder-as-orchestrator.md
+      - Build 실행 모델: adrs/0002-build-execution-model.md
+      - 영속 Build 저장소: adrs/0003-persistent-build-store.md
+      - Plugin Exporter 계약: adrs/0004-plugin-exporter-contract.md
+      - API 계약 단일 소스: adrs/0005-api-contract-single-source.md
+      - 서비스 인증 & 배포: adrs/0006-service-auth-and-deployment.md
+      - 버전 호환성 정책: adrs/0007-kpubdata-version-compatibility-policy.md
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## 요약
이슈 #213의 kpubdata 버전 호환성 정책 문서화를 완료합니다. ADR 0007을 추가하여 의존성 핀 정책(`>=0.5.0,<0.6`)과 하한 테스트 절차를 명문화하고, CONTRIBUTING.md와 문서 내비게이션을 갱신했습니다.

## 변경 내용
- ADR 0007 추가: kpubdata 버전 호환성 정책 결정 기록 (배경/문제/대안/권고/영향)
- ADR README 갱신: ADR 0007 목록 추가
- CONTRIBUTING.md §3-1 갱신: ADR 0007 링크 추가
- mkdocs.yml 내비게이션 갱신: ADR 0007 메뉴 추가

이 PR은 문서화만 담당하며, 핀 설정(`>=0.5.0,<0.6`)과 CI 하한 테스트는 이전 커밋에서 이미 구현된 상태입니다.

## 관련 이슈
Closes #213

## 검증
- [x] `uv run ruff check .` 통과
- [x] 테스트 통과 (`uv run pytest`)
- [x] 문서 변경 시 `mkdocs build` 통과

## 체크리스트
- [x] 기능 브랜치에서 작업했으며 `main`에 직접 push하지 않았다
- [x] 커밋 메시지를 영어로 작성했다
- [x] `kpubdata` provider 로직을 중복 구현하지 않았다
- [x] 필요한 단위/단계 인지형 테스트를 추가했다
- [x] 사용자 노출 기능 변경 시 문서를 분류해 갱신했습니다: 제품 계약→PRD, 향후 의도→ROADMAP, 릴리스 변경→CHANGELOG (해당 시)