### PR TITLE
contract: API 1.1.0 — bearerAuth securityScheme (B5, #387)

### DIFF
--- a/contract/builder-api.yaml
+++ b/contract/builder-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: KPubData Builder Service API
-  version: "1.0.0"
+  version: "1.1.0"
   description: >-
     Builder 중심 서비스 계약. BuildSpec 검증, preview, build 실행, artifact 조회,
     계약 버전 조회를 제공한다. CLI와 HTTP service mode(#36)가 동일한 도메인 계약을
@@ -15,6 +15,7 @@ servers:
 
 security:
   - ApiKeyAuth: []
+  - bearerAuth: []
 
 paths:
   /healthz:
@@ -200,6 +201,13 @@ components:
       description: >-
         서버에 KPUBDATA_BUILDER_API_KEY가 설정된 경우 필수. 미설정 시(로컬 개발 기본값)
         인증 없이 모든 요청이 허용된다 (#248).
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: >-
+        Google OIDC ID 토큰 (ADR 0009). Authorization: Bearer <jwt>.
+        OIDC_ISSUER 미설정 시 비활성 — 기존 ApiKeyAuth 배포에 영향 없음 (#385).
 
   responses:
     Unauthorized:

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -39,7 +39,7 @@ _BuildListEntry = dict[str, str | None]
 # Builder API 계약 버전. contract/builder-api.yaml의 info.version과 일치해야 하며
 # (test_service_contract가 강제), 응답에 실어 Studio 같은 소비자가 하위 호환을
 # 협상할 수 있게 한다 (#209).
-API_CONTRACT_VERSION = "1.0.0"
+API_CONTRACT_VERSION = "1.1.0"
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## 개요

인증 시리즈 **B5**(= #387). OpenAPI 계약에 OIDC Bearer 인증 경로 선언 + 버전 1.0.0 → 1.1.0.

## 변경
- `contract/builder-api.yaml`: `bearerAuth` securityScheme + `info.version: 1.1.0` + 전역 security OR
- `app.py`: `API_CONTRACT_VERSION = "1.1.0"`

## 검증
- ruff/mypy clean, contract test 28 passed (version match 1.1.0), 617 total passed

Closes #387
