### PR TITLE
feat: 무인증 /healthz + Dockerfile HEALTHCHECK (#372, A2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,9 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 # KPUBDATA_BUILDER_PORT(기본 8000)가 이 포트를 가리킨다.
 EXPOSE 8000
 
+# 무인증 /healthz로 liveness probe (#372). python-slim에 curl/wget이 없으므로
+# 표준 라이브러리 urllib를 사용한다. 포트는 KPUBDATA_BUILDER_PORT를 따른다.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD python -c "import os,urllib.request; urllib.request.urlopen('http://localhost:'+os.environ.get('KPUBDATA_BUILDER_PORT','8000')+'/healthz',timeout=3)"
+
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/contract/builder-api.yaml
+++ b/contract/builder-api.yaml
@@ -17,6 +17,19 @@ security:
   - ApiKeyAuth: []
 
 paths:
+  /healthz:
+    get:
+      operationId: healthz
+      summary: 무인증 liveness probe (버전·메타 정보 없이 status만)
+      security: []
+      responses:
+        "200":
+          description: 서비스 정상
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+
   /version:
     get:
       operationId: getVersion
@@ -329,6 +342,15 @@ components:
           type: string
         api_version:
           type: string
+
+    HealthResponse:
+      type: object
+      required: [status]
+      description: liveness probe 응답 (버전·메타 정보 없이 status만, #372)
+      properties:
+        status:
+          type: string
+          const: "ok"
 
     ValidateResponse:
       type: object

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -399,6 +399,12 @@ def dispatch(
     반환값:
         ServiceResponse 또는 FileResponse (#323).
     """
+    # /healthz는 인증 게이트 밖에서 무인증 노출 (#372).
+    # liveness/readiness probe(ACA/AKS/App Gateway)가 자격증명을 실을 수 없으므로,
+    # 버전·메타 정보 없이 {"status":"ok"}만 반환한다.
+    if method == "GET" and path == "/healthz":
+        return ServiceResponse(200, {"status": "ok"})
+
     if not _verify_api_key(api_key):
         return ServiceResponse(401, {"error": "unauthorized"})
 

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -393,8 +393,8 @@ def dispatch(
 ) -> ServiceResponse | FileResponse:
     """(method, path)를 BuilderService 연산으로 라우팅한다.
 
-    라우팅 전에 X-API-Key를 검증한다 (#248). KPUBDATA_BUILDER_API_KEY가
-    설정되지 않으면 인증을 건너뛴다.
+    GET /healthz는 인증 없이 반환하고 (#372), 그 외 엔드포인트는
+    X-API-Key(또는 Bearer) 검증 후 라우팅한다 (#248).
 
     반환값:
         ServiceResponse 또는 FileResponse (#323).

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -651,6 +651,21 @@ class TestHttpAdapter:
         with urllib.request.urlopen(req, timeout=2.0) as response:
             assert response.status == 200
 
+    def test_healthz_accessible_without_api_key(
+        self,
+        http_server_with_auth: tuple[str, HTTPServer, threading.Thread],
+    ) -> None:
+        # /healthz는 인증 게이트 밖에서 무인증 노출된다 (#372).
+        # 프로브가 자격증명을 실을 수 없으므로 키 없이 200 + {"status":"ok"}만 반환.
+        base_url, _, _ = http_server_with_auth
+        with urllib.request.urlopen(f"{base_url}/healthz", timeout=2.0) as response:
+            assert response.status == 200
+            body = cast(dict[str, object], json.loads(response.read()))
+        assert body == {"status": "ok"}
+        # 버전·서비스 메타 정보가 누출되지 않아야 한다.
+        assert "api_version" not in body
+        assert "service" not in body
+
 
 class TestHttpRobustness:
     """#218 (JSON 500 handler) 과 #219 (DoS hardening) 검증."""

--- a/tests/unit/test_service_contract.py
+++ b/tests/unit/test_service_contract.py
@@ -34,6 +34,7 @@ _CONTRACT_PATH = Path(__file__).parents[2] / "contract" / "builder-api.yaml"
 # service/app.py:dispatch의 라우팅 규칙을 기계적으로 추출하기 어렵기 때문에
 # 명시적으로 선언하여 유지보수성을 높인다.
 _DISPATCH_ROUTES: dict[tuple[str, str], str] = {
+    ("/healthz", "GET"): "healthz",
     ("/version", "GET"): "getVersion",
     ("/validate", "POST"): "validateSpec",
     ("/preview", "POST"): "previewBuild",
@@ -45,6 +46,7 @@ _DISPATCH_ROUTES: dict[tuple[str, str], str] = {
 # (path, method) 형태의 계약 필수 오퍼레이션. BuilderService.dispatch가 실제로
 # 라우팅하는 동기 엔드포인트와 1:1로 대응한다.
 _REQUIRED_OPERATIONS = [
+    ("/healthz", "get"),
     ("/version", "get"),
     ("/validate", "post"),
     ("/preview", "post"),
@@ -110,6 +112,7 @@ def test_service_api_version_matches_contract() -> None:
 # 계약이 기술하는 모든 오퍼레이션은 BuilderService에 실제로 구현돼 있어야 한다.
 # 구현 경로 이름은 계약과 1:1로 일치한다(#226: aspirational 비동기/publish 라우트 제거).
 _IMPLEMENTED_OPERATIONS = {
+    "healthz",  # GET /healthz (무인증, #372)
     "getVersion",  # GET /version
     "validateSpec",  # POST /validate
     "previewBuild",  # POST /preview
@@ -285,6 +288,7 @@ def test_planned_operations_excluded_from_implementation_check() -> None:
 # 각 operation이 YAML에 선언한 상태 코드와 실제 구현이 반환하는 상태 코드의
 # 매핑. service/app.py:dispatch와 각 service 메서드를 분석하여 작성한다.
 _OPERATION_STATUS_CODES: dict[str, set[int]] = {
+    "healthz": {200},
     "getVersion": {200},
     "validateSpec": {200, 400},
     "previewBuild": {200, 400},
@@ -330,9 +334,10 @@ def test_declared_status_codes_match_implementation() -> None:
         # YAML에 선언된 상태 코드 추출
         declared_codes = _extract_declared_status_codes(operation)
 
-        # 실제 구현의 상태 코드 (401 인증 오류는 모든 엔드포인트에 공통이므로 추가)
+        # 401은 인증 게이트 안의 엔드포인트에 공통. 단 security: [] (무인증, #372)는 제외.
+        is_unauthenticated = operation.get("security") == []
         implemented_codes = _OPERATION_STATUS_CODES.get(operation_id, set())
-        all_implemented_codes = implemented_codes | {401}
+        all_implemented_codes = implemented_codes | (set() if is_unauthenticated else {401})
 
         assert declared_codes == all_implemented_codes, (
             f"상태 코드 불일치: {method} {path} (operationId: {operation_id})\n"


### PR DESCRIPTION
## 개요
리뷰 **A2**(= #372). `dispatch()`가 라우팅 전 인증해 프로브가 키를 못 실으므로 liveness/readiness가 막히고, `Dockerfile`에 `HEALTHCHECK`도 없었음.

## 변경
- **`GET /healthz`** — 인증 게이트 *앞*에서 무인증 노출. `{"status":"ok"}`만 반환(버전/메타 누출 없음).
- **`contract/builder-api.yaml`** — `/healthz` path + `security: []` + `HealthResponse` 스키마.
- **`Dockerfile`** — `HEALTHCHECK` 추가(python-slim에 curl/wget 없어 표준 urllib 사용, `KPUBDATA_BUILDER_PORT` 준수).
- **계약 테스트** — 양방향 커버리지(operationId 집합·dispatch 매핑·필수 op·상태코드 맵)에 healthz 반영; 상태코드 적합 테스트가 `security: []` operation에는 401을 자동 추가하지 않도록 정정.

## 검증
- ruff / mypy clean
- pytest **589 passed** (+1 healthz 회귀 테스트)

Closes #372
