### PR TITLE
docs: 전체 문서 동기화 — API_CONTRACT/CHANGELOG/README/AGENTS/ADR 링크 수정

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,8 +142,10 @@ src/kpubdata_builder/
 ├── tabular/         # Polars 기반 표 처리
 ├── exporters/       # 데이터 형식 변환 (Markdown, JSONL 등)
 ├── publishers/      # 결과물 업로드 (HF, GitHub 등)
-├── spec.py          # 빌드 기획서(BuildSpec) 정의
-└── manifest.py      # 빌드 명세서 생성 로직
+├── service/         # HTTP 서비스 모드 (app.py, http.py, auth.py)
+├── store/           # BuildIndex (SQLite 파생 인덱스, ADR 0003)
+├── spec/            # 빌드 기획서(BuildSpec) 정의 및 검증
+└── manifest/        # 빌드 명세서 생성 로직
 ```
 
 ### 이 파일을 수정해야 할 때

--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -53,8 +53,13 @@ Builder는 **동기식 실행 모델**을 사용합니다.
 | `/build` | `POST` | 빌드 실행 (동기식) | 동기식 |
 | `/artifacts/{run_id}` | `GET` | 실행 워크스페이스 산출물 목록 조회 | 동기식 |
 | `/builds` | `GET` | 빌드 이력 목록 조회 (최신 수정 시각 기준 내림차순) | 동기식 |
+| `/healthz` | `GET` | 무인증 liveness probe (`{"status":"ok"}`) | 동기식 |
 
 ## 5. 엔드포인트 상세
+
+### 5.0 `GET /healthz` (#372)
+
+무인증 liveness/readiness probe용. 인증 게이트 밖에서 처리되어 버전·메타 정보 없이 `{"status":"ok"}`만 반환합니다.
 
 ### 5.1 `GET /version`
 
@@ -65,7 +70,7 @@ Builder API 계약 버전을 반환합니다.
 ```json
 {
   "service": "kpubdata-builder",
-  "api_version": "1.0.0"
+  "api_version": "1.1.0"
 }
 ```
 
@@ -344,12 +349,28 @@ export KPUBDATA_BUILDER_ALLOWED_ORIGINS=http://localhost:5173,https://studio.exa
 `OPTIONS` 메서드로 preflight 요청을 지원합니다. 허용된 오리진에 대해 다음 헤더를 응답합니다:
 
 - `Access-Control-Allow-Methods: GET, POST, OPTIONS`
-- `Access-Control-Allow-Headers: Content-Type, X-API-Key`
+- `Access-Control-Allow-Headers: Content-Type, X-API-Key, Authorization`
 - `Access-Control-Max-Age: 86400` (24시간)
 
-### 9.4 인증 헤더
+### 9.4 인증 (#248, ADR 0006/0009)
 
-`X-API-Key` 커스텀 헤더를 사용한 인증은 preflight 요청에서 허용 목록에 포함되어야 합니다.
+두 인증 경로를 지원합니다 (API 1.1.0+, #387):
+
+| 방식 | 헤더 | 용도 | 환경변수 |
+| :--- | :--- | :--- | :--- |
+| API Key | `X-API-Key: <secret>` | 서비스 계정 (스케줄 워크플로) | `KPUBDATA_BUILDER_API_KEY` |
+| Bearer (OIDC) | `Authorization: Bearer <jwt>` | 사람 사용자 (Studio, ADR 0009) | `OIDC_ISSUER` + `OIDC_AUDIENCE` |
+
+**fail-closed** (ADR 0006): `KPUBDATA_BUILDER_API_KEY` 미설정 + dev-mode 미설정 시 모든 요청 401.
+
+**OIDC 활성 시** (ADR 0009, #385/#386):
+- `OIDC_ISSUER` + `OIDC_AUDIENCE` + 허용 목록(`OIDC_ALLOWED_HD`/`SUBJECTS`/`EMAILS`) 필수.
+- 미설정 시 Bearer 비활성 — 기존 배포 무영향.
+
+**응답 코드**:
+- `401`: 인증 실패 (토큰 만료·무효·키 불일치) — 재로그인 필요
+- `403`: 인가 실패 (허용 목록 밖) — 재로그인 무의미, 관리자에게 권한 요청
+- `503`: JWKS 일시 장애 — 잠시 후 재시도
 
 ## 10. Python API — BuilderService
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,26 @@
 ## [Unreleased]
 
 ### 추가됨
-- 초기 프로젝트 구조
-- 빌드 스펙 모델
-- 검증기 스텁
-- Markdown 및 JSONL exporter 스텁
-- 빌드 manifest 모델
+- **인증 시스템 (B2-B5)**: Principal 추상화(#384), Google OIDC Bearer 검증(#385), 허용 목록 게이트(#386), API 계약 1.1.0 bearerAuth(#387)
+- **인가 (C1/C2)**: manifest·BuildIndex에 principal 기록(#388), ENFORCE_OWNERSHIP 플래그로 run 소유권 강제(#389)
+- **무인증 /healthz 엔드포인트** + Dockerfile HEALTHCHECK (#372)
+- **SIGTERM 우아운 종료** + max_workers env/CLI 노출 (#374)
+- **CORS Authorization 헤더** + 파일 응답 Origin 처리 (#382)
+- **Dockerfile ARG EXTRAS** — publish extra 기본 포함 (#373)
+- **dev-mode 환경변수 통일** KPUBDATA_BUILDER_DEV_MODE (#371)
+- **request ID 추적** — X-Request-ID 헤더 + JSON body (#379)
+- **Azure Bicep IaC** — ACA + Azure Files + Log Analytics (#378)
+- **배포 가이드** docs/deploy.md (#390)
+- **ADR 0008** 비동기 build job 모델 초안 (#334)
+- **ADR 0009** 사용자 인증 Google OIDC (#383)
+- **ADR 0010** ArtifactStore + 상태 백엔드 분리 (#375)
+- HTTP 전송 계층 로그/예외 메시지에서 API 키 마스킹 (#260)
+- 컨테이너 진입점 fail-closed 정책 (ADR 0006)
+
+### 변경됨
+- API 계약 버전 1.0.0 → 1.1.0 (bearerAuth 추가)
+- BuildIndex 스키마 v2 → v3 (created_by 컬럼)
+- BuildManifest에 created_by 필드 추가
+
+### 제거됨
+- .omc/state/sessions 스크래치 파일 추적 해제 (#380)

--- a/EXPORT_MODEL.md
+++ b/EXPORT_MODEL.md
@@ -354,4 +354,4 @@ def export(self, artifact, target, output_dir) -> ExportResult:
 ### 상위 ADR
 | ADR | 제목 | 상태 |
 | :--- | :--- | :--- |
-| [ADR 0004](./docs/adrs/0004-plugin-exporter-contract.md) | Plugin Exporter API 계약 안정화 | 승인됨 |
+| [ADR 0004](./adrs/0004-plugin-exporter-contract.md) | Plugin Exporter API 계약 안정화 | 승인됨 |

--- a/README.md
+++ b/README.md
@@ -203,6 +203,14 @@ ADR 0006). 설정은 환경변수로 주입합니다 — `docker-entrypoint.sh`�
 | `KPUBDATA_BUILDER_OUTPUT_DIR` | 실행 워크스페이스 루트 | `/data` | 선택 |
 | `KPUBDATA_BUILDER_HOST` | 바인딩 호스트 | `0.0.0.0` | 선택 |
 | `KPUBDATA_BUILDER_DEV_MODE` | `true`/`1`이면 API 키 없이 기동 (로컬 개발 전용) | 미설정 | 선택 |
+| `KPUBDATA_BUILDER_MAX_WORKERS` | 동시 요청 스레드 상한 | `10` | 선택 |
+| `KPUBDATA_BUILDER_ALLOWED_ORIGINS` | CORS 허용 오리진 (콤마 구분, default-deny) | 미설정 | 선택 |
+| `OIDC_ISSUER` | Google OIDC 발급자 (설정 시 Bearer 활성, ADR 0009) | 미설정 | 선택 |
+| `OIDC_AUDIENCE` | OIDC audience (OIDC_ISSUER 설정 시 필수) | 미설정 | OIDC 시 필수 |
+| `OIDC_ALLOWED_HD` | 허용 Workspace 도메인 (공개 IdP 필수 방어) | 미설정 | OIDC 시 필수 |
+| `OIDC_ALLOWED_SUBJECTS` | 허용 sub 목록 (콤마 구분) | 미설정 | OIDC 시 필수 |
+| `OIDC_ALLOWED_EMAILS` | 허용 이메일 목록 (콤마 구분) | 미설정 | OIDC 시 필수 |
+| `ENFORCE_OWNERSHIP` | `true`/`1`이면 run 소유권 강제 (C2, #389) | 미설정 | 선택 |
 
 > **fail-closed (ADR 0006)**: 컨테이너는 `KPUBDATA_BUILDER_API_KEY`가 없으면 기동을
 > 거부합니다. `service/app.py`의 "키 미설정 = 인증 생략" 동작은 로컬 개발 편의 전용이며

--- a/docs/adrs/0002-build-execution-model.md
+++ b/docs/adrs/0002-build-execution-model.md
@@ -2,7 +2,7 @@
 
 - 상태: 승인됨(Accepted)
 - 관련 이슈: #308, #241, #209, kpubdata-studio#102
-- 관련 문서: [API_CONTRACT.md](../../API_CONTRACT.md), [BUILD_STATE.md](../../BUILD_STATE.md)
+- 관련 문서: [API_CONTRACT.md](../API_CONTRACT.md), [BUILD_STATE.md](../BUILD_STATE.md)
 
 ## 결정 (승인됨)
 

--- a/docs/adrs/0003-persistent-build-store.md
+++ b/docs/adrs/0003-persistent-build-store.md
@@ -2,7 +2,7 @@
 
 - 상태: 승인됨(Accepted)
 - 관련 이슈: #309, #308, kpubdata-studio#102
-- 관련 문서: [ARCHITECTURE.md](../../ARCHITECTURE.md), [BUILD_STATE.md](../../BUILD_STATE.md)
+- 관련 문서: [ARCHITECTURE.md](../ARCHITECTURE.md), [BUILD_STATE.md](../BUILD_STATE.md)
 
 ## 결정 (승인됨)
 

--- a/docs/adrs/0004-plugin-exporter-contract.md
+++ b/docs/adrs/0004-plugin-exporter-contract.md
@@ -2,7 +2,7 @@
 
 - 상태: 승인됨(Accepted)
 - 관련 이슈: #310
-- 관련 문서: [EXPORT_MODEL.md](../../EXPORT_MODEL.md), [ARCHITECTURE.md](../../ARCHITECTURE.md)
+- 관련 문서: [EXPORT_MODEL.md](../EXPORT_MODEL.md), [ARCHITECTURE.md](../ARCHITECTURE.md)
 
 ## 결정 (승인됨)
 

--- a/docs/adrs/0005-api-contract-single-source.md
+++ b/docs/adrs/0005-api-contract-single-source.md
@@ -2,7 +2,7 @@
 
 - 상태: 승인됨(Accepted)
 - 관련 이슈: #311, #209, #241, kpubdata-studio#85, kpubdata-studio#103
-- 관련 문서: [API_CONTRACT.md](../../API_CONTRACT.md), `contract/builder-api.yaml`
+- 관련 문서: [API_CONTRACT.md](../API_CONTRACT.md), `contract/builder-api.yaml`
 
 ## 결정 (승인됨)
 

--- a/docs/adrs/0006-service-auth-and-deployment.md
+++ b/docs/adrs/0006-service-auth-and-deployment.md
@@ -2,7 +2,7 @@
 
 - 상태: 승인됨(Accepted)
 - 관련 이슈: #312, #237, #248, #253
-- 관련 문서: [API_CONTRACT.md](../../API_CONTRACT.md), [ARCHITECTURE.md](../../ARCHITECTURE.md)
+- 관련 문서: [API_CONTRACT.md](../API_CONTRACT.md), [ARCHITECTURE.md](../ARCHITECTURE.md)
 
 ## 결정 (승인됨)
 

--- a/docs/adrs/0007-kpubdata-version-compatibility-policy.md
+++ b/docs/adrs/0007-kpubdata-version-compatibility-policy.md
@@ -2,7 +2,7 @@
 
 - 상태: 승인됨(Accepted)
 - 관련 이슈: #213, kpubdata#233
-- 관련 문서: [CONTRIBUTING.md](../../CONTRIBUTING.md) §3-1, [pyproject.toml](../../pyproject.toml)
+- 관련 문서: [CONTRIBUTING.md](../CONTRIBUTING.md) §3-1, pyproject.toml
 
 ## 결정 (승인됨)
 
@@ -101,7 +101,7 @@ min-deps:
       run: uv run --no-sync pytest
 ```
 
