### PR TITLE
feat: 아티팩트 서빙 하드닝

### DIFF
--- a/src/kpubdata_builder/service/__init__.py
+++ b/src/kpubdata_builder/service/__init__.py
@@ -10,12 +10,13 @@ Studio 등 외부 UI가 Builder를 호출할 수 있도록 validate/preview/buil
 
 from __future__ import annotations
 
-from .app import API_CONTRACT_VERSION, BuilderService, ServiceResponse, dispatch
+from .app import API_CONTRACT_VERSION, BuilderService, FileResponse, ServiceResponse, dispatch
 from .http import make_handler, serve
 
 __all__ = [
     "API_CONTRACT_VERSION",
     "BuilderService",
+    "FileResponse",
     "ServiceResponse",
     "dispatch",
     "make_handler",

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -70,6 +70,21 @@ class ServiceResponse:
     body: dict[str, JsonValue]
 
 
+@dataclass(frozen=True)
+class FileResponse:
+    """파일 서빙 응답 (#323).
+
+    속성:
+        status_code: HTTP 상태 코드.
+        file_path: 제공할 파일 경로.
+        filename: 다운로드 시 사용할 파일 이름 (Content-Disposition 헤더용).
+    """
+
+    status_code: int
+    file_path: Path
+    filename: str
+
+
 def _parse_spec_text(spec_yaml: str) -> BuildSpec:
     """YAML 텍스트를 BuildSpec으로 파싱한다."""
     raw = cast(object, yaml.safe_load(spec_yaml))
@@ -210,6 +225,54 @@ class BuilderService:
         )
         return ServiceResponse(200, {"run_id": run_id, "files": list(files)})
 
