### PR TITLE
feat:SQLite 빌드 인덱스 스키마와 초기화 구현

### DIFF
--- a/src/kpubdata_builder/index/__init__.py
+++ b/src/kpubdata_builder/index/__init__.py
@@ -1,0 +1,15 @@
+"""SQLite 빌드 인덱스 모듈 (#328).
+
+ADR 0003에 따라 완료된 빌드의 파생 인덱스를 제공한다.
+manifest.json이 정본이며, 이 SQLite 인덱스는 목록/조회 성능 최적화를 위한 캐시이다.
+
+주요 구성:
+    BuildIndex: SQLite 연결 및 쿼리 래퍼
+    initialize_schema: 스키마 생성/마이그레이션
+"""
+
+from __future__ import annotations
+
+from .index import _SCHEMA_VERSION, BuildIndex, initialize_schema
+
+__all__ = ["BuildIndex", "_SCHEMA_VERSION", "initialize_schema"]

--- a/src/kpubdata_builder/index/index.py
+++ b/src/kpubdata_builder/index/index.py
@@ -1,0 +1,231 @@
+"""SQLite 빌드 인덱스 구현 (#328).
+
+ADR 0003에 따른 완료된 빌드 파생 인덱스. manifest.json이 정본이며,
+이 SQLite 인덱스는 목록/조회 성능 최적화를 위한 캐시 역할을 한다.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Literal
+
+# 현재 스키마 버전 (마이그레이션 대비)
+_SCHEMA_VERSION = 1
+
+# 빌드 상태 타입
+BuildStatus = Literal["completed", "failed", "cancelled"]
+
+
+def initialize_schema(db_path: Path) -> None:
+    """SQLite 데이터베이스 스키마를 초기화한다 (#328).
+
+    매개변수:
+        db_path: 데이터베이스 파일 경로.
+
+    스키마:
+        - builds 테이블 (run_id, status, started_at, finished_at, spec_digest,
+          error, schema_version)
+        - 인덱스 (finished_at, status)
+        - WAL 모드 활성화
+        - busy_timeout 설정 (5초)
+    """
+    # 데이터베이스 파일이 없으면 부모 디렉터리 생성
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with _get_connection(db_path) as conn:
+        cursor = conn.cursor()
+
+        # builds 테이블 생성
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS builds (
+                run_id TEXT PRIMARY KEY,
+                status TEXT NOT NULL,
+                started_at TEXT NOT NULL,
+                finished_at TEXT NOT NULL,
+                spec_digest TEXT,
+                error TEXT,
+                schema_version INTEGER NOT NULL DEFAULT 1
+            )
+            """
+        )
+
+        # 인덱스 생성 (목록 조회 최적화)
+        cursor.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_builds_finished_at
+            ON builds(finished_at DESC)
+            """
+        )
+        cursor.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_builds_status
+            ON builds(status)
+            """
+        )
+
+        # WAL 모드 활성화 (Write-Ahead Logging)
+        # - 동시 읽기/쓰기 허용
+        # - 크래시 발생 시 복구 가능
+        cursor.execute("PRAGMA journal_mode=WAL")
+
+        # busy_timeout 설정 (5초)
+        # - 데이터베이스가 잠겨 있을 때 대기 시간
+        cursor.execute("PRAGMA busy_timeout=5000")
+
+        conn.commit()
+
+
+@contextmanager
+def _get_connection(db_path: Path) -> Iterator[sqlite3.Connection]:
+    """SQLite 연결 컨텍스트 매니저."""
+    conn = sqlite3.connect(db_path, timeout=5.0)
+    conn.execute("PRAGMA foreign_keys=ON")
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+class BuildIndex:
+    """SQLite 빌드 인덱스 래퍼 (#328).
+
+    빌드 생성/상태전이 시 인덱스를 갱신하며,
+    list_builds 쿼리를 제공한다.
+    """
+
+    def __init__(self, db_path: Path) -> None:
+        """빌드 인덱스를 초기화한다.
+
+        매개변수:
+            db_path: 데이터베이스 파일 경로.
+        """
+        self._db_path = db_path
+        # 데이터베이스가 없으면 스키마 초기화
+        if not db_path.exists():
+            initialize_schema(db_path)
+
+    def record_build(
+        self,
+        *,
+        run_id: str,
+        status: BuildStatus,
+        started_at: str,
+        finished_at: str,
+        spec_digest: str | None = None,
+        error: str | None = None,
+    ) -> None:
+        """빌드를 인덱스에 기록한다.
+
+        매개변수:
+            run_id: 실행 식별자.
+            status: 빌드 상태 (completed/failed/cancelled).
+            started_at: 시작 시간 (ISO 8601 문자열).
+            finished_at: 종료 시간 (ISO 8601 문자열).
+            spec_digest: 스펙 해시 (변경 감지용, 선택).
+            error: 실패 시 오류 메시지 (선택).
+
+        예외:
+            sqlite3.Error: 데이터베이스 오류 발생 시.
+        """
+        with _get_connection(self._db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                INSERT OR REPLACE INTO builds
+                (run_id, status, started_at, finished_at, spec_digest, error, schema_version)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (run_id, status, started_at, finished_at, spec_digest, error, _SCHEMA_VERSION),
+            )
+            conn.commit()
+
+    def list_builds(
+        self,
+        *,
+        limit: int = 50,
+        status: BuildStatus | None = None,
+    ) -> list[dict[str, object]]:
+        """빌드 목록을 조회한다.
+
+        매개변수:
+            limit: 최대 반환 개수 (기본값 50).
+            status: 필터링할 상태 (선택).
+
+        반환값:
+            빌드 정보 목록 (최신순).
+        """
+        with _get_connection(self._db_path) as conn:
+            cursor = conn.cursor()
+
+            if status:
+                cursor.execute(
+                    """
+                    SELECT run_id, status, started_at, finished_at, spec_digest, error
+                    FROM builds
+                    WHERE status = ?
+                    ORDER BY finished_at DESC
+                    LIMIT ?
+                    """,
+                    (status, limit),
+                )
+            else:
+                cursor.execute(
+                    """
+                    SELECT run_id, status, started_at, finished_at, spec_digest, error
+                    FROM builds
+                    ORDER BY finished_at DESC
+                    LIMIT ?
+                    """,
+                    (limit,),
+                )
+
+            rows = cursor.fetchall()
+            return [
+                {
+                    "run_id": row[0],
+                    "status": row[1],
+                    "started_at": row[2],
+                    "finished_at": row[3],
+                    "spec_digest": row[4],
+                    "error": row[5],
+                }
+                for row in rows
+            ]
+
+    def get_build(self, run_id: str) -> dict[str, object] | None:
+        """특정 빌드를 조회한다.
+
+        매개변수:
+            run_id: 실행 식별자.
+
+        반환값:
+            빌드 정보 딕셔너리 또는 None (없는 경우).
+        """
+        with _get_connection(self._db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT run_id, status, started_at, finished_at, spec_digest, error
+                FROM builds
+                WHERE run_id = ?
+                """,
+                (run_id,),
+            )
+            row = cursor.fetchone()
+            if row is None:
+                return None
+            return {
+                "run_id": row[0],
+                "status": row[1],
+                "started_at": row[2],
+                "finished_at": row[3],
+                "spec_digest": row[4],
+                "error": row[5],
+            }
+
+
+__all__ = ["BuildIndex", "initialize_schema", "_SCHEMA_VERSION"]

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -1,0 +1,199 @@
+"""SQLite 빌드 인덱스 테스트 (#328)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kpubdata_builder.index import _SCHEMA_VERSION, BuildIndex, initialize_schema
+
+
+class TestBuildIndexSchema:
+    """스키마 생성 및 초기화 테스트."""
+
+    def test_initialize_schema_creates_database(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "_builds.sqlite"
+
+        initialize_schema(db_path)
+
+        assert db_path.exists()
+
+    def test_initialize_schema_creates_builds_table(self, tmp_path: Path) -> None:
+        import sqlite3
+
+        db_path = tmp_path / "_builds.sqlite"
+        initialize_schema(db_path)
+
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='builds'")
+            tables = cursor.fetchall()
+
+        assert len(tables) == 1
+        assert tables[0][0] == "builds"
+
+    def test_builds_table_has_all_columns(self, tmp_path: Path) -> None:
+        import sqlite3
+
+        db_path = tmp_path / "_builds.sqlite"
+        initialize_schema(db_path)
+
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute("PRAGMA table_info(builds)")
+            columns = {row[1] for row in cursor.fetchall()}
+
+        expected_columns = {
+            "run_id",
+            "status",
+            "started_at",
+            "finished_at",
+            "spec_digest",
+            "error",
+            "schema_version",
+        }
+        assert columns == expected_columns
+
+    def test_schema_version_is_set(self, tmp_path: Path) -> None:
+        assert _SCHEMA_VERSION == 1
+
+    def test_initialize_schema_applies_pragma_settings(self, tmp_path: Path) -> None:
+        import sqlite3
+
+        db_path = tmp_path / "_builds.sqlite"
+        initialize_schema(db_path)
+
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute("PRAGMA journal_mode")
+            journal_mode = cursor.fetchone()[0]
+            assert journal_mode == "wal"
+
+            cursor.execute("PRAGMA busy_timeout")
+            busy_timeout = cursor.fetchone()[0]
+            assert busy_timeout == 5000
+
+
+class TestBuildIndex:
+    """BuildIndex CRUD 테스트."""
+
+    def test_record_build_inserts_row(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "_builds.sqlite"
+        index = BuildIndex(db_path)
+
+        index.record_build(
+            run_id="test-run-1",
+            status="completed",
+            started_at="2025-01-01T00:00:00Z",
+            finished_at="2025-01-01T00:01:00Z",
+            spec_digest="abc123",
+        )
+
+        build = index.get_build("test-run-1")
+        assert build is not None
+        assert build["run_id"] == "test-run-1"
+        assert build["status"] == "completed"
+
+    def test_record_build_replaces_existing(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "_builds.sqlite"
+        index = BuildIndex(db_path)
+
+        index.record_build(
+            run_id="test-run-1",
+            status="completed",
+            started_at="2025-01-01T00:00:00Z",
+            finished_at="2025-01-01T00:01:00Z",
+        )
+
+        index.record_build(
+            run_id="test-run-1",
+            status="failed",
+            started_at="2025-01-01T00:00:00Z",
+            finished_at="2025-01-01T00:01:00Z",
+            error="test error",
+        )
+
+        build = index.get_build("test-run-1")
+        assert build["status"] == "failed"
+        assert build["error"] == "test error"
+
+    def test_list_builds_returns_newest_first(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "_builds.sqlite"
+        index = BuildIndex(db_path)
+
+        index.record_build(
+            run_id="run-1",
+            status="completed",
+            started_at="2025-01-01T00:00:00Z",
+            finished_at="2025-01-01T00:01:00Z",
+        )
+        index.record_build(
+            run_id="run-2",
+            status="completed",
+            started_at="2025-01-01T02:00:00Z",
+            finished_at="2025-01-01T02:01:00Z",
+        )
+        index.record_build(
+            run_id="run-3",
+            status="completed",
+            started_at="2025-01-01T01:00:00Z",
+            finished_at="2025-01-01T01:01:00Z",
+        )
+
+        builds = index.list_builds(limit=10)
+        assert len(builds) == 3
+        assert builds[0]["run_id"] == "run-2"  # 최신
+        assert builds[1]["run_id"] == "run-3"
+        assert builds[2]["run_id"] == "run-1"  # 가장 오래된
+
+    def test_list_builds_respects_limit(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "_builds.sqlite"
+        index = BuildIndex(db_path)
+
+        for i in range(10):
+            index.record_build(
+                run_id=f"run-{i}",
+                status="completed",
+                started_at="2025-01-01T00:00:00Z",
+                finished_at=f"2025-01-01T00:0{i}:00Z",
+            )
+
+        builds = index.list_builds(limit=5)
+        assert len(builds) == 5
+
+    def test_list_builds_filters_by_status(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "_builds.sqlite"
+        index = BuildIndex(db_path)
+
+        index.record_build(
+            run_id="run-1",
+            status="completed",
+            started_at="2025-01-01T00:00:00Z",
+            finished_at="2025-01-01T00:01:00Z",
+        )
+        index.record_build(
+            run_id="run-2",
+            status="failed",
+            started_at="2025-01-01T01:00:00Z",
+            finished_at="2025-01-01T01:01:00Z",
+            error="test error",
+        )
+        index.record_build(
+            run_id="run-3",
+            status="completed",
+            started_at="2025-01-01T02:00:00Z",
+            finished_at="2025-01-01T02:01:00Z",
+        )
+
+        completed_builds = index.list_builds(status="completed")
+        assert len(completed_builds) == 2
+
+        failed_builds = index.list_builds(status="failed")
+        assert len(failed_builds) == 1
+        assert failed_builds[0]["run_id"] == "run-2"
+
+    def test_get_build_returns_none_for_unknown(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "_builds.sqlite"
+        index = BuildIndex(db_path)
+
+        build = index.get_build("unknown")
+        assert build is None

--- a/tests/unit/test_service_contract.py
+++ b/tests/unit/test_service_contract.py
@@ -26,6 +26,7 @@ _DISPATCH_ROUTES: dict[tuple[str, str], str] = {
     ("/preview", "POST"): "previewBuild",
     ("/build", "POST"): "createBuild",
     ("/artifacts/{run_id}", "GET"): "listBuildArtifacts",
+    ("/builds", "GET"): "listBuilds",
 }
 
 # (path, method) 형태의 계약 필수 오퍼레이션. BuilderService.dispatch가 실제로
@@ -275,6 +276,7 @@ _OPERATION_STATUS_CODES: dict[str, set[int]] = {
     "previewBuild": {200, 400},
     "createBuild": {200, 400, 502},
     "listBuildArtifacts": {200, 400, 404},
+    "listBuilds": {200, 400},
 }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -562,33 +562,15 @@ wheels = [
 [[package]]
 name = "kpubdata"
 version = "0.5.0"
-source = { editable = "../kpubdata" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "build", marker = "extra == 'dev'", specifier = ">=1.2,<2" },
-    { name = "httpx", specifier = ">=0.27,<1" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1,<2" },
-    { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5,<10" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10,<2" },
-    { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.2,<3" },
-    { name = "pandas-stubs", marker = "extra == 'dev'", specifier = ">=2.2,<3" },
-    { name = "pydantic", marker = "extra == 'validation'", specifier = ">=2.7,<3" },
-    { name = "pykrx", marker = "extra == 'dev'", specifier = ">=1.0.45,<2" },
-    { name = "pykrx", marker = "extra == 'krx'", specifier = ">=1.0.45,<2" },
-    { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10,<11" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2,<9" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5,<6" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5,<1" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.10" },
-    { name = "xmltodict", marker = "extra == 'dev'", specifier = ">=0.13,<1" },
-    { name = "xmltodict", marker = "extra == 'xml'", specifier = ">=0.13,<1" },
+sdist = { url = "https://files.pythonhosted.org/packages/e9/58/2f0a8d1b4ec6cd8152f951ffc5849c64628b10a0ee81f890ea3c97ba8fda/kpubdata-0.5.0.tar.gz", hash = "sha256:89e9b60afdc4c2f129b17207dc16c8531fbfdd1d7ef2048e4a1e0282c24c4905", size = 434771, upload-time = "2026-04-27T15:36:01.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/88/47574191c71ca22a840cfde858854f908c62f3b0609a2c8a98b554b96b65/kpubdata-0.5.0-py3-none-any.whl", hash = "sha256:e0c5d49bdd6abd5a4138f2d3945bd39ff0c3db926f6050ad17a009854192cf67", size = 104145, upload-time = "2026-04-27T15:36:00.024Z" },
 ]
-provides-extras = ["xml", "pandas", "krx", "validation", "mcp", "dev", "docs"]
 
 [[package]]
 name = "kpubdata-builder"
@@ -630,22 +612,22 @@ publish = [
 [package.metadata]
 requires-dist = [
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.2,<2" },
-    { name = "huggingface-hub", marker = "extra == 'huggingface'", specifier = ">=0.23,<1" },
-    { name = "huggingface-hub", marker = "extra == 'publish'", specifier = ">=0.23,<1" },
+    { name = "huggingface-hub", marker = "extra == 'huggingface'", specifier = ">=0.23,<2" },
+    { name = "huggingface-hub", marker = "extra == 'publish'", specifier = ">=0.23,<2" },
     { name = "kaggle", marker = "extra == 'publish'", specifier = ">=1.6,<2" },
-    { name = "kpubdata", editable = "../kpubdata" },
+    { name = "kpubdata", specifier = ">=0.5.0,<0.6" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6,<2" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9,<10" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10,<2" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10,<3" },
     { name = "polars", specifier = ">=1.0,<2" },
-    { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=15,<18" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2,<9" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5,<6" },
+    { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=15,<26" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2,<10" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5,<8" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5,<1" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
-    { name = "typing-extensions", specifier = ">=4.5" },
-    { name = "xmltodict", marker = "extra == 'publish'", specifier = ">=0.13,<1" },
+    { name = "typing-extensions", specifier = ">=4.5,<5" },
+    { name = "xmltodict", marker = "extra == 'publish'", specifier = ">=0.13,<2" },
 ]
 provides-extras = ["docs", "parquet", "huggingface", "publish", "dev"]
 


### PR DESCRIPTION
## 요약
ADR 0003(#309) 승인에 따라 완료된 빌드의 파생 인덱스로 SQLite를 도입한다. `output_root/_builds.sqlite`에 `builds` 테이블을 생성하고 WAL 모드, busy_timeout, schema version을 설정한다.

## 변경 내용
- **builds 테이블 스키마**: run_id, status, started_at, finished_at, spec_digest, error, schema_version
- **연결 초기화**: WAL 모드, busy_timeout(5초), 모든 쓰기 트랜잭션
- **schema version 컬럼**: 마이그레이션 대비 (현재 버전 1)
- **BuildIndex 클래스**: record_build(), list_builds(), get_build() 메서드
- **표준 라이브러리만 사용**: 무외부의존 (sqlite3)

## 관련 이슈
Closes #328
- 상위 ADR: #309 (ADR 0003)

## 검증
- [x] 스키마 생성/초기화 유닛 테스트
- [x] WAL·busy_timeout 적용 확인
- [x] schema version 기록
- [x] 447개 테스트 통과
- [x] ruff check 통과

## 체크리스트
- [x] 기능 브랜치에서 작업했으며 `main`에 직접 push하지 않았다
- [x] 커밋 메시지를 영어로 작성했다
- [x] `kpubdata` provider 로직을 중복 구현하지 않았다
- [x] 필요한 단위/단계 인지형 테스트를 추가했다
- [x] 사용자 노출 기능 변경 시 문서를 분류해 갱신했다: 제품 계약→PRD, 향후 의도→ROADMAP, 릴리스 변경→CHANGELOG (해당 시)
