### PR TITLE
docs: 동기 POST /build 응답 계약 명확화(ADR 0002)

### DIFF
--- a/contract/builder-api.yaml
+++ b/contract/builder-api.yaml
@@ -7,8 +7,8 @@ info:
     계약 버전 조회를 제공한다. CLI와 HTTP service mode(#36)가 동일한 도메인 계약을
     공유한다. 본 문서는 BuilderService(service/app.py)의 dispatch 라우팅과 실제
     wire 형태를 기계 판독용(OpenAPI 3.1) 단일 소스로 고정하며, Studio 같은 소비자가
-    타입 클라이언트를 생성하는 기준이 된다. 구현되지 않은 비동기/publish 엔드포인트는
-    드리프트를 막기 위해 계약에서 제거했다(#226).
+    타입 클라이언트를 생성하는 기준이 된다. v0.4에서는 동기식 build만 유지하며
+    비동기/publish 엔드포인트는 제외된다(ADR 0002, #226).
 servers:
   - url: http://localhost:8000
     description: 로컬 builder 개발 서버

--- a/tests/unit/test_service_contract.py
+++ b/tests/unit/test_service_contract.py
@@ -26,6 +26,7 @@ _DISPATCH_ROUTES: dict[tuple[str, str], str] = {
     ("/preview", "POST"): "previewBuild",
     ("/build", "POST"): "createBuild",
     ("/artifacts/{run_id}", "GET"): "listBuildArtifacts",
+    ("/builds", "GET"): "listBuilds",
 }
 
 # (path, method) 형태의 계약 필수 오퍼레이션. BuilderService.dispatch가 실제로
@@ -275,6 +276,7 @@ _OPERATION_STATUS_CODES: dict[str, set[int]] = {
     "previewBuild": {200, 400},
     "createBuild": {200, 400, 502},
     "listBuildArtifacts": {200, 400, 404},
+    "listBuilds": {200, 400},
 }
 
 


### PR DESCRIPTION
## 요약
ADR 0002(#308)에 따라 v0.4에서는 동기식 POST /build만 유지하며, 비동기/publish 엔드포인트는 제외된다는 사실을 API 계약 문서에 명확히 반영합니다. 기존 계약의 응답 스펙(200 성공, 502 업스트림 실패)은 유지되며, 단일 진실 공급원(SSOT) 원칙에 따라 계약 커버리지 테스트를 추가합니다.

## 변경 내용
- contract/builder-api.yaml의 description에 ADR 0002 참조 추가
  - "v0.4에서는 동기식 build만 유지하며 비동기/publish 엔드포인트는 제외된다(ADR 0002, #226)" 명시
- tests/unit/test_service_contract.py에 /builds 엔드포인트 커버리지 추가
  - _DISPATCH_ROUTES에 /builds → listBuilds 매핑 추가
  - _OPERATION_STATUS_CODES에 listBuilds → {200, 400} 추가

## 관련 이슈
Closes #332

## 검증
- [x] uv run ruff check . 통과
- [x] uv run mypy tests/unit/test_service_contract.py 통과
- [x] 테스트 통과 (uv run pytest tests/unit/test_service_contract.py) - 15개 테스트 모두 통과

## 체크리스트
- [x] 기능 브랜치에서 작업했으며 main에 직접 push하지 않았다
- [x] 커밋 메시지를 영어로 작성했다
- [x] 필요한 단위/단계 인지형 테스트를 추가했다