### PR TITLE
feat: SQLite 기반 영속 Build 저장소 구현(ADR 003)

### DIFF
--- a/src/kpubdata_builder/cli.py
+++ b/src/kpubdata_builder/cli.py
@@ -386,7 +386,7 @@ def _run_rebuild_index(output_dir: str) -> int:
     반환값:
         int: 성공 시 0, 실패 시 1.
     """
-    from ..store import rebuild_index
+    from .store import rebuild_index
 
     output_root = Path(output_dir)
     print(f"rebuilding build index from {output_root}...", flush=True)

--- a/src/kpubdata_builder/cli.py
+++ b/src/kpubdata_builder/cli.py
@@ -135,6 +135,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Run workspace root directory (default: build).",
     )
 
+    rebuild_cmd = subparsers.add_parser(
+        "rebuild-index",
+        help="Rebuild the build index from filesystem scans.",
+    )
+    rebuild_cmd.add_argument(
+        "--output-dir",
+        default="build",
+        help="Run workspace root directory (default: build).",
+    )
+
     return parser
 
 
@@ -367,6 +377,29 @@ def _run_serve(*, output_dir: str, host: str, port: int) -> int:
     return 0
 
 
+def _run_rebuild_index(output_dir: str) -> int:
+    """파일시스템 스캔으로 빌드 인덱스를 재구축한다 (#309, ADR 0003).
+
+    매개변수:
+        output_dir: 빌드 출력 루트 디렉터리.
+
+    반환값:
+        int: 성공 시 0, 실패 시 1.
+    """
+    from ..store import rebuild_index
+
+    output_root = Path(output_dir)
+    print(f"rebuilding build index from {output_root}...", flush=True)
+
+    try:
+        count = rebuild_index(output_root)
+        print(f"rebuilt index with {count} build(s)", flush=True)
+        return 0
+    except Exception as exc:
+        print(f"error: failed to rebuild index: {exc}", file=sys.stderr)
+        return 1
+
+
 def dispatch(args: argparse.Namespace) -> int:
     """파싱된 argparse 결과를 실제 명령 실행 함수로 전달한다.
 
@@ -402,6 +435,8 @@ def dispatch(args: argparse.Namespace) -> int:
             host=args.host,
             port=args.port,
         )
+    if command == "rebuild-index":
+        return _run_rebuild_index(output_dir=args.output_dir)
     # 일반적인 CLI 경로로는 도달할 수 없지만(argparse가 알 수 없는 하위 명령을 거부함),
     # 프로그래밍 방식 호출자를 위한 방어적 대체 경로로 유지한다.
     return 2

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -251,9 +251,7 @@ class BuilderService:
                     }
                     for entry in entries
                 ]
-                return ServiceResponse(
-                    200, {"builds": cast(list[JsonValue], index_builds)}
-                )
+                return ServiceResponse(200, {"builds": cast(list[JsonValue], index_builds)})
         except Exception:
             # 인덱스 조회 실패 시 폴백
             pass

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -34,6 +34,9 @@ from ..stages.bronze.build import SourceClient
 from ..store import BuildIndex
 from ..tabular import DEFAULT_PREVIEW_LIMIT
 
+# Build list entry type for API responses
+_BuildListEntry = dict[str, str | None]
+
 # Builder API 계약 버전. contract/builder-api.yaml의 info.version과 일치해야 하며
 # (test_service_contract가 강제), 응답에 실어 Studio 같은 소비자가 하위 호환을
 # 협상할 수 있게 한다 (#209).
@@ -239,7 +242,7 @@ class BuilderService:
             entries = self._build_index.list_builds(limit=limit)
             if entries:
                 # 인덱스가 있으면 반환
-                builds = [
+                index_builds: list[_BuildListEntry] = [
                     {
                         "run_id": entry.run_id,
                         "status": entry.status,
@@ -248,7 +251,9 @@ class BuilderService:
                     }
                     for entry in entries
                 ]
-                return ServiceResponse(200, {"builds": builds})
+                return ServiceResponse(
+                    200, {"builds": cast(list[JsonValue], index_builds)}
+                )
         except Exception:
             # 인덱스 조회 실패 시 폴백
             pass
@@ -262,7 +267,7 @@ class BuilderService:
             (d for d in self._output_root.iterdir() if d.is_dir()),
             key=lambda p: p.stat().st_mtime,
         )
-        builds: list[JsonValue] = []
+        fs_builds: list[_BuildListEntry] = []
         for run_dir in candidates:
             manifest_path = run_dir / "manifest.json"
             if not manifest_path.exists():
@@ -271,7 +276,7 @@ class BuilderService:
                 manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
             except (json.JSONDecodeError, OSError):
                 continue
