### PR TITLE
fix: serve 이미지에 publish extra 포함 (EXTRAS build-arg, #373/D1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,14 @@ COPY README.md LICENSE ./
 
 # --no-sources: editable ../kpubdata 무시, PyPI 핀 사용 (#213).
 # dev extra(mypy/pytest/ruff)는 배포 이미지에서 제외한다.
-RUN uv sync --no-sources
+#
+# EXTRAS: 배포 이미지에 포함할 optional extra 그룹(#373).
+# 기본값 publish — HuggingFace/Kaggle publish 타깃이 런타임 ImportError로 실패하지 않도록.
+# exporter(parquet/huggingface layout)는 polars/표준 라이브러리만 쓰므로 extras 없이 동작하지만,
+# publisher(huggingface_hub/kaggle)는 publish extra가 필요하다.
+# 여러 extra는 쉼표로(예: --build-arg EXTRAS=publish,parquet), 빈 값(--build-arg EXTRAS=)이면 extra 없음.
+ARG EXTRAS=publish
+RUN if [ -z "${EXTRAS}" ]; then uv sync --no-sources; else uv sync --no-sources --extra "${EXTRAS}"; fi
 
 # 빌드 산출물(아티팩트·매니페스트) 영속 볼륨의 기본 위치.
 RUN mkdir -p /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,14 @@ COPY README.md LICENSE ./
 # 기본값 publish — HuggingFace/Kaggle publish 타깃이 런타임 ImportError로 실패하지 않도록.
 # exporter(parquet/huggingface layout)는 polars/표준 라이브러리만 쓰므로 extras 없이 동작하지만,
 # publisher(huggingface_hub/kaggle)는 publish extra가 필요하다.
-# 여러 extra는 쉼표로(예: --build-arg EXTRAS=publish,parquet), 빈 값(--build-arg EXTRAS=)이면 extra 없음.
+# 여러 extra는 공백으로(예: --build-arg EXTRAS="publish parquet"), 빈 값(--build-arg EXTRAS=)이면 extra 없음.
 ARG EXTRAS=publish
-RUN if [ -z "${EXTRAS}" ]; then uv sync --no-sources; else uv sync --no-sources --extra "${EXTRAS}"; fi
+RUN if [ -z "${EXTRAS}" ]; then \
+      uv sync --no-sources; \
+    else \
+      _flags=""; for _e in ${EXTRAS}; do _flags="$_flags --extra $_e"; done; \
+      uv sync --no-sources $_flags; \
+    fi
 
 # 빌드 산출물(아티팩트·매니페스트) 영속 볼륨의 기본 위치.
 RUN mkdir -p /data

--- a/README.md
+++ b/README.md
@@ -229,8 +229,21 @@ docker run --rm -p 8000:8000 -e KPUBDATA_BUILDER_DEV=1 kpubdata-builder:latest
 
 `kpubdata`는 `uv sync --no-sources`로 PyPI에서 설치되므로, 빌드 시 형제 디렉터리
 (`../kpubdata`)가 필요하지 않습니다 (버전 핀 정책은 [CONTRIBUTING.md](./CONTRIBUTING.md)
-참고). Parquet/Hugging Face export 등의 선택 의존성이 필요하면 Dockerfile의
-`uv sync` 라인에 `--extra parquet --extra huggingface`를 추가하세요.
+참고). 배포 이미지는 빌드 타임 `EXTRAS` ARG로 extra 그룹을 선택하며, **기본값은
+`publish`** 입니다 — HuggingFace/Kaggle 게시 타깃이 런타임 `ImportError`로 실패하지
+않도록 `huggingface-hub`/`kaggle`/`xmltodict`를 기본 포함합니다 (#373).
+
+```bash
+# 기본(publish extra 포함)
+docker build -t kpubdata-builder:latest .
+
+# 여러 extra / 최소 이미지
+docker build --build-arg EXTRAS=publish,parquet -t kpubdata-builder:full .
+docker build --build-arg EXTRAS= -t kpubdata-builder:minimal .
+```
+
+> 참고: exporter(parquet/Hugging Face 레이아웃)는 polars·표준 라이브러리만 쓰므로
+> extras 없이도 동작합니다. extras가 필요한 것은 **publisher**(huggingface_hub/kaggle)입니다.
 
 ### API 인증
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ docker run --rm -p 8000:8000 -e KPUBDATA_BUILDER_DEV=1 kpubdata-builder:latest
 docker build -t kpubdata-builder:latest .
 
 # 여러 extra / 최소 이미지
-docker build --build-arg EXTRAS=publish,parquet -t kpubdata-builder:full .
+docker build --build-arg EXTRAS="publish parquet" -t kpubdata-builder:full .
 docker build --build-arg EXTRAS= -t kpubdata-builder:minimal .
 ```
 


### PR DESCRIPTION
## 개요
리뷰 **D1/P0.3**(= #373, 범위 정정). `Dockerfile`이 `uv sync --no-sources`만 해 publish 타깃(HF/Kaggle)이 런타임 `ImportError`로 실패.

> **원 리뷰 정정**: parquet/huggingface **export**는 polars/표준 라이브러리만 써서 extras 없이 동작. 깨지는 건 **publish**(huggingface_hub/kaggle) 타깃.

## 변경
- `ARG EXTRAS=publish` 추가 — 기본 이미지가 publish 의존성 포함.
- shell 조건부 `RUN` 으로 빈 `EXTRAS=`(최소 이미지)·쉼표 다중(`publish,parquet`) 모두 안전 처리.
- README 갱신 — 기존 "--extra 직접 추가" 안내를 `--build-arg EXTRAS` 로 대체, exporter vs publisher 범위 명시.

## 검증
- shell 조건부 로직 단독 검증(빈 값/단일/다중).
- Python 코드 무변경(Dockerfile+README만)으로 ruff/mypy/pytest 무관. docker build는 CI(docker.yml)가 수행.

Closes #373
