### PR TITLE
fix: dev-mode 환경변수 통일 — KPUBDATA_BUILDER_DEV_MODE (#371, A1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,11 +202,11 @@ ADR 0006). 설정은 환경변수로 주입합니다 — `docker-entrypoint.sh`�
 | `KPUBDATA_BUILDER_PORT` | 바인딩 포트 | `8000` | 선택 |
 | `KPUBDATA_BUILDER_OUTPUT_DIR` | 실행 워크스페이스 루트 | `/data` | 선택 |
 | `KPUBDATA_BUILDER_HOST` | 바인딩 호스트 | `0.0.0.0` | 선택 |
-| `KPUBDATA_BUILDER_DEV` | `1`이면 API 키 없이 기동 (로컬 개발 전용) | 미설정 | 선택 |
+| `KPUBDATA_BUILDER_DEV_MODE` | `true`/`1`이면 API 키 없이 기동 (로컬 개발 전용) | 미설정 | 선택 |
 
 > **fail-closed (ADR 0006)**: 컨테이너는 `KPUBDATA_BUILDER_API_KEY`가 없으면 기동을
 > 거부합니다. `service/app.py`의 "키 미설정 = 인증 생략" 동작은 로컬 개발 편의 전용이며
-> 컨테이너로 누출되지 않습니다. 로컬에서 인증 없이 띄우려면 `KPUBDATA_BUILDER_DEV=1`을
+> 컨테이너로 누출되지 않습니다. 로컬에서 인증 없이 띄우려면 `KPUBDATA_BUILDER_DEV_MODE=1`을
 > 명시하세요.
 
 ```bash
@@ -224,7 +224,7 @@ curl -s -H "X-API-Key: ${API_KEY}" http://localhost:8000/version
 # {"service": "kpubdata-builder", "api_version": "1.0.0"}
 
 # 로컬 개발 — 인증 생략 (dev-mode)
-docker run --rm -p 8000:8000 -e KPUBDATA_BUILDER_DEV=1 kpubdata-builder:latest
+docker run --rm -p 8000:8000 -e KPUBDATA_BUILDER_DEV_MODE=1 kpubdata-builder:latest
 ```
 
 `kpubdata`는 `uv sync --no-sources`로 PyPI에서 설치되므로, 빌드 시 형제 디렉터리

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,11 +5,20 @@
 # 컨테이너 경계에서 강제하는 것 — service/app.py의 "키 미설정 = 인증 생략" 동작은
 # 로컬 개발 편의 전용이며 컨테이너로 누출되지 않아야 한다. 따라서 API 키가 없으면
 # (명시적 dev 플래그가 없는 한) 기동을 거부한다.
+#
+# dev-mode 플래그 이름은 service/app.py:_is_dev_mode()가 읽는
+# KPUBDATA_BUILDER_DEV_MODE와 동일해야 한다 (#371).
 set -eu
 
-if [ -z "${KPUBDATA_BUILDER_API_KEY:-}" ] && [ "${KPUBDATA_BUILDER_DEV:-0}" != "1" ]; then
+# app.py의 _is_dev_mode()와 동일하게 'true'/'1'을 대소문자 무관으로 받는다.
+case "${KPUBDATA_BUILDER_DEV_MODE:-}" in
+  [Tt][Rr][Uu][Ee] | 1) _dev_mode=1 ;;
+  *) _dev_mode=0 ;;
+esac
+
+if [ -z "${KPUBDATA_BUILDER_API_KEY:-}" ] && [ "$_dev_mode" != "1" ]; then
   echo "kpubdata-builder: KPUBDATA_BUILDER_API_KEY is required (fail-closed, ADR 0006)." >&2
-  echo "  set KPUBDATA_BUILDER_API_KEY=<secret>, or KPUBDATA_BUILDER_DEV=1 for" >&2
+  echo "  set KPUBDATA_BUILDER_API_KEY=<secret>, or KPUBDATA_BUILDER_DEV_MODE=1 for" >&2
   echo "  unauthenticated local use." >&2
   exit 1
 fi

