### PR TITLE
fix: auth 응답 reason 반영 + JWKS lock + 구체적 예외 (#406-408)

### DIFF
--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -374,7 +374,7 @@ def dispatch(
     # 인증 게이트 (#384): Principal을 얻지 못하면 401.
     principal = authenticate(api_key=api_key, bearer_token=bearer_token)
     if isinstance(principal, AuthError):
-        return ServiceResponse(principal.status_code, {"error": "unauthorized"})
+        return ServiceResponse(principal.status_code, {"error": principal.reason})
 
     if method == "GET" and path == "/version":
         return service.version()

--- a/src/kpubdata_builder/service/auth.py
+++ b/src/kpubdata_builder/service/auth.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import hmac
 import os
+import threading
 from dataclasses import dataclass
 
 # 서버가 요구하는 API 키. 환경변수로만 주입한다 (#248).
@@ -82,6 +83,7 @@ def _verify_api_key(api_key: str | None) -> Principal | AuthError:
 # JWKS 클라이언트는 지연 생성·캐시한다. OIDC 비활성 시 None.
 _jwks_client: object | None = None
 _jwks_url_cached: str | None = None
+_jwks_lock = threading.Lock()
 
 
 def _oidc_issuers() -> list[str]:
@@ -147,15 +149,16 @@ def validate_oidc_config() -> None:
 
 
 def _get_jwks_client() -> object:
-    """PyJWKClient 를 지연 생성·캐시한다."""
+    """PyJWKClient 를 지연 생성·캐시한다 (thread-safe)."""
     global _jwks_client, _jwks_url_cached
-    url = _oidc_jwks_url()
-    if _jwks_client is None or _jwks_url_cached != url:
-        from jwt import PyJWKClient
+    with _jwks_lock:
+        url = _oidc_jwks_url()
+        if _jwks_client is None or _jwks_url_cached != url:
+            from jwt import PyJWKClient
 
-        ttl = int(os.environ.get(_OIDC_JWKS_TTL_ENV, "") or _DEFAULT_JWKS_TTL_SECONDS)
-        _jwks_client = PyJWKClient(url, cache_jwk_set=True, lifespan=ttl)
-        _jwks_url_cached = url
+            ttl = int(os.environ.get(_OIDC_JWKS_TTL_ENV, "") or _DEFAULT_JWKS_TTL_SECONDS)
+            _jwks_client = PyJWKClient(url, cache_jwk_set=True, lifespan=ttl)
+            _jwks_url_cached = url
     return _jwks_client
 
 
@@ -172,9 +175,7 @@ def _verify_bearer_token(token: str) -> Principal | AuthError:
     try:
         client = _get_jwks_client()
         signing_key = client.get_signing_key_from_jwt(token)  # type: ignore[attr-defined]
-    except (PyJWKClientError, ConnectionError):
-        return AuthError(reason="auth service unavailable (jwks)", status_code=503)
-    except Exception:
+    except (PyJWKClientError, ConnectionError, OSError):
         return AuthError(reason="auth service unavailable (jwks)", status_code=503)
 
     audience = os.environ.get(_OIDC_AUDIENCE_ENV, "").strip()

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -296,7 +296,7 @@ class TestApiKeyAuth:
         monkeypatch.delenv("KPUBDATA_BUILDER_DEV_MODE", raising=False)
         resp = dispatch(_service(tmp_path), "GET", "/version", None)
         assert resp.status_code == 401
-        assert resp.body == {"error": "unauthorized"}
+        assert resp.body["error"]  # 구체적 reason은 auth 구현에 위임
 
     def test_auth_skipped_in_dev_mode(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -323,7 +323,7 @@ class TestApiKeyAuth:
         monkeypatch.setenv("KPUBDATA_BUILDER_API_KEY", "secret")
         resp = dispatch(_service(tmp_path), "GET", "/version", None)
         assert resp.status_code == 401
-        assert resp.body == {"error": "unauthorized"}
+        assert resp.body["error"]  # 구체적 reason은 auth 구현에 위임
 
     def test_rejects_wrong_api_key_when_configured(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## 개요

코드 리뷰에서 발견한 3건 수정.

## 변경

1. **#406** — `dispatch()` 가 `principal.reason`을 응답 body에 반영 (기존: 고정 `"unauthorized"`)
   - 401: `"api key not configured"` / `"invalid api key"`
   - 403: `"principal not in allowlist"`
   - 503: `"auth service unavailable (jwks)"`
2. **#407** — `_verify_bearer_token`의 `except Exception` 제거, `PyJWKClientError`/`ConnectionError`/`OSError`만 503 매핑
3. **#408** — `_get_jwks_client`에 `threading.Lock()` 추가 (race condition 방지)

## 검증

- ruff/mypy clean, **617 passed** (기존 auth 테스트 2건 body assertion 완화)

Closes #406, Closes #407, Closes #408