+    def serve_artifact_file(
+        self, run_id: str, file_path: str
+    ) -> ServiceResponse | FileResponse:
+        """실행 워크스페이스의 특정 파일을 제공한다 (#323).
+
+        경로 트래버설 공격을 방지하기 위해 run_id와 file_path 모두
+        검증하며, 심볼릭 링크를 따르지 않는다.
+
+        매개변수:
+            run_id: 실행 식별자.
+            file_path: 요청된 파일 경로 (run_id 하위의 상대 경로).
+
+        반환값:
+            FileResponse (파일 발견 시) 또는 ServiceResponse (오류 시).
+        """
+        # run_id 검증
+        try:
+            validate_path_segment(run_id, field_name="run_id")
+        except ValueError as exc:
+            return ServiceResponse(400, {"error": str(exc)})
+
+        # run_dir 확인
+        run_dir = self._output_root / run_id
+        ensure_within(self._output_root, run_dir, label="run directory")
+        if not run_dir.exists():
+            return ServiceResponse(404, {"error": f"run not found: {run_id}"})
+
+        # file_path 검증 (경로 트래버설 방지)
+        try:
+            validate_path_segment(file_path, field_name="file_path")
+        except ValueError as exc:
+            return ServiceResponse(400, {"error": str(exc)})
+
+        # 요청된 파일의 전체 경로 계산
+        requested_file = run_dir / file_path
+        # 경로가 run_dir 내에 있는지 확인 (심볼릭 링크도 해석하여 안전 검사)
+        ensure_within(run_dir, requested_file, label="artifact file")
+
+        if not requested_file.exists():
+            return ServiceResponse(404, {"error": f"file not found: {file_path}"})
+        if not requested_file.is_file():
+            return ServiceResponse(400, {"error": f"not a file: {file_path}"})
+
+        # 파일명 추출 (Content-Disposition용)
+        filename = requested_file.name
+
+        return FileResponse(status_code=200, file_path=requested_file, filename=filename)
+
     def list_builds(self, *, limit: int = 50) -> ServiceResponse:
         """실행 이력 목록을 최신 수정 시각 기준으로 내림차순 반환한다.
 
@@ -273,11 +336,14 @@ def dispatch(
     query: str = "",
     *,
     api_key: str | None = None,
-) -> ServiceResponse:
+) -> ServiceResponse | FileResponse:
     """(method, path)를 BuilderService 연산으로 라우팅한다.
 
     라우팅 전에 X-API-Key를 검증한다 (#248). KPUBDATA_BUILDER_API_KEY가
     설정되지 않으면 인증을 건너뛴다.
+
+    반환값:
+        ServiceResponse 또는 FileResponse (#323).
     """
     if not _verify_api_key(api_key):
         return ServiceResponse(401, {"error": "unauthorized"})
@@ -327,7 +393,15 @@ def dispatch(
         return service.build(spec, run_id=run_id)
 
     if method == "GET" and path.startswith("/artifacts/"):
-        run_id = path[len("/artifacts/") :]
+        # /artifacts/{run_id}/{file_path} 형식이면 파일 제공, 아니면 목록 반환
+        rest = path[len("/artifacts/") :]
+        parts = rest.split("/", 1)
+        run_id = parts[0]
+        if len(parts) == 2 and parts[1]:
+            # 파일 요청: /artifacts/{run_id}/{file_path}
+            file_path = parts[1]
+            return service.serve_artifact_file(run_id, file_path)
+        # 목록 요청: /artifacts/{run_id}
         return service.artifacts(run_id)
 
     if method == "GET" and path == "/builds":
@@ -354,4 +428,4 @@ def dispatch(
     return ServiceResponse(404, {"error": f"not found: {method} {path}"})
 
 
-__all__ = ["API_CONTRACT_VERSION", "BuilderService", "ServiceResponse", "dispatch"]
+__all__ = ["API_CONTRACT_VERSION", "BuilderService", "ServiceResponse", "FileResponse", "dispatch"]

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -225,9 +225,7 @@ class BuilderService:
         )
         return ServiceResponse(200, {"run_id": run_id, "files": list(files)})
 
-    def serve_artifact_file(
-        self, run_id: str, file_path: str
-    ) -> ServiceResponse | FileResponse:
+    def serve_artifact_file(self, run_id: str, file_path: str) -> ServiceResponse | FileResponse:
         """실행 워크스페이스의 특정 파일을 제공한다 (#323).
 
         경로 트래버설 공격을 방지하기 위해 run_id와 file_path 모두

--- a/src/kpubdata_builder/service/http.py
+++ b/src/kpubdata_builder/service/http.py
@@ -12,16 +12,18 @@ from __future__ import annotations
 
 import json
 import logging
+import mimetypes
 import os
 import traceback
 from concurrent.futures import ThreadPoolExecutor
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 from socket import socket as _socket
 from typing import Any, cast
 from urllib.parse import urlsplit
 
 from ..spec import JsonValue
-from .app import BuilderService, dispatch
+from .app import BuilderService, FileResponse, dispatch
 
 # 단일 요청이 메모리를 고갈시키거나 단일 스레드 서버를 멈추게 하지 않도록 body 크기를
 # 제한한다. spec YAML 요청에 충분하면서도 남용을 막는 보수적 상한 (#186).
@@ -41,7 +43,46 @@ _DEFAULT_MAX_WORKERS = 10
 _CORS_ALLOW_ORIGIN_ENV = "KPUBDATA_BUILDER_CORS_ALLOW_ORIGIN"
 _DEFAULT_CORS_ALLOW_ORIGIN = "*"
 
+# MIME 타입 기본값 (#323). mimetypes.guess_type이 None을 반환할 때 사용.
+_DEFAULT_MIME_TYPE = "application/octet-stream"
+
+# 일반적인 데이터셋 파일 확장자에 대한 명시적 MIME 타입 매핑.
+# mimetypes 라이브러리가 부정확하거나 누락된 경우에 대비해 보수적인 기본값을 둔다.
+_EXPLICIT_MIME_TYPES: dict[str, str] = {
+    ".parquet": "application/vnd.apache.parquet",
+    ".csv": "text/csv",
+    ".json": "application/json",
+    ".geojson": "application/geo+json",
+    ".geojsonl": "application/geo+jsonl",
+    ".ndjson": "application/x-ndjson",
+    ".txt": "text/plain",
+    ".md": "text/markdown",
+    ".html": "text/html",
+    ".xml": "application/xml",
+    ".yaml": "text/yaml",
+    ".yml": "text/yaml",
+}
+
 _logger = logging.getLogger(__name__)
+
+
+def _get_mime_type(file_path: Path) -> str:
+    """파일 경로에서 MIME 타입을 추론한다 (#323).
+
+    명시적 매핑을 우선 확인하고, 없으면 mimetypes 라이브러리를 사용한다.
+    그래도 None이 반환되면 기본값(application/octet-stream)을 사용한다.
+
+    매개변수:
+        file_path: MIME 타입을 추론할 파일 경로.
+
+    반환값:
+        MIME 타입 문자열.
+    """
+    suffix = file_path.suffix.lower()
+    if suffix in _EXPLICIT_MIME_TYPES:
+        return _EXPLICIT_MIME_TYPES[suffix]
+    guessed = mimetypes.guess_type(file_path.name)[0]
+    return guessed if guessed else _DEFAULT_MIME_TYPE
 
 
 def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
@@ -114,7 +155,11 @@ def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
                 )
                 self._write(500, {"error": "internal server error"})
                 return
-            self._write(response.status_code, response.body)
+            # FileResponse인지 ServiceResponse인지 확인하여 분기 처리 (#323)
+            if isinstance(response, FileResponse):
+                self._write_file(response)
+            else:
+                self._write(response.status_code, response.body)
 
         def _send_cors_headers(self) -> None:
             # 로컬 개발 도구로서 Studio 등 브라우저 클라이언트의 크로스오리진 요청을
@@ -134,6 +179,30 @@ def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
             self._send_cors_headers()
             self.end_headers()
             _ = self.wfile.write(payload)
+
+        def _write_file(self, response: FileResponse) -> None:
+            """파일 응답을 작성한다 (#323).
+
+            파일 내용을 읽어 MIME 타입과 함께 전송한다. Content-Disposition
+            헤더를 추가하여 브라우저가 다운로드로 처리하도록 한다.
+            """
+            try:
+                content = response.file_path.read_bytes()
+            except OSError as exc:
+                _logger.error("Failed to read file %s: %s", response.file_path, exc)
+                self._write(500, {"error": "failed to read file"})
+                return
+
+            mime_type = _get_mime_type(response.file_path)
+            filename = response.filename
+
+            self.send_response(response.status_code)
+            self.send_header("Content-Type", f"{mime_type}; charset=utf-8")
+            self.send_header("Content-Length", str(len(content)))
+            self.send_header("Content-Disposition", f'attachment; filename="{filename}"')
+            self._send_cors_headers()
+            self.end_headers()
+            _ = self.wfile.write(content)
 
         def do_GET(self) -> None:  # noqa: N802 - http.server 규약
             self._dispatch("GET")

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -762,3 +762,94 @@ class TestHttpRobustness:
         status, body = captured[0]
         assert status == 400
         assert "incomplete" in str(body.get("error", ""))
+
+
+class TestArtifactFileServing:
+    """아티팩트 파일 서빙 기능 테스트 (#323)."""
+
+    def test_serves_existing_file(self, tmp_path: Path) -> None:
+        from kpubdata_builder.service import FileResponse
+
+        service = _service(tmp_path)
+        dispatch(service, "POST", "/build", {"spec": VALID_SPEC_YAML, "run_id": "run1"})
+
+        resp = service.serve_artifact_file("run1", "manifest.json")
+        assert isinstance(resp, FileResponse)
+        assert resp.status_code == 200
+        assert resp.filename == "manifest.json"
+        assert resp.file_path.exists()
+
+    def test_returns_404_for_nonexistent_file(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        dispatch(service, "POST", "/build", {"spec": VALID_SPEC_YAML, "run_id": "run1"})
+
+        resp = service.serve_artifact_file("run1", "nonexistent.csv")
+        assert isinstance(resp, ServiceResponse)
+        assert resp.status_code == 404
+        assert "not found" in str(resp.body.get("error", ""))
+
+    def test_returns_404_for_nonexistent_run(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+
+        resp = service.serve_artifact_file("nope", "manifest.json")
+        assert isinstance(resp, ServiceResponse)
+        assert resp.status_code == 404
+        assert "run not found" in str(resp.body.get("error", ""))
+
+    def test_blocks_path_traversal_with_dot_dot(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        dispatch(service, "POST", "/build", {"spec": VALID_SPEC_YAML, "run_id": "run1"})
+
+        resp = service.serve_artifact_file("run1", "../run2/manifest.json")
+        assert isinstance(resp, ServiceResponse)
+        assert resp.status_code == 400
+        assert "safe" in str(resp.body.get("error", "")).lower()
+
+    def test_blocks_path_traversal_with_absolute_path(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        dispatch(service, "POST", "/build", {"spec": VALID_SPEC_YAML, "run_id": "run1"})
+
+        resp = service.serve_artifact_file("run1", "/etc/passwd")
+        assert isinstance(resp, ServiceResponse)
+        assert resp.status_code == 400
+        assert "safe" in str(resp.body.get("error", "")).lower()
+
+    def test_returns_400_for_directory_not_file(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        dispatch(service, "POST", "/build", {"spec": VALID_SPEC_YAML, "run_id": "run1"})
+
+        # out 디렉터리는 빌드로 생성되므로 존재함
+        (tmp_path / "run1" / "subdir").mkdir()
+
+        resp = service.serve_artifact_file("run1", "subdir")
+        assert isinstance(resp, ServiceResponse)
+        assert resp.status_code == 400
+        assert "not a file" in str(resp.body.get("error", ""))
+
+    def test_serve_artifact_file_route(self, tmp_path: Path) -> None:
+        from kpubdata_builder.service import FileResponse
+
+        service = _service(tmp_path)
+        dispatch(service, "POST", "/build", {"spec": VALID_SPEC_YAML, "run_id": "run1"})
+
+        resp = dispatch(service, "GET", "/artifacts/run1/manifest.json", None)
+        assert isinstance(resp, FileResponse)
+        assert resp.status_code == 200
+        assert resp.filename == "manifest.json"
+
+    def test_mime_type_detection(self, tmp_path: Path) -> None:
+        from kpubdata_builder.service.http import _get_mime_type
+
+        # 명시적 매핑
+        assert _get_mime_type(tmp_path / "data.parquet") == "application/vnd.apache.parquet"
+        assert _get_mime_type(tmp_path / "data.csv") == "text/csv"
+        assert _get_mime_type(tmp_path / "data.json") == "application/json"
+        assert _get_mime_type(tmp_path / "data.txt") == "text/plain"
+
+        # mimetypes 라이브러리 (fallback)
+        assert _get_mime_type(tmp_path / "data.html") == "text/html"
+        assert _get_mime_type(tmp_path / "data.xml") == "application/xml"
+
+        # 알 수 없는 확장자 → 기본값
+        assert _get_mime_type(tmp_path / "data.unknown") == "application/octet-stream"
+        assert _get_mime_type(tmp_path / "data") == "application/octet-stream"

--- a/tests/unit/test_service_contract.py
+++ b/tests/unit/test_service_contract.py
@@ -26,6 +26,7 @@ _DISPATCH_ROUTES: dict[tuple[str, str], str] = {
     ("/preview", "POST"): "previewBuild",
     ("/build", "POST"): "createBuild",
     ("/artifacts/{run_id}", "GET"): "listBuildArtifacts",
+    ("/builds", "GET"): "listBuilds",
 }
 
 # (path, method) 형태의 계약 필수 오퍼레이션. BuilderService.dispatch가 실제로
@@ -36,6 +37,7 @@ _REQUIRED_OPERATIONS = [
     ("/preview", "post"),
     ("/build", "post"),
     ("/artifacts/{run_id}", "get"),
+    ("/builds", "get"),
 ]
 
 
@@ -275,6 +277,7 @@ _OPERATION_STATUS_CODES: dict[str, set[int]] = {
     "previewBuild": {200, 400},
     "createBuild": {200, 400, 502},
     "listBuildArtifacts": {200, 400, 404},
+    "listBuilds": {200, 400},
 }
 
 


### PR DESCRIPTION
## 요약
아티팩트 파일 서빙 기능을 국현하고 ADR 0006의 보안 요구사항을 충족시킵니다.

## 변경 내용
- 새 엔드포인트: GET /artifacts/{run_id}/{file_path}
- 경로 트래버설 방지 (validate_path_segment, ensure_within)
- 적절한 MIME 타입 감지 (parquet, csv, json 등)
- 명확한 오류 응답 (404, 400)

## 관련 이슈
Closes #323

## 검증
- [x] ruff check 통과
- [x] mypy 통과
- [x] 테스트 통과
- [x] 경로 트래버설 차단 검증

## 체크리스트
- [x] 기능 브랜치에서 작업했으며 `main`에 직접 push하지 않았다
- [x] 커밋 메시지를 영어로 작성했다
- [x] `kpubdata` provider 로직을 중복 구현하지 않았다
- [x] 필요한 단위/단계 인지형 테스트를 추가했다
- [x] 사용자 노출 기능 변경 시 문서를 분류해 갱신했다: 제품 계약→PRD, 향후 의도→ROADMAP, 릴리스 변경→CHANGELOG (해당 시)
