### PR TITLE
contract: API 1.2.0 — /catalog + StructuredProblem 스키마 (BL4, #418)

### DIFF
--- a/contract/builder-api.yaml
+++ b/contract/builder-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: KPubData Builder Service API
-  version: "1.1.0"
+  version: "1.2.0"
   description: >-
     Builder 중심 서비스 계약. BuildSpec 검증, preview, build 실행, artifact 조회,
     계약 버전 조회를 제공한다. CLI와 HTTP service mode(#36)가 동일한 도메인 계약을
@@ -44,6 +44,22 @@ paths:
                 $ref: "#/components/schemas/VersionResponse"
         "401":
           $ref: "#/components/responses/Unauthorized"
+
+  /catalog:
+    get:
+      operationId: getCatalog
+      summary: provider/dataset 카탈로그 조회 (BL2, #416)
+      responses:
+        "200":
+          description: 사용 가능한 provider와 dataset 목록
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CatalogResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "502":
+          description: 카탈로그 조회 실패
 
   /validate:
     post:
@@ -359,6 +375,53 @@ components:
         status:
           type: string
           const: "ok"
+
+    CatalogResponse:
+      type: object
+      required: [providers]
+      description: provider/dataset 카탈로그 (#416, BL2)
+      properties:
+        providers:
+          type: array
+          items:
+            $ref: "#/components/schemas/CatalogProvider"
+
+    CatalogProvider:
+      type: object
+      required: [name, datasets]
+      properties:
+        name:
+          type: string
+        datasets:
+          type: array
+          items:
+            $ref: "#/components/schemas/CatalogDataset"
+
+    CatalogDataset:
+      type: object
+      required: [name, title, requires_service_key]
+      properties:
+        name:
+          type: string
+        title:
+          type: string
+        requires_service_key:
+          type: boolean
+
+    StructuredProblem:
+      type: object
+      required: [code, path, message]
+      description: 구조화된 검증 문제 (#417, BL3)
+      properties:
+        code:
+          type: string
+        path:
+          type: string
+        message:
+          type: string
+        hint:
+          type: string
+          nullable: true
 
     ValidateResponse:
       type: object

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -79,7 +79,7 @@ _BuildListEntry = dict[str, str | None]
 # Builder API 계약 버전. contract/builder-api.yaml의 info.version과 일치해야 하며
 # (test_service_contract가 강제), 응답에 실어 Studio 같은 소비자가 하위 호환을
 # 협상할 수 있게 한다 (#209).
-API_CONTRACT_VERSION = "1.1.0"
+API_CONTRACT_VERSION = "1.2.0"
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_service_contract.py
+++ b/tests/unit/test_service_contract.py
@@ -36,6 +36,7 @@ _CONTRACT_PATH = Path(__file__).parents[2] / "contract" / "builder-api.yaml"
 _DISPATCH_ROUTES: dict[tuple[str, str], str] = {
     ("/healthz", "GET"): "healthz",
     ("/version", "GET"): "getVersion",
+    ("/catalog", "GET"): "getCatalog",
     ("/validate", "POST"): "validateSpec",
     ("/preview", "POST"): "previewBuild",
     ("/build", "POST"): "createBuild",
@@ -48,6 +49,7 @@ _DISPATCH_ROUTES: dict[tuple[str, str], str] = {
 _REQUIRED_OPERATIONS = [
     ("/healthz", "get"),
     ("/version", "get"),
+    ("/catalog", "get"),
     ("/validate", "post"),
     ("/preview", "post"),
     ("/build", "post"),
@@ -112,13 +114,14 @@ def test_service_api_version_matches_contract() -> None:
 # 계약이 기술하는 모든 오퍼레이션은 BuilderService에 실제로 구현돼 있어야 한다.
 # 구현 경로 이름은 계약과 1:1로 일치한다(#226: aspirational 비동기/publish 라우트 제거).
 _IMPLEMENTED_OPERATIONS = {
-    "healthz",  # GET /healthz (무인증, #372)
-    "getVersion",  # GET /version
-    "validateSpec",  # POST /validate
-    "previewBuild",  # POST /preview
-    "createBuild",  # POST /build
-    "listBuildArtifacts",  # GET /artifacts/{run_id}
-    "listBuilds",  # GET /builds
+    "healthz",
+    "getVersion",
+    "getCatalog",
+    "validateSpec",
+    "previewBuild",
+    "createBuild",
+    "listBuildArtifacts",
+    "listBuilds",
 }
 
 
@@ -290,6 +293,7 @@ def test_planned_operations_excluded_from_implementation_check() -> None:
 _OPERATION_STATUS_CODES: dict[str, set[int]] = {
     "healthz": {200},
     "getVersion": {200},
+    "getCatalog": {200, 502},
     "validateSpec": {200, 400},
     "previewBuild": {200, 400},
     "createBuild": {200, 400, 502},


### PR DESCRIPTION
## 개요

**BL4**(#418). API 계약 1.1.0 → 1.2.0. BL2(/catalog)와 BL3(problems 구조화)를 계약에 반영.

## 변경
- `API_CONTRACT_VERSION` → 1.2.0
- `/catalog` path + CatalogResponse/CatalogProvider/CatalogDataset 스키마
- StructuredProblem 스키마 ({code, path, message, hint})
- contract test: getCatalog 추가 (routes, operations, status codes)

Closes #418
