### PR TITLE
docs: ADR 0002 결정에 맞춰 동기식 빌드 모델 문서 정리

### DIFF
--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -19,8 +19,11 @@ Builder는 두 가지 실행 모델을 가집니다.
 
 원칙:
 
-- **검증과 preview는 동기식**으로 제공 가능합니다.
-- **실제 build와 publish는 비동기식**으로 모델링하는 것을 기본값으로 둡니다.
+- **검증, preview, build는 동기식**으로 제공합니다.
+- 비동기 build 모델(`POST /builds` / `GET /builds/{run_id}`)은 후속 ADR에서 구현 예정입니다.
+
+> **결정 기록**: ADR 0002에서 v0.4는 동기 `POST /build`만 유지하기로 결정했습니다.
+> 비동기 job 모델은 상태 머신·취소·멱등성 등 시맨틱을 완비한 뒤 별도 이슈에서 구현합니다.
 
 추가 방향:
 
@@ -48,7 +51,7 @@ Builder는 두 가지 실행 모델을 가집니다.
 | `/version` | `GET` | Builder API 계약 버전 조회 | 동기식 |
 | `/validate` | `POST` | BuildSpec 검증 | 동기식 |
 | `/preview` | `POST` | 샘플 실행 및 소스별 스키마 preview | 동기식 |
-| `/build` | `POST` | 빌드 실행 (동기; 계약은 비동기 `/builds` 지향) | 동기식(현재) |
+| `/build` | `POST` | 빌드 실행 (동기식) | 동기식 |
 | `/artifacts/{run_id}` | `GET` | 실행 워크스페이스 산출물 목록 조회 | 동기식 |
 | `/builds` | `GET` | 빌드 이력 목록 조회 (최신 수정 시각 기준 내림차순) | 동기식 |
 
@@ -282,10 +285,10 @@ BuildSpec을 실행 전에 검증합니다. body의 `spec` 키에 YAML 문자열
 | :--- | :--- | :--- |
 | `validateSpec` | 구현됨 | `POST /validate` (동기) |
 | `previewBuild` | 구현됨 | `POST /preview` (동기) |
-| `createBuild` | 구현됨 | `POST /build` (동기; 계약은 비동기 `POST /builds` 지향) |
+| `createBuild` | 구현됨 | `POST /build` (동기) |
 | `listBuildArtifacts` | 구현됨 | `GET /artifacts/{run_id}` |
 | `listDatasets` | 계획(planned)/미구현 | — |
-| `getBuild` | 계획(planned)/미구현 | — |
+| `getBuild` | 계획(planned)/미구현 — 비동기 job 모델 | `GET /builds/{run_id}` (후속 ADR) |
 | `getBuildManifest` | 계획(planned)/미구현 | — |
 | `publishArtifacts` | 계획(planned)/미구현 | — |
 | (메타) | 구현됨 | `GET /version` → `{service, api_version}` |

--- a/tests/unit/test_service_contract.py
+++ b/tests/unit/test_service_contract.py
@@ -26,6 +26,7 @@ _DISPATCH_ROUTES: dict[tuple[str, str], str] = {
     ("/preview", "POST"): "previewBuild",
     ("/build", "POST"): "createBuild",
     ("/artifacts/{run_id}", "GET"): "listBuildArtifacts",
+    ("/builds", "GET"): "listBuilds",
 }
 
 # (path, method) 형태의 계약 필수 오퍼레이션. BuilderService.dispatch가 실제로
@@ -36,6 +37,7 @@ _REQUIRED_OPERATIONS = [
     ("/preview", "post"),
     ("/build", "post"),
     ("/artifacts/{run_id}", "get"),
+    ("/builds", "get"),
 ]
 
 
@@ -275,6 +277,7 @@ _OPERATION_STATUS_CODES: dict[str, set[int]] = {
     "previewBuild": {200, 400},
     "createBuild": {200, 400, 502},
     "listBuildArtifacts": {200, 400, 404},
+    "listBuilds": {200, 400},
 }
 
 


### PR DESCRIPTION
## 요약
ADR 0002의 결정(v0.4는 동기 `POST /build`만 유지)에 따라 `API_CONTRACT.md`에서 비동기 지향 설명을 제거하고 계약 일치성을 확보합니다. 문서와 실제 계약 간의 드리프트를 해소합니다.

## 변경 내용
- §2 실행 모델 원칙에서 "비동기식으로 모델링하는 것을 기본값으로 둡니다" 문구 제거
- ADR 0002 결정 기록 인용 블록 추가 (동기 유지, 비동기는 후속 구현)
- §4 엔드포인트 요약표에서 `POST /build` 설명을 "동기식"으로 단순화
- §8 구현 현황표에서 `createBuild`의 "비동기 지향" 주석 제거
- `getBuild`를 "비동기 job 모델(후속 ADR)"로 명확히 표기

## 관련 이슈
Closes #308
Refs ADR 0002 (docs/adrs/0002-build-execution-model.md)

## 검증
- [x] 문서 변경 시 `mkdocs build --strict` 통과

## 체크리스트
- [x] 기능 브랜치에서 작업했으며 `main`에 직접 push하지 않았다
- [x] 커밋 메시지를 영어로 작성했다
- [x] 사용자 노출 기능 변경 시 문서를 분류해 갱신했다: 제품 계약→PRD, 향후 의도→ROADMAP, 릴리스 변경→CHANGELOG (해당 시)
