### PR TITLE
feat: 빌드 인덱스 재구축 커맨드 — 스캔으로 재생성

### DIFF
--- a/src/kpubdata_builder/cli.py
+++ b/src/kpubdata_builder/cli.py
@@ -135,6 +135,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Run workspace root directory (default: build).",
     )
 
+    reindex_cmd = subparsers.add_parser(
+        "reindex",
+        help="Rebuild the build index from directory scan (#330).",
+    )
+    reindex_cmd.add_argument(
+        "--output-dir",
+        default="build",
+        help="Run workspace root directory to scan (default: build).",
+    )
+
     return parser
 
 
@@ -337,6 +347,100 @@ def _run_publish(
     return 0
 
 
+def _run_reindex(*, output_dir: str) -> int:
+    """output_root를 스캔하여 SQLite 인덱스를 재구축한다 (#330).
+
+    매개변수:
+        output_dir: 스캔할 실행 워크스페이스 루트.
+
+    반환값:
+        int: 성공 시 0, 실패 시 1.
+    """
+    import json
+
+    from .index import BuildIndex, initialize_schema
+
+    output_root = Path(output_dir)
+
+    if not output_root.exists():
+        print(f"error: output directory does not exist: {output_root}", file=sys.stderr)
+        return 1
+
+    # 기존 인덱스 백업 (원자적 교체를 위해)
+    index_path = output_root / "_builds.sqlite"
+    backup_path = output_root / "_builds.sqlite.bak"
+
+    if index_path.exists():
+        print(f"backing up existing index to {backup_path.name}...")
+        try:
+            import shutil
+
+            shutil.copy2(index_path, backup_path)
+        except OSError as exc:
+            print(f"error: failed to backup index: {exc}", file=sys.stderr)
+            return 1
+
+    # 새 인덱스 생성
+    temp_index_path = output_root / "_builds.sqlite.tmp"
+    try:
+        print(f"scanning {output_root} for builds...")
+        initialize_schema(temp_index_path)
+        temp_index = BuildIndex(db_path=temp_index_path)
+
+        build_count = 0
+        for run_dir in output_root.iterdir():
+            if not run_dir.is_dir():
+                continue
+            manifest_path = run_dir / "manifest.json"
+            if not manifest_path.exists():
+                continue
+
+            try:
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                print(f"warning: skipping {run_dir.name}: invalid manifest", file=sys.stderr)
+                continue
+
+            run_id = run_dir.name
+            started_at = manifest.get("started_at")
+            finished_at = manifest.get("finished_at")
+
+            # 상태 결정 (manifest의 errors 유무로 판단)
+            build_status = "failed" if manifest.get("errors") else "completed"
+
+            # 인덱스에 기록
+            temp_index.record_build(
+                run_id=run_id,
+                status=build_status,  # type: ignore[arg-type]
+                started_at=started_at or finished_at or "",
+                finished_at=finished_at or started_at or "",
+            )
+            build_count += 1
+
+        print(f"indexed {build_count} builds")
+
+        # 원자적 교체
+        print(f"replacing {index_path.name}...")
+        if index_path.exists():
+            index_path.unlink()
+
+        temp_index_path.rename(index_path)
+
+        # 백업 삭제
+        if backup_path.exists():
+            backup_path.unlink()
+
+        print(f"reindex complete: {index_path}")
+        return 0
+
+    except Exception as exc:
+        # 실패 시 임시 파일 정리
+        if temp_index_path.exists():
+            temp_index_path.unlink()
+        print(f"error: reindex failed: {exc}", file=sys.stderr)
+        return 1
+
+
 def _run_serve(*, output_dir: str, host: str, port: int) -> int:
     """BuilderService를 HTTP 서버로 실행한다 (#249).
 
@@ -402,6 +506,8 @@ def dispatch(args: argparse.Namespace) -> int:
             host=args.host,
             port=args.port,
         )
+    if command == "reindex":
+        return _run_reindex(output_dir=args.output_dir)
     # 일반적인 CLI 경로로는 도달할 수 없지만(argparse가 알 수 없는 하위 명령을 거부함),
     # 프로그래밍 방식 호출자를 위한 방어적 대체 경로로 유지한다.
     return 2

--- a/src/kpubdata_builder/index/__init__.py
+++ b/src/kpubdata_builder/index/__init__.py
@@ -1,0 +1,22 @@
+"""SQLite 빌드 인덱스 모듈 (#328).
+
+ADR 0003에 따라 완료된 빌드의 파생 인덱스를 제공한다.
+manifest.json이 정본이며, 이 SQLite 인덱스는 목록/조회 성능 최적화를 위한 캐시이다.
+
+주요 구성:
+    BuildIndex: SQLite 연결 및 쿼리 래퍼
+    BuildStatus: 빌드 상태 타입
+    initialize_schema: 스키마 생성/마이그레이션
+"""
+
+from __future__ import annotations
+
+from .index import (
+    BuildIndex,
+    BuildStatus,
+    initialize_schema,
+)
+
+_SCHEMA_VERSION = 1
+
+__all__ = ["BuildIndex", "BuildStatus", "initialize_schema", "_SCHEMA_VERSION"]

--- a/src/kpubdata_builder/index/index.py
+++ b/src/kpubdata_builder/index/index.py
@@ -1,0 +1,231 @@
+"""SQLite 빌드 인덱스 구현 (#328).
+
+ADR 0003에 따른 완료된 빌드 파생 인덱스. manifest.json이 정본이며,
+이 SQLite 인덱스는 목록/조회 성능 최적화를 위한 캐시 역할을 한다.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Literal
+
+# 현재 스키마 버전 (마이그레이션 대비)
+_SCHEMA_VERSION = 1
+
+# 빌드 상태 타입
+BuildStatus = Literal["completed", "failed", "cancelled"]
+
+
+def initialize_schema(db_path: Path) -> None:
+    """SQLite 데이터베이스 스키마를 초기화한다 (#328).
+
+    매개변수:
+        db_path: 데이터베이스 파일 경로.
+
+    스키마:
+        - builds 테이블 (run_id, status, started_at, finished_at, spec_digest,
+          error, schema_version)
+        - 인덱스 (finished_at, status)
+        - WAL 모드 활성화
+        - busy_timeout 설정 (5초)
+    """
+    # 데이터베이스 파일이 없으면 부모 디렉터리 생성
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with _get_connection(db_path) as conn:
+        cursor = conn.cursor()
+
+        # builds 테이블 생성
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS builds (
+                run_id TEXT PRIMARY KEY,
+                status TEXT NOT NULL,
+                started_at TEXT NOT NULL,
+                finished_at TEXT NOT NULL,
+                spec_digest TEXT,
+                error TEXT,
+                schema_version INTEGER NOT NULL DEFAULT 1
+            )
+            """
+        )
+
+        # 인덱스 생성 (목록 조회 최적화)
+        cursor.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_builds_finished_at
+            ON builds(finished_at DESC)
+            """
+        )
+        cursor.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_builds_status
+            ON builds(status)
+            """
+        )
+
+        # WAL 모드 활성화 (Write-Ahead Logging)
+        # - 동시 읽기/쓰기 허용
+        # - 크래시 발생 시 복구 가능
+        cursor.execute("PRAGMA journal_mode=WAL")
+
+        # busy_timeout 설정 (5초)
+        # - 데이터베이스가 잠겨 있을 때 대기 시간
+        cursor.execute("PRAGMA busy_timeout=5000")
+
+        conn.commit()
+
+
+@contextmanager
+def _get_connection(db_path: Path) -> Iterator[sqlite3.Connection]:
+    """SQLite 연결 컨텍스트 매니저."""
+    conn = sqlite3.connect(db_path, timeout=5.0)
+    conn.execute("PRAGMA foreign_keys=ON")
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+class BuildIndex:
+    """SQLite 빌드 인덱스 래퍼 (#328).
+
+    빌드 생성/상태전이 시 인덱스를 갱신하며,
+    list_builds 쿼리를 제공한다.
+    """
+
+    def __init__(self, db_path: Path) -> None:
+        """빌드 인덱스를 초기화한다.
+
+        매개변수:
+            db_path: 데이터베이스 파일 경로.
+        """
+        self._db_path = db_path
+        # 데이터베이스가 없으면 스키마 초기화
+        if not db_path.exists():
+            initialize_schema(db_path)
+
+    def record_build(
+        self,
+        *,
+        run_id: str,
+        status: BuildStatus,
+        started_at: str,
+        finished_at: str,
+        spec_digest: str | None = None,
+        error: str | None = None,
+    ) -> None:
+        """빌드를 인덱스에 기록한다.
+
+        매개변수:
+            run_id: 실행 식별자.
+            status: 빌드 상태 (completed/failed/cancelled).
+            started_at: 시작 시간 (ISO 8601 문자열).
+            finished_at: 종료 시간 (ISO 8601 문자열).
+            spec_digest: 스펙 해시 (변경 감지용, 선택).
+            error: 실패 시 오류 메시지 (선택).
+
+        예외:
+            sqlite3.Error: 데이터베이스 오류 발생 시.
+        """
+        with _get_connection(self._db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                INSERT OR REPLACE INTO builds
+                (run_id, status, started_at, finished_at, spec_digest, error, schema_version)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (run_id, status, started_at, finished_at, spec_digest, error, _SCHEMA_VERSION),
+            )
+            conn.commit()
+
+    def list_builds(
+        self,
+        *,
+        limit: int = 50,
+        status: BuildStatus | None = None,
+    ) -> list[dict[str, object]]:
+        """빌드 목록을 조회한다.
+
+        매개변수:
+            limit: 최대 반환 개수 (기본값 50).
+            status: 필터링할 상태 (선택).
+
+        반환값:
+            빌드 정보 목록 (최신순).
+        """
+        with _get_connection(self._db_path) as conn:
+            cursor = conn.cursor()
+
+            if status:
+                cursor.execute(
+                    """
+                    SELECT run_id, status, started_at, finished_at, spec_digest, error
+                    FROM builds
+                    WHERE status = ?
+                    ORDER BY finished_at DESC
+                    LIMIT ?
+                    """,
+                    (status, limit),
+                )
+            else:
+                cursor.execute(
+                    """
+                    SELECT run_id, status, started_at, finished_at, spec_digest, error
+                    FROM builds
+                    ORDER BY finished_at DESC
+                    LIMIT ?
+                    """,
+                    (limit,),
+                )
+
+            rows = cursor.fetchall()
+            return [
+                {
+                    "run_id": row[0],
+                    "status": row[1],
+                    "started_at": row[2],
+                    "finished_at": row[3],
+                    "spec_digest": row[4],
+                    "error": row[5],
+                }
+                for row in rows
+            ]
+
+    def get_build(self, run_id: str) -> dict[str, object] | None:
+        """특정 빌드를 조회한다.
+
+        매개변수:
+            run_id: 실행 식별자.
+
+        반환값:
+            빌드 정보 딕셔너리 또는 None (없는 경우).
+        """
+        with _get_connection(self._db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT run_id, status, started_at, finished_at, spec_digest, error
+                FROM builds
+                WHERE run_id = ?
+                """,
+                (run_id,),
+            )
+            row = cursor.fetchone()
+            if row is None:
+                return None
+            return {
+                "run_id": row[0],
+                "status": row[1],
+                "started_at": row[2],
+                "finished_at": row[3],
+                "spec_digest": row[4],
+                "error": row[5],
+            }
+
+
+__all__ = ["BuildIndex", "initialize_schema", "_SCHEMA_VERSION"]

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import heapq
 import hmac
 import json
+import logging
 import os
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
@@ -26,12 +27,15 @@ from urllib.parse import parse_qs
 import yaml
 
 from ..errors import SpecLoadError, ValidationError
-from ..pipeline import preview_build, run_build
+from ..index import BuildIndex, BuildStatus
+from ..pipeline import BuildResult, preview_build, run_build
 from ..spec import BuildSpec, JsonValue, parse_spec
 from ..spec.validator import validate_spec
 from ..stages._path_safety import ensure_within, validate_path_segment
 from ..stages.bronze.build import SourceClient
 from ..tabular import DEFAULT_PREVIEW_LIMIT
+
+_logger = logging.getLogger(__name__)
 
 # Builder API 계약 버전. contract/builder-api.yaml의 info.version과 일치해야 하며
 # (test_service_contract가 강제), 응답에 실어 Studio 같은 소비자가 하위 호환을
@@ -81,6 +85,8 @@ def _parse_spec_text(spec_yaml: str) -> BuildSpec:
 class BuilderService:
     """Builder 연산을 HTTP 전송과 무관하게 제공하는 서비스."""
 
+    _BUILD_INDEX_DB = "_builds.sqlite"
+
     def __init__(
         self,
         *,
@@ -89,6 +95,15 @@ class BuilderService:
     ) -> None:
         self._output_root = output_root
         self._client_factory = client_factory
+        # SQLite 인덱스 경로만 저장하고 lazy 초기화 (#329)
+        self._build_index_path = output_root / self._BUILD_INDEX_DB
+        self._build_index: BuildIndex | None = None
+
+    def _get_build_index(self) -> BuildIndex:
+        """BuildIndex를 lazy하게 초기화한다 (#329)."""
+        if self._build_index is None:
+            self._build_index = BuildIndex(db_path=self._build_index_path)
+        return self._build_index
 
     def version(self) -> ServiceResponse:
         """Builder API 계약 버전을 반환한다 (#209).
@@ -153,8 +168,11 @@ class BuilderService:
         응답 코드 정책:
             - 모든 소스 성공: 200
             - 하나라도 소스 fetch/stage가 실패: 502 (upstream 소스 의존 실패).
-              매니페스트는 partial 정책으로 남기 때문에 body에 outcomes와 manifest가
+              매니페스트는 partial 정책으로 남기기 때문에 body에 outcomes와 manifest가
               실린다.
+
+        빌드 완료 후 SQLite 인덱스 갱신을 시도한다 (#329). 인덱스 쓰기 실패는
+        빌드 성공에 영향을 주지 않는다(best-effort).
         """
         spec_or_error = self._load_validated(spec_yaml)
         if isinstance(spec_or_error, ServiceResponse):
@@ -191,7 +209,64 @@ class BuilderService:
                 (o.error for o in result.outcomes if o.status != "ok" and o.error), None
             )
             body["error"] = first_error or "build failed"
+
+        # 빌드 완료 후 인덱스 갱신 (best-effort, 실패해도 빌드는 성공) (#329)
+        self._update_build_index(result)
+
         return ServiceResponse(status_code, body)
+
+    def _update_build_index(self, result: BuildResult) -> None:
+        """빌드 완료 후 SQLite 인덱스를 갱신한다 (#329).
+
+        best-effort로 실행되며, 인덱스 쓰기 실패는 빌드 성공에 영향을 주지
+        않는다(ADR 0003). 실패 시 로그만 남기고 진행한다.
+        """
+        try:
+            from datetime import datetime
+
+            # manifest에서 시작/종료 시간 추출
+            started_at: str | None = None
+            finished_at: str | None = None
+            try:
+                manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+                started_at = manifest.get("started_at")
+                finished_at = manifest.get("finished_at")
+            except (json.JSONDecodeError, OSError):
+                # manifest 읽기 실패 시 현재 시간 사용
+                now = datetime.utcnow().isoformat() + "Z"
+                if not started_at:
+                    started_at = now
+                if not finished_at:
+                    finished_at = now
+
+            # 빌드 상태 결정
+            if result.status == "ok":
+                build_status: BuildStatus = "completed"
+            else:
+                build_status = "failed"
+
+            # 실패한 빌드의 첫 번째 에러 메시지 추출
+            error_msg: str | None = None
+            if result.status != "ok":
+                error_msg = next(
+                    (o.error for o in result.outcomes if o.status != "ok" and o.error), None
+                )
+
+            # 인덱스에 기록
+            self._get_build_index().record_build(
+                run_id=result.context.run_id,
+                status=build_status,
+                started_at=started_at or finished_at or "",
+                finished_at=finished_at or started_at or "",
+                error=error_msg,
+            )
+        except Exception as exc:
+            # 인덱스 쓰기 실패는 빌드 성공에 영향을 주지 않음 (#329)
+            _logger.warning(
+                "Failed to update build index for run %s: %s",
+                result.context.run_id,
+                exc,
+            )
 
     def artifacts(self, run_id: str) -> ServiceResponse:
         """실행 워크스페이스의 산출물 파일 목록을 반환한다."""
@@ -213,9 +288,35 @@ class BuilderService:
     def list_builds(self, *, limit: int = 50) -> ServiceResponse:
         """실행 이력 목록을 최신 수정 시각 기준으로 내림차순 반환한다.
 
-        output_root 아래의 디렉터리를 스캔해 manifest.json이 있는 실행만
-        포함한다. Studio 같은 소비자가 빌드 이력 목록을 표시하는 데 쓰인다 (#250).
+        ADR 0003에 따라 SQLite 인덱스를 우선 조회하고, 인덱스 부재 시
+        디렉터리 스캔으로 폴백한다 (#329). Studio 같은 소비자가 빌드 이력
+        목록을 표시하는 데 쓰인다 (#250).
         """
+        # 인덱스 우선 조회 (#329)
+        try:
+            indexed_builds = self._get_build_index().list_builds(limit=limit)
+            if indexed_builds:
+                # 인덱스 결과를 API 계약에 맞게 변환
+                # 인덱스의 "completed"를 "ok"로 매핑 (ADR 0003 vs 기존 계약)
+                builds: list[JsonValue] = [
+                    {
+                        "run_id": cast(str, b["run_id"]),
+                        "status": (
+                            "ok"
+                            if cast(str, b["status"]) == "completed"
+                            else cast(str, b["status"])
+                        ),
+                        "started_at": cast(str | None, b["started_at"]),
+                        "finished_at": cast(str | None, b["finished_at"]),
+                    }
+                    for b in indexed_builds
+                ]
+                return ServiceResponse(200, {"builds": builds})
+        except Exception as exc:
+            # 인덱스 조회 실패 시 스캔으로 폴백하고 로그만 남김 (#329)
+            _logger.warning("Build index query failed, falling back to directory scan: %s", exc)
+
+        # 폴백: 디렉터리 스캔 (#329)
         if not self._output_root.exists():
             return ServiceResponse(200, {"builds": []})
 
@@ -224,7 +325,7 @@ class BuilderService:
             (d for d in self._output_root.iterdir() if d.is_dir()),
             key=lambda p: p.stat().st_mtime,
         )