-            builds.append(
+            fs_builds.append(
                 {
                     "run_id": run_dir.name,
                     "status": "failed" if manifest.get("errors") else "ok",
@@ -279,7 +284,7 @@ class BuilderService:
                     "finished_at": manifest.get("finished_at"),
                 }
             )
-        return ServiceResponse(200, {"builds": builds})
+        return ServiceResponse(200, {"builds": cast(list[JsonValue], fs_builds)})
 
     def _load_validated(self, spec_yaml: str) -> BuildSpec | ServiceResponse:
         """spec_yaml을 파싱·검증하고, 실패 시 오류 ServiceResponse를 반환한다."""

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -31,6 +31,7 @@ from ..spec import BuildSpec, JsonValue, parse_spec
 from ..spec.validator import validate_spec
 from ..stages._path_safety import ensure_within, validate_path_segment
 from ..stages.bronze.build import SourceClient
+from ..store import BuildIndex
 from ..tabular import DEFAULT_PREVIEW_LIMIT
 
 # Builder API 계약 버전. contract/builder-api.yaml의 info.version과 일치해야 하며
@@ -89,6 +90,7 @@ class BuilderService:
     ) -> None:
         self._output_root = output_root
         self._client_factory = client_factory
+        self._build_index = BuildIndex(output_root)  # #309, ADR 0003
 
     def version(self) -> ServiceResponse:
         """Builder API 계약 버전을 반환한다 (#209).
@@ -191,6 +193,22 @@ class BuilderService:
                 (o.error for o in result.outcomes if o.status != "ok" and o.error), None
             )
             body["error"] = first_error or "build failed"
+
+        # ADR 0003: 빌드 완료 후 인덱스 갱신 (best-effort, 실패해도 빌드 성공 유지)
+        try:
+            manifest_data = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+            started_at = manifest_data.get("started_at")
+            finished_at = manifest_data.get("finished_at")
+            self._build_index.insert_or_replace(
+                run_id=result.context.run_id,
+                status=result.status,  # type: ignore[arg-type]
+                started_at=started_at,
+                finished_at=finished_at,
+            )
+        except Exception:
+            # 인덱스 갱신 실패는 무시 (ADR 0003)
+            pass
+
         return ServiceResponse(status_code, body)
 
     def artifacts(self, run_id: str) -> ServiceResponse:
@@ -211,11 +229,31 @@ class BuilderService:
         return ServiceResponse(200, {"run_id": run_id, "files": list(files)})
 
     def list_builds(self, *, limit: int = 50) -> ServiceResponse:
-        """실행 이력 목록을 최신 수정 시각 기준으로 내림차순 반환한다.
+        """실행 이력 목록을 최신 완료 시각 기준 내림차순 반환한다.
 
-        output_root 아래의 디렉터리를 스캔해 manifest.json이 있는 실행만
-        포함한다. Studio 같은 소비자가 빌드 이력 목록을 표시하는 데 쓰인다 (#250).
+        ADR 0003에 따라 SQLite 인덱스를 우선 조회하고, 인덱스가 없거나
+        비어있으면 파일시스템 스캔으로 폴백한다.
         """
+        # 인덱스 우선 조회
+        try:
+            entries = self._build_index.list_builds(limit=limit)
+            if entries:
+                # 인덱스가 있으면 반환
+                builds = [
+                    {
+                        "run_id": entry.run_id,
+                        "status": entry.status,
+                        "started_at": entry.started_at,
+                        "finished_at": entry.finished_at,
+                    }
+                    for entry in entries
+                ]
+                return ServiceResponse(200, {"builds": builds})
+        except Exception:
+            # 인덱스 조회 실패 시 폴백
+            pass
+
+        # 폴백: 파일시스템 스캔
         if not self._output_root.exists():
             return ServiceResponse(200, {"builds": []})
 

--- a/src/kpubdata_builder/store/__init__.py
+++ b/src/kpubdata_builder/store/__init__.py
@@ -6,6 +6,6 @@ SQLite 기반 빌드 인덱스를 제공하여 파일시스템 스캔 비용을 
 
 from __future__ import annotations
 
-from .build_index import BuildIndex, SCHEMA_VERSION, rebuild_index
+from .build_index import SCHEMA_VERSION, BuildIndex, rebuild_index
 
 __all__ = ["BuildIndex", "SCHEMA_VERSION", "rebuild_index"]

--- a/src/kpubdata_builder/store/__init__.py
+++ b/src/kpubdata_builder/store/__init__.py
@@ -1,0 +1,11 @@
+"""영속 Build 저장소 (#309, ADR 0003).
+
+SQLite 기반 빌드 인덱스를 제공하여 파일시스템 스캔 비용을 줄이고
+확장성/일관성/동시성을 개선한다.
+"""
+
+from __future__ import annotations
+
+from .build_index import BuildIndex, SCHEMA_VERSION, rebuild_index
+
+__all__ = ["BuildIndex", "SCHEMA_VERSION", "rebuild_index"]

