### PR TITLE
feat:  list_builds 인덱스 우선 조회 + 스캔 폴백, 빌드 완료 시 인덱스 갱신

### DIFF
--- a/src/kpubdata_builder/index/__init__.py
+++ b/src/kpubdata_builder/index/__init__.py
@@ -1,0 +1,22 @@
+"""SQLite 빌드 인덱스 모듈 (#328).
+
+ADR 0003에 따라 완료된 빌드의 파생 인덱스를 제공한다.
+manifest.json이 정본이며, 이 SQLite 인덱스는 목록/조회 성능 최적화를 위한 캐시이다.
+
+주요 구성:
+    BuildIndex: SQLite 연결 및 쿼리 래퍼
+    BuildStatus: 빌드 상태 타입
+    initialize_schema: 스키마 생성/마이그레이션
+"""
+
+from __future__ import annotations
+
+from .index import (
+    BuildIndex,
+    BuildStatus,
+    initialize_schema,
+)
+
+_SCHEMA_VERSION = 1
+
+__all__ = ["BuildIndex", "BuildStatus", "initialize_schema", "_SCHEMA_VERSION"]

--- a/src/kpubdata_builder/index/index.py
+++ b/src/kpubdata_builder/index/index.py
@@ -1,0 +1,231 @@
+"""SQLite 빌드 인덱스 구현 (#328).
+
+ADR 0003에 따른 완료된 빌드 파생 인덱스. manifest.json이 정본이며,
+이 SQLite 인덱스는 목록/조회 성능 최적화를 위한 캐시 역할을 한다.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Literal
+
+# 현재 스키마 버전 (마이그레이션 대비)
+_SCHEMA_VERSION = 1
+
+# 빌드 상태 타입
+BuildStatus = Literal["completed", "failed", "cancelled"]
+
+
+def initialize_schema(db_path: Path) -> None:
+    """SQLite 데이터베이스 스키마를 초기화한다 (#328).
+
+    매개변수:
+        db_path: 데이터베이스 파일 경로.
+
+    스키마:
+        - builds 테이블 (run_id, status, started_at, finished_at, spec_digest,
+          error, schema_version)
+        - 인덱스 (finished_at, status)
+        - WAL 모드 활성화
+        - busy_timeout 설정 (5초)
+    """
+    # 데이터베이스 파일이 없으면 부모 디렉터리 생성
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with _get_connection(db_path) as conn:
+        cursor = conn.cursor()
+
+        # builds 테이블 생성
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS builds (
+                run_id TEXT PRIMARY KEY,
+                status TEXT NOT NULL,
+                started_at TEXT NOT NULL,
+                finished_at TEXT NOT NULL,
+                spec_digest TEXT,
+                error TEXT,
+                schema_version INTEGER NOT NULL DEFAULT 1
+            )
+            """
+        )
+
+        # 인덱스 생성 (목록 조회 최적화)
+        cursor.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_builds_finished_at
+            ON builds(finished_at DESC)
+            """
+        )
+        cursor.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_builds_status
+            ON builds(status)
+            """
+        )
+
+        # WAL 모드 활성화 (Write-Ahead Logging)
+        # - 동시 읽기/쓰기 허용
+        # - 크래시 발생 시 복구 가능
+        cursor.execute("PRAGMA journal_mode=WAL")
+
+        # busy_timeout 설정 (5초)
+        # - 데이터베이스가 잠겨 있을 때 대기 시간
+        cursor.execute("PRAGMA busy_timeout=5000")
+
+        conn.commit()
+
+
+@contextmanager
+def _get_connection(db_path: Path) -> Iterator[sqlite3.Connection]:
+    """SQLite 연결 컨텍스트 매니저."""
+    conn = sqlite3.connect(db_path, timeout=5.0)
+    conn.execute("PRAGMA foreign_keys=ON")
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+class BuildIndex:
+    """SQLite 빌드 인덱스 래퍼 (#328).
+
+    빌드 생성/상태전이 시 인덱스를 갱신하며,
+    list_builds 쿼리를 제공한다.
+    """
+
+    def __init__(self, db_path: Path) -> None:
+        """빌드 인덱스를 초기화한다.
+
+        매개변수:
+            db_path: 데이터베이스 파일 경로.
+        """
+        self._db_path = db_path
+        # 데이터베이스가 없으면 스키마 초기화
+        if not db_path.exists():
+            initialize_schema(db_path)
+
+    def record_build(
+        self,
+        *,
+        run_id: str,
+        status: BuildStatus,
+        started_at: str,
+        finished_at: str,
+        spec_digest: str | None = None,
+        error: str | None = None,
+    ) -> None:
+        """빌드를 인덱스에 기록한다.
+
+        매개변수:
+            run_id: 실행 식별자.
+            status: 빌드 상태 (completed/failed/cancelled).
+            started_at: 시작 시간 (ISO 8601 문자열).
+            finished_at: 종료 시간 (ISO 8601 문자열).
+            spec_digest: 스펙 해시 (변경 감지용, 선택).
+            error: 실패 시 오류 메시지 (선택).
+
+        예외:
+            sqlite3.Error: 데이터베이스 오류 발생 시.
+        """
+        with _get_connection(self._db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                INSERT OR REPLACE INTO builds
+                (run_id, status, started_at, finished_at, spec_digest, error, schema_version)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (run_id, status, started_at, finished_at, spec_digest, error, _SCHEMA_VERSION),
+            )
+            conn.commit()
+
+    def list_builds(
+        self,
+        *,
+        limit: int = 50,
+        status: BuildStatus | None = None,
+    ) -> list[dict[str, object]]:
+        """빌드 목록을 조회한다.
+
+        매개변수:
+            limit: 최대 반환 개수 (기본값 50).
+            status: 필터링할 상태 (선택).
+
+        반환값:
+            빌드 정보 목록 (최신순).
+        """
+        with _get_connection(self._db_path) as conn:
+            cursor = conn.cursor()
+
+            if status:
+                cursor.execute(
+                    """
+                    SELECT run_id, status, started_at, finished_at, spec_digest, error
+                    FROM builds
+                    WHERE status = ?
+                    ORDER BY finished_at DESC
+                    LIMIT ?
+                    """,
+                    (status, limit),
+                )
+            else:
+                cursor.execute(
+                    """
+                    SELECT run_id, status, started_at, finished_at, spec_digest, error
+                    FROM builds
+                    ORDER BY finished_at DESC
+                    LIMIT ?
+                    """,
+                    (limit,),
+                )
+
+            rows = cursor.fetchall()
+            return [
+                {
+                    "run_id": row[0],
+                    "status": row[1],
+                    "started_at": row[2],
+                    "finished_at": row[3],
+                    "spec_digest": row[4],
+                    "error": row[5],
+                }
+                for row in rows
+            ]
+
+    def get_build(self, run_id: str) -> dict[str, object] | None:
+        """특정 빌드를 조회한다.
+
+        매개변수:
+            run_id: 실행 식별자.
+
+        반환값:
+            빌드 정보 딕셔너리 또는 None (없는 경우).
+        """
+        with _get_connection(self._db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT run_id, status, started_at, finished_at, spec_digest, error
+                FROM builds
+                WHERE run_id = ?
+                """,
+                (run_id,),
+            )
+            row = cursor.fetchone()
+            if row is None:
+                return None
+            return {
+                "run_id": row[0],
+                "status": row[1],
+                "started_at": row[2],
+                "finished_at": row[3],
+                "spec_digest": row[4],
+                "error": row[5],
+            }
+
+
+__all__ = ["BuildIndex", "initialize_schema", "_SCHEMA_VERSION"]

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -301,7 +301,11 @@ class BuilderService:
                 builds: list[JsonValue] = [
                     {
                         "run_id": cast(str, b["run_id"]),
-                        "status": "ok" if cast(str, b["status"]) == "completed" else cast(str, b["status"]),
+                        "status": (
+                            "ok"
+                            if cast(str, b["status"]) == "completed"
+                            else cast(str, b["status"])
+                        ),
                         "started_at": cast(str | None, b["started_at"]),
                         "finished_at": cast(str | None, b["finished_at"]),
                     }

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -29,7 +29,7 @@ import yaml
 from ..errors import SpecLoadError, ValidationError
 from ..index import BuildIndex, BuildStatus
 from ..pipeline import BuildResult, preview_build, run_build
-from ..spec import BuildSpec, JsonValue, JsonValue as SpecJsonValue, parse_spec
+from ..spec import BuildSpec, JsonValue, parse_spec
 from ..spec.validator import validate_spec
 from ..stages._path_safety import ensure_within, validate_path_segment
 from ..stages.bronze.build import SourceClient
@@ -301,7 +301,7 @@ class BuilderService:
                 builds: list[JsonValue] = [
                     {
                         "run_id": cast(str, b["run_id"]),
-                        "status": "ok" if b["status"] == "completed" else b["status"],
+                        "status": "ok" if cast(str, b["status"]) == "completed" else cast(str, b["status"]),
                         "started_at": cast(str | None, b["started_at"]),
                         "finished_at": cast(str | None, b["finished_at"]),
                     }

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import heapq
 import hmac
 import json
+import logging
 import os
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
@@ -26,12 +27,15 @@ from urllib.parse import parse_qs
 import yaml
 
 from ..errors import SpecLoadError, ValidationError
-from ..pipeline import preview_build, run_build
-from ..spec import BuildSpec, JsonValue, parse_spec
+from ..index import BuildIndex, BuildStatus
+from ..pipeline import BuildResult, preview_build, run_build
+from ..spec import BuildSpec, JsonValue, JsonValue as SpecJsonValue, parse_spec
 from ..spec.validator import validate_spec
 from ..stages._path_safety import ensure_within, validate_path_segment
 from ..stages.bronze.build import SourceClient
 from ..tabular import DEFAULT_PREVIEW_LIMIT
+
+_logger = logging.getLogger(__name__)
 
 # Builder API 계약 버전. contract/builder-api.yaml의 info.version과 일치해야 하며
 # (test_service_contract가 강제), 응답에 실어 Studio 같은 소비자가 하위 호환을
@@ -81,6 +85,8 @@ def _parse_spec_text(spec_yaml: str) -> BuildSpec:
 class BuilderService:
     """Builder 연산을 HTTP 전송과 무관하게 제공하는 서비스."""
 
+    _BUILD_INDEX_DB = "_builds.sqlite"
+
     def __init__(
         self,
         *,
@@ -89,6 +95,15 @@ class BuilderService:
     ) -> None:
         self._output_root = output_root
         self._client_factory = client_factory
+        # SQLite 인덱스 경로만 저장하고 lazy 초기화 (#329)
+        self._build_index_path = output_root / self._BUILD_INDEX_DB
+        self._build_index: BuildIndex | None = None
+
+    def _get_build_index(self) -> BuildIndex:
+        """BuildIndex를 lazy하게 초기화한다 (#329)."""
+        if self._build_index is None:
+            self._build_index = BuildIndex(db_path=self._build_index_path)
+        return self._build_index
 
     def version(self) -> ServiceResponse:
         """Builder API 계약 버전을 반환한다 (#209).
@@ -153,8 +168,11 @@ class BuilderService:
         응답 코드 정책:
             - 모든 소스 성공: 200
             - 하나라도 소스 fetch/stage가 실패: 502 (upstream 소스 의존 실패).
-              매니페스트는 partial 정책으로 남기 때문에 body에 outcomes와 manifest가
+              매니페스트는 partial 정책으로 남기기 때문에 body에 outcomes와 manifest가
               실린다.
+
+        빌드 완료 후 SQLite 인덱스 갱신을 시도한다 (#329). 인덱스 쓰기 실패는
+        빌드 성공에 영향을 주지 않는다(best-effort).
         """
         spec_or_error = self._load_validated(spec_yaml)
         if isinstance(spec_or_error, ServiceResponse):
@@ -191,7 +209,64 @@ class BuilderService:
                 (o.error for o in result.outcomes if o.status != "ok" and o.error), None
             )
             body["error"] = first_error or "build failed"
+
+        # 빌드 완료 후 인덱스 갱신 (best-effort, 실패해도 빌드는 성공) (#329)
+        self._update_build_index(result)
+
         return ServiceResponse(status_code, body)
+
+    def _update_build_index(self, result: BuildResult) -> None:
+        """빌드 완료 후 SQLite 인덱스를 갱신한다 (#329).
+
+        best-effort로 실행되며, 인덱스 쓰기 실패는 빌드 성공에 영향을 주지
+        않는다(ADR 0003). 실패 시 로그만 남기고 진행한다.
+        """
+        try:
+            from datetime import datetime
+
+            # manifest에서 시작/종료 시간 추출
+            started_at: str | None = None
+            finished_at: str | None = None
+            try:
+                manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+                started_at = manifest.get("started_at")
+                finished_at = manifest.get("finished_at")
+            except (json.JSONDecodeError, OSError):
+                # manifest 읽기 실패 시 현재 시간 사용
+                now = datetime.utcnow().isoformat() + "Z"
+                if not started_at:
+                    started_at = now
+                if not finished_at:
+                    finished_at = now
+
+            # 빌드 상태 결정
+            if result.status == "ok":
+                build_status: BuildStatus = "completed"
+            else:
+                build_status = "failed"
+
+            # 실패한 빌드의 첫 번째 에러 메시지 추출
+            error_msg: str | None = None
+            if result.status != "ok":
+                error_msg = next(
+                    (o.error for o in result.outcomes if o.status != "ok" and o.error), None
+                )
+
+            # 인덱스에 기록
+            self._get_build_index().record_build(
+                run_id=result.context.run_id,
+                status=build_status,
+                started_at=started_at or finished_at or "",
+                finished_at=finished_at or started_at or "",
+                error=error_msg,
+            )
+        except Exception as exc:
+            # 인덱스 쓰기 실패는 빌드 성공에 영향을 주지 않음 (#329)
+            _logger.warning(
+                "Failed to update build index for run %s: %s",
+                result.context.run_id,
+                exc,
+            )
 
     def artifacts(self, run_id: str) -> ServiceResponse:
         """실행 워크스페이스의 산출물 파일 목록을 반환한다."""
@@ -213,9 +288,31 @@ class BuilderService:
     def list_builds(self, *, limit: int = 50) -> ServiceResponse:
         """실행 이력 목록을 최신 수정 시각 기준으로 내림차순 반환한다.
 
-        output_root 아래의 디렉터리를 스캔해 manifest.json이 있는 실행만
-        포함한다. Studio 같은 소비자가 빌드 이력 목록을 표시하는 데 쓰인다 (#250).
+        ADR 0003에 따라 SQLite 인덱스를 우선 조회하고, 인덱스 부재 시
+        디렉터리 스캔으로 폴백한다 (#329). Studio 같은 소비자가 빌드 이력
+        목록을 표시하는 데 쓰인다 (#250).
         """
+        # 인덱스 우선 조회 (#329)
+        try:
+            indexed_builds = self._get_build_index().list_builds(limit=limit)
+            if indexed_builds:
+                # 인덱스 결과를 API 계약에 맞게 변환
+                # 인덱스의 "completed"를 "ok"로 매핑 (ADR 0003 vs 기존 계약)
+                builds: list[JsonValue] = [
+                    {
+                        "run_id": cast(str, b["run_id"]),
+                        "status": "ok" if b["status"] == "completed" else b["status"],
+                        "started_at": cast(str | None, b["started_at"]),
+                        "finished_at": cast(str | None, b["finished_at"]),
+                    }
+                    for b in indexed_builds
+                ]
+                return ServiceResponse(200, {"builds": builds})
+        except Exception as exc:
+            # 인덱스 조회 실패 시 스캔으로 폴백하고 로그만 남김 (#329)
+            _logger.warning("Build index query failed, falling back to directory scan: %s", exc)
+
+        # 폴백: 디렉터리 스캔 (#329)
         if not self._output_root.exists():
             return ServiceResponse(200, {"builds": []})
 
@@ -224,7 +321,7 @@ class BuilderService:
             (d for d in self._output_root.iterdir() if d.is_dir()),
             key=lambda p: p.stat().st_mtime,
         )
