### PR TITLE
feat: request ID 추적 + 구조화 에러 로깅 (#379)

### DIFF
--- a/src/kpubdata_builder/service/http.py
+++ b/src/kpubdata_builder/service/http.py
@@ -15,6 +15,7 @@ import logging
 import mimetypes
 import os
 import traceback
+import uuid
 from concurrent.futures import ThreadPoolExecutor
 from functools import lru_cache
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -136,6 +137,7 @@ def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
         timeout = _SOCKET_TIMEOUT_SECONDS
 
         def _dispatch(self, method: str) -> None:
+            self._request_id = uuid.uuid4().hex[:12]
             try:
                 length = int(self.headers.get("Content-Length", 0) or 0)
             except ValueError:
@@ -196,6 +198,7 @@ def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
                     method,
                     path,
                     traceback.format_exc(),
+                    extra={"request_id": getattr(self, "_request_id", None)},
                 )
                 self._write(500, {"error": "internal server error"})
                 return
@@ -226,10 +229,14 @@ def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
                 self.send_header("Access-Control-Max-Age", "86400")
 
         def _write(self, status_code: int, body: dict[str, JsonValue]) -> None:
+            if hasattr(self, "_request_id"):
+                body.setdefault("request_id", self._request_id)
             payload = json.dumps(body, ensure_ascii=False, default=str).encode("utf-8")
             self.send_response(status_code)
             self.send_header("Content-Type", "application/json; charset=utf-8")
             self.send_header("Content-Length", str(len(payload)))
+            if hasattr(self, "_request_id"):
+                self.send_header("X-Request-ID", self._request_id)
             self._send_cors_headers(origin=self.headers.get("Origin"))
             self.end_headers()
             _ = self.wfile.write(payload)

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -715,7 +715,8 @@ class TestHttpAdapter:
         with urllib.request.urlopen(f"{base_url}/healthz", timeout=2.0) as response:
             assert response.status == 200
             body = cast(dict[str, object], json.loads(response.read()))
-        assert body == {"status": "ok"}
+        assert body["status"] == "ok"
+        assert "request_id" in body
         # 버전·서비스 메타 정보가 누출되지 않아야 한다.
         assert "api_version" not in body
         assert "service" not in body


### PR DESCRIPTION
## 개요

**#379**. 모든 HTTP 요청에 12자리 hex request_id를 부여해 추적성을 확보한다. 외부 로깅 스택 없이 표준 라이브러리만으로 구현.

## 변경 (`src/kpubdata_builder/service/http.py`)

- **request_id 생성**: `_dispatch()` 시작 시 `uuid.uuid4().hex[:12]`
- **X-Request-ID 응답 헤더**: 모든 응답에 포함
- **JSON body에 request_id**: 에러/정상 응답 모두 `request_id` 필드 포함
- **에러 로깅**: `extra={"request_id": ...}` — 구조화 로깅 핸들러에서 추출 가능

JSON 포매터 자체는 별도 로깅 스택 결정 후 도입(App Insights/Datadog 등). request_id 전파가 스택 무관한 기반.

## 검증
- ruff/mypy clean, **617 passed** (healthz 테스트 request_id 포함하도록 갱신)

Refs #379