--- a/tests/unit/test_docker_entrypoint.py
+++ b/tests/unit/test_docker_entrypoint.py
@@ -1,0 +1,90 @@
+"""docker-entrypoint.sh 계약 테스트 (#371).
+
+컨테이너 진입점이 service/app.py:_is_dev_mode()와 동일한 환경변수
+(``KPUBDATA_BUILDER_DEV_MODE``)를 읽는지, 그리고 fail-closed 게이트가
+API 키·dev-mode 조합에 대해 올바로 동작하는지 검증한다. 예전 이름
+(``KPUBDATA_BUILDER_DEV``)은 더 이상 허용되지 않아야 한다(회귀 방지).
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ENTRYPOINT = REPO_ROOT / "docker-entrypoint.sh"
+
+# 모듈이 sh 없는 환경에서는 건너뛴다(이 프로젝트 CI는 Linux).
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="entrypoint is a POSIX sh script")
+
+# 진입점이 게이트 통과 후 exec 하는 ``kpubdata-builder``를 가로채기 위한 더미.
+_STUB_SCRIPT = "#!/bin/sh\nexit 0\n"
+
+
+def _stub_bin_dir(tmp_path: Path) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    stub = bin_dir / "kpubdata-builder"
+    stub.write_text(_STUB_SCRIPT)
+    stub.chmod(stub.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return bin_dir
+
+
+def _run_entrypoint(env: dict[str, str], bin_dir: Path) -> subprocess.CompletedProcess[bytes]:
+    # 테스트 러너 환경의 키 변수 누수를 막기 위해 제어 대상 변수는 한 번 비우고 다시 주입.
+    full_env = {k: v for k, v in os.environ.items() if k not in _CONTROLLED_ENVS}
+    full_env["PATH"] = f"{bin_dir}:{full_env.get('PATH', '')}"
+    for key, value in env.items():
+        if value:
+            full_env[key] = value
+    return subprocess.run(["sh", str(ENTRYPOINT)], env=full_env, capture_output=True, check=False)
+
+
+_CONTROLLED_ENVS = {
+    "KPUBDATA_BUILDER_API_KEY",
+    "KPUBDATA_BUILDER_DEV_MODE",
+    "KPUBDATA_BUILDER_DEV",
+}
+
+
+@pytest.fixture()
+def bin_dir(tmp_path: Path) -> Path:
+    return _stub_bin_dir(tmp_path)
+
+
+class TestEntrypointDevModeContract:
+    """진입점 게이트가 app.py의 dev-mode 시맨틱과 일치하는지 검증 (#371)."""
+
+    def test_no_key_no_dev_mode_rejected(self, bin_dir: Path) -> None:
+        # fail-closed: 둘 다 없으면 기동 거부 (exit 1).
+        result = _run_entrypoint({}, bin_dir)
+        assert result.returncode == 1, result.stderr
+        assert b"KPUBDATA_BUILDER_API_KEY is required" in result.stderr
+
+    def test_api_key_set_proceeds(self, bin_dir: Path) -> None:
+        result = _run_entrypoint({"KPUBDATA_BUILDER_API_KEY": "secret"}, bin_dir)
+        assert result.returncode == 0, result.stderr
+
+    def test_dev_mode_1_allows_no_key(self, bin_dir: Path) -> None:
+        result = _run_entrypoint({"KPUBDATA_BUILDER_DEV_MODE": "1"}, bin_dir)
+        assert result.returncode == 0, result.stderr
+
+    def test_dev_mode_true_case_insensitive(self, bin_dir: Path) -> None:
+        # app.py:_is_dev_mode()가 'true'/'1'을 대소문자 무관으로 받으므로 진입점도 동일.
+        for value in ("true", "TRUE", "True"):
+            result = _run_entrypoint({"KPUBDATA_BUILDER_DEV_MODE": value}, bin_dir)
+            assert result.returncode == 0, f"DEV_MODE={value!r} should allow startup"
+
+    def test_dev_mode_explicit_false_rejected(self, bin_dir: Path) -> None:
+        result = _run_entrypoint({"KPUBDATA_BUILDER_DEV_MODE": "0"}, bin_dir)
+        assert result.returncode == 1, result.stderr
+
+    def test_legacy_DEV_name_not_recognized(self, bin_dir: Path) -> None:
+        # 회귀 방지: 예전 이름 KPUBDATA_BUILDER_DEV 는 더 이상 효과가 없어야 한다.
+        result = _run_entrypoint({"KPUBDATA_BUILDER_DEV": "1"}, bin_dir)
+        assert result.returncode == 1, "legacy KPUBDATA_BUILDER_DEV must NOT bypass fail-closed"


### PR DESCRIPTION
## 개요

리뷰 P0 중 **A1**(= #371). `docker-entrypoint.sh`·`README.md`가 `KPUBDATA_BUILDER_DEV`를 쓰는데 `service/app.py`는 `KPUBDATA_BUILDER_DEV_MODE`를 읽어 **양방향이 모두 깨진** 버그.

| 상황 | 결과 |
| :--- | :--- |
| README대로 `DEV=1` | 컨테이너는 기동하나 `_verify_api_key`가 fail-closed → **모든 요청 401** |
| `DEV_MODE=true`만 지정 | entrypoint가 기동 **거부** |

## 변경

- `docker-entrypoint.sh`: `KPUBDATA_BUILDER_DEV` → `KPUBDATA_BUILDER_DEV_MODE`. app.py의 `_is_dev_mode()`와 동일하게 `true`/`1`을 대소문자 무관으로 받도록 POSIX `case` 사용.
- `README.md`: 환경변수 표와 예제 동일 이름으로 갱신.
- `tests/unit/test_docker_entrypoint.py`(신규): entrypoint 계약 테스트 6건 — `API_KEY × DEV_MODE` 매트릭스 + 예전 `DEV` 이름이 더 이상 fail-closed를 우회하지 않음(회귀 방지).

## 검증

- `uv run ruff check .` / `format --check .` / `mypy` 통과
- `uv run pytest` — **594 passed** (신규 6 포함, 회귀 없음)

## 메모

- 본 PR은 인증 강화(ADR 0009 방향, #383)와 무관하게 선행 처리한 P0. Bearer 도입 전에 기본 dev-mode 게이트가 문서대로 동작해야 함.

Closes #371