-        builds: list[JsonValue] = []
+        builds_from_scan: list[JsonValue] = []
         for run_dir in candidates:
             manifest_path = run_dir / "manifest.json"
             if not manifest_path.exists():
@@ -233,7 +334,7 @@ class BuilderService:
                 manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
             except (json.JSONDecodeError, OSError):
                 continue
-            builds.append(
+            builds_from_scan.append(
                 {
                     "run_id": run_dir.name,
                     "status": "failed" if manifest.get("errors") else "ok",
@@ -241,7 +342,7 @@ class BuilderService:
                     "finished_at": manifest.get("finished_at"),
                 }
             )
-        return ServiceResponse(200, {"builds": builds})
+        return ServiceResponse(200, {"builds": builds_from_scan})
 
     def _load_validated(self, spec_yaml: str) -> BuildSpec | ServiceResponse:
         """spec_yaml을 파싱·검증하고, 실패 시 오류 ServiceResponse를 반환한다."""

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -9,6 +9,7 @@ import pytest
 
 from kpubdata_builder import __version__
 from kpubdata_builder.cli import build_parser, main
+from kpubdata_builder.publishers import PUBLISHER_REGISTRY
 from kpubdata_builder.publishers.base import PublishResult
 
 VALID_SPEC_YAML = (
@@ -280,9 +281,7 @@ def test_publish_huggingface_stub(
     stub.expects_directory = False
     stub.publish.return_value = fake_result
 
-    import kpubdata_builder.cli as cli_module
-
-    monkeypatch.setitem(cli_module.PUBLISHER_REGISTRY, "huggingface", stub)
+    monkeypatch.setitem(PUBLISHER_REGISTRY, "huggingface", stub)
 
     exit_code = main(
         [
@@ -660,4 +659,3 @@ class TestReindexCommand:
         builds = index.list_builds(limit=10)
 
         assert len(builds) == 0
-

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -450,3 +450,214 @@ def test_serve_invokes_http_server(
         "output_root": tmp_path,
     }
     assert "serving kpubdata-builder" in out
+
+
+# ---------------------------------------------------------------------------
+# reindex 명령 테스트 (#330)
+# ---------------------------------------------------------------------------
+
+
+class TestReindexCommand:
+    """reindex 커맨드 테스트 (#330)."""
+
+    def test_reindex_command_exists(self) -> None:
+        """reindex 하위 명령이 존재해야 한다."""
+        parser = build_parser()
+        args = parser.parse_args(["reindex"])
+        assert args.command == "reindex"
+        assert args.output_dir == "build"
+
+    def test_reindex_command_with_custom_output_dir(self) -> None:
+        """--output-dir 옵션을 지정할 수 있어야 한다."""
+        parser = build_parser()
+        args = parser.parse_args(["reindex", "--output-dir", "/custom/path"])
+        assert args.command == "reindex"
+        assert args.output_dir == "/custom/path"
+
+    def test_reindex_scans_and_creates_index(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """output_root를 스캔하여 인덱스를 생성한다."""
+        import json
+
+        from kpubdata_builder.index import BuildIndex
+
+        # 테스트용 빌드 디렉터리 및 manifest 생성
+        run1_dir = tmp_path / "run1"
+        run1_dir.mkdir()
+        (run1_dir / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "run_id": "run1",
+                    "status": "ok",
+                    "started_at": "2025-01-01T00:00:00Z",
+                    "finished_at": "2025-01-01T00:01:00Z",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        run2_dir = tmp_path / "run2"
+        run2_dir.mkdir()
+        (run2_dir / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "run_id": "run2",
+                    "status": "failed",
+                    "errors": ["test error"],
+                    "started_at": "2025-01-01T01:00:00Z",
+                    "finished_at": "2025-01-01T01:01:00Z",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        # manifest 없는 디렉터리 (무시되어야 함)
+        (tmp_path / "no-manifest").mkdir()
+
+        # reindex 실행
+        exit_code = main(["reindex", "--output-dir", str(tmp_path)])
+        captured = capsys.readouterr()
+
+        assert exit_code == 0
+        assert "indexed 2 builds" in captured.out
+
+        # 인덱스 확인
+        index_path = tmp_path / "_builds.sqlite"
+        assert index_path.exists()
+
+        index = BuildIndex(db_path=index_path)
+        builds = index.list_builds(limit=10)
+
+        assert len(builds) == 2
+        run_ids = {b["run_id"] for b in builds}
+        assert "run1" in run_ids
+        assert "run2" in run_ids
+
+        # 상태 확인
+        run1_build = next(b for b in builds if b["run_id"] == "run1")
+        assert run1_build["status"] == "completed"
+
+        run2_build = next(b for b in builds if b["run_id"] == "run2")
+        assert run2_build["status"] == "failed"
+
+    def test_reindex_replaces_existing_index(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """기존 인덱스가 있으면 원자적 교체한다."""
+        import json
+
+        from kpubdata_builder.index import BuildIndex, initialize_schema
+
+        # 기존 인덱스 생성 (오래된 데이터)
+        old_index_path = tmp_path / "_builds.sqlite"
+        initialize_schema(old_index_path)
+        old_index = BuildIndex(db_path=old_index_path)
+        old_index.record_build(
+            run_id="old-run",
+            status="completed",
+            started_at="2024-01-01T00:00:00Z",
+            finished_at="2024-01-01T00:01:00Z",
+        )
+
+        # 새 빌드 추가
+        run_dir = tmp_path / "new-run"
+        run_dir.mkdir()
+        (run_dir / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "run_id": "new-run",
+                    "status": "ok",
+                    "started_at": "2025-01-01T00:00:00Z",
+                    "finished_at": "2025-01-01T00:01:00Z",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        # reindex 실행
+        exit_code = main(["reindex", "--output-dir", str(tmp_path)])
+        captured = capsys.readouterr()
+
+        assert exit_code == 0
+        assert "backing up existing index" in captured.out
+
+        # 인덱스가 갱신되었는지 확인
+        index = BuildIndex(db_path=old_index_path)
+        builds = index.list_builds(limit=10)
+
+        assert len(builds) == 1
+        assert builds[0]["run_id"] == "new-run"
+        assert "old-run" not in {b["run_id"] for b in builds}
+
+    def test_reindex_handles_invalid_manifests(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """손상된 manifest는 건너뛰고 계속 진행한다."""
+        import json
+
+        from kpubdata_builder.index import BuildIndex
+
+        # 유효한 빌드
+        run1_dir = tmp_path / "run1"
+        run1_dir.mkdir()
+        (run1_dir / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "run_id": "run1",
+                    "status": "ok",
+                    "started_at": "2025-01-01T00:00:00Z",
+                    "finished_at": "2025-01-01T00:01:00Z",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        # 손상된 manifest
+        run2_dir = tmp_path / "run2"
+        run2_dir.mkdir()
+        (run2_dir / "manifest.json").write_text("invalid json{{{}}", encoding="utf-8")
+
+        # reindex 실행
+        exit_code = main(["reindex", "--output-dir", str(tmp_path)])
+        captured = capsys.readouterr()
+
+        # 손상된 manifest가 있어도 성공해야 함
+        assert exit_code == 0
+        assert "skipping run2" in captured.err
+
+        # 유효한 빌드만 인덱싱되었는지 확인
+        index = BuildIndex(db_path=tmp_path / "_builds.sqlite")
+        builds = index.list_builds(limit=10)
+
+        assert len(builds) == 1
+        assert builds[0]["run_id"] == "run1"
+
+    def test_reindex_returns_error_for_nonexistent_output_dir(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """존재하지 않는 output_dir면 에러를 반환한다."""
+        nonexistent = tmp_path / "nonexistent"
+        exit_code = main(["reindex", "--output-dir", str(nonexistent)])
+        captured = capsys.readouterr()
+
+        assert exit_code == 1
+        assert "does not exist" in captured.err
+
+    def test_reindex_handles_empty_output_dir(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """빈 output_dir면 빈 인덱스를 생성한다."""
+        from kpubdata_builder.index import BuildIndex
+
+        exit_code = main(["reindex", "--output-dir", str(tmp_path)])
+        captured = capsys.readouterr()
+
+        assert exit_code == 0
+        assert "indexed 0 builds" in captured.out
+
+        index = BuildIndex(db_path=tmp_path / "_builds.sqlite")
+        builds = index.list_builds(limit=10)
+
+        assert len(builds) == 0
+

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -1,0 +1,199 @@
+"""SQLite 빌드 인덱스 테스트 (#328)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kpubdata_builder.index import _SCHEMA_VERSION, BuildIndex, initialize_schema
+
+
+class TestBuildIndexSchema:
+    """스키마 생성 및 초기화 테스트."""
+
+    def test_initialize_schema_creates_database(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "_builds.sqlite"
+
+        initialize_schema(db_path)
+
+        assert db_path.exists()
+
+    def test_initialize_schema_creates_builds_table(self, tmp_path: Path) -> None:
+        import sqlite3
+
+        db_path = tmp_path / "_builds.sqlite"
+        initialize_schema(db_path)
+
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='builds'")
+            tables = cursor.fetchall()
+
+        assert len(tables) == 1
+        assert tables[0][0] == "builds"
+
+    def test_builds_table_has_all_columns(self, tmp_path: Path) -> None:
+        import sqlite3
+
+        db_path = tmp_path / "_builds.sqlite"
+        initialize_schema(db_path)
+
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute("PRAGMA table_info(builds)")
+            columns = {row[1] for row in cursor.fetchall()}
+
+        expected_columns = {
+            "run_id",
+            "status",
+            "started_at",
+            "finished_at",
+            "spec_digest",
+            "error",
+            "schema_version",
+        }
+        assert columns == expected_columns
+
+    def test_schema_version_is_set(self, tmp_path: Path) -> None:
+        assert _SCHEMA_VERSION == 1
+
+    def test_initialize_schema_applies_pragma_settings(self, tmp_path: Path) -> None:
+        import sqlite3
+
+        db_path = tmp_path / "_builds.sqlite"
+        initialize_schema(db_path)
+
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute("PRAGMA journal_mode")
+            journal_mode = cursor.fetchone()[0]
+            assert journal_mode == "wal"
+
+            cursor.execute("PRAGMA busy_timeout")
+            busy_timeout = cursor.fetchone()[0]
+            assert busy_timeout == 5000
+
+
+class TestBuildIndex:
+    """BuildIndex CRUD 테스트."""
+
+    def test_record_build_inserts_row(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "_builds.sqlite"
+        index = BuildIndex(db_path)
+
+        index.record_build(
+            run_id="test-run-1",
+            status="completed",
+            started_at="2025-01-01T00:00:00Z",
+            finished_at="2025-01-01T00:01:00Z",
+            spec_digest="abc123",
+        )
+
+        build = index.get_build("test-run-1")
+        assert build is not None
+        assert build["run_id"] == "test-run-1"
+        assert build["status"] == "completed"
+
+    def test_record_build_replaces_existing(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "_builds.sqlite"
+        index = BuildIndex(db_path)
+
+        index.record_build(
+            run_id="test-run-1",
+            status="completed",
+            started_at="2025-01-01T00:00:00Z",
+            finished_at="2025-01-01T00:01:00Z",
+        )
+
+        index.record_build(
+            run_id="test-run-1",
+            status="failed",
+            started_at="2025-01-01T00:00:00Z",
+            finished_at="2025-01-01T00:01:00Z",
+            error="test error",
+        )
+
+        build = index.get_build("test-run-1")
+        assert build["status"] == "failed"
+        assert build["error"] == "test error"
+
+    def test_list_builds_returns_newest_first(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "_builds.sqlite"
+        index = BuildIndex(db_path)
+
+        index.record_build(
+            run_id="run-1",
+            status="completed",
+            started_at="2025-01-01T00:00:00Z",
+            finished_at="2025-01-01T00:01:00Z",
+        )
+        index.record_build(
+            run_id="run-2",
+            status="completed",
+            started_at="2025-01-01T02:00:00Z",
+            finished_at="2025-01-01T02:01:00Z",
+        )
+        index.record_build(
+            run_id="run-3",
+            status="completed",
+            started_at="2025-01-01T01:00:00Z",
+            finished_at="2025-01-01T01:01:00Z",
+        )
+
+        builds = index.list_builds(limit=10)
+        assert len(builds) == 3
+        assert builds[0]["run_id"] == "run-2"  # 최신
+        assert builds[1]["run_id"] == "run-3"
+        assert builds[2]["run_id"] == "run-1"  # 가장 오래된
+
+    def test_list_builds_respects_limit(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "_builds.sqlite"
+        index = BuildIndex(db_path)
+
+        for i in range(10):
+            index.record_build(
+                run_id=f"run-{i}",
+                status="completed",
+                started_at="2025-01-01T00:00:00Z",
+                finished_at=f"2025-01-01T00:0{i}:00Z",
+            )
+
+        builds = index.list_builds(limit=5)
+        assert len(builds) == 5
+
+    def test_list_builds_filters_by_status(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "_builds.sqlite"
+        index = BuildIndex(db_path)
+
+        index.record_build(
+            run_id="run-1",
+            status="completed",
+            started_at="2025-01-01T00:00:00Z",
+            finished_at="2025-01-01T00:01:00Z",
+        )
+        index.record_build(
+            run_id="run-2",
+            status="failed",
+            started_at="2025-01-01T01:00:00Z",
+            finished_at="2025-01-01T01:01:00Z",
+            error="test error",
+        )
+        index.record_build(
+            run_id="run-3",
+            status="completed",
+            started_at="2025-01-01T02:00:00Z",
+            finished_at="2025-01-01T02:01:00Z",
+        )
+
+        completed_builds = index.list_builds(status="completed")
+        assert len(completed_builds) == 2
+
+        failed_builds = index.list_builds(status="failed")
+        assert len(failed_builds) == 1
+        assert failed_builds[0]["run_id"] == "run-2"
+
+    def test_get_build_returns_none_for_unknown(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "_builds.sqlite"
+        index = BuildIndex(db_path)
+
+        build = index.get_build("unknown")
+        assert build is None

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -113,6 +113,7 @@ class TestBuildIndex:
         )
 
         build = index.get_build("test-run-1")
+        assert build is not None
         assert build["status"] == "failed"
         assert build["error"] == "test error"
 

--- a/tests/unit/test_service_contract.py
+++ b/tests/unit/test_service_contract.py
@@ -25,6 +25,7 @@ _DISPATCH_ROUTES: dict[tuple[str, str], str] = {
     ("/validate", "POST"): "validateSpec",
     ("/preview", "POST"): "previewBuild",
     ("/build", "POST"): "createBuild",
+    ("/builds", "GET"): "listBuilds",
     ("/artifacts/{run_id}", "GET"): "listBuildArtifacts",
 }
 
@@ -274,6 +275,7 @@ _OPERATION_STATUS_CODES: dict[str, set[int]] = {
     "validateSpec": {200, 400},
     "previewBuild": {200, 400},
     "createBuild": {200, 400, 502},
+    "listBuilds": {200, 400},
     "listBuildArtifacts": {200, 400, 404},
 }
 

--- a/uv.lock
+++ b/uv.lock
@@ -630,22 +630,22 @@ publish = [
 [package.metadata]
 requires-dist = [
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.2,<2" },
-    { name = "huggingface-hub", marker = "extra == 'huggingface'", specifier = ">=0.23,<1" },
-    { name = "huggingface-hub", marker = "extra == 'publish'", specifier = ">=0.23,<1" },
+    { name = "huggingface-hub", marker = "extra == 'huggingface'", specifier = ">=0.23,<2" },
+    { name = "huggingface-hub", marker = "extra == 'publish'", specifier = ">=0.23,<2" },
     { name = "kaggle", marker = "extra == 'publish'", specifier = ">=1.6,<2" },
     { name = "kpubdata", editable = "../kpubdata" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6,<2" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9,<10" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10,<2" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10,<3" },
     { name = "polars", specifier = ">=1.0,<2" },
-    { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=15,<18" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2,<9" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5,<6" },
+    { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=15,<26" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2,<10" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5,<8" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5,<1" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
-    { name = "typing-extensions", specifier = ">=4.5" },
-    { name = "xmltodict", marker = "extra == 'publish'", specifier = ">=0.13,<1" },
+    { name = "typing-extensions", specifier = ">=4.5,<5" },
+    { name = "xmltodict", marker = "extra == 'publish'", specifier = ">=0.13,<2" },
 ]
 provides-extras = ["docs", "parquet", "huggingface", "publish", "dev"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -562,33 +562,15 @@ wheels = [
 [[package]]
 name = "kpubdata"
 version = "0.5.0"
-source = { editable = "../kpubdata" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "build", marker = "extra == 'dev'", specifier = ">=1.2,<2" },
-    { name = "httpx", specifier = ">=0.27,<1" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1,<2" },
-    { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5,<10" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10,<2" },
-    { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.2,<3" },
-    { name = "pandas-stubs", marker = "extra == 'dev'", specifier = ">=2.2,<3" },
-    { name = "pydantic", marker = "extra == 'validation'", specifier = ">=2.7,<3" },
-    { name = "pykrx", marker = "extra == 'dev'", specifier = ">=1.0.45,<2" },
-    { name = "pykrx", marker = "extra == 'krx'", specifier = ">=1.0.45,<2" },
-    { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10,<11" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2,<9" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5,<6" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5,<1" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.10" },
-    { name = "xmltodict", marker = "extra == 'dev'", specifier = ">=0.13,<1" },
-    { name = "xmltodict", marker = "extra == 'xml'", specifier = ">=0.13,<1" },
+sdist = { url = "https://files.pythonhosted.org/packages/e9/58/2f0a8d1b4ec6cd8152f951ffc5849c64628b10a0ee81f890ea3c97ba8fda/kpubdata-0.5.0.tar.gz", hash = "sha256:89e9b60afdc4c2f129b17207dc16c8531fbfdd1d7ef2048e4a1e0282c24c4905", size = 434771, upload-time = "2026-04-27T15:36:01.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/88/47574191c71ca22a840cfde858854f908c62f3b0609a2c8a98b554b96b65/kpubdata-0.5.0-py3-none-any.whl", hash = "sha256:e0c5d49bdd6abd5a4138f2d3945bd39ff0c3db926f6050ad17a009854192cf67", size = 104145, upload-time = "2026-04-27T15:36:00.024Z" },
 ]
-provides-extras = ["xml", "pandas", "krx", "validation", "mcp", "dev", "docs"]
 
 [[package]]
 name = "kpubdata-builder"
@@ -633,7 +615,7 @@ requires-dist = [
     { name = "huggingface-hub", marker = "extra == 'huggingface'", specifier = ">=0.23,<2" },
     { name = "huggingface-hub", marker = "extra == 'publish'", specifier = ">=0.23,<2" },
     { name = "kaggle", marker = "extra == 'publish'", specifier = ">=1.6,<2" },
-    { name = "kpubdata", editable = "../kpubdata" },
+    { name = "kpubdata", specifier = ">=0.5.0,<0.6" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6,<2" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9,<10" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10,<3" },


### PR DESCRIPTION
## 요약
이 PR은 output_root를 스캔하여 SQLite 빌드 인덱스를 재구축하는 CLI 커맨드를 추가합니다. 인덱스가 손상되었거나 불일치가 있는 경우 스캔으로 복구할 수 있으며, 기존 인덱스를 원자적으로 교체하여 안전하게 갱신합니다.

## 변경 내용
- reindex CLI 커맨드 추가 (#330)
  - kpubdata-builder reindex 하위 명령 추가
  - --output-dir 옵션으로 스캔할 디렉터리 지정 (기본값: build)
- 디렉터리 스캔으로 인덱스 재구축
  - output_root 아래 모든 디렉터리를 스캔하여 manifest.json 파일 탐색
  - manifest의 started_at, finished_at, errors 필드로 인덱스 레코드 생성
  - errors 있으면 failed, 없으면 completed 상태로 기록
- 안전한 인덱스 교체
  - 기존 인덱스 백업 (_builds.sqlite.bak)
  - 임시 파일에 새 인덱스 생성 (_builds.sqlite.tmp)
  - 원자적 교체: 기존 파일 삭제 후 임시 파일 이름 변경
  - 성공 시 백업 삭제, 실패 시 임시 파일 정리
- 에러 처리
  - 존재하지 않는 output_dir: 에러 메시지와 종료 코드 1
  - 손상된 manifest: 경고 로그 후 건너뛰고 계속 진행
  - 빈 output_dir: 빈 인덱스 생성
 
## 관련 이슈
Closes #330
- ADR 0003 (#309) - 영속 Build 저장소 설계

## 테스트
- CLI 파싱 테스트
  - reindex 하위 명령 존재 확인
  - --output-dir 옵션 파싱 확인
- 기능 테스트
  - 정상 manifest 스캔 및 인덱스 생성
  - 기존 인덱스 원자적 교체
  - 손상된 manifest 건너뛰기
  - 존재하지 않는 output_dir 에러 처리
  - 빈 output_dir 빈 인덱스 생성

완료 조건 (DoD)
- [x] 재구축 커맨드로 스캔 결과와 일치하는 인덱스 생성
- [x] 유닛 테스트