### PR TITLE
feat: 허용 목록 게이트 — 공개 IdP 필수 방어 (B4, #386)

### DIFF
--- a/src/kpubdata_builder/service/auth.py
+++ b/src/kpubdata_builder/service/auth.py
@@ -28,6 +28,9 @@ _OIDC_JWKS_URL_ENV = "OIDC_JWKS_URL"
 _OIDC_JWKS_TTL_ENV = "OIDC_JWKS_TTL"
 _DEFAULT_JWKS_TTL_SECONDS = 3600
 _TOKEN_LEEWAY_SECONDS = 60
+_OIDC_ALLOWED_HD_ENV = "OIDC_ALLOWED_HD"
+_OIDC_ALLOWED_SUBJECTS_ENV = "OIDC_ALLOWED_SUBJECTS"
+_OIDC_ALLOWED_EMAILS_ENV = "OIDC_ALLOWED_EMAILS"
 
 
 @dataclass(frozen=True)
@@ -99,6 +102,20 @@ def _oidc_jwks_url() -> str:
     return issuer.rstrip("/") + "/.well-known/jwks.json"
 
 
+def _oidc_allowlists() -> tuple[set[str], set[str], set[str]]:
+    """(hd, subjects, emails) 허용 목록. Google은 공개 IdP라 필수 방어 (#386)."""
+
+    def _parse(env_name: str) -> set[str]:
+        raw = os.environ.get(env_name, "")
+        return {s.strip() for s in raw.replace(" ", ",").split(",") if s.strip()}
+
+    return (
+        _parse(_OIDC_ALLOWED_HD_ENV),
+        _parse(_OIDC_ALLOWED_SUBJECTS_ENV),
+        _parse(_OIDC_ALLOWED_EMAILS_ENV),
+    )
+
+
 def validate_oidc_config() -> None:
     """서버 기동 시 호출 (serve). OIDC 설정 오류면 RuntimeError (fail-closed, #385).
 
@@ -119,6 +136,14 @@ def validate_oidc_config() -> None:
         raise RuntimeError(
             "OIDC is enabled but pyjwt is not installed; install with: uv sync --extra auth"
         ) from e
+    # 허용 목록 필수 — Google은 공개 IdP (계정만 있으면 유효 토큰 획득, #386).
+    hd, subs, emails = _oidc_allowlists()
+    if not (hd or subs or emails):
+        raise RuntimeError(
+            "OIDC_ISSUER is set but no allowlist is configured "
+            "(OIDC_ALLOWED_HD/SUBJECTS/EMAILS); refusing to start — "
+            "Google is a public IdP (fail-closed, ADR 0009, #386)."
+        )
 
 
 def _get_jwks_client() -> object:
@@ -168,6 +193,17 @@ def _verify_bearer_token(token: str) -> Principal | AuthError:
 
     if not payload.get("email_verified", False):
         return AuthError(reason="email not verified")
+
+    # 허용 목록 검사 (Google 공개 IdP, #386). 설정된 목록 중 하나라도 매칭되면 통과.
+    hd_set, sub_set, email_set = _oidc_allowlists()
+    if hd_set or sub_set or email_set:
+        matched = (
+            (bool(hd_set) and str(payload.get("hd", "")) in hd_set)
+            or (bool(sub_set) and str(payload.get("sub", "")) in sub_set)
+            or (bool(email_set) and str(payload.get("email", "")) in email_set)
+        )
+        if not matched:
+            return AuthError(reason="principal not in allowlist", status_code=403)
 
     sub = str(payload.get("sub", ""))
     # 로그 추적용 식별자로 sub 앞 8자만(전체 sub 노출 최소화).

--- a/tests/unit/test_oidc_auth.py
+++ b/tests/unit/test_oidc_auth.py
@@ -209,3 +209,59 @@ class TestValidateOidcConfig:
         monkeypatch.delenv("OIDC_AUDIENCE", raising=False)
         with pytest.raises(RuntimeError, match="OIDC_AUDIENCE"):
             validate_oidc_config()
+
+    def test_rejects_when_no_allowlist(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OIDC_ISSUER", _ISSUER)
+        monkeypatch.setenv("OIDC_AUDIENCE", _AUDIENCE)
+        with pytest.raises(RuntimeError, match="allowlist"):
+            validate_oidc_config()
+
+
+class TestAllowlistGate:
+    """허용 목록 게이트 (#386). Google은 공개 IdP — 허용 목록 없이는 인터넷 전체에 노출."""
+
+    def test_hd_allowlist_match(self, oidc_env: bytes, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OIDC_ALLOWED_HD", "example.com")
+        token = _make_token(oidc_env, hd="example.com")
+        result = authenticate(bearer_token=f"Bearer {token}")
+        assert isinstance(result, Principal)
+        assert result.kind == "oidc"
+
+    def test_hd_allowlist_miss(self, oidc_env: bytes, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OIDC_ALLOWED_HD", "other.com")
+        token = _make_token(oidc_env, hd="example.com")
+        result = authenticate(bearer_token=f"Bearer {token}")
+        assert isinstance(result, AuthError)
+        assert result.status_code == 403
+
+    def test_subject_allowlist_match(
+        self, oidc_env: bytes, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OIDC_ALLOWED_SUBJECTS", "user-1234567890")
+        token = _make_token(oidc_env)
+        result = authenticate(bearer_token=f"Bearer {token}")
+        assert isinstance(result, Principal)
+
+    def test_email_allowlist_match(self, oidc_env: bytes, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OIDC_ALLOWED_EMAILS", "user@example.com")
+        token = _make_token(oidc_env)
+        result = authenticate(bearer_token=f"Bearer {token}")
+        assert isinstance(result, Principal)
+
+    def test_hd_missing_rejected_when_hd_required(
+        self, oidc_env: bytes, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OIDC_ALLOWED_HD", "example.com")
+        token = _make_token(oidc_env)
+        result = authenticate(bearer_token=f"Bearer {token}")
+        assert isinstance(result, AuthError)
+        assert result.status_code == 403
+
+    def test_multiple_lists_match_any(
+        self, oidc_env: bytes, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OIDC_ALLOWED_HD", "other.com")
+        monkeypatch.setenv("OIDC_ALLOWED_EMAILS", "user@example.com")
+        token = _make_token(oidc_env, hd="example.com")
+        result = authenticate(bearer_token=f"Bearer {token}")
+        assert isinstance(result, Principal)


### PR DESCRIPTION
## 개요

인증 시리즈 **B4**(= #386). Google은 공개 IdP — 허용 목록 없이 `OIDC_ISSUER` 배포 시 Builder가 인터넷 전체에 노출.

## 변경

- `_oidc_allowlists()`: `OIDC_ALLOWED_HD`/`SUBJECTS`/`EMAILS` 파싱
- `validate_oidc_config()`: 3종 모두 비어 있으면 기동 거부 (fail-closed)
- `_verify_bearer_token`: OR 시맨틱 허용 목록 검사, 불일치 → 403

## 테스트 (7건)

HD match/miss, subject/email match, hd 누락 거부, 다중 목록 OR, validate 거부. **617 passed**.

Closes #386