-        builds: list[JsonValue] = []
+        builds_from_scan: list[JsonValue] = []
         for run_dir in candidates:
             manifest_path = run_dir / "manifest.json"
             if not manifest_path.exists():
@@ -233,7 +330,7 @@ class BuilderService:
                 manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
             except (json.JSONDecodeError, OSError):
                 continue
-            builds.append(
+            builds_from_scan.append(
                 {
                     "run_id": run_dir.name,
                     "status": "failed" if manifest.get("errors") else "ok",
@@ -241,7 +338,7 @@ class BuilderService:
                     "finished_at": manifest.get("finished_at"),
                 }
             )
-        return ServiceResponse(200, {"builds": builds})
+        return ServiceResponse(200, {"builds": builds_from_scan})
 
     def _load_validated(self, spec_yaml: str) -> BuildSpec | ServiceResponse:
         """spec_yaml을 파싱·검증하고, 실패 시 오류 ServiceResponse를 반환한다."""

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -1,0 +1,199 @@
+"""SQLite 빌드 인덱스 테스트 (#328)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kpubdata_builder.index import _SCHEMA_VERSION, BuildIndex, initialize_schema
+
+
+class TestBuildIndexSchema:
+    """스키마 생성 및 초기화 테스트."""
+
+    def test_initialize_schema_creates_database(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "_builds.sqlite"
+
+        initialize_schema(db_path)
+
+        assert db_path.exists()
+
+    def test_initialize_schema_creates_builds_table(self, tmp_path: Path) -> None:
+        import sqlite3
+
+        db_path = tmp_path / "_builds.sqlite"
+        initialize_schema(db_path)
+
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='builds'")
+            tables = cursor.fetchall()
+
+        assert len(tables) == 1
+        assert tables[0][0] == "builds"
+
+    def test_builds_table_has_all_columns(self, tmp_path: Path) -> None:
+        import sqlite3
+
+        db_path = tmp_path / "_builds.sqlite"
+        initialize_schema(db_path)
+
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute("PRAGMA table_info(builds)")
+            columns = {row[1] for row in cursor.fetchall()}
+
+        expected_columns = {
+            "run_id",
+            "status",
+            "started_at",
+            "finished_at",
+            "spec_digest",
+            "error",
+            "schema_version",
+        }
+        assert columns == expected_columns
+
+    def test_schema_version_is_set(self, tmp_path: Path) -> None:
+        assert _SCHEMA_VERSION == 1
+
+    def test_initialize_schema_applies_pragma_settings(self, tmp_path: Path) -> None:
+        import sqlite3
+
+        db_path = tmp_path / "_builds.sqlite"
+        initialize_schema(db_path)
+
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute("PRAGMA journal_mode")
+            journal_mode = cursor.fetchone()[0]
+            assert journal_mode == "wal"
+
+            cursor.execute("PRAGMA busy_timeout")
+            busy_timeout = cursor.fetchone()[0]
+            assert busy_timeout == 5000
+
+
+class TestBuildIndex:
+    """BuildIndex CRUD 테스트."""
+
+    def test_record_build_inserts_row(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "_builds.sqlite"
+        index = BuildIndex(db_path)
+
+        index.record_build(
+            run_id="test-run-1",
+            status="completed",
+            started_at="2025-01-01T00:00:00Z",
+            finished_at="2025-01-01T00:01:00Z",
+            spec_digest="abc123",
+        )
+
+        build = index.get_build("test-run-1")
+        assert build is not None
+        assert build["run_id"] == "test-run-1"
+        assert build["status"] == "completed"
+
+    def test_record_build_replaces_existing(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "_builds.sqlite"
+        index = BuildIndex(db_path)
+
+        index.record_build(
+            run_id="test-run-1",
+            status="completed",
+            started_at="2025-01-01T00:00:00Z",
+            finished_at="2025-01-01T00:01:00Z",
+        )
+
+        index.record_build(
+            run_id="test-run-1",
+            status="failed",
+            started_at="2025-01-01T00:00:00Z",
+            finished_at="2025-01-01T00:01:00Z",
+            error="test error",
+        )
+
+        build = index.get_build("test-run-1")
+        assert build["status"] == "failed"
+        assert build["error"] == "test error"
+
+    def test_list_builds_returns_newest_first(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "_builds.sqlite"
+        index = BuildIndex(db_path)
+
+        index.record_build(
+            run_id="run-1",
+            status="completed",
+            started_at="2025-01-01T00:00:00Z",
+            finished_at="2025-01-01T00:01:00Z",
+        )
+        index.record_build(
+            run_id="run-2",
+            status="completed",
+            started_at="2025-01-01T02:00:00Z",
+            finished_at="2025-01-01T02:01:00Z",
+        )
+        index.record_build(
+            run_id="run-3",
+            status="completed",
+            started_at="2025-01-01T01:00:00Z",
+            finished_at="2025-01-01T01:01:00Z",
+        )
+
+        builds = index.list_builds(limit=10)
+        assert len(builds) == 3
+        assert builds[0]["run_id"] == "run-2"  # 최신
+        assert builds[1]["run_id"] == "run-3"
+        assert builds[2]["run_id"] == "run-1"  # 가장 오래된
+
+    def test_list_builds_respects_limit(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "_builds.sqlite"
+        index = BuildIndex(db_path)
+
+        for i in range(10):
+            index.record_build(
+                run_id=f"run-{i}",
+                status="completed",
+                started_at="2025-01-01T00:00:00Z",
+                finished_at=f"2025-01-01T00:0{i}:00Z",
+            )
+
+        builds = index.list_builds(limit=5)
+        assert len(builds) == 5
+
+    def test_list_builds_filters_by_status(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "_builds.sqlite"
+        index = BuildIndex(db_path)
+
+        index.record_build(
+            run_id="run-1",
+            status="completed",
+            started_at="2025-01-01T00:00:00Z",
+            finished_at="2025-01-01T00:01:00Z",
+        )
+        index.record_build(
+            run_id="run-2",
+            status="failed",
+            started_at="2025-01-01T01:00:00Z",
+            finished_at="2025-01-01T01:01:00Z",
+            error="test error",
+        )
+        index.record_build(
+            run_id="run-3",
+            status="completed",
+            started_at="2025-01-01T02:00:00Z",
+            finished_at="2025-01-01T02:01:00Z",
+        )
+
+        completed_builds = index.list_builds(status="completed")
+        assert len(completed_builds) == 2
+
+        failed_builds = index.list_builds(status="failed")
+        assert len(failed_builds) == 1
+        assert failed_builds[0]["run_id"] == "run-2"
+
+    def test_get_build_returns_none_for_unknown(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "_builds.sqlite"
+        index = BuildIndex(db_path)
+
+        build = index.get_build("unknown")
+        assert build is None

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -222,6 +222,63 @@ class TestListBuilds:
         resp = dispatch(_service(tmp_path), "GET", "/builds", None, query="limit=abc")
         assert resp.status_code == 400
 
+    def test_index_fallback_to_scan_on_corruption(self, tmp_path: Path) -> None:
+        """인덱스 손상 시 스캔으로 폴백 (#329)."""
+        service = _service(tmp_path)
+        # 먼저 빌드를 실행해서 manifest 생성
+        service.build(VALID_SPEC_YAML, run_id="run1")
+
+        # 인덱스가 생성되었는지 확인
+        index_path = tmp_path / "_builds.sqlite"
+        assert index_path.exists()
+
+        # 인덱스를 손상시킴 (파일 내용을 비움)
+        index_path.write_text("corrupted")
+
+        # list_builds는 여전히 작동해야 함 (폴백)
+        resp = service.list_builds()
+        assert resp.status_code == 200
+        builds = resp.body["builds"]
+        assert isinstance(builds, list)
+        assert len(builds) == 1
+        assert builds[0]["run_id"] == "run1"  # type: ignore[index]
+
+    def test_build_succeeds_even_if_index_write_fails(self, tmp_path: Path) -> None:
+        """인덱스 쓰기 실패해도 빌드는 성공해야 함 (best-effort, #329)."""
+        import stat
+
+        service = _service(tmp_path)
+
+        # 인덱스 파일을 읽기 전용으로 만들어 쓰기 실패 유도
+        index_path = tmp_path / "_builds.sqlite"
+        index_path.parent.mkdir(parents=True, exist_ok=True)
+        index_path.write_text("readonly")  # 빈 파일 생성
+
+        # 읽기 전용으로 설정
+        index_path.chmod(stat.S_IRUSR | stat.S_IREAD)
+
+        try:
+            # 빌드 실행 - 인덱스 쓰기가 실패해도 성공해야 함
+            resp = service.build(VALID_SPEC_YAML, run_id="run1")
+            assert resp.status_code == 200
+            assert resp.body["run_id"] == "run1"
+
+            # manifest는 정상적으로 생성되어야 함
+            manifest_path = tmp_path / "run1" / "manifest.json"
+            assert manifest_path.exists()
+        finally:
+            # 권한 복원 (cleanup)
+            index_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+    def test_index_query_returns_empty_when_no_builds(self, tmp_path: Path) -> None:
+        """인덱스만 조회하고 빌드가 없으면 빈 목록 반환 (#329)."""
+        service = _service(tmp_path)
+
+        # 인덱스 초기화 (list_builds 호출 시 lazy 초기화)
+        resp = service.list_builds()
+        assert resp.status_code == 200
+        assert resp.body["builds"] == []
+
 
 class TestDispatch:
     def test_routes_post_validate(self, tmp_path: Path) -> None:

--- a/tests/unit/test_service_contract.py
+++ b/tests/unit/test_service_contract.py
@@ -25,6 +25,7 @@ _DISPATCH_ROUTES: dict[tuple[str, str], str] = {
     ("/validate", "POST"): "validateSpec",
     ("/preview", "POST"): "previewBuild",
     ("/build", "POST"): "createBuild",
+    ("/builds", "GET"): "listBuilds",
     ("/artifacts/{run_id}", "GET"): "listBuildArtifacts",
 }
 
@@ -274,6 +275,7 @@ _OPERATION_STATUS_CODES: dict[str, set[int]] = {
     "validateSpec": {200, 400},
     "previewBuild": {200, 400},
     "createBuild": {200, 400, 502},
+    "listBuilds": {200, 400},
     "listBuildArtifacts": {200, 400, 404},
 }
 

--- a/uv.lock
+++ b/uv.lock
@@ -630,22 +630,22 @@ publish = [
 [package.metadata]
 requires-dist = [
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.2,<2" },
-    { name = "huggingface-hub", marker = "extra == 'huggingface'", specifier = ">=0.23,<1" },
-    { name = "huggingface-hub", marker = "extra == 'publish'", specifier = ">=0.23,<1" },
+    { name = "huggingface-hub", marker = "extra == 'huggingface'", specifier = ">=0.23,<2" },
+    { name = "huggingface-hub", marker = "extra == 'publish'", specifier = ">=0.23,<2" },
     { name = "kaggle", marker = "extra == 'publish'", specifier = ">=1.6,<2" },
     { name = "kpubdata", editable = "../kpubdata" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6,<2" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9,<10" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10,<2" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10,<3" },
     { name = "polars", specifier = ">=1.0,<2" },
-    { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=15,<18" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2,<9" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5,<6" },
+    { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=15,<26" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2,<10" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5,<8" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5,<1" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
-    { name = "typing-extensions", specifier = ">=4.5" },
-    { name = "xmltodict", marker = "extra == 'publish'", specifier = ">=0.13,<1" },
+    { name = "typing-extensions", specifier = ">=4.5,<5" },
+    { name = "xmltodict", marker = "extra == 'publish'", specifier = ">=0.13,<2" },
 ]
 provides-extras = ["docs", "parquet", "huggingface", "publish", "dev"]
 


### PR DESCRIPTION
## 요약
이 PR은 list_builds를 SQLite 인덱스 우선 조회로 변경하여 성능을 최적화하고, 빌드 완료 시 인덱스를 자동 갱신합니다. 인덱스 부재/손상 시 기존 디렉터리 스캔으로 폴백하여 안정성을 보장하며, 인덱스 쓰기 실패가 빌드 성공에 영향을 주지 않도록 best-effort로 구현했습니다.

## 변경 내용
- SQLite 빌드 인덱스 스키마 구현 (#328 후속)
  - builds 테이블 (run_id, status, started_at, finished_at, spec_digest, error, schema_version)
  - WAL 모드 및 busy_timeout (5초) 설정으로 동시성 안전장치 적용
  - BuildIndex 클래스: 인덱스 기록/조회 기능 제공
- list_builds 인덱스 우선 조회 + 스캔 폴백 (#329)
  - SQLite 인덱스를 우선 조회하여 성능 최적화
  - 인덱스 부재/손상 시 기존 디렉터리 스캔으로 폴백 (ADR 0003)
  - 인덱스 상태 'completed'를 API 계약 'ok'로 매핑하여 기존 소비자와 호환
- 빌드 완료 시 인덱스 갱신 (#329)
  - 빌드 성공/실프와 무관하게 인덱스 기록 (best-effort)
  - 인덱스 쓰기 실패 시 로그만 남기고 빌드는 정상 완료 (ADR 0003)
  - manifest에서 시작/종료 시간 추출하여 인덱스에 기록
- BuildIndex 지연 초기화
  - preview 등 인덱스 불필요 작업 시 데이터베이스 파일 생성 방지
  - 첫 번째 list_builds/build 호출 시 초기화

## 관련 이슈
Closes #329
- ADR 0003 (#309) - 영속 Build 저장소 설계

## 검증
- 인덱스 CRUD 테스트 (tests/unit/test_index.py)
  - 스키마 초기화, 레코드 기록/조회/목록 확인
- 인덱스 우선/폴백 경로 테스트 (tests/unit/test_service.py)
  - 인덱스 손상 시 스캔 폴백 동작 확인
  - 인덱스 쓰기 실패 시 빌드 성공 유지 확인
  - 인덱스 없는 상태에서 list_builds 빈 목록 반환 확인
- Service Contract 테스트 (tests/unit/test_service_contract.py)
  - GET /builds 엔드포인트 상태 코드 검증
  - 기존 GET /builds 계약 회귀 없음 확인

## 완료 조건 (DoD)
- [x] 인덱스 우선/폴백 경로
- [x] 인덱스 쓰기 실패 시 빌드 성공 유지 테스트
- [x] 기존 GET /builds 계약