### PR TITLE
contract: API 1.1.0 — bearerAuth securityScheme (B5, #387)

### DIFF
--- a/contract/builder-api.yaml
+++ b/contract/builder-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: KPubData Builder Service API
-  version: "1.0.0"
+  version: "1.1.0"
   description: >-
     Builder 중심 서비스 계약. BuildSpec 검증, preview, build 실행, artifact 조회,
     계약 버전 조회를 제공한다. CLI와 HTTP service mode(#36)가 동일한 도메인 계약을
@@ -15,6 +15,7 @@ servers:
 
 security:
   - ApiKeyAuth: []
+  - bearerAuth: []
 
 paths:
   /version:
@@ -187,6 +188,13 @@ components:
       description: >-
         서버에 KPUBDATA_BUILDER_API_KEY가 설정된 경우 필수. 미설정 시(로컬 개발 기본값)
         인증 없이 모든 요청이 허용된다 (#248).
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: >-
+        Google OIDC ID 토큰 (ADR 0009). Authorization: Bearer <jwt>.
+        OIDC_ISSUER 미설정 시 비활성 — 기존 ApiKeyAuth 배포에 영향 없음 (#385).
 
   responses:
     Unauthorized:

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -39,7 +39,7 @@ _BuildListEntry = dict[str, str | None]
 # Builder API 계약 버전. contract/builder-api.yaml의 info.version과 일치해야 하며
 # (test_service_contract가 강제), 응답에 실어 Studio 같은 소비자가 하위 호환을
 # 협상할 수 있게 한다 (#209).
-API_CONTRACT_VERSION = "1.0.0"
+API_CONTRACT_VERSION = "1.1.0"
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## 개요

인증 시리즈 **B5**(= #387). OpenAPI 계약에 OIDC Bearer 인증 경로를 선언한다. 기존 `ApiKeyAuth`와 함께 **OR 시맨틱**으로 동작 — 서비스 계정은 `X-API-Key`, 사람 사용자는 `Bearer`(B3 #385). 버전 `1.0.0` → `1.1.0` (추가적 변경, 기존 소비자 호환).

> **Stacked on B4 (#402)**. base = `feat/issue-386-allowlist-gate`.

## 변경

### `contract/builder-api.yaml`
- `info.version`: `"1.0.0"` → `"1.1.0"`
- 전역 `security`: `ApiKeyAuth` + `bearerAuth` (둘 중 하나면 인증 통과)
- `securitySchemes`에 `bearerAuth` 추가 (`type: http`, `scheme: bearer`, `bearerFormat: JWT`)

### `app.py`
- `API_CONTRACT_VERSION = "1.1.0"`

## 검증

- `ruff check` / `format --check` / `mypy` (70 files) — 전부 clean
- `test_service_api_version_matches_contract` — 1.1.0 정합 통과 (28 contract tests passed)
- `pytest` — **609 passed** (회귀 없음)

## 메모

- Studio **#192**(S7)가 `API_CONTRACT_VERSION`을 `1.1.0`으로 동기화해야 함 — `SettingsPage` 버전 불일치 경고 방지.
- bearerAuth는 선언만 추가 — 실제 Bearer 검증은 B3(#401)에서 구현됨. 이 계약 PR이 "광고"하는 기능은 B3 구현과 정합.

## 인증 B-시리즈 완성

B1(ADR #398) → B2(#397) → B3(#401) → B4(#402) → **B5(본 PR)**

Closes #387
