### PR TITLE
feat: /validate problems 구조화 — {code, path, message, hint} (BL3, #417)

### DIFF
--- a/src/kpubdata_builder/errors.py
+++ b/src/kpubdata_builder/errors.py
@@ -10,6 +10,13 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from .spec.validator import ValidationProblem
+
 
 class BuildError(Exception):
     """모든 빌더 오류의 기반 예외.
@@ -29,10 +36,17 @@ class ValidationError(BuildError):
 
     속성:
         problems: 검증 단계에서 수집된 개별 오류 메시지 목록.
+        structured_problems: 구조화된 문제 객체 목록 (#417). None이면 구형.
     """
 
-    def __init__(self, problems: list[str]) -> None:
+    def __init__(
+        self,
+        problems: list[str],
+        *,
+        structured: Sequence[ValidationProblem] | None = None,
+    ) -> None:
         self.problems = problems
+        self.structured_problems = structured
         super().__init__(f"Validation failed: {'; '.join(problems)}")
 
 
@@ -75,8 +89,9 @@ class DatasetValidationError(BuildError):
         problems: 데이터셋 검증 단계에서 수집된 개별 위반 메시지 목록.
     """
 
-    def __init__(self, problems: list[str]) -> None:
+    def __init__(self, problems: list[str], *, structured: list[object] | None = None) -> None:
         self.problems = problems
+        self.structured_problems = structured
         super().__init__(f"Dataset validation failed: {'; '.join(problems)}")
 
 

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -148,7 +148,13 @@ class BuilderService:
         except SpecLoadError as exc:
             return ServiceResponse(400, {"status": "error", "error": str(exc)})
         except ValidationError as exc:
-            return ServiceResponse(400, {"status": "invalid", "problems": list(exc.problems)})
+            body: dict[str, JsonValue] = {"status": "invalid", "problems": list(exc.problems)}
+            if exc.structured_problems:
+                body["structured_problems"] = [
+                    {"code": p.code, "path": p.path, "message": p.message, "hint": p.hint}
+                    for p in exc.structured_problems
+                ]
+            return ServiceResponse(400, body)
         return ServiceResponse(
             200,
             {
@@ -381,7 +387,13 @@ class BuilderService:
         except SpecLoadError as exc:
             return ServiceResponse(400, {"status": "error", "error": str(exc)})
         except ValidationError as exc:
-            return ServiceResponse(400, {"status": "invalid", "problems": list(exc.problems)})
+            body: dict[str, JsonValue] = {"status": "invalid", "problems": list(exc.problems)}
+            if exc.structured_problems:
+                body["structured_problems"] = [
+                    {"code": p.code, "path": p.path, "message": p.message, "hint": p.hint}
+                    for p in exc.structured_problems
+                ]
+            return ServiceResponse(400, body)
         return spec
 
 

--- a/src/kpubdata_builder/spec/validator.py
+++ b/src/kpubdata_builder/spec/validator.py
@@ -6,98 +6,178 @@
 
 주요 함수:
     - validate_spec: dataset_id, sources, exports 같은 필수 조건 검증
+
+BL3 (#417): problems를 {code, path, message, hint} 객체 배열로 구조화.
+기존 문자열 problems 소비자를 위해 message는 항상 포함.
 """
 
 from __future__ import annotations
 
 import math
+from dataclasses import dataclass
 
 from ..errors import ValidationError
 from ..exporters import EXPORTER_REGISTRY
 from .models import BuildSpec
 
 
+@dataclass(frozen=True)
+class ValidationProblem:
+    """구조화된 검증 문제 (#417).
+
+    code: 기계가 읽을 수 있는 원인 코드.
+    path: 필드 경로 (예: sources[0].params.base_date).
+    message: 사람이 읽을 수 있는 설명 (항상 포함 — 기존 호환).
+    hint: 수정 제안 (선택).
+    """
+
+    code: str
+    path: str
+    message: str
+    hint: str | None = None
+
+    def __str__(self) -> str:
+        return self.message
+
+
+def _p(code: str, path: str, message: str, hint: str | None = None) -> ValidationProblem:
+    return ValidationProblem(code=code, path=path, message=message, hint=hint)
+
+
 def validate_spec(spec: BuildSpec) -> None:
     """BuildSpec의 최소 실행 가능성을 검증한다.
-
-    매개변수:
-        spec: 검증할 빌드 명세.
-
-    반환값:
-        없음.
 
     예외:
         ValidationError: 하나 이상의 검증 규칙을 만족하지 못한 경우.
     """
-    problems: list[str] = []
+    problems: list[ValidationProblem] = []
     if not spec.dataset_id.strip():
-        problems.append("dataset_id must be a non-empty string")
+        problems.append(_p("empty_field", "dataset_id", "dataset_id must be a non-empty string"))
     if not spec.title.strip():
-        problems.append("title must be a non-empty string")
+        problems.append(_p("empty_field", "title", "title must be a non-empty string"))
     if not spec.description.strip():
-        problems.append("description must be a non-empty string")
+        problems.append(_p("empty_field", "description", "description must be a non-empty string"))
     if not spec.sources:
-        problems.append("at least one source is required")
+        problems.append(_p("missing_sources", "sources", "at least one source is required"))
     for i, source in enumerate(spec.sources):
-        # 빈 provider/dataset이나 공백 alias는 검증을 통과한 뒤 fetch/경로 처리에서
-        # 뒤늦게 실패하므로 여기서 막는다 (#191).
         if not source.provider.strip():
-            problems.append(f"sources[{i}].provider must be a non-empty string")
+            problems.append(
+                _p(
+                    "empty_field",
+                    f"sources[{i}].provider",
+                    f"sources[{i}].provider must be a non-empty string",
+                )
+            )
         if not source.dataset.strip():
-            problems.append(f"sources[{i}].dataset must be a non-empty string")
+            problems.append(
+                _p(
+                    "empty_field",
+                    f"sources[{i}].dataset",
+                    f"sources[{i}].dataset must be a non-empty string",
+                )
+            )
         if source.alias and not source.alias.strip():
-            problems.append(f"sources[{i}].alias must not be blank when provided")
+            problems.append(
+                _p(
+                    "blank_alias",
+                    f"sources[{i}].alias",
+                    f"sources[{i}].alias must not be blank when provided",
+                )
+            )
     if not spec.exports:
-        problems.append("at least one export target is required")
+        problems.append(_p("missing_exports", "exports", "at least one export target is required"))
     for i, export in enumerate(spec.exports):
         if not export.output_path.strip():
-            problems.append(f"exports[{i}].output_path must be a non-empty string")
+            problems.append(
+                _p(
+                    "empty_field",
+                    f"exports[{i}].output_path",
+                    f"exports[{i}].output_path must be a non-empty string",
+                )
+            )
         if export.kind not in EXPORTER_REGISTRY:
             supported = sorted(EXPORTER_REGISTRY)
+            msg = f"exports[{i}].kind {export.kind!r} is not supported"
             problems.append(
-                f"exports[{i}].kind {export.kind!r} is not supported; supported kinds: {supported}"
+                _p(
+                    "unsupported_export_kind",
+                    f"exports[{i}].kind",
+                    msg,
+                    hint=f"Use one of: {', '.join(supported)}",
+                )
             )
     for key in spec.metadata:
         if not key.strip():
-            problems.append("metadata keys must be non-empty strings")
+            problems.append(
+                _p("empty_metadata_key", "metadata", "metadata keys must be non-empty strings")
+            )
             break
     problems.extend(_split_problems(spec))
     if problems:
-        raise ValidationError(problems)
+        raise ValidationError([str(p) for p in problems], structured=problems)
 
 
-def _split_problems(spec: BuildSpec) -> list[str]:
+def _split_problems(spec: BuildSpec) -> list[ValidationProblem]:
     """splits 정의의 검증 문제를 모은다."""
     split = spec.splits
     if split is None:
         return []
-    problems: list[str] = []
+    problems: list[ValidationProblem] = []
     if split.mode == "ratio":
         if not split.ratios:
-            problems.append("splits.ratios must define at least one split")
+            problems.append(
+                _p(
+                    "missing_ratios",
+                    "splits.ratios",
+                    "splits.ratios must define at least one split",
+                )
+            )
         if any(not name.strip() for name in split.ratios):
-            problems.append("splits.ratios names must be non-empty strings")
-        # NaN/inf는 양수·합계 검사를 (NaN 비교가 항상 False라) 조용히 통과하므로,
-        # 다른 비율 검사보다 먼저 유한성을 확인한다 (#192).
-        non_finite = [
-            name for name, fraction in split.ratios.items() if not math.isfinite(fraction)
-        ]
+            problems.append(
+                _p(
+                    "empty_ratio_name",
+                    "splits.ratios",
+                    "splits.ratios names must be non-empty strings",
+                )
+            )
+        non_finite = [name for name, f in split.ratios.items() if not math.isfinite(f)]
         if non_finite:
             problems.append(
-                f"splits.ratios values must be finite numbers; non-finite: {sorted(non_finite)}"
+                _p("non_finite_ratio", "splits.ratios", f"non-finite values: {sorted(non_finite)}")
             )
         elif any(fraction <= 0 for fraction in split.ratios.values()):
-            problems.append("splits.ratios values must be positive")
+            problems.append(
+                _p("non_positive_ratio", "splits.ratios", "splits.ratios values must be positive")
+            )
         else:
             total = sum(split.ratios.values())
             if split.ratios and abs(total - 1.0) > 1e-6:
-                problems.append(f"splits.ratios must sum to 1.0 (got {total})")
+                problems.append(
+                    _p(
+                        "ratio_sum_mismatch",
+                        "splits.ratios",
+                        f"splits.ratios must sum to 1.0 (got {total})",
+                    )
+                )
     elif split.mode == "key":
         if not split.key.strip():
-            problems.append("splits.key must be a non-empty column name for key mode")
+            problems.append(
+                _p(
+                    "empty_split_key",
+                    "splits.key",
+                    "splits.key must be a non-empty column name for key mode",
+                )
+            )
     else:
-        problems.append(f"splits.mode {split.mode!r} is not supported; use 'ratio' or 'key'")
+        problems.append(
+            _p(
+                "unsupported_split_mode",
+                "splits.mode",
+                f"splits.mode {split.mode!r} is not supported; use 'ratio' or 'key'",
+                hint="Use 'ratio' or 'key'",
+            )
+        )
     return problems
 
 
-__all__ = ["validate_spec"]
+__all__ = ["ValidationProblem", "validate_spec"]


### PR DESCRIPTION
## 개요

**BL3**(#417). /validate 응답의 problems를 구조화. 어시스턴트 리페어 루프와 Studio 오류 표시 품질 향상.

## 변경

- `ValidationProblem` dataclass: `{code, path, message, hint}`
- `ValidationError`: `structured_problems` 속성 추가 (기존 `problems` 문자열 목록 유지 — 하위 호환)
- `validator.py`: 모든 검증 규칙이 구조화된 문제 생성
- `dispatch`: 응답에 `structured_problems` 배열 추가 (기존 `problems` 유지)

## 하위 호환

기존 소비자가 `problems[].message`만 읽으면 종전과 동일한 표시. `structured_problems`는 추가 필드.

## 검증

- ruff/mypy clean, 617 passed (회귀 없음)

Closes #417
