### PR TITLE
feat: manifest·BuildIndex에 principal 기록 (C1, #388)

### DIFF
--- a/src/kpubdata_builder/manifest/models.py
+++ b/src/kpubdata_builder/manifest/models.py
@@ -54,6 +54,7 @@ class BuildManifest:
     provenance: tuple[SourceProvenance, ...] = ()
     build_environment: BuildEnvironment | None = None
     inputs_fingerprint: str | None = None
+    created_by: str | None = None
 
 
 __all__ = ["MANIFEST_SCHEMA_VERSION", "BuildManifest"]

--- a/src/kpubdata_builder/pipeline/orchestrator.py
+++ b/src/kpubdata_builder/pipeline/orchestrator.py
@@ -263,6 +263,7 @@ def run_build(
     client: SourceClient,
     output_root: Path,
     run_id: str | None = None,
+    created_by: str | None = None,
 ) -> BuildResult:
     """BuildSpec을 Medallion 파이프라인으로 실행한다.
 
@@ -330,6 +331,7 @@ def run_build(
         provenance=tuple(provenance),
         build_environment=capture_build_environment(),
         inputs_fingerprint=compute_inputs_fingerprint(provenance),
+        created_by=created_by,
     )
     manifest_path = context.output_root / context.run_id / "manifest.json"
     manifest_writer(manifest, manifest_path)

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -148,7 +148,9 @@ class BuilderService:
         ]
         return ServiceResponse(200, {"dataset_id": spec_or_error.dataset_id, "previews": previews})
 
-    def build(self, spec_yaml: str, *, run_id: str | None = None) -> ServiceResponse:
+    def build(
+        self, spec_yaml: str, *, run_id: str | None = None, created_by: str | None = None
+    ) -> ServiceResponse:
         """파이프라인을 실행하고 결과를 반환한다.
 
         응답 코드 정책:
@@ -166,6 +168,7 @@ class BuilderService:
             client=self._client_factory(),
             output_root=self._output_root,
             run_id=run_id,
+            created_by=created_by,
         )
         outcomes: list[JsonValue] = [
             {
@@ -203,6 +206,7 @@ class BuilderService:
                 status=result.status,  # type: ignore[arg-type]
                 started_at=started_at,
                 finished_at=finished_at,
+                created_by=manifest_data.get("created_by"),
             )
         except Exception:
             # 인덱스 갱신 실패는 무시 (ADR 0003)
@@ -418,7 +422,7 @@ def dispatch(
             except ValueError as exc:
                 return ServiceResponse(400, {"error": str(exc)})
             run_id = run_id_value
-        return service.build(spec, run_id=run_id)
+        return service.build(spec, run_id=run_id, created_by=principal.label)
 
     if method == "GET" and path.startswith("/artifacts/"):
         # /artifacts/{run_id}/{file_path} 형식이면 파일 제공, 아니면 목록 반환

--- a/src/kpubdata_builder/service/auth.py
+++ b/src/kpubdata_builder/service/auth.py
@@ -47,6 +47,11 @@ class Principal:
     kind: str
     identifier: str | None = None
 
+    @property
+    def label(self) -> str:
+        """manifest created_by용 라벨 (#388)."""
+        return f"{self.kind}:{self.identifier}" if self.identifier else self.kind
+
 
 @dataclass(frozen=True)
 class AuthError:

--- a/src/kpubdata_builder/store/build_index.py
+++ b/src/kpubdata_builder/store/build_index.py
@@ -21,7 +21,7 @@ else:
 
 # 스키마 버전: 인덱스 구조 변경 시 증가
 # 스키마 버전 2: status 어휘를 ok/failed/cancelled로 확장 (#334 비동기 job 모델 대비)
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 # 빌드 인덱스 status 어휘. ADR 0003 파생 캐시. manifest.json이 정본.
 BuildStatus = Literal["ok", "failed", "cancelled"]
@@ -40,6 +40,7 @@ class BuildEntry:
     finished_at: str | None
     spec_digest: str | None
     error: str | None
+    created_by: str | None = None
 
 
 class BuildIndex:
@@ -107,7 +108,8 @@ class BuildIndex:
                         started_at TEXT,
                         finished_at TEXT,
                         spec_digest TEXT,
-                        error TEXT
+                        error TEXT,
+                        created_by TEXT
                     )
                     """
                 )
@@ -141,6 +143,7 @@ class BuildIndex:
         finished_at: str | None,
         spec_digest: str | None = None,
         error: str | None = None,
+        created_by: str | None = None,
     ) -> None:
         """빌드 엔트리를 삽입 또는 대체한다.
 
@@ -151,16 +154,17 @@ class BuildIndex:
             finished_at: 빌드 완료 시각 (ISO 8601)
             spec_digest: spec 해시 (선택)
             error: 오류 메시지 (실패 시)
+            created_by: 빌드를 요청한 주체 라벨 (선택, #388)
         """
         try:
             with self._transaction():
                 self._conn.execute(
                     """
                     INSERT OR REPLACE INTO builds
-                    (run_id, status, started_at, finished_at, spec_digest, error)
-                    VALUES (?, ?, ?, ?, ?, ?)
+                    (run_id, status, started_at, finished_at, spec_digest, error, created_by)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
                     """,
-                    (run_id, status, started_at, finished_at, spec_digest, error),
+                    (run_id, status, started_at, finished_at, spec_digest, error, created_by),
                 )
         except Exception:
             # ADR 0003: 인덱스 쓰기 실패가 빌드 실패의 원인이 되어서는 안 됨
@@ -177,7 +181,7 @@ class BuildIndex:
         """
         cur = self._conn.execute(
             """
-            SELECT run_id, status, started_at, finished_at, spec_digest, error
+            SELECT run_id, status, started_at, finished_at, spec_digest, error, created_by
             FROM builds
             ORDER BY finished_at DESC
             LIMIT ?
@@ -192,6 +196,7 @@ class BuildIndex:
                 finished_at=row[3],
                 spec_digest=row[4],
                 error=row[5],
+                created_by=row[6],
             )
             for row in cur
         ]
@@ -207,7 +212,7 @@ class BuildIndex:
         """
         cur = self._conn.execute(
             """
-            SELECT run_id, status, started_at, finished_at, spec_digest, error
+            SELECT run_id, status, started_at, finished_at, spec_digest, error, created_by
             FROM builds
             WHERE run_id = ?
             """,
@@ -223,6 +228,7 @@ class BuildIndex:
             finished_at=row[3],
             spec_digest=row[4],
             error=row[5],
+            created_by=row[6],
         )
 
     def delete(self, run_id: str) -> None:
@@ -299,6 +305,7 @@ def rebuild_index(output_root: Path) -> int:
                 status=status,  # type: ignore[arg-type]
                 started_at=started_at,
                 finished_at=finished_at,
+                created_by=manifest.get("created_by"),
             )
             count += 1
     finally:


### PR DESCRIPTION
## 개요

인가 시리즈 **C1**(= #388). 인증된 Principal을 빌드 파이프라인에 전달해 각 빌드가 **누가 만들었는지**를 기록한다. 접근 제어는 하지 않는다 (C2/#389의 역할).

## 변경 (5 파일)

- **`Principal.label`** property — `"kind:identifier"` 또는 `"kind"` (민감 값 미포함, #388)
- **`BuildManifest`** — `created_by: str | None = None` 필드 추가
- **`run_build`** — `created_by` param → `BuildManifest` 생성 시 전달
- **`dispatch`** — `principal.label`을 `created_by`로 `service.build()`에 전달
- **`BuildIndex`** — `SCHEMA_VERSION` 2→3, `created_by TEXT` 컬럼, `BuildEntry` 필드, `insert_or_replace`/`list_builds`/`get`/`rebuild_index` 전부 `created_by` 반영

## 인수 기준

- 기록만 하고 접근 제어는 하지 않음 — 기존 클라이언트 무영향 ✅ (모든 필드 optional, 기본 None)
- 기존 인덱스 SCHEMA_VERSION 2→3 마이그레이션 — 기존 인덱스 DROP 후 재생성 (ADR 0003 파생 캐시, manifest.json이 정본, `rebuild-index`로 복구 가능)
- 617 tests passed, ruff/mypy clean

Closes #388