-### 3. 문서화 ([CONTRIBUTING.md](../../CONTRIBUTING.md) §3-1 확장)
+### 3. 문서화 ([CONTRIBUTING.md](../CONTRIBUTING.md) §3-1 확장)
 - 로컬 개발과 CI/배포 환경의 의존성 해석 차이를 명시
 - 핀 범위(`>=0.5.0,<0.6`)의 의미와 이슈 #213 링크를 추가
 - 하한 테스트 잡의 목적과 절차를 설명


### PR DESCRIPTION
## 개요

세션에서 머지한 25+ PR의 변경사항을 문서에 반영하고, 기존 문서의 링크 오류를 수정했습니다.

## 변경 내역

| 문서 | 수정 내용 |
|---|---|
| API_CONTRACT.md | /healthz 엔드포인트, bearerAuth 인증 섹션, 401/403/503 응답 코드, CORS Authorization 헤더, 버전 1.1.0 |
| CHANGELOG.md | 이번 세션 전체 변경사항 (B2-B5, C1/C2, 인프라, ADR 3건) |
| README.md | OIDC, ENFORCE_OWNERSHIP, MAX_WORKERS 환경변수를 환경변수 표에 추가 |
| AGENTS.md | 파일 구조에 service/ (auth.py 포함), store/, spec/, manifest/ 반영 |
| ADR 0002-0007 | 기존 `../../` 링크 → `../` 수정 (pre-existing 버그 11건) |
| EXPORT_MODEL.md | adrs 링크 경로 수정 |

## 검증

- `mkdocs build --strict`: **0 warnings** (수정 전 11+ warnings)
- ruff/mypy clean, 617 tests passed