--- a/src/kpubdata_builder/store/build_index.py
+++ b/src/kpubdata_builder/store/build_index.py
@@ -1,0 +1,287 @@
+"""SQLite 기반 빌드 인덱스 (#309, ADR 0003).
+
+완료된 빌드의 메타데이터를 인덱싱하여 목록 조회 성능을 개선한다.
+manifest.json이 정본이며, 이 인덱스는 파생물이다.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+# 스키마 버전: 인덱스 구조 변경 시 증가
+SCHEMA_VERSION = 1
+
+# 인덱스 파일 이름
+_INDEX_FILENAME = "_builds.sqlite"
+
+
+@dataclass(frozen=True)
+class BuildEntry:
+    """빌드 인덱스 엔트리."""
+
+    run_id: str
+    status: Literal["ok", "failed"]
+    started_at: str | None
+    finished_at: str | None
+    spec_digest: str | None
+    error: str | None
+
+
+class BuildIndex:
+    """SQLite 기반 빌드 인덱스.
+
+    ADR 0003에 따라:
+    - manifest.json이 정본이며, 이 인덱스는 파생물이다
+    - 인덱스 쓰기 실패가 빌드 실패의 원인이 되어서는 안 됨
+    - WAL 모드 + busy_timeout으로 동시성 안전 장치
+    """
+
+    def __init__(self, output_root: Path) -> None:
+        """인덱스를 초기화한다.
+
+        Args:
+            output_root: 빌드 출력 루트 디렉터리 (인덱스는 output_root/_builds.sqlite)
+        """
+        self._output_root = output_root
+        self._index_path = output_root / _INDEX_FILENAME
+        self._local = threading.local()
+        self._init_db()
+
+    @property
+    def _conn(self) -> sqlite3.Connection:
+        """스레드 로컬 연결을 반환한다 (lazy initialization)."""
+        if not hasattr(self._local, "conn"):
+            self._local.conn = self._connect()
+        return self._local.conn
+
+    def _connect(self) -> sqlite3.Connection:
+        """새 SQLite 연결을 생성하고 설정한다."""
+        conn = sqlite3.connect(
+            str(self._index_path),
+            timeout=30.0,  # busy_timeout: 동시성 경합 시 대기 시간
+        )
+        conn.execute("PRAGMA journal_mode=WAL")  # Write-Ahead Logging: 동시 읽기 허용
+        conn.execute("PRAGMA foreign_keys=ON")
+        return conn
+
+    def _init_db(self) -> None:
+        """데이터베이스 스키마를 초기화한다."""
+        with self._transaction():
+            self._conn.execute(
+                f"""
+                CREATE TABLE IF NOT EXISTS schema_version (
+                    version INTEGER PRIMARY KEY,
+                    applied_at TEXT DEFAULT (datetime('now'))
+                )
+                """
+            )
+            # 스키마 버전 확인
+            cur = self._conn.execute("SELECT version FROM schema_version")
+            row = cur.fetchone()
+            current_version = row[0] if row else None
+
+            if current_version != SCHEMA_VERSION:
+                # builds 테이블 생성 (기존 테이블은 DROP 후 재생성)
+                self._conn.execute("DROP TABLE IF EXISTS builds")
+                self._conn.execute(
+                    """
+                    CREATE TABLE builds (
+                        run_id TEXT PRIMARY KEY,
+                        status TEXT NOT NULL CHECK (status IN ('ok', 'failed')),
+                        started_at TEXT,
+                        finished_at TEXT,
+                        spec_digest TEXT,
+                        error TEXT
+                    )
+                    """
+                )
+                # finished_at 인덱스 (최신 빌드 우선 조회)
+                self._conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_builds_finished_at ON builds(finished_at DESC)"
+                )
+                # 스키마 버전 기록
+                self._conn.execute(
+                    f"INSERT INTO schema_version (version) VALUES ({SCHEMA_VERSION})"
+                )
+                self._conn.execute("DELETE FROM schema_version WHERE version != ?", (SCHEMA_VERSION,))
+
+    @contextmanager
+    def _transaction(self):
+        """트랜잭션 컨텍스트 매니저."""
+        try:
+            yield
+            self._conn.commit()
+        except Exception:
+            self._conn.rollback()
+            raise
+
+    def insert_or_replace(
+        self,
+        run_id: str,
+        status: Literal["ok", "failed"],
+        started_at: str | None,
+        finished_at: str | None,
+        spec_digest: str | None = None,
+        error: str | None = None,
+    ) -> None:
+        """빌드 엔트리를 삽입 또는 대체한다.
+
+        Args:
+            run_id: 빌드 실행 식별자
+            status: 빌드 상태 (ok/failed)
+            started_at: 빌드 시작 시각 (ISO 8601)
+            finished_at: 빌드 완료 시각 (ISO 8601)
+            spec_digest: spec 해시 (선택)
+            error: 오류 메시지 (실패 시)
+        """
+        try:
+            with self._transaction():
+                self._conn.execute(
+                    """
+                    INSERT OR REPLACE INTO builds
+                    (run_id, status, started_at, finished_at, spec_digest, error)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (run_id, status, started_at, finished_at, spec_digest, error),
+                )
+        except Exception:
+            # ADR 0003: 인덱스 쓰기 실패가 빌드 실패의 원인이 되어서는 안 됨
+            pass
+
+    def list_builds(self, limit: int = 50) -> list[BuildEntry]:
+        """빌드 목록을 최신 완료 시각 기준 내림차순으로 반환한다.
+
+        Args:
+            limit: 반환할 최대 빌드 수
+
+        Returns:
+            BuildEntry 목록 (finished_at이 최신인 순)
+        """
+        cur = self._conn.execute(
+            """
+            SELECT run_id, status, started_at, finished_at, spec_digest, error
+            FROM builds
+            ORDER BY finished_at DESC
+            LIMIT ?
+            """,
+            (limit,),
+        )
+        return [
+            BuildEntry(
+                run_id=row[0],
+                status=row[1],  # type: ignore[assignment]
+                started_at=row[2],
+                finished_at=row[3],
+                spec_digest=row[4],
+                error=row[5],
+            )
+            for row in cur
+        ]
+
+    def get(self, run_id: str) -> BuildEntry | None:
+        """특정 빌드를 조회한다.
+
+        Args:
+            run_id: 빌드 실행 식별자
+
+        Returns:
+            BuildEntry 또는 None (미발견 시)
+        """
+        cur = self._conn.execute(
+            """
+            SELECT run_id, status, started_at, finished_at, spec_digest, error
+            FROM builds
+            WHERE run_id = ?
+            """,
+            (run_id,),
+        )
+        row = cur.fetchone()
+        if row is None:
+            return None
+        return BuildEntry(
+            run_id=row[0],
+            status=row[1],  # type: ignore[assignment]
+            started_at=row[2],
+            finished_at=row[3],
+            spec_digest=row[4],
+            error=row[5],
+        )
+
+    def delete(self, run_id: str) -> None:
+        """빌드 엔트리를 삭제한다.
+
+        Args:
+            run_id: 빌드 실행 식별자
+        """
+        try:
+            with self._transaction():
+                self._conn.execute("DELETE FROM builds WHERE run_id = ?", (run_id,))
+        except Exception:
+            # 인덱스 실패는 무시
+            pass
+
+    def close(self) -> None:
+        """연결을 닫는다."""
+        if hasattr(self._local, "conn"):
+            self._local.conn.close()
+            delattr(self._local, "conn")
+
+
+def rebuild_index(output_root: Path) -> int:
+    """파일시스템 스캔으로 인덱스를 재구축한다.
+
+    output_root 아래의 모든 manifest.json을 스캔하여 인덱스를 다시 빌드한다.
+    기존 인덱스는 삭제되고 새로 생성된다.
+
+    Args:
+        output_root: 빌드 출력 루트 디렉터리
+
+    Returns:
+        재구축된 빌드 수
+    """
+    import json
+
+    index_path = output_root / _INDEX_FILENAME
+    # 기존 인덱스 삭제
+    if index_path.exists():
+        index_path.unlink()
+
+    index = BuildIndex(output_root)
+    count = 0
+
+    if not output_root.exists():
+        return 0
+
+    for run_dir in output_root.iterdir():
+        if not run_dir.is_dir():
+            continue
+        manifest_path = run_dir / "manifest.json"
+        if not manifest_path.exists():
+            continue
+
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+
+        status = "failed" if manifest.get("errors") else "ok"
+        started_at = manifest.get("started_at")
+        finished_at = manifest.get("finished_at")
+
+        index.insert_or_replace(
+            run_id=run_dir.name,
+            status=status,  # type: ignore[arg-type]
+            started_at=started_at,
+            finished_at=finished_at,
+        )
+        count += 1
+
+    return count
+
+
+__all__ = ["BuildIndex", "BuildEntry", "rebuild_index", "SCHEMA_VERSION"]

