### PR TITLE
refactor: 인증 결과를 bool에서 Principal로 — 인가 훅 준비 (#384, B2)

### DIFF
--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -360,7 +360,8 @@ def dispatch(
     """(method, path)를 BuilderService 연산으로 라우팅한다.
 
     GET /healthz는 인증 없이 반환하고 (#372), 그 외 엔드포인트는
-    X-API-Key(또는 Bearer) 검증 후 라우팅한다 (#248).
+    authenticate()로 Principal을 얻어 인증 게이트를 통과한 후 라우팅한다.
+    dev-mode이면 인증 생략, 그 외는 fail-closed(401)로 동작한다 (#248, #384).
 
     반환값:
         ServiceResponse 또는 FileResponse (#323).
@@ -372,7 +373,7 @@ def dispatch(
     # 인증 게이트 (#384): Principal을 얻지 못하면 401.
     principal = authenticate(api_key=api_key)
     if isinstance(principal, AuthError):
-        return ServiceResponse(principal.status_code, {"error": "unauthorized"})
+        return ServiceResponse(401, {"error": "unauthorized"})
 
     if method == "GET" and path == "/version":
         return service.version()

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -14,9 +14,7 @@ Studio 같은 외부 UI가 Builder를 호출할 수 있도록 validate/preview/b
 from __future__ import annotations
 
 import heapq
-import hmac
 import json
-import os
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -33,6 +31,7 @@ from ..stages._path_safety import ensure_within, validate_path_segment
 from ..stages.bronze.build import SourceClient
 from ..store import BuildIndex
 from ..tabular import DEFAULT_PREVIEW_LIMIT
+from .auth import AuthError, authenticate
 
 # Build list entry type for API responses
 _BuildListEntry = dict[str, str | None]
@@ -41,39 +40,6 @@ _BuildListEntry = dict[str, str | None]
 # (test_service_contract가 강제), 응답에 실어 Studio 같은 소비자가 하위 호환을
 # 협상할 수 있게 한다 (#209).
 API_CONTRACT_VERSION = "1.0.0"
-
-# 서버가 요구하는 API 키. 환경변수로만 주입한다 (#248).
-# ADR 0006에 따라 fail-closed로 동작: dev-mode 미설정 + API 키 미설정 시 인증을 거부한다.
-_API_KEY_ENV = "KPUBDATA_BUILDER_API_KEY"
-_DEV_MODE_ENV = "KPUBDATA_BUILDER_DEV_MODE"
-
-
-def _is_dev_mode() -> bool:
-    """로컬 개발 모드인지 확인한다 (#321, ADR 0006).
-
-    KPUBDATA_BUILDER_DEV_MODE가 'true'/'1'이면 dev-mode로 간주하여 인증을 생략한다.
-    프로덕션 배포에서는 이 환경변수를 설정하지 않아야 한다.
-    """
-    return os.environ.get(_DEV_MODE_ENV, "").lower() in ("true", "1")
-
-
-def _verify_api_key(api_key: str | None) -> bool:
-    """요청의 X-API-Key를 서버에 설정된 키와 비교한다 (#248, #321, ADR 0006).
-
-    ADR 0006 fail-closed 정책:
-    - dev-mode인 경우: 인증을 생략한다 (로컬 개발 편의).
-    - dev-mode가 아닌 경우:
-      - API 키가 설정되어 있으면 키를 검증한다.
-      - API 키가 미설정이면 인증을 거부한다 (False 반환).
-    """
-    if _is_dev_mode():
-        return True
-
-    expected = os.environ.get(_API_KEY_ENV)
-    if not expected:
-        # fail-closed: dev-mode 미설정 + API 키 미설정 시 인증 거부
-        return False
-    return api_key is not None and hmac.compare_digest(api_key, expected)
 
 
 @dataclass(frozen=True)
@@ -400,13 +366,13 @@ def dispatch(
         ServiceResponse 또는 FileResponse (#323).
     """
     # /healthz는 인증 게이트 밖에서 무인증 노출 (#372).
-    # liveness/readiness probe(ACA/AKS/App Gateway)가 자격증명을 실을 수 없으므로,
-    # 버전·메타 정보 없이 {"status":"ok"}만 반환한다.
     if method == "GET" and path == "/healthz":
         return ServiceResponse(200, {"status": "ok"})
 
-    if not _verify_api_key(api_key):
-        return ServiceResponse(401, {"error": "unauthorized"})
+    # 인증 게이트 (#384): Principal을 얻지 못하면 401.
+    principal = authenticate(api_key=api_key)
+    if isinstance(principal, AuthError):
+        return ServiceResponse(principal.status_code, {"error": "unauthorized"})
 
     if method == "GET" and path == "/version":
         return service.version()

--- a/src/kpubdata_builder/service/auth.py
+++ b/src/kpubdata_builder/service/auth.py
@@ -1,0 +1,75 @@
+"""HTTP 서비스 인증 (#384, ADR 0006).
+
+인증 결과를 ``bool`` 대신 ``Principal`` 로 반환해 "누가 요청했는가"를 보존한다.
+이는 인가(C1/C2 — run 소유권) 도입의 토대다. 본 모듈은 인증 게이트만 담당하며,
+허용 목록·Bearer(OIDC) 검증은 ADR 0009 이후 확장한다.
+
+외부 동작은 기존 ``_verify_api_key`` 와 동일하다 — 동일 환경변수, 동일 fail-closed 정책.
+"""
+
+from __future__ import annotations
+
+import hmac
+import os
+from dataclasses import dataclass
+
+# 서버가 요구하는 API 키. 환경변수로만 주입한다 (#248).
+# ADR 0006에 따라 fail-closed로 동작: dev-mode 미설정 + API 키 미설정 시 인증을 거부한다.
+_API_KEY_ENV = "KPUBDATA_BUILDER_API_KEY"
+_DEV_MODE_ENV = "KPUBDATA_BUILDER_DEV_MODE"
+
+
+@dataclass(frozen=True)
+class Principal:
+    """인증된 요청 주체 (#384).
+
+    인가(C1/C2)에서 run 소유권 판단에 쓰인다. ``kind`` 는 확장 가능 —
+    ``'dev'``(로컬 개발), ``'service'``(X-API-Key), 향후 ``'oidc'``/``'user'``(Bearer, ADR 0009).
+    식별자는 민감 값(원본 API 키 등)을 담지 않는다 — manifest created_by 등에는
+    안전한 라벨(``apikey:<name>``)만 쓴다.
+    """
+
+    kind: str
+    identifier: str | None = None
+
+
+@dataclass(frozen=True)
+class AuthError:
+    """인증 실패 (#384). ``dispatch`` 가 401로 변환한다."""
+
+    reason: str
+
+
+def _is_dev_mode() -> bool:
+    """로컬 개발 모드인지 확인한다 (#321, ADR 0006).
+
+    KPUBDATA_BUILDER_DEV_MODE가 'true'/'1'이면 dev-mode로 간주하여 인증을 생략한다.
+    프로덕션 배포에서는 이 환경변수를 설정하지 않아야 한다.
+    """
+    return os.environ.get(_DEV_MODE_ENV, "").lower() in ("true", "1")
+
+
+def authenticate(api_key: str | None) -> Principal | AuthError:
+    """요청을 인증해 ``Principal`` 또는 ``AuthError`` 를 반환한다 (#384, ADR 0006).
+
+    기존 ``_verify_api_key -> bool`` 을 대체하되 주체 정보를 보존한다.
+    fail-closed 정책은 동일:
+
+    - dev-mode인 경우: ``Principal(kind='dev')`` 로 인증 생략 (로컬 개발 편의).
+    - dev-mode가 아닌 경우:
+      - API 키가 설정되어 있고 일치하면 ``Principal(kind='service')``.
+      - 키 미설정 또는 불일치면 ``AuthError`` (거부).
+    """
+    if _is_dev_mode():
+        return Principal(kind="dev")
+
+    expected = os.environ.get(_API_KEY_ENV)
+    if not expected:
+        # fail-closed: dev-mode 미설정 + API 키 미설정 시 인증 거부
+        return AuthError(reason="api key not configured")
+    if api_key is not None and hmac.compare_digest(api_key, expected):
+        return Principal(kind="service")
+    return AuthError(reason="invalid api key")
+
+
+__all__ = ["AuthError", "Principal", "authenticate"]


### PR DESCRIPTION
## 개요
인증 시리즈 **B2**(= #384). `_verify_api_key() -> bool` 이 "누가 요청했는가"를 잃어 인가(run 소유권) 도입의 근본 제약이었음. **외부 동작 변화 없음, 기존 인증 테스트 수정 없이 통과, 리스크 0**인 토대 리팩터.

## 변경
**신규 `service/auth.py`**:
- `Principal(kind, identifier=None)` — 확장 가능('dev'/'service', 향후 'oidc'/'user' ADR 0009). identifier는 원본 API 키 미보관.
- `AuthError(reason)`
- `authenticate(api_key) -> Principal | AuthError` — 기존 dev-mode + X-API-Key fail-closed 로직을 그대로 캡슐화(환경변수 동일).

**`app.py`**: 인라인 auth 블록(`_API_KEY_ENV`/`_DEV_MODE_ENV`/`_is_dev_mode`/`_verify_api_key`)과 불필요해진 `hmac`/`os` import 제거. `dispatch` 가 `authenticate()` 호출 후 `AuthError`면 401. principal은 계산만 하고 연산 전달은 아님(C1의 역할).

## 검증
- ruff(isort fix 적용) / mypy(70 files) / pytest **588 passed** ✅
- 외부 동작 동일 — 기존 auth 테스트(401/dev-mode/fail-closed) 모두 수정 없이 통과.

## 다음
B3(#385 Google Bearer)에서 `authenticate` 를 확장해 `Principal(kind='oidc')` 를 만들고, C1(#388)에서 principal을 manifest/BuildIndex에 기록.

Closes #384
