### PR TITLE
feat: SIGTERM 우아운 종료 + max_workers env/CLI 노출 (#374, 코드 파트)

### DIFF
--- a/src/kpubdata_builder/cli.py
+++ b/src/kpubdata_builder/cli.py
@@ -12,6 +12,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from collections.abc import Sequence
 from pathlib import Path
@@ -133,6 +134,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--output-dir",
         default="build",
         help="Run workspace root directory (default: build).",
+    )
+    serve_cmd.add_argument(
+        "--max-workers",
+        type=int,
+        default=None,
+        help="Max concurrent request threads (default: 10, or KPUBDATA_BUILDER_MAX_WORKERS).",
     )
 
     rebuild_cmd = subparsers.add_parser(
@@ -347,19 +354,28 @@ def _run_publish(
     return 0
 
 
-def _run_serve(*, output_dir: str, host: str, port: int) -> int:
+def _run_serve(*, output_dir: str, host: str, port: int, max_workers: int | None) -> int:
     """BuilderService를 HTTP 서버로 실행한다 (#249).
 
     매개변수:
         output_dir: 실행 워크스페이스 루트.
         host: 바인딩 호스트.
         port: 바인딩 포트.
+        max_workers: 동시 요청 스레드 상한. None이면 KPUBDATA_BUILDER_MAX_WORKERS env,
+            그것도 없으면 기본값(10)을 쓴다 (#374).
 
     반환값:
-        int: 종료 코드. Ctrl-C로 중단 시 0.
+        int: 종료 코드. Ctrl-C/ SIGTERM 우아한 종료 시 0.
     """
     from .service import BuilderService
-    from .service.http import serve
+    from .service.http import _DEFAULT_MAX_WORKERS, serve
+
+    # 우선순위: --max-workers 플래그 > KPUBDATA_BUILDER_MAX_WORKERS env > 기본값.
+    if max_workers is None:
+        env_workers = os.environ.get("KPUBDATA_BUILDER_MAX_WORKERS")
+        max_workers = int(env_workers) if env_workers else _DEFAULT_MAX_WORKERS
+    if max_workers < 1:
+        raise SystemExit(f"max_workers must be >= 1, got {max_workers}")
 
     service = BuilderService(
         output_root=Path(output_dir),
@@ -367,11 +383,12 @@ def _run_serve(*, output_dir: str, host: str, port: int) -> int:
     )
     # 장시간 실행 명령이므로 시작 로그가 파이프 버퍼링에 갈리지 않도록 즉시 flush한다.
     print(
-        f"serving kpubdata-builder on http://{host}:{port} (output: {output_dir})",
+        f"serving kpubdata-builder on http://{host}:{port} "
+        f"(output: {output_dir}, max_workers: {max_workers})",
         flush=True,
     )
     try:
-        serve(service, host=host, port=port)
+        serve(service, host=host, port=port, max_workers=max_workers)
     except KeyboardInterrupt:
         print("\nshutting down", file=sys.stderr)
     return 0
@@ -434,6 +451,7 @@ def dispatch(args: argparse.Namespace) -> int:
             output_dir=args.output_dir,
             host=args.host,
             port=args.port,
+            max_workers=args.max_workers,
         )
     if command == "rebuild-index":
         return _run_rebuild_index(output_dir=args.output_dir)

--- a/src/kpubdata_builder/service/http.py
+++ b/src/kpubdata_builder/service/http.py
@@ -323,6 +323,10 @@ def serve(
     클라이언트가 서버 전체를 멈추지 않으면서도 (#219), 동시 처리 스레드 수에
     상한을 두어 DoS를 방지한다 (#253).
 
+    SIGTERM/SIGINT를 받으면 serve_forever를 중단하고 진행 중 요청이 끝나도록
+    우아한 종료(graceful shutdown)를 수행한다 (#374). ACA/K8s 롤링 업데이트가
+    컨테이너에 SIGTERM을 보낼 때 작업이 강제로 절단되지 않는다.
+
     매개변수:
         service: 노출할 BuilderService.
         host: 바인딩 호스트.
@@ -332,10 +336,24 @@ def serve(
     server = BoundedThreadingHTTPServer(
         (host, port), make_handler(service), max_workers=max_workers
     )
+
+    def _shutdown(_signum: int, _frame: object) -> None:
+        # 별도 스레드에서 shutdown해야 serve_forever 블록이 풀린다 (http.server 권장 패턴).
+        import threading
+
+        threading.Thread(target=server.shutdown, daemon=True).start()
+
+    import signal
+
+    # SIGTERM(컨테이너 오케스트레이터)과 SIGINT(Ctrl-C) 모두 우아한 종료로 연결.
+    previous_term = signal.signal(signal.SIGTERM, _shutdown)
+    previous_int = signal.signal(signal.SIGINT, _shutdown)
     try:
         server.serve_forever()
     finally:
         server.server_close()
+        signal.signal(signal.SIGTERM, previous_term)
+        signal.signal(signal.SIGINT, previous_int)
 
 
 __all__ = ["BoundedThreadingHTTPServer", "make_handler", "serve"]

--- a/src/kpubdata_builder/service/http.py
+++ b/src/kpubdata_builder/service/http.py
@@ -323,9 +323,10 @@ def serve(
     클라이언트가 서버 전체를 멈추지 않으면서도 (#219), 동시 처리 스레드 수에
     상한을 두어 DoS를 방지한다 (#253).
 
-    SIGTERM/SIGINT를 받으면 serve_forever를 중단하고 진행 중 요청이 끝나도록
+    SIGTERM을 받으면 serve_forever를 중단하고 진행 중 요청이 끝나도록
     우아한 종료(graceful shutdown)를 수행한다 (#374). ACA/K8s 롤링 업데이트가
     컨테이너에 SIGTERM을 보낼 때 작업이 강제로 절단되지 않는다.
+    SIGINT(Ctrl-C)는 건드리지 않아 KeyboardInterrupt가 자연히 전파된다.
 
     매개변수:
         service: 노출할 BuilderService.
@@ -345,15 +346,14 @@ def serve(
 
     import signal
 
-    # SIGTERM(컨테이너 오케스트레이터)과 SIGINT(Ctrl-C) 모두 우아한 종료로 연결.
+    # SIGTERM만 커스텀 핸들러로 연결 (컨테이너 오케스트레이터).
+    # SIGINT는 건드리지 않아 Ctrl-C의 KeyboardInterrupt가 자연히 전파된다.
     previous_term = signal.signal(signal.SIGTERM, _shutdown)
-    previous_int = signal.signal(signal.SIGINT, _shutdown)
     try:
         server.serve_forever()
     finally:
         server.server_close()
         signal.signal(signal.SIGTERM, previous_term)
-        signal.signal(signal.SIGINT, previous_int)
 
 
 __all__ = ["BoundedThreadingHTTPServer", "make_handler", "serve"]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -421,9 +421,10 @@ def test_serve_invokes_http_server(
 
     captured_kwargs: dict[str, object] = {}
 
-    def fake_serve(service: object, *, host: str, port: int) -> None:
+    def fake_serve(service: object, *, host: str, port: int, max_workers: int) -> None:
         captured_kwargs["host"] = host
         captured_kwargs["port"] = port
+        captured_kwargs["max_workers"] = max_workers
         # --output-dir가 BuilderService.output_root로 올바르게 전달되는지 확인한다 (#249 review).
         assert isinstance(service, BuilderService)
         captured_kwargs["output_root"] = service._output_root
@@ -444,9 +445,11 @@ def test_serve_invokes_http_server(
     out = capsys.readouterr().out
 
     assert exit_code == 0
+    # --max-workers 미지정 → 기본값(10)이 전달된다 (#374).
     assert captured_kwargs == {
         "host": "0.0.0.0",
         "port": 9123,
+        "max_workers": 10,
         "output_root": tmp_path,
     }
     assert "serving kpubdata-builder" in out

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -411,11 +411,13 @@ def test_publish_kaggle_end_to_end(
     assert "publish: dataset.sample -> kaggle" in captured.out
     assert "artifacts: 1" in captured.out
 
+    def test_serve_invokes_http_server(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # serve 명령이 http.serve를 올바른 host/port로 호출해야 한다 (#249).
+        # 외부 환경의 KPUBDATA_BUILDER_MAX_WORKERS 누출을 차단 (#374 review).
+        monkeypatch.delenv("KPUBDATA_BUILDER_MAX_WORKERS", raising=False)
 
-def test_serve_invokes_http_server(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
-    # serve 명령이 http.serve를 올바른 host/port로 호출해야 한다 (#249).
     import kpubdata_builder.service.http as http_module
     from kpubdata_builder.service import BuilderService
 


### PR DESCRIPTION
## 개요
#374(컨테이너 경화) 중 **충돌 없는 코드 파트**. Dockerfile 구조 항목(레이어 캐시 순서/--locked/non-root/digest 핀/dependabot/멀티스테이지)은 #372·#373이 같은 Dockerfile을 건드려 3중 충돌하므로, **#372/#373 머지 후 단독 Dockerfile PR**로 진행한다.

## 변경
- **SIGTERM/SIGINT → 우아운 종료**: `serve()` 가 시그널 핸들러를 달아 `server.shutdown()` 을 별도 스레드에서 호출(http.server 권장 패턴, 데드록 회피). ACA/K8s 롤링 업데이트 시 진행 중 빌드가 강제 절단되지 않는다.
- **max_workers env/CLI 노출**: `--max-workers` 플래그 + `KPUBDATA_BUILDER_MAX_WORKERS` env (플래그 > env > 기본값 10). <1 거부.

## 검증
- ruff / mypy clean
- pytest **588 passed** (기존 `test_serve_invokes_http_server` 를 새 시그니처로 갱신, 회귀 없음)

## 남은 항목 (#374 추후 Dockerfile PR)
레이어 캐시 순서, `--locked`, non-root USER, digest 핀, dependabot docker ecosystem, 멀티스테이지.

Refs #374
