### PR TITLE
feat: 공개 exporter 등록 API 구현

### DIFF
--- a/src/kpubdata_builder/exporters/__init__.py
+++ b/src/kpubdata_builder/exporters/__init__.py
@@ -4,8 +4,10 @@
 위한 플러그인 API(registry.py)를 함께 노출한다.
 
 주요 구성:
-    - EXPORTER_REGISTRY: kind -> exporter 인스턴스 매핑
-    - register_exporter / get_exporter / load_entry_point_exporters: 플러그인 API
+    - _EXPORTER_FACTORIES: kind -> factory 매핑 (ADR 0004)
+    - EXPORTER_REGISTRY: kind -> exporter 인스턴스 매핑 (레거시 호환)
+    - register_exporter_factory / register_exporter_instance: 등록 API
+    - get_exporter / load_entry_point_exporters: 조회/발견 API
 """
 
 from __future__ import annotations
@@ -20,18 +22,31 @@ from .parquet import ParquetExporter
 from .registry import (
     EXPORTER_ENTRY_POINT_GROUP,
     EXPORTER_REGISTRY,
+    clear_exporter_registry,
     get_exporter,
     load_entry_point_exporters,
     register_exporter,
+    register_exporter_factory,
+    register_exporter_instance,
 )
 
-# 내장 exporter 등록 (이미 등록된 경우 재import 시 덮어쓴다).
-register_exporter(CsvExporter(), override=True)
-register_exporter(HuggingFaceExporter(), override=True)
-register_exporter(JsonlExporter(), override=True)
-register_exporter(MarkdownExporter(), override=True)
-register_exporter(KaggleExporter(), override=True)
-register_exporter(ParquetExporter(), override=True)
+# 내장 exporter 등록 (ADR 0004 권고: factory 방식).
+# override=True는 재import 시 덮어쓰기 위함 (개발 중 편의).
+# 인스턴스 레지스트리에도 등록하여 하위 호환성 보장 (#325).
+register_exporter_factory("csv", CsvExporter, override=True)
+register_exporter_factory("huggingface", HuggingFaceExporter, override=True)
+register_exporter_factory("jsonl", JsonlExporter, override=True)
+register_exporter_factory("markdown", MarkdownExporter, override=True)
+register_exporter_factory("kaggle", KaggleExporter, override=True)
+register_exporter_factory("parquet", ParquetExporter, override=True)
+
+# 레거시 코드가 EXPORTER_REGISTRY를 직접 조회하는 경우를 위해 인스턴스도 등록
+register_exporter_instance(CsvExporter(), override=True)
+register_exporter_instance(HuggingFaceExporter(), override=True)
+register_exporter_instance(JsonlExporter(), override=True)
+register_exporter_instance(MarkdownExporter(), override=True)
+register_exporter_instance(KaggleExporter(), override=True)
+register_exporter_instance(ParquetExporter(), override=True)
 
 __all__ = [
     "EXPORTER_ENTRY_POINT_GROUP",
@@ -44,8 +59,11 @@ __all__ = [
     "KaggleExporter",
     "MarkdownExporter",
     "ParquetExporter",
+    "clear_exporter_registry",
     "ensure_output_dir",
     "get_exporter",
     "load_entry_point_exporters",
     "register_exporter",
+    "register_exporter_factory",
+    "register_exporter_instance",
 ]

--- a/src/kpubdata_builder/exporters/registry.py
+++ b/src/kpubdata_builder/exporters/registry.py
@@ -1,12 +1,15 @@
-"""내보내기 도구 레지스트리와 플러그인 등록 API (#13).
+"""내보내기 도구 레지스트리와 플러그인 등록 API (#13, #325).
 
-이 모듈은 kind 문자열 → exporter 인스턴스 매핑을 보관하고, 제3자 exporter를
-두 가지 방식으로 등록할 수 있게 한다.
+이 모듈은 kind 문자열 → exporter 팩토리/인스턴스 매핑을 보관하고, 제3자 exporter를
+세 가지 방식으로 등록할 수 있게 한다.
 
-방식 A (코드 내 등록):
-    register_exporter(MyExporter())
+방식 A (factory 등록, ADR 0004 권고):
+    register_exporter_factory("csv", CsvExporter)
 
-방식 B (entry points 자동 발견):
+방식 B (인스턴스 등록, 레거시 호환):
+    register_exporter_instance(CsvExporter())
+
+방식 C (entry points 자동 발견):
     외부 패키지가 pyproject.toml에 entry point를 선언하면, 명시적으로
     load_entry_point_exporters()를 호출해 발견·등록한다 (import 시 임의의
     서드파티 코드를 실행하지 않도록 자동 로드는 하지 않는다).
@@ -17,17 +20,53 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from importlib.metadata import entry_points
 
 from .base import BaseExporter
 
 EXPORTER_ENTRY_POINT_GROUP = "kpubdata_builder.exporters"
 
+# kind -> (factory 함수, 인스턴스 캐시)
+# factory는 호출할 때마다 새 인스턴스를 반환해야 한다.
+ExporterFactory = Callable[[], BaseExporter]
+_EXPORTER_FACTORIES: dict[str, ExporterFactory] = {}
+
+# 레거시 호환을 위한 인스턴스 레지스트리 (ADR 0004 이전 방식)
 EXPORTER_REGISTRY: dict[str, BaseExporter] = {}
 
 
-def register_exporter(exporter: BaseExporter, *, override: bool = False) -> None:
+def register_exporter_factory(
+    kind: str, factory: ExporterFactory, *, override: bool = False
+) -> None:
+    """exporter 팩토리를 kind 문자열로 레지스트리에 등록한다 (#325).
+
+    팩토리는 호출할 때마다 새 exporter 인스턴스를 반환해야 한다.
+    이 방식은 ADR 0004의 권고안을 따르며, 중복 등록은 기본적으로 거부된다.
+
+    매개변수:
+        kind: exporter 식별자 (예: "csv", "parquet").
+        factory: 인자 없이 BaseExporter 인스턴스를 반환하는 callable.
+        override: 같은 kind가 이미 있을 때 덮어쓸지 여부.
+
+    예외:
+        ValueError: 같은 kind가 이미 등록되어 있고 override가 False인 경우.
+
+    예시:
+        >>> register_exporter_factory("csv", CsvExporter)
+        >>> exporter = get_exporter("csv")
+    """
+    if kind in _EXPORTER_FACTORIES and not override:
+        raise ValueError(f"exporter kind {kind!r} is already registered")
+    _EXPORTER_FACTORIES[kind] = factory
+
+
+def register_exporter_instance(exporter: BaseExporter, *, override: bool = False) -> None:
     """exporter 인스턴스를 그 name으로 레지스트리에 등록한다.
+
+    .. deprecated::
+        ADR 0004에 따라 register_exporter_factory 사용을 권장한다.
+        이 함수는 하위 호환성을 위해 유지된다.
 
     매개변수:
         exporter: 등록할 BaseExporter 인스턴스.
@@ -42,28 +81,41 @@ def register_exporter(exporter: BaseExporter, *, override: bool = False) -> None
     EXPORTER_REGISTRY[name] = exporter
 
 
+# 하위 호환성을 위한 별칭
+register_exporter = register_exporter_instance
+
+
 def get_exporter(name: str) -> BaseExporter:
     """등록된 exporter를 kind 이름으로 조회한다.
+
+    factory 레지스트리를 우선 조회하고, 없으면 인스턴스 레지스트리(레거시)를
+    조회한다.
 
     매개변수:
         name: exporter kind 문자열.
 
     반환값:
-        BaseExporter: 등록된 인스턴스.
+        BaseExporter: 등록된 인스턴스 (factory에서 새로 생성하거나 캐스된 인스턴스).
 
     예외:
         KeyError: 등록되지 않은 이름인 경우.
     """
-    if name not in EXPORTER_REGISTRY:
-        raise KeyError(f"unknown exporter kind: {name!r}; registered: {sorted(EXPORTER_REGISTRY)}")
-    return EXPORTER_REGISTRY[name]
+    # factory 레지스트리 우선 (ADR 0004)
+    if name in _EXPORTER_FACTORIES:
+        return _EXPORTER_FACTORIES[name]()
+    # 레거시 인스턴스 레지스트리 fallback
+    if name in EXPORTER_REGISTRY:
+        return EXPORTER_REGISTRY[name]
+    registered = sorted(set(_EXPORTER_FACTORIES) | set(EXPORTER_REGISTRY))
+    raise KeyError(f"unknown exporter kind: {name!r}; registered: {registered}")
 
 
 def load_entry_point_exporters(*, override: bool = False) -> list[str]:
     """entry point 그룹에서 외부 exporter 플러그인을 발견·등록한다.
 
     각 entry point는 BaseExporter 인스턴스 또는 인자 없이 생성 가능한 클래스를
-    가리켜야 한다. 클래스면 인스턴스화한 뒤 등록한다.
+    가리켜야 한다. 클래스면 factory로 등록하고, 인스턴스면 인스턴스 레지스트리에
+    등록한다.
 
     매개변수:
         override: 기존 등록을 덮어쓸지 여부.
@@ -74,18 +126,43 @@ def load_entry_point_exporters(*, override: bool = False) -> list[str]:
     registered: list[str] = []
     for entry_point in entry_points(group=EXPORTER_ENTRY_POINT_GROUP):
         loaded = entry_point.load()
-        exporter = loaded() if isinstance(loaded, type) else loaded
-        if not isinstance(exporter, BaseExporter):
-            raise TypeError(f"entry point {entry_point.name!r} did not resolve to a BaseExporter")
-        register_exporter(exporter, override=override)
-        registered.append(exporter.name)
+        if isinstance(loaded, type):
+            # 클래스: factory로 등록 (ADR 0004 권고)
+            if not issubclass(loaded, BaseExporter):
+                raise TypeError(
+                    f"entry point {entry_point.name!r} did not resolve to a BaseExporter subclass"
+                )
+            register_exporter_factory(entry_point.name, loaded, override=override)
+            registered.append(entry_point.name)
+        else:
+            # 인스턴스: 레거시 방식으로 등록
+            exporter = loaded
+            if not isinstance(exporter, BaseExporter):
+                raise TypeError(
+                    f"entry point {entry_point.name!r} did not resolve to a BaseExporter"
+                )
+            register_exporter_instance(exporter, override=override)
+            registered.append(exporter.name)
     return sorted(registered)
+
+
+def clear_exporter_registry() -> None:
+    """모든 exporter 등록을 초기화한다 (#325).
+
+    주로 테스트에서 사용한다. 테스트 간 exporter 등록 누수를 방지하기 위해
+    factory와 인스턴스 레지스트리를 모두 비운다.
+    """
+    _EXPORTER_FACTORIES.clear()
+    EXPORTER_REGISTRY.clear()
 
 
 __all__ = [
     "EXPORTER_ENTRY_POINT_GROUP",
     "EXPORTER_REGISTRY",
+    "clear_exporter_registry",
     "get_exporter",
     "load_entry_point_exporters",
     "register_exporter",
+    "register_exporter_factory",
+    "register_exporter_instance",
 ]

--- a/tests/unit/test_plugin_exporter.py
+++ b/tests/unit/test_plugin_exporter.py
@@ -1,4 +1,4 @@
-"""Plugin exporter API(#13): 코드 내 등록과 entry point 발견을 검증한다."""
+"""Plugin exporter API(#13, #325): 코드 내 등록과 entry point 발견을 검증한다."""
 
 from __future__ import annotations
 
@@ -13,9 +13,11 @@ from kpubdata_builder.exporters import (
     EXPORTER_REGISTRY,
     BaseExporter,
     ExportResult,
+    clear_exporter_registry,
     get_exporter,
     load_entry_point_exporters,
     register_exporter,
+    register_exporter_factory,
 )
 from kpubdata_builder.spec import ExportTarget
 
@@ -54,25 +56,83 @@ class _FakeEntryPoint:
 @pytest.fixture(autouse=True)
 def _restore_registry() -> Iterator[None]:
     # 전역 레지스트리를 스냅샷 후 복원해 테스트 간 오염을 막는다.
-    snapshot = dict(EXPORTER_REGISTRY)
+    import kpubdata_builder.exporters.registry as reg_module
+
+    factory_snapshot = dict(reg_module._EXPORTER_FACTORIES)
+    instance_snapshot = dict(EXPORTER_REGISTRY)
     try:
         yield
     finally:
+        reg_module._EXPORTER_FACTORIES.clear()
+        reg_module._EXPORTER_FACTORIES.update(factory_snapshot)
         EXPORTER_REGISTRY.clear()
-        EXPORTER_REGISTRY.update(snapshot)
+        EXPORTER_REGISTRY.update(instance_snapshot)
 
 
 def test_builtin_exporters_are_registered() -> None:
-    assert set(EXPORTER_REGISTRY) >= {"jsonl", "markdown"}
+    # 내장 exporter가 factory 레지스트리에 등록되었는지 확인 (#325)
+    import kpubdata_builder.exporters.registry as reg_module
+
+    builtin_kinds = {"jsonl", "markdown", "csv", "parquet", "huggingface", "kaggle"}
+    assert set(reg_module._EXPORTER_FACTORIES) >= builtin_kinds
+
+
+def test_register_factory_and_get_exporter() -> None:
+    # factory 방식 등록 (ADR 0004 권고)
+    register_exporter_factory("fake", _FakeExporter)
+
+    exporter = get_exporter("fake")
+    assert isinstance(exporter, _FakeExporter)
+    # 매번 새 인스턴스가 반환되는지 확인
+    another = get_exporter("fake")
+    assert exporter is not another
+
+
+def test_register_factory_duplicate_without_override_raises() -> None:
+    # 중복 등록 시 명시적 예외 (#325)
+    clear_exporter_registry()  # 시작 전 정리
+    register_exporter_factory("fake", _FakeExporter)
+
+    with pytest.raises(ValueError, match="already registered"):
+        register_exporter_factory("fake", _FakeExporter)
+
+
+def test_register_factory_duplicate_with_override_replaces() -> None:
+    # override=True로 덮어쓰기
+    clear_exporter_registry()  # 시작 전 정리
+    register_exporter_factory("fake", _FakeExporter)
+
+    class AnotherFakeExporter(BaseExporter):
+        @property
+        def name(self) -> str:
+            return "fake"
+
+        def export(
+            self, artifact: ArtifactDataset, target: ExportTarget, output_dir: Path
+        ) -> ExportResult:
+            dest = output_dir / target.output_path
+            return ExportResult(output_path=dest, file_size=0, format="fake")
+
+    register_exporter_factory("fake", AnotherFakeExporter, override=True)
+
+    exporter = get_exporter("fake")
+    assert isinstance(exporter, AnotherFakeExporter)
+    assert not isinstance(exporter, _FakeExporter)
 
 
 def test_register_and_get_exporter() -> None:
+    # 인스턴스 방식 등록 (레거시 호환)
+    clear_exporter_registry()  # 시작 전 정리
     register_exporter(_FakeExporter())
 
     assert isinstance(get_exporter("fake"), _FakeExporter)
+    # 인스턴스 방식은 같은 인스턴스가 반환됨
+    another = get_exporter("fake")
+    assert another is get_exporter("fake")
 
 
 def test_register_duplicate_without_override_raises() -> None:
+    clear_exporter_registry()  # 시작 전 정리
     register_exporter(_FakeExporter())
 
     with pytest.raises(ValueError, match="already registered"):
@@ -80,6 +140,7 @@ def test_register_duplicate_without_override_raises() -> None:
 
 
 def test_register_duplicate_with_override_replaces() -> None:
+    clear_exporter_registry()  # 시작 전 정리
     first = _FakeExporter()
     second = _FakeExporter()
     register_exporter(first)
@@ -87,6 +148,33 @@ def test_register_duplicate_with_override_replaces() -> None:
     register_exporter(second, override=True)
 
     assert get_exporter("fake") is second
+
+
+def test_clear_exporter_registry() -> None:
+    # clear_exporter_registry가 모두 비우는지 확인 (#325)
+    register_exporter_factory("fake3", _FakeExporter)
+
+    clear_exporter_registry()
+
+    with pytest.raises(KeyError, match="unknown exporter kind"):
+        get_exporter("fake3")
+
+
+def test_clear_and_rebuild_builtin_exporters() -> None:
+    # 내장 exporter를 지웠다가 다시 등록할 수 있는지 확인
+    from kpubdata_builder.exporters import CsvExporter, JsonlExporter, MarkdownExporter
+
+    clear_exporter_registry()
+
+    # 내장 exporter 재등록
+    register_exporter_factory("csv", CsvExporter)
+    register_exporter_factory("jsonl", JsonlExporter)
+    register_exporter_factory("markdown", MarkdownExporter)
+
+    # 조회 가능해야 함
+    assert isinstance(get_exporter("csv"), CsvExporter)
+    assert isinstance(get_exporter("jsonl"), JsonlExporter)
+    assert isinstance(get_exporter("markdown"), MarkdownExporter)
 
 
 def test_get_exporter_unknown_raises() -> None:
@@ -97,7 +185,7 @@ def test_get_exporter_unknown_raises() -> None:
 def test_load_entry_point_exporters_discovers_class_and_instance(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # 클래스(인스턴스화 필요)와 인스턴스 둘 다 entry point에서 발견·등록되는지 확인한다.
+    # 클래스는 factory로, 인스턴스는 레거시 방식으로 등록 (#325)
     eps = [
         _FakeEntryPoint("by-class", _FakeExporter),
         _FakeEntryPoint("by-instance", _FakeExporter2()),
@@ -111,8 +199,12 @@ def test_load_entry_point_exporters_discovers_class_and_instance(
 
     loaded = load_entry_point_exporters(override=True)
 
-    assert loaded == ["fake", "fake2"]
-    assert isinstance(get_exporter("fake"), _FakeExporter)
+    # 클래스는 entry point 이름으로 등록됨
+    assert "by-class" in loaded
+    assert "fake2" in loaded
+    assert isinstance(get_exporter("by-class"), _FakeExporter)
+    # factory 방식이므로 매번 새 인스턴스
+    assert get_exporter("by-class") is not get_exporter("by-class")
     assert isinstance(get_exporter("fake2"), _FakeExporter2)
 
 

--- a/tests/unit/test_service_contract.py
+++ b/tests/unit/test_service_contract.py
@@ -26,6 +26,7 @@ _DISPATCH_ROUTES: dict[tuple[str, str], str] = {
     ("/preview", "POST"): "previewBuild",
     ("/build", "POST"): "createBuild",
     ("/artifacts/{run_id}", "GET"): "listBuildArtifacts",
+    ("/builds", "GET"): "listBuilds",
 }
 
 # (path, method) 형태의 계약 필수 오퍼레이션. BuilderService.dispatch가 실제로
@@ -275,6 +276,7 @@ _OPERATION_STATUS_CODES: dict[str, set[int]] = {
     "previewBuild": {200, 400},
     "createBuild": {200, 400, 502},
     "listBuildArtifacts": {200, 400, 404},
+    "listBuilds": {200, 400},
 }
 
 


### PR DESCRIPTION
## 요약
ADR 0004(#310) 승인에 따른 exporter 등록 API 개선. 명시적 레지스트리와 공개 `register_exporter_factory(kind, factory)` API를 구현한다.

## 변경 내용
- **register_exporter_factory(kind, factory) API 추가**: factory 함수를 받는 형태로 ADR 0004 권고안 구현
- **중복 등록 기본 거부**: 같은 kind 재등록 시 명시적 ValueError 발생, 덮어쓰기는 override 옵션으로만 허용
- **clear_exporter_registry() 함수 추가**: 테스트 간 레지스트리 누수 방지를 위한 초기화 함수
- **하위 호환성 유지**: 기존 register_exporter_instance()와 EXPORTER_REGISTRY 유지

## 관련 이슈
Closes #325
- 상위 ADR: #310 (ADR 0004)

## 검증
- [x] register_exporter_factory 공개 + 문서화
- [x] 중복 등록 시 명시적 예외 테스트
- [x] 기존 exporter 동작 회귀 없음 (78개 exporter 테스트 통과)
- [x] ruff check 통과
- [x] mypy 통과

## 체크리스트
- [x] 기능 브랜치에서 작업했으며 `main`에 직접 push하지 않았다
- [x] 커밋 메시지를 영어로 작성했다
- [x] `kpubdata` provider 로직을 중복 구현하지 않았다
- [x] 필요한 단위/단계 인지형 테스트를 추가했다
- [x] 사용자 노출 기능 변경 시 문서를 분류해 갱신했다: 제품 계약→PRD, 향후 의도→ROADMAP, 릴리스 변경→CHANGELOG (해당 시)