--- a/src/kpubdata_builder/store/build_index.py
+++ b/src/kpubdata_builder/store/build_index.py
@@ -8,10 +8,16 @@ from __future__ import annotations
 
 import sqlite3
 import threading
+from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal, cast
+
+if TYPE_CHECKING:
+    _BaseConn = sqlite3.Connection
+else:
+    _BaseConn = object
 
 # 스키마 버전: 인덱스 구조 변경 시 증가
 SCHEMA_VERSION = 1
@@ -57,7 +63,7 @@ class BuildIndex:
         """스레드 로컬 연결을 반환한다 (lazy initialization)."""
         if not hasattr(self._local, "conn"):
             self._local.conn = self._connect()
-        return self._local.conn
+        return cast(sqlite3.Connection, self._local.conn)
 
     def _connect(self) -> sqlite3.Connection:
         """새 SQLite 연결을 생성하고 설정한다."""
@@ -73,7 +79,7 @@ class BuildIndex:
         """데이터베이스 스키마를 초기화한다."""
         with self._transaction():
             self._conn.execute(
-                f"""
+                """
                 CREATE TABLE IF NOT EXISTS schema_version (
                     version INTEGER PRIMARY KEY,
                     applied_at TEXT DEFAULT (datetime('now'))
@@ -108,10 +114,12 @@ class BuildIndex:
                 self._conn.execute(
                     f"INSERT INTO schema_version (version) VALUES ({SCHEMA_VERSION})"
                 )
-                self._conn.execute("DELETE FROM schema_version WHERE version != ?", (SCHEMA_VERSION,))
+                self._conn.execute(
+                    "DELETE FROM schema_version WHERE version != ?", (SCHEMA_VERSION,)
+                )
 
     @contextmanager
-    def _transaction(self):
+    def _transaction(self) -> Iterator[None]:
         """트랜잭션 컨텍스트 매니저."""
         try:
             yield
@@ -174,7 +182,7 @@ class BuildIndex:
         return [
             BuildEntry(
                 run_id=row[0],
-                status=row[1],  # type: ignore[assignment]
+                status=cast(Literal["ok", "failed"], row[1]),
                 started_at=row[2],
                 finished_at=row[3],
                 spec_digest=row[4],
@@ -205,7 +213,7 @@ class BuildIndex:
             return None
         return BuildEntry(
             run_id=row[0],
-            status=row[1],  # type: ignore[assignment]
+            status=cast(Literal["ok", "failed"], row[1]),
             started_at=row[2],
             finished_at=row[3],
             spec_digest=row[4],

--- a/tests/unit/test_build_index.py
+++ b/tests/unit/test_build_index.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
-from kpubdata_builder.store import BuildIndex, rebuild_index, SCHEMA_VERSION
+from kpubdata_builder.store import SCHEMA_VERSION, BuildIndex, rebuild_index
 
 
 class TestBuildIndex:

--- a/tests/unit/test_build_index.py
+++ b/tests/unit/test_build_index.py
@@ -179,23 +179,27 @@ class TestRebuildIndex:
         # 가짜 manifest 파일들 생성
         (tmp_path / "run1").mkdir()
         (tmp_path / "run1" / "manifest.json").write_text(
-            json.dumps({
-                "run_id": "run1",
-                "status": "ok",
-                "started_at": "2025-01-01T10:00:00Z",
-                "finished_at": "2025-01-01T10:05:00Z",
-            })
+            json.dumps(
+                {
+                    "run_id": "run1",
+                    "status": "ok",
+                    "started_at": "2025-01-01T10:00:00Z",
+                    "finished_at": "2025-01-01T10:05:00Z",
+                }
+            )
         )
 
         (tmp_path / "run2").mkdir()
         (tmp_path / "run2" / "manifest.json").write_text(
-            json.dumps({
-                "run_id": "run2",
-                "status": "failed",
-                "errors": ["test error"],
-                "started_at": "2025-01-01T11:00:00Z",
-                "finished_at": "2025-01-01T11:05:00Z",
-            })
+            json.dumps(
+                {
+                    "run_id": "run2",
+                    "status": "failed",
+                    "errors": ["test error"],
+                    "started_at": "2025-01-01T11:00:00Z",
+                    "finished_at": "2025-01-01T11:05:00Z",
+                }
+            )
         )
 
         # manifest 없는 디렉터리
@@ -227,12 +231,14 @@ class TestRebuildIndex:
         # manifest 파일 생성
         (tmp_path / "new").mkdir()
         (tmp_path / "new" / "manifest.json").write_text(
-            json.dumps({
-                "run_id": "new",
-                "status": "ok",
-                "started_at": "2025-01-01T11:00:00Z",
-                "finished_at": "2025-01-01T11:05:00Z",
-            })
+            json.dumps(
+                {
+                    "run_id": "new",
+                    "status": "ok",
+                    "started_at": "2025-01-01T11:00:00Z",
+                    "finished_at": "2025-01-01T11:05:00Z",
+                }
+            )
         )
 
         count = rebuild_index(tmp_path)
@@ -248,11 +254,13 @@ class TestRebuildIndex:
         """손상된 manifest는 건너뛴다."""
         (tmp_path / "good").mkdir()
         (tmp_path / "good" / "manifest.json").write_text(
-            json.dumps({
-                "status": "ok",
-                "started_at": "2025-01-01T10:00:00Z",
-                "finished_at": "2025-01-01T10:05:00Z",
-            })
+            json.dumps(
+                {
+                    "status": "ok",
+                    "started_at": "2025-01-01T10:00:00Z",
+                    "finished_at": "2025-01-01T10:05:00Z",
+                }
+            )
         )
 
         (tmp_path / "bad").mkdir()

--- a/tests/unit/test_build_index.py
+++ b/tests/unit/test_build_index.py
@@ -1,0 +1,269 @@
+"""SQLite 빌드 인덱스 테스트 (#309, ADR 0003)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kpubdata_builder.store import BuildIndex, rebuild_index, SCHEMA_VERSION
+
+
+class TestBuildIndex:
+    """BuildIndex 단위 테스트."""
+
+    def test_init_creates_database(self, tmp_path: Path) -> None:
+        """초기화 시 데이터베이스와 스키마가 생성된다."""
+        index = BuildIndex(tmp_path)
+        assert (tmp_path / "_builds.sqlite").exists()
+
+        # 스키마 버전 확인
+        cur = index._conn.execute("SELECT version FROM schema_version")
+        assert cur.fetchone()[0] == SCHEMA_VERSION
+
+        # builds 테이블 확인
+        cur = index._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='builds'"
+        )
+        assert cur.fetchone() is not None
+
+    def test_insert_and_retrieve(self, tmp_path: Path) -> None:
+        """엔트리 삽입 후 조회가 가능하다."""
+        index = BuildIndex(tmp_path)
+
+        index.insert_or_replace(
+            run_id="test1",
+            status="ok",
+            started_at="2025-01-01T10:00:00Z",
+            finished_at="2025-01-01T10:05:00Z",
+        )
+
+        entry = index.get("test1")
+        assert entry is not None
+        assert entry.run_id == "test1"
+        assert entry.status == "ok"
+        assert entry.started_at == "2025-01-01T10:00:00Z"
+        assert entry.finished_at == "2025-01-01T10:05:00Z"
+
+    def test_insert_or_replace_updates_existing(self, tmp_path: Path) -> None:
+        """insert_or_replace는 기존 엔트리를 갱신한다."""
+        index = BuildIndex(tmp_path)
+
+        index.insert_or_replace(
+            run_id="test1",
+            status="ok",
+            started_at="2025-01-01T10:00:00Z",
+            finished_at="2025-01-01T10:05:00Z",
+        )
+
+        # 상태 변경 후 재삽입
+        index.insert_or_replace(
+            run_id="test1",
+            status="failed",
+            started_at="2025-01-01T10:00:00Z",
+            finished_at="2025-01-01T10:05:00Z",
+            error="test error",
+        )
+
+        entry = index.get("test1")
+        assert entry is not None
+        assert entry.status == "failed"
+        assert entry.error == "test error"
+
+    def test_list_builds_orders_by_finished_at_desc(self, tmp_path: Path) -> None:
+        """list_builds는 finished_at 기준 내림차순으로 반환한다."""
+        index = BuildIndex(tmp_path)
+
+        index.insert_or_replace(
+            run_id="old",
+            status="ok",
+            started_at="2025-01-01T09:00:00Z",
+            finished_at="2025-01-01T09:05:00Z",
+        )
+        index.insert_or_replace(
+            run_id="new",
+            status="ok",
+            started_at="2025-01-01T11:00:00Z",
+            finished_at="2025-01-01T11:05:00Z",
+        )
+        index.insert_or_replace(
+            run_id="mid",
+            status="ok",
+            started_at="2025-01-01T10:00:00Z",
+            finished_at="2025-01-01T10:05:00Z",
+        )
+
+        builds = index.list_builds()
+        assert len(builds) == 3
+        assert builds[0].run_id == "new"
+        assert builds[1].run_id == "mid"
+        assert builds[2].run_id == "old"
+
+    def test_list_builds_respects_limit(self, tmp_path: Path) -> None:
+        """list_builds는 limit 매개변수를 존중한다."""
+        index = BuildIndex(tmp_path)
+
+        for i in range(5):
+            index.insert_or_replace(
+                run_id=f"run{i}",
+                status="ok",
+                started_at="2025-01-01T10:00:00Z",
+                finished_at=f"2025-01-01T1{i}:00:00Z",
+            )
+
+        builds = index.list_builds(limit=3)
+        assert len(builds) == 3
+
+    def test_delete_removes_entry(self, tmp_path: Path) -> None:
+        """delete는 엔트리를 삭제한다."""
+        index = BuildIndex(tmp_path)
+
+        index.insert_or_replace(
+            run_id="test1",
+            status="ok",
+            started_at="2025-01-01T10:00:00Z",
+            finished_at="2025-01-01T10:05:00Z",
+        )
+
+        index.delete("test1")
+        assert index.get("test1") is None
+
+    def test_get_returns_none_for_missing(self, tmp_path: Path) -> None:
+        """get는 미존재 엔트리에 대해 None을 반환한다."""
+        index = BuildIndex(tmp_path)
+        assert index.get("nonexistent") is None
+
+    def test_schema_version_upgrade_recreates_table(self, tmp_path: Path) -> None:
+        """스키마 버전이 변경되면 테이블이 재생성된다."""
+        # 첫 번째 인덱스 생성
+        index1 = BuildIndex(tmp_path)
+        index1.insert_or_replace(
+            run_id="old",
+            status="ok",
+            started_at="2025-01-01T10:00:00Z",
+            finished_at="2025-01-01T10:05:00Z",
+        )
+        index1.close()
+
+        # 스키마 버전을 조작하여 업그레이드 시뮬레이션
+        import sqlite3
+
+        conn = sqlite3.connect(tmp_path / "_builds.sqlite")
+        conn.execute("UPDATE schema_version SET version = 0")
+        conn.commit()
+        conn.close()
+
+        # 새 인덱스 (스키마 재생성)
+        index2 = BuildIndex(tmp_path)
+
+        # 이전 데이터는 삭제되어야 함
+        assert index2.get("old") is None
+
+        # 새 버전 확인
+        cur = index2._conn.execute("SELECT version FROM schema_version")
+        assert cur.fetchone()[0] == SCHEMA_VERSION
+
+
+class TestRebuildIndex:
+    """rebuild_index 함수 테스트."""
+
+    def test_rebuild_from_empty_directory(self, tmp_path: Path) -> None:
+        """빈 디렉터리에서는 빈 인덱스가 생성된다."""
+        count = rebuild_index(tmp_path)
+        assert count == 0
+
+        index = BuildIndex(tmp_path)
+        assert index.list_builds() == []
+
+    def test_rebuild_scans_manifest_files(self, tmp_path: Path) -> None:
+        """파일시스템의 manifest.json을 스캔하여 인덱스를 재구축한다."""
+        # 가짜 manifest 파일들 생성
+        (tmp_path / "run1").mkdir()
+        (tmp_path / "run1" / "manifest.json").write_text(
+            json.dumps({
+                "run_id": "run1",
+                "status": "ok",
+                "started_at": "2025-01-01T10:00:00Z",
+                "finished_at": "2025-01-01T10:05:00Z",
+            })
+        )
+
+        (tmp_path / "run2").mkdir()
+        (tmp_path / "run2" / "manifest.json").write_text(
+            json.dumps({
+                "run_id": "run2",
+                "status": "failed",
+                "errors": ["test error"],
+                "started_at": "2025-01-01T11:00:00Z",
+                "finished_at": "2025-01-01T11:05:00Z",
+            })
+        )
+
+        # manifest 없는 디렉터리
+        (tmp_path / "no-manifest").mkdir()
+
+        count = rebuild_index(tmp_path)
+        assert count == 2
+
+        index = BuildIndex(tmp_path)
+        builds = index.list_builds()
+        assert len(builds) == 2
+
+        # run_id로 정렬 확인 (finished_at DESC)
+        assert builds[0].run_id == "run2"
+        assert builds[1].run_id == "run1"
+
+    def test_rebuild_replaces_existing_index(self, tmp_path: Path) -> None:
+        """rebuild는 기존 인덱스를 삭제하고 다시 생성한다."""
+        # 먼저 인덱스 생성
+        index = BuildIndex(tmp_path)
+        index.insert_or_replace(
+            run_id="old",
+            status="ok",
+            started_at="2025-01-01T09:00:00Z",
+            finished_at="2025-01-01T09:05:00Z",
+        )
+        index.close()
+
+        # manifest 파일 생성
+        (tmp_path / "new").mkdir()
+        (tmp_path / "new" / "manifest.json").write_text(
+            json.dumps({
+                "run_id": "new",
+                "status": "ok",
+                "started_at": "2025-01-01T11:00:00Z",
+                "finished_at": "2025-01-01T11:05:00Z",
+            })
+        )
+
+        count = rebuild_index(tmp_path)
+        assert count == 1
+
+        index = BuildIndex(tmp_path)
+        builds = index.list_builds()
+        assert len(builds) == 1
+        assert builds[0].run_id == "new"
+        assert index.get("old") is None
+
+    def test_rebuild_skips_malformed_manifest(self, tmp_path: Path) -> None:
+        """손상된 manifest는 건너뛴다."""
+        (tmp_path / "good").mkdir()
+        (tmp_path / "good" / "manifest.json").write_text(
+            json.dumps({
+                "status": "ok",
+                "started_at": "2025-01-01T10:00:00Z",
+                "finished_at": "2025-01-01T10:05:00Z",
+            })
+        )
+
+        (tmp_path / "bad").mkdir()
+        (tmp_path / "bad" / "manifest.json").write_text("invalid json")
+
+        count = rebuild_index(tmp_path)
+        assert count == 1
+
+        index = BuildIndex(tmp_path)
+        builds = index.list_builds()
+        assert len(builds) == 1
+        assert builds[0].run_id == "good"

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -126,7 +126,9 @@ class TestPreview:
 
     def test_preview_writes_no_files(self, tmp_path: Path) -> None:
         _service(tmp_path).preview(VALID_SPEC_YAML)
-        assert list(tmp_path.iterdir()) == []
+        # SQLite 인덱스 파일은 제외 (#309, ADR 0003)
+        files = [p.name for p in tmp_path.iterdir() if not p.name.startswith("_builds")]
+        assert files == []
 
 
 class TestPreviewLimitGuard:

--- a/tests/unit/test_service_contract.py
+++ b/tests/unit/test_service_contract.py
@@ -26,6 +26,7 @@ _DISPATCH_ROUTES: dict[tuple[str, str], str] = {
     ("/preview", "POST"): "previewBuild",
     ("/build", "POST"): "createBuild",
     ("/artifacts/{run_id}", "GET"): "listBuildArtifacts",
+    ("/builds", "GET"): "listBuilds",
 }
 
 # (path, method) 형태의 계약 필수 오퍼레이션. BuilderService.dispatch가 실제로
@@ -36,6 +37,7 @@ _REQUIRED_OPERATIONS = [
     ("/preview", "post"),
     ("/build", "post"),
     ("/artifacts/{run_id}", "get"),
+    ("/builds", "get"),
 ]
 
 
@@ -275,6 +277,7 @@ _OPERATION_STATUS_CODES: dict[str, set[int]] = {
     "previewBuild": {200, 400},
     "createBuild": {200, 400, 502},
     "listBuildArtifacts": {200, 400, 404},
+    "listBuilds": {200, 400},
 }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -630,22 +630,22 @@ publish = [
 [package.metadata]
 requires-dist = [
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.2,<2" },
-    { name = "huggingface-hub", marker = "extra == 'huggingface'", specifier = ">=0.23,<1" },
-    { name = "huggingface-hub", marker = "extra == 'publish'", specifier = ">=0.23,<1" },
+    { name = "huggingface-hub", marker = "extra == 'huggingface'", specifier = ">=0.23,<2" },
+    { name = "huggingface-hub", marker = "extra == 'publish'", specifier = ">=0.23,<2" },
     { name = "kaggle", marker = "extra == 'publish'", specifier = ">=1.6,<2" },
     { name = "kpubdata", editable = "../kpubdata" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6,<2" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9,<10" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10,<2" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10,<3" },
     { name = "polars", specifier = ">=1.0,<2" },
-    { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=15,<18" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2,<9" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5,<6" },
+    { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=15,<26" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2,<10" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5,<8" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5,<1" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
-    { name = "typing-extensions", specifier = ">=4.5" },
-    { name = "xmltodict", marker = "extra == 'publish'", specifier = ">=0.13,<1" },
+    { name = "typing-extensions", specifier = ">=4.5,<5" },
+    { name = "xmltodict", marker = "extra == 'publish'", specifier = ">=0.13,<2" },
 ]
 provides-extras = ["docs", "parquet", "huggingface", "publish", "dev"]
 


### PR DESCRIPTION
## 요약
1. SQLite BuildIndex 모듈 (src/kpubdata_builder/store/)
  - WAL 모드, busy_timeout, 트랜잭션으로 동시성 안전 장치
  - 스키마 버전 관리 (SCHEMA_VERSION = 1)
  - 인덱스 쓰기 실패가 빌드 실패의 원인이 되지 않도록 best-effort
2. list_builds 개선
  - 인덱스 우선 조회 → 파일시스템 스캔 폴백
  - 확장성/일관성/동시성 개선
3. 자동 인덱싱
  - 빌드 완료 시 manifest.json에서 메타데이터 추출하여 인덱스 자동 갱신
4. rebuild-index CLI 커맨드
  - kpubdata-builder rebuild-index
  - 파일시스템 스캔으로 인덱스 재구축

## 변경 내용
- src/kpubdata_builder/store/__init__.py (새로 생성)
- src/kpubdata_builder/store/build_index.py (새로 생성)
- src/kpubdata_builder/service/app.py (list_builds, build 수정)
- src/kpubdata_builder/cli.py (rebuild-index 커맨드)
- tests/unit/test_build_index.py (새로 생성)
- tests/unit/test_service.py (인덱스 파일 처리)
- tests/unit/test_service_contract.py (listBuilds 매핑)

## 관련 이슈
Closes #309

## 검증
- [x] `uv run ruff check .` 통과
- [x] `uv run mypy` 통과 (해당 시)
- [x] 테스트 통과 (`uv run pytest`)
- [x] 문서 변경 시 `mkdocs build --strict` 통과
- [x] manifest/골든 테스트 영향 확인 (해당 없음)

## 체크리스트
- [x] 기능 브랜치에서 작업했으며 `main`에 직접 push하지 않았다
- [x] 커밋 메시지를 영어로 작성했다
- [x] `kpubdata` provider 로직을 중복 구현하지 않았다
- [x] 필요한 단위/단계 인지형 테스트를 추가했다
- [x] 사용자 노출 기능 변경 시 문서를 분류해 갱신했다: 제품 계약→PRD, 향후 의도→ROADMAP, 릴리스 변경→CHANGELOG (해당 시)
