### PR TITLE
fix: rebuild_index를 원자적 .bak/.tmp 교체 방식으로 변경 (#366)

### DIFF
--- a/src/kpubdata_builder/store/build_index.py
+++ b/src/kpubdata_builder/store/build_index.py
@@ -51,14 +51,15 @@ class BuildIndex:
     - WAL 모드 + busy_timeout으로 동시성 안전 장치
     """
 
-    def __init__(self, output_root: Path) -> None:
+    def __init__(self, output_root: Path, *, index_path: Path | None = None) -> None:
         """인덱스를 초기화한다.
 
         Args:
             output_root: 빌드 출력 루트 디렉터리 (인덱스는 output_root/_builds.sqlite)
+            index_path: 인덱스 파일 경로 오버라이드 (rebuild_index의 원자적 교체용 임시 파일 등)
         """
         self._output_root = output_root
-        self._index_path = output_root / _INDEX_FILENAME
+        self._index_path = index_path if index_path is not None else output_root / _INDEX_FILENAME
         self._local = threading.local()
         self._init_db()
 
@@ -238,8 +239,13 @@ class BuildIndex:
             pass
 
     def close(self) -> None:
-        """연결을 닫는다."""
+        """연결을 닫는다.
+
+        파일을 이름 변경(rename)만으로 안전하게 이관할 수 있도록,
+        닫기 전에 WAL 내용을 메인 DB 파일로 체크포인트한다.
+        """
         if hasattr(self._local, "conn"):
+            self._local.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
             self._local.conn.close()
             delattr(self._local, "conn")
 
@@ -247,8 +253,9 @@ class BuildIndex:
 def rebuild_index(output_root: Path) -> int:
     """파일시스템 스캔으로 인덱스를 재구축한다.
 
-    output_root 아래의 모든 manifest.json을 스캔하여 인덱스를 다시 빌드한다.
-    기존 인덱스는 삭제되고 새로 생성된다.
+    output_root 아래의 모든 manifest.json을 스캔하여 새 인덱스를 .tmp 파일에
+    빌드한 뒤, 기존 인덱스를 .bak으로 백업하고 .tmp를 원자적으로 rename하여
+    교체한다 (#366). 스캔 도중 실패해도 기존 인덱스는 그대로 남는다.
 
     Args:
         output_root: 빌드 출력 루트 디렉터리
@@ -258,40 +265,59 @@ def rebuild_index(output_root: Path) -> int:
     """
     import json
 
-    index_path = output_root / _INDEX_FILENAME
-    # 기존 인덱스 삭제
-    if index_path.exists():
-        index_path.unlink()
-
-    index = BuildIndex(output_root)
-    count = 0
-
     if not output_root.exists():
         return 0
 
-    for run_dir in output_root.iterdir():
-        if not run_dir.is_dir():
-            continue
-        manifest_path = run_dir / "manifest.json"
-        if not manifest_path.exists():
-            continue
+    index_path = output_root / _INDEX_FILENAME
+    tmp_path = output_root / f"{_INDEX_FILENAME}.tmp"
+    backup_path = output_root / f"{_INDEX_FILENAME}.bak"
 
-        try:
-            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            continue
+    # 이전 실행이 중단되어 남은 임시 파일 정리
+    tmp_path.unlink(missing_ok=True)
 
-        status = "failed" if manifest.get("errors") else "ok"
-        started_at = manifest.get("started_at")
-        finished_at = manifest.get("finished_at")
+    index = BuildIndex(output_root, index_path=tmp_path)
+    try:
+        count = 0
+        for run_dir in output_root.iterdir():
+            if not run_dir.is_dir():
+                continue
+            manifest_path = run_dir / "manifest.json"
+            if not manifest_path.exists():
+                continue
 
-        index.insert_or_replace(
-            run_id=run_dir.name,
-            status=status,  # type: ignore[arg-type]
-            started_at=started_at,
-            finished_at=finished_at,
-        )
-        count += 1
+            try:
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                continue
+
+            status = "failed" if manifest.get("errors") else "ok"
+            started_at = manifest.get("started_at")
+            finished_at = manifest.get("finished_at")
+
+            index.insert_or_replace(
+                run_id=run_dir.name,
+                status=status,  # type: ignore[arg-type]
+                started_at=started_at,
+                finished_at=finished_at,
+            )
+            count += 1
+    finally:
+        index.close()
+
+    # 원자적 교체: 기존 인덱스를 .bak으로 백업 후 .tmp를 원본 자리로 rename
+    backup_path.unlink(missing_ok=True)
+    if index_path.exists():
+        index_path.rename(backup_path)
+
+    try:
+        tmp_path.rename(index_path)
+    except OSError:
+        # 교체 실패 시 백업에서 복원
+        if backup_path.exists():
+            backup_path.rename(index_path)
+        raise
+    else:
+        backup_path.unlink(missing_ok=True)
 
     return count
 

--- a/tests/unit/test_build_index.py
+++ b/tests/unit/test_build_index.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from kpubdata_builder.store import SCHEMA_VERSION, BuildIndex, rebuild_index
 
 
@@ -273,3 +275,59 @@ class TestRebuildIndex:
         builds = index.list_builds()
         assert len(builds) == 1
         assert builds[0].run_id == "good"
+
+    def test_rebuild_leaves_no_tmp_or_bak_after_success(self, tmp_path: Path) -> None:
+        """정상 재구축 후에는 .tmp/.bak 잔여 파일이 남지 않는다 (#366)."""
+        index = BuildIndex(tmp_path)
+        index.close()
+
+        rebuild_index(tmp_path)
+
+        assert (tmp_path / "_builds.sqlite").exists()
+        assert not (tmp_path / "_builds.sqlite.tmp").exists()
+        assert not (tmp_path / "_builds.sqlite.bak").exists()
+
+    def test_rebuild_cleans_up_stale_tmp_file(self, tmp_path: Path) -> None:
+        """이전 실행이 중단되어 남은 .tmp 파일이 있어도 재구축은 정상 동작한다 (#366)."""
+        stale_tmp = tmp_path / "_builds.sqlite.tmp"
+        stale_tmp.write_text("stale garbage")
+
+        count = rebuild_index(tmp_path)
+
+        assert count == 0
+        assert not stale_tmp.exists()
+
+    def test_rebuild_restores_backup_when_swap_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """.tmp -> 원본 교체가 실패하면 기존 인덱스를 백업에서 복원한다 (#366)."""
+        index = BuildIndex(tmp_path)
+        index.insert_or_replace(
+            run_id="old",
+            status="ok",
+            started_at="2025-01-01T09:00:00Z",
+            finished_at="2025-01-01T09:05:00Z",
+        )
+        index.close()
+
+        index_path = tmp_path / "_builds.sqlite"
+        tmp_index_path = tmp_path / "_builds.sqlite.tmp"
+        original_rename = Path.rename
+
+        def flaky_rename(self: Path, target: Path) -> Path:
+            if self == tmp_index_path:
+                raise OSError("simulated rename failure")
+            return original_rename(self, target)
+
+        monkeypatch.setattr(Path, "rename", flaky_rename)
+
+        with pytest.raises(OSError):
+            rebuild_index(tmp_path)
+
+        monkeypatch.undo()
+
+        assert index_path.exists()
+        assert not (tmp_path / "_builds.sqlite.bak").exists()
+
+        restored = BuildIndex(tmp_path)
+        assert restored.get("old") is not None


### PR DESCRIPTION
## 요약
기존에는 인덱스를 삭제 후 재생성하는 방식이라 재구축 도중 실패하면 인덱스가 통째로 유실될 수 있었다. 새 인덱스를 .tmp로 먼저 완성한 뒤
기존 파일을 .bak으로 백업하고 원자적으로 rename하며, 교체가 실패하면 백업에서 복원한다.

## 변경 내용
## 배경

`store.rebuild_index()`는 기존 `_builds.sqlite`를 삭제한 뒤 스캔 결과로 다시 생성하는 방식이었다. 재구축 도중 실패(디스크 오류, 프로세스 강제 종료 등)가 발생하면 인덱스가 통째로 유실될 수 있었다.

이 원자적 교체 아이디어는 PR #356 에서 제안되었고, 그중 재구축 부분만 이슈 #366 으로 분리되었습니다 (동일 기능은 이미 PR #347로 병합됨).

## 변경 사항

- `rebuild_index()`가 새 인덱스를 `_builds.sqlite.tmp`에 먼저 완성한 뒤, 다음 순서로 원자적 교체를 수행하도록 변경:
  1. 기존 `_builds.sqlite` → `_builds.sqlite.bak`으로 이동
  2. `_builds.sqlite.tmp` → `_builds.sqlite`로 rename
  3. 성공 시 `.bak` 삭제, `rename` 실패 시 `.bak`에서 원본을 복원 후 예외 재발생
- 이전 실행이 중단되어 남아있는 `.tmp` 파일은 재구축 시작 시 자동 정리
- `BuildIndex.__init__`에 `index_path` 오버라이드 옵션 추가 (임시 파일 경로에 인덱스를 빌드하기 위함)
- `BuildIndex.close()`가 닫기 전에 `PRAGMA wal_checkpoint(TRUNCATE)`를 실행하도록 변경 — WAL 모드에서 rename만으로 안전하게 파일을 이관하기 위함

## 관련 이슈
Closes #366

## 검증
- [x] `test_rebuild_leaves_no_tmp_or_bak_after_success`: 정상 재구축 후 `.tmp`/`.bak` 잔여 파일이 없는지 확인
- [x] `test_rebuild_cleans_up_stale_tmp_file`: 이전 실행에서 남은 `.tmp` 파일이 있어도 정상 동작하는지 확인
- [x] `test_rebuild_restores_backup_when_swap_fails`: `.tmp` → 원본 rename이 실패하면 백업에서 기존 인덱스를 복원하는지 확인
- [x] 기존 `rebuild_index` 테스트(빈 디렉터리, manifest 스캔, 손상된 manifest 등) 전부 통과

## 체크리스트
- [x] 재구축 커맨드로 스캔 결과와 일치하는 인덱스 생성
- [x] 원자적 교체(.bak/.tmp swap) 적용
- [x] 유닛 테스트 추가
- [x] `uv run pytest` 전체 통과 (588 passed)
- [x] `uv run mypy`, `uv run ruff check` 통과