### PR TITLE
fix: CORS — Authorization 헤더 + 파일 응답 Origin 처리 (#382, A3)

### DIFF
--- a/src/kpubdata_builder/service/http.py
+++ b/src/kpubdata_builder/service/http.py
@@ -44,6 +44,9 @@ _DEFAULT_MAX_WORKERS = 10
 # KPUBDATA_BUILDER_ALLOWED_ORIGINS=http://localhost:5173,https://studio.example.com).
 _ALLOWED_ORIGINS_ENV = "KPUBDATA_BUILDER_ALLOWED_ORIGINS"
 
+# 프리플라이트가 허가하는 요청 헤더. Bearer 인증(ADR 0009)을 위해 Authorization 포함 (#382).
+_CORS_ALLOWED_HEADERS = "Content-Type, X-API-Key, Authorization"
+
 # MIME 타입 기본값 (#323). mimetypes.guess_type이 None을 반환할 때 사용.
 _DEFAULT_MIME_TYPE = "application/octet-stream"
 
@@ -217,7 +220,7 @@ def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
                     # Same-origin 요청이면 특정 오리진 제한 없이 허용한다.
                     self.send_header("Access-Control-Allow-Origin", "*")
                 self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-                self.send_header("Access-Control-Allow-Headers", "Content-Type, X-API-Key")
+                self.send_header("Access-Control-Allow-Headers", _CORS_ALLOWED_HEADERS)
                 self.send_header("Access-Control-Max-Age", "86400")
 
         def _write(self, status_code: int, body: dict[str, JsonValue]) -> None:
@@ -249,7 +252,7 @@ def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
             self.send_header("Content-Type", f"{mime_type}; charset=utf-8")
             self.send_header("Content-Length", str(len(content)))
             self.send_header("Content-Disposition", f'attachment; filename="{filename}"')
-            self._send_cors_headers()
+            self._send_cors_headers(origin=self.headers.get("Origin"))
             self.end_headers()
             _ = self.wfile.write(content)
 

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -547,9 +547,11 @@ class TestHttpAdapter:
         with urllib.request.urlopen(req, timeout=2.0) as response:
             assert response.status == 204
             assert response.headers["Access-Control-Allow-Origin"] == "*"
-            assert "POST" in response.headers["Access-Control-Allow-Methods"]
-            assert "OPTIONS" in response.headers["Access-Control-Allow-Methods"]
-            assert response.headers["Access-Control-Allow-Headers"] == "Content-Type, X-API-Key"
+            assert response.headers["Access-Control-Allow-Methods"] == "GET, POST, OPTIONS"
+            assert (
+                response.headers["Access-Control-Allow-Headers"]
+                == "Content-Type, X-API-Key, Authorization"
+            )
             assert response.headers["Access-Control-Max-Age"] == "86400"
 
     def test_response_includes_cors_header(
@@ -577,6 +579,58 @@ class TestHttpAdapter:
         with urllib.request.urlopen(req, timeout=2.0) as response:
             # default-deny이므로 CORS 헤더가 없어야 함
             assert "Access-Control-Allow-Origin" not in response.headers
+
+    def test_cors_file_download_respects_allowlist(
+        self,
+        http_server: tuple[str, HTTPServer, threading.Thread],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # 파일 응답(_write_file)도 CORS 허용 목록을 따라야 한다 (#382).
+        # 이전에는 _write_file이 Origin을 전달하지 않아 same-origin으로 취급되어
+        # 허용되지 않은 오리진에도 Access-Control-Allow-Origin: * 를 보냈다.
+        monkeypatch.delenv("KPUBDATA_BUILDER_ALLOWED_ORIGINS", raising=False)
+        base_url, _, _ = http_server
+        build_req = urllib.request.Request(
+            f"{base_url}/build",
+            data=json.dumps({"spec": VALID_SPEC_YAML, "run_id": "run1"}).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(build_req, timeout=5.0) as response:
+            assert response.status == 200
+        # 크로스오리진 파일 다운로드 요청
+        req = urllib.request.Request(
+            f"{base_url}/artifacts/run1/manifest.json",
+            headers={"Origin": "http://localhost:5173"},
+        )
+        with urllib.request.urlopen(req, timeout=2.0) as response:
+            assert response.status == 200
+            # default-deny: 허용 목록에 없는 오리진은 CORS 헤더를 받지 않는다
+            assert "Access-Control-Allow-Origin" not in response.headers
+
+    def test_cors_file_download_allowed_origin_echoed(
+        self,
+        http_server: tuple[str, HTTPServer, threading.Thread],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # 허용된 오리진의 파일 다운로드는 해당 오리진을 echo 해야 한다 (#382).
+        monkeypatch.setenv("KPUBDATA_BUILDER_ALLOWED_ORIGINS", "http://localhost:5173")
+        base_url, _, _ = http_server
+        build_req = urllib.request.Request(
+            f"{base_url}/build",
+            data=json.dumps({"spec": VALID_SPEC_YAML, "run_id": "run1"}).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(build_req, timeout=5.0) as response:
+            assert response.status == 200
+        req = urllib.request.Request(
+            f"{base_url}/artifacts/run1/manifest.json",
+            headers={"Origin": "http://localhost:5173"},
+        )
+        with urllib.request.urlopen(req, timeout=2.0) as response:
+            assert response.status == 200
+            assert response.headers["Access-Control-Allow-Origin"] == "http://localhost:5173"
 
     def test_cors_allowed_origins_configurable(
         self,


### PR DESCRIPTION
## 개요

리뷰 **A3**(= #382). `service/http.py` 의 CORS 두 가지 간극.

| 간극 | 원인 | 결과 |
| :--- | :--- | :--- |
| `Access-Control-Allow-Headers` 에 `Authorization` 누락 | hardcoded `Content-Type, X-API-Key` | Bearer 토큰 프리플라이트 거부 (ADR 0009 인증 도입의 선행 조건) |
| `_write_file` 이 Origin 미전달 | `_send_cors_headers()` 를 인자 없이 호출 | 크로스오리진 파일 다운로드가 same-origin 취급 → `Allow-Origin: *` → default-deny 정책(#322) 우회 |

## 변경

- `_CORS_ALLOWED_HEADERS` 모듈 상수 신설(`Authorization` 포함) — 허용 헤더 단일 소스.
- `_write_file` 이 `self._send_cors_headers(origin=self.headers.get("Origin"))` 로 `_write` 와 동일하게 Origin 전달.

## 테스트

- 기존 preflight 어설션 갱신(새 헤더값).
- 회귀 2건 추가: 파일 다운로드 경로에서 (1) 허용되지 않은 오리진 → CORS 헤더 없음, (2) 허용된 오리진 → 해당 오리진 echo.

## 검증

- `ruff check` / `format --check` / `mypy` 통과
- `pytest` — **590 passed** (+2 신규, 회귀 없음)

Closes #382