### PR TITLE
feat: implement fail-closed authentication per ADR 0006 (#321)

### DIFF
--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -38,22 +38,37 @@ from ..tabular import DEFAULT_PREVIEW_LIMIT
 # 협상할 수 있게 한다 (#209).
 API_CONTRACT_VERSION = "1.0.0"
 
-# 서버가 요구하는 API 키. 환경변수로만 주입하며, 미설정 시 인증을 건너뛴다(로컬 개발
-# 편의를 위한 기본값으로 CORS 기본 오리진 정책과 동일한 접근). /build가 비용이 큰
-# 외부 API 호출과 파일 시스템 쓰기를 유발하므로, 프로덕션 배포 시 반드시 설정해야
-# 한다 (#248).
+# 서버가 요구하는 API 키. 환경변수로만 주입한다 (#248).
+# ADR 0006에 따라 fail-closed로 동작: dev-mode 미설정 + API 키 미설정 시 인증을 거부한다.
 _API_KEY_ENV = "KPUBDATA_BUILDER_API_KEY"
+_DEV_MODE_ENV = "KPUBDATA_BUILDER_DEV_MODE"
+
+
+def _is_dev_mode() -> bool:
+    """로컬 개발 모드인지 확인한다 (#321, ADR 0006).
+
+    KPUBDATA_BUILDER_DEV_MODE가 'true'/'1'이면 dev-mode로 간주하여 인증을 생략한다.
+    프로덕션 배포에서는 이 환경변수를 설정하지 않아야 한다.
+    """
+    return os.environ.get(_DEV_MODE_ENV, "").lower() in ("true", "1")
 
 
 def _verify_api_key(api_key: str | None) -> bool:
-    """요청의 X-API-Key를 서버에 설정된 키와 비교한다 (#248).
+    """요청의 X-API-Key를 서버에 설정된 키와 비교한다 (#248, #321, ADR 0006).
 
-    KPUBDATA_BUILDER_API_KEY가 설정되지 않으면 인증을 건너뛴다. 설정된 경우
-    타이밍 공격을 막기 위해 hmac.compare_digest로 비교한다.
+    ADR 0006 fail-closed 정책:
+    - dev-mode인 경우: 인증을 생략한다 (로컬 개발 편의).
+    - dev-mode가 아닌 경우:
+      - API 키가 설정되어 있으면 키를 검증한다.
+      - API 키가 미설정이면 인증을 거부한다 (False 반환).
     """
+    if _is_dev_mode():
+        return True
+
     expected = os.environ.get(_API_KEY_ENV)
     if not expected:
-        return True
+        # fail-closed: dev-mode 미설정 + API 키 미설정 시 인증 거부
+        return False
     return api_key is not None and hmac.compare_digest(api_key, expected)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+"""테스트 설정 공유."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def dev_mode_for_tests(monkeypatch: pytest.MonkeyPatch) -> None:
+    """모든 테스트에서 dev-mode를 설정하여 인증을 생략한다 (#321, ADR 0006).
+
+    개별 테스트에서 인증 동작을 검증하려면 이 fixture를 오버라이드하거나
+    명시적으로 환경변수를 삭제/설정하면 된다.
+    """
+    monkeypatch.setenv("KPUBDATA_BUILDER_DEV_MODE", "true")

--- a/tests/integration/test_http_service.py
+++ b/tests/integration/test_http_service.py
@@ -99,8 +99,10 @@ def _service(tmp_path: Path) -> BuilderService:
 
 
 @pytest.fixture()
-def http_server(tmp_path: Path) -> Iterable[str]:
+def http_server(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterable[str]:
     """실제 HTTPServer를 임의 포트에 기동해 http.py를 경유한 왕복을 검증한다."""
+    # 테스트에서는 dev-mode를 설정하여 인증을 생략한다 (#321, ADR 0006).
+    monkeypatch.setenv("KPUBDATA_BUILDER_DEV_MODE", "true")
     server = HTTPServer(("127.0.0.1", 0), make_handler(_service(tmp_path)))
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -284,19 +284,40 @@ class TestDispatch:
 
 
 class TestApiKeyAuth:
-    """API 키 인증(#248): X-API-Key 검증."""
+    """API 키 인증(#248, #321, ADR 0006): X-API-Key 검증, fail-closed 정책."""
 
-    def test_auth_skipped_when_env_unset(
+    def test_auth_required_when_env_and_dev_mode_unset(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # KPUBDATA_BUILDER_API_KEY 미설정 시 인증 없이 통과한다(로컬 개발 편의).
+        # ADR 0006 fail-closed: dev-mode 미설정 + API 키 미설정 시 인증 거부 (401).
         monkeypatch.delenv("KPUBDATA_BUILDER_API_KEY", raising=False)
+        monkeypatch.delenv("KPUBDATA_BUILDER_DEV_MODE", raising=False)
+        resp = dispatch(_service(tmp_path), "GET", "/version", None)
+        assert resp.status_code == 401
+        assert resp.body == {"error": "unauthorized"}
+
+    def test_auth_skipped_in_dev_mode(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # dev-mode 설정 시 API 키가 없어도 인증 생략 (로컬 개발 편의).
+        monkeypatch.delenv("KPUBDATA_BUILDER_API_KEY", raising=False)
+        monkeypatch.setenv("KPUBDATA_BUILDER_DEV_MODE", "true")
+        resp = dispatch(_service(tmp_path), "GET", "/version", None)
+        assert resp.status_code == 200
+
+    def test_auth_skipped_in_dev_mode_variant(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # dev-mode="1"도 인증 생략.
+        monkeypatch.delenv("KPUBDATA_BUILDER_API_KEY", raising=False)
+        monkeypatch.setenv("KPUBDATA_BUILDER_DEV_MODE", "1")
         resp = dispatch(_service(tmp_path), "GET", "/version", None)
         assert resp.status_code == 200
 
     def test_rejects_missing_api_key_when_configured(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        monkeypatch.delenv("KPUBDATA_BUILDER_DEV_MODE", raising=False)
         monkeypatch.setenv("KPUBDATA_BUILDER_API_KEY", "secret")
         resp = dispatch(_service(tmp_path), "GET", "/version", None)
         assert resp.status_code == 401
@@ -305,6 +326,7 @@ class TestApiKeyAuth:
     def test_rejects_wrong_api_key_when_configured(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        monkeypatch.delenv("KPUBDATA_BUILDER_DEV_MODE", raising=False)
         monkeypatch.setenv("KPUBDATA_BUILDER_API_KEY", "secret")
         resp = dispatch(_service(tmp_path), "GET", "/version", None, api_key="wrong")
         assert resp.status_code == 401
@@ -312,6 +334,7 @@ class TestApiKeyAuth:
     def test_accepts_matching_api_key(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        monkeypatch.delenv("KPUBDATA_BUILDER_DEV_MODE", raising=False)
         monkeypatch.setenv("KPUBDATA_BUILDER_API_KEY", "secret")
         resp = dispatch(_service(tmp_path), "GET", "/version", None, api_key="secret")
         assert resp.status_code == 200
@@ -320,6 +343,7 @@ class TestApiKeyAuth:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         # /build처럼 비용이 큰 엔드포인트도 예외 없이 보호돼야 한다.
+        monkeypatch.delenv("KPUBDATA_BUILDER_DEV_MODE", raising=False)
         monkeypatch.setenv("KPUBDATA_BUILDER_API_KEY", "secret")
         resp = dispatch(
             _service(tmp_path), "POST", "/build", {"spec": VALID_SPEC_YAML, "run_id": "auth1"}
@@ -341,8 +365,32 @@ class TestBuildFailureResponseCode:
 @pytest.fixture()
 def http_server(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> Iterable[tuple[str, HTTPServer, threading.Thread]]:
     """실제 HTTPServer를 임의 포트에 띄워서 어댑터 레벨 동작을 검증한다."""
+    # 테스트에서는 dev-mode를 설정하여 인증을 생략한다 (#321, ADR 0006).
+    monkeypatch.setenv("KPUBDATA_BUILDER_DEV_MODE", "true")
+    service = _service(tmp_path)
+    server = HTTPServer(("127.0.0.1", 0), make_handler(service))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base_url = f"http://{server.server_address[0]}:{server.server_address[1]}"
+    try:
+        yield base_url, server, thread
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1.0)
+
+
+@pytest.fixture()
+def http_server_with_auth(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterable[tuple[str, HTTPServer, threading.Thread]]:
+    """인증이 활성화된 HTTPServer (dev-mode 미설정, API 키 설정)."""
+    monkeypatch.delenv("KPUBDATA_BUILDER_DEV_MODE", raising=False)
+    monkeypatch.setenv("KPUBDATA_BUILDER_API_KEY", "secret")
     service = _service(tmp_path)
     server = HTTPServer(("127.0.0.1", 0), make_handler(service))
     thread = threading.Thread(target=server.serve_forever, daemon=True)
@@ -516,23 +564,20 @@ class TestHttpAdapter:
 
     def test_missing_api_key_returns_401_when_configured(
         self,
-        http_server: tuple[str, HTTPServer, threading.Thread],
-        monkeypatch: pytest.MonkeyPatch,
+        http_server_with_auth: tuple[str, HTTPServer, threading.Thread],
     ) -> None:
         # 어댑터가 X-API-Key 헤더를 dispatch로 전달해야 한다 (#248).
-        monkeypatch.setenv("KPUBDATA_BUILDER_API_KEY", "secret")
-        base_url, _, _ = http_server
+        base_url, _, _ = http_server_with_auth
         with pytest.raises(urllib.error.HTTPError) as exc_info:
             urllib.request.urlopen(f"{base_url}/version", timeout=2.0)
         assert exc_info.value.code == 401
 
     def test_valid_api_key_header_is_accepted(
         self,
-        http_server: tuple[str, HTTPServer, threading.Thread],
-        monkeypatch: pytest.MonkeyPatch,
+        http_server_with_auth: tuple[str, HTTPServer, threading.Thread],
     ) -> None:
-        monkeypatch.setenv("KPUBDATA_BUILDER_API_KEY", "secret")
-        base_url, _, _ = http_server
+        # http_server_with_auth fixture가 이미 API 키를 설정하므로 monkeypatch 불필요
+        base_url, _, _ = http_server_with_auth
         req = urllib.request.Request(f"{base_url}/version", headers={"X-API-Key": "secret"})
         with urllib.request.urlopen(req, timeout=2.0) as response:
             assert response.status == 200

--- a/tests/unit/test_service_contract.py
+++ b/tests/unit/test_service_contract.py
@@ -26,6 +26,7 @@ _DISPATCH_ROUTES: dict[tuple[str, str], str] = {
     ("/preview", "POST"): "previewBuild",
     ("/build", "POST"): "createBuild",
     ("/artifacts/{run_id}", "GET"): "listBuildArtifacts",
+    ("/builds", "GET"): "listBuilds",
 }
 
 # (path, method) 형태의 계약 필수 오퍼레이션. BuilderService.dispatch가 실제로
@@ -36,6 +37,7 @@ _REQUIRED_OPERATIONS = [
     ("/preview", "post"),
     ("/build", "post"),
     ("/artifacts/{run_id}", "get"),
+    ("/builds", "get"),
 ]
 
 
@@ -275,6 +277,7 @@ _OPERATION_STATUS_CODES: dict[str, set[int]] = {
     "previewBuild": {200, 400},
     "createBuild": {200, 400, 502},
     "listBuildArtifacts": {200, 400, 404},
+    "listBuilds": {200, 400},
 }
 
 


### PR DESCRIPTION
## 요약
ADR 0006의 결정에 따라 Docker 배포 환경에서의 보안을 강화하기 위해 fail-closed 인증 정책을 구현합니다. `KPUBDATA_BUILDER_DEV_MODE` 환경변수를 도입하여 로컬 개발과 프로덕션 환경의 인증 동작을 명확히 분리하고, API 키 미설정 시 인증을 거부하도록 변경합니다.

## 변경 내용
- `KPUBDATA_BUILDER_DEV_MODE` 환경변수 추가 (true/1 시 인증 생략)
- `_is_dev_mode()` 헬퍼 함수 추가
- `_verify_api_key()` 함수를 fail-closed 정책으로 수정:
  - dev-mode 미설정 + API 키 미설정 → 401 반환 (기존: 인증 생략)
  - dev-mode 설정 → 인증 생략 (로컬 개발 편의 유지)
  - API 키 설정 → hmac.compare_digest로 안전 비교
- fail-closed 동작 검증 테스트 추가 (3개 케이스)
- `http_server_with_auth` fixture 추가 (API 키 테스트 전용)
- `tests/conftest.py` 추가 (autouse dev-mode fixture)
- `test_service_contract.py`에 listBuilds 매핑 추가

## 관련 이슈
Closes #321
Refs ADR 0006 (docs/adrs/0006-service-auth-and-deployment.md)

## 검증
- [x] `uv run ruff check .` 통과
- [x] 테스트 통과 (`uv run pytest`)

## 체크리스트
- [x] 기능 브랜치에서 작업했으며 `main`에 직접 push하지 않았다
- [x] 커밋 메시지를 영어로 작성했다
- [x] `kpubdata` provider 로직을 중복 구현하지 않았다
- [x] 필요한 단위/단계 인지형 테스트를 추가했다
- [x] 사용자 노출 기능 변경 시 문서를 분류해 갱신했다: 제품 계약→PRD, 향후 의도→ROADMAP, 릴리스 변경→CHANGELOG (해당 시)
