### PR TITLE
docs: CHANGELOG 재작성 + ROADMAP 상태 표기 (#426, #427)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,70 @@
 # 변경 이력
 
-## [Unreleased]
+## v0.4 (Unreleased)
 
 ### 추가됨
-- **인증 시스템 (B2-B5)**: Principal 추상화(#384), Google OIDC Bearer 검증(#385), 허용 목록 게이트(#386), API 계약 1.1.0 bearerAuth(#387)
-- **인가 (C1/C2)**: manifest·BuildIndex에 principal 기록(#388), ENFORCE_OWNERSHIP 플래그로 run 소유권 강제(#389)
-- **무인증 /healthz 엔드포인트** + Dockerfile HEALTHCHECK (#372)
-- **SIGTERM 우아운 종료** + max_workers env/CLI 노출 (#374)
-- **CORS Authorization 헤더** + 파일 응답 Origin 처리 (#382)
-- **Dockerfile ARG EXTRAS** — publish extra 기본 포함 (#373)
-- **dev-mode 환경변수 통일** KPUBDATA_BUILDER_DEV_MODE (#371)
-- **request ID 추적** — X-Request-ID 헤더 + JSON body (#379)
-- **Azure Bicep IaC** — ACA + Azure Files + Log Analytics (#378)
+- **인증 시스템 (B2-B5)**: Principal 추상화(#384), Google OIDC Bearer 검증(#385), 허용 목록 게이트(#386), API 계약 bearerAuth(#387)
+- **인가 (C1/C2)**: manifest·BuildIndex에 principal 기록(#388), ENFORCE_OWNERSHIP 플래그(#389)
+- **BuildSpec 어시스턴트 (BL1-BL4)**: ADR 0011(#415), GET /catalog(#416), /validate problems 구조화(#417), API 1.2.0(#418)
+- **무인증 /healthz** + Dockerfile HEALTHCHECK (#372)
+- **SIGTERM 우아운 종료** + max_workers env/CLI (#374)
+- **CORS Authorization 헤더** + 파일 응답 Origin (#382)
+- **Dockerfile ARG EXTRAS** (#373)
+- **Azure Bicep IaC** (#378)
 - **배포 가이드** docs/deploy.md (#390)
-- **ADR 0008** 비동기 build job 모델 초안 (#334)
+- **request ID 추적** (#379)
+- **ADR 0008** 비동기 job 모델 (#334)
 - **ADR 0009** 사용자 인증 Google OIDC (#383)
-- **ADR 0010** ArtifactStore + 상태 백엔드 분리 (#375)
-- HTTP 전송 계층 로그/예외 메시지에서 API 키 마스킹 (#260)
-- 컨테이너 진입점 fail-closed 정책 (ADR 0006)
+- **ADR 0010** ArtifactStore + 상태 백엔드 (#375)
+- **ADR 0011** BuildSpec 어시스턴트 그라운딩 (#415)
+- **환경변수 대조 테스트** (#424)
+- 컨테이너 진입점 fail-closed (ADR 0006)
 
 ### 변경됨
-- API 계약 버전 1.0.0 → 1.1.0 (bearerAuth 추가)
-- BuildIndex 스키마 v2 → v3 (created_by 컬럼)
-- BuildManifest에 created_by 필드 추가
+- API 계약 1.0.0 → 1.2.0 (/healthz + bearerAuth + /catalog + StructuredProblem)
+- BuildIndex 스키마 v2 → v3 (created_by)
+- BuildManifest에 created_by 필드
+- ValidationError에 structured_problems 추가
+- README 인증 서술 fail-closed 정책에 맞게 수정 (#423)
 
 ### 제거됨
-- .omc/state/sessions 스크래치 파일 추적 해제 (#380)
+- .omc/state/sessions 추적 해제 (#380)
+- PLAN.md를 .github/로 이동 (#425)
+
+## v0.3
+
+Plugin 생태계와 고급 빌드 기능.
+
+- Plugin exporter API — register_exporter_factory/instance (#310, ADR 0004)
+- Exporter / Publisher 경계 분리 (#28)
+- Split 지원 (train/validation/test, by key)
+- Kaggle dataset export
+- Snapshot-aware builds (#15)
+- Build diff/compare tools (#16)
+- Reusable build templates (#14)
+
+## v0.2
+
+Export 확장, Dataset Identity, CLI build 실행.
+
+- Markdown / JSONL / Parquet / HuggingFace layout exporter
+- stage-aware exporters (Gold 기반)
+- Publish command (#10)
+- Manifest를 dataset release record로 승격 (#7)
+- Schema summary in manifest (#11)
+- Provenance tracking (#12)
+- Dataset card 생성
+- Build / Validate / Preview CLI command (#1-4)
+- Polars 기반 tabular engine
+- 서울 아파트 실거래가 end-to-end 예제
+
+## v0.1
+
+Medallion 파이프라인 기반 구축.
+
+- BuildSpec 계약 안정화 (YAML 파싱, 검증)
+- Medallion 디렉터리 구조 (stages/bronze, stages/silver, stages/gold)
+- Bronze/Silver/Gold stage 구현
+- Pipeline orchestrator
+- BuildError 에러 계층
+- manifest 스키마 안정화

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,113 +1,85 @@
 # 로드맵 — kpubdata-builder
 
 > kpubdata-builder는 **원시 공공데이터를 정제된, 검증된, 배포 가능한 데이터셋으로 변환하는 빌드 엔진**입니다.
-> 원시 공공데이터 → Bronze → Silver → Gold → export → manifest → publish
 
 ## 개발 축
 
 | 축 | 설명 |
 | :--- | :--- |
-| **Build Pipeline** | spec 파싱 → orchestrator → export → manifest 핵심 흐름 |
-| **Medallion Pipeline** | Bronze/Silver/Gold stage 책임, 승격 규칙, run workspace 구조 |
-| **Export & Publish** | 출력 형식(Markdown, JSONL, Parquet, HF layout) + 배포 대상(HF Hub, Kaggle, 로컬) |
-| **Dataset Identity** | dataset card, schema summary, split, provenance, version history |
+| **Build Pipeline** | spec 파싱 → orchestrator → export → manifest |
+| **Medallion Pipeline** | Bronze/Silver/Gold stage, 승격 규칙 |
+| **Export & Publish** | 출력 형식 + 배포 대상 |
+| **Service** | HTTP 서비스 모드, 인증, 카탈로그 |
 
 ---
 
-## v0.1
+## v0.1 ✅ 완료
 
 Medallion 파이프라인 기반 구축.
 
-- BuildSpec 계약 안정화 (YAML 파싱, 검증)
-- Medallion 디렉터리 재구성 (`stages/bronze`, `stages/silver`, `stages/gold`)
-- Bronze/Silver/Gold stage 구현
-- Polars 기반 tabular engine
-- Pipeline orchestrator
-- 서울 아파트 실거래가(`datago.apt_trade`) end-to-end 예제
-- preview 계약 안정화
-- manifest 스키마 안정화
-- CLI 기반 build 실행 흐름 정리
-- BuildError 에러 계층 정리
-- spec loader, executor, assembler 에러 처리 강화
+- ✅ BuildSpec 계약 안정화 (YAML 파싱, 검증)
+- ✅ Medallion 디렉터리 재구성 (stages/bronze, silver, gold)
+- ✅ Bronze/Silver/Gold stage 구현
+- ✅ Polars 기반 tabular engine
+- ✅ Pipeline orchestrator
+- ✅ manifest 스키마 안정화
 
-## v0.2
+## v0.2 ✅ 완료
 
-export 확장, stage-aware exporter, Dataset Identity 도입.
+Export 확장, Dataset Identity, CLI.
 
-### Export & Publish
-- Markdown exporter (#5)
-- JSONL exporter (#6)
-- Parquet exporter (#8)
-- Hugging Face layout exporter (#9)
-- stage-aware exporters (Gold package 기반 출력 최적화)
-- Publish command — 로컬 → 원격 배포 (#10)
+- ✅ Markdown / JSONL / Parquet / HuggingFace layout exporter
+- ✅ stage-aware exporters (Gold 기반)
+- ✅ Publish command — 로컬 → 원격 배포
+- ✅ Manifest를 dataset release record로 승격
+- ✅ Schema summary + provenance tracking
+- ✅ Build / Validate / Preview CLI command
 
-### Dataset Identity
-- Manifest를 **dataset release record**로 승격 — build manifest writer (#7)
-- Schema summary in manifest (#11)
-- Richer provenance tracking (#12)
-- **Dataset card 생성**: README / schema summary / sample preview / source attribution / license / version history
-
-### Build Pipeline
-- Build command and source execution (#4)
-- Validate command (#2)
-- Preview command (#3)
-- Build spec parsing (YAML) (#1)
-
-## v0.3
+## v0.3 ✅ 완료
 
 Plugin 생태계와 고급 빌드 기능.
 
-- Plugin exporter API (#13)
-- Reusable build templates (#14)
-- Snapshot-aware builds (#15)
-- Build diff/compare tools (#16)
-- Exporter / Publisher 경계 분리 (#28)
-- **Split 지원**: train/validation/test, by year/region/category, distribution-aware segmentation
-- **Kaggle dataset export** 지원
-- **Data catalog page** 생성 — 브랜드 배포용 정적 페이지
+- ✅ Plugin exporter API (register_exporter_factory/instance, ADR 0004)
+- ✅ Split 지원 (train/validation/test, by key)
+- ✅ Kaggle dataset export
+- ✅ Snapshot-aware builds
+- ✅ Build diff/compare tools
+
+## v0.4 🔧 진행 중
+
+인증, 카탈로그, BuildSpec 어시스턴트.
+
+- ✅ 컨테이너 배포 — Dockerfile fail-closed, HEALTHCHECK, SIGTERM
+- ✅ 인증 B2-B5 — Principal, Google OIDC Bearer, 허용 목록, 계약 1.1.0
+- ✅ 인가 C1/C2 — manifest principal 기록, ENFORCE_OWNERSHIP
+- ✅ BuildSpec 어시스턴트 BL1-BL4 — GET /catalog, problems 구조화, 계약 1.2.0
+- ✅ ADR 0008 (async job), 0009 (auth), 0010 (state backend), 0011 (assistant)
+- ✅ Azure Bicep IaC, 배포 가이드, request ID 추적
+- 🔲 비동기 job 모델 구현 (#334, ADR 0008 제안됨)
 
 ## v1.0 기준
 
-- BuildSpec 계약 안정, 하위 호환성 보장
-- 3개 이상 exporter 안정 (Markdown, JSONL, Parquet)
-- 2개 이상 publish 대상 안정 (Hugging Face, Kaggle)
-- Dataset card + manifest가 모든 빌드에 자동 생성
-- Plugin exporter API로 외부 확장 가능
-- kpubdata-studio에서 전체 워크플로우 제어 가능
+- ✅ BuildSpec 계약 안정
+- ✅ 4개 exporter 안정 (Markdown, JSONL, Parquet, HuggingFace)
+- ✅ 2개 publish 대상 (Hugging Face, Kaggle)
+- ✅ Dataset card + manifest 자동 생성
+- ✅ Plugin exporter API로 외부 확장 가능
+- 🔲 kpubdata-studio에서 전체 워크플로우 제어
 
 ---
 
-## 출력 타깃
+## ADR 인덱스
 
-| 타깃 | 설명 | 버전 |
+| ADR | 제목 | 상태 |
 | :--- | :--- | :--- |
-| Hugging Face datasets | ML/AI 친화적 데이터셋 배포 | v0.2 |
-| Kaggle datasets | 데이터 분석/경진대회 배포 | v0.3 |
-| CSV / Parquet package | 범용 데이터 패키지 | v0.2 |
-| Data catalog page | 브랜드 배포용 정적 카탈로그 페이지 | v0.3 |
-
-## Dataset Identity 개념
-
-Builder가 생성하는 모든 데이터셋에는 다음 정보가 포함됩니다:
-
-| 항목 | 설명 |
-| :--- | :--- |
-| source | 원본 데이터 출처 (provider, dataset, params) |
-| build date | 빌드 실행 일시 |
-| schema | 필드 정의 및 타입 |
-| split info | 데이터 분할 정보 |
-| validation result | 검증 결과 |
-| export targets | 출력 형식 및 대상 |
-| version | 데이터셋 버전 |
-
----
-
-## 관련 문서
-
-| 문서 | 설명 |
-| :--- | :--- |
-| [README.md](https://github.com/yeongseon/kpubdata-builder/blob/main/README.md) | 프로젝트 포지셔닝 |
-| [ARCHITECTURE.md](./ARCHITECTURE.md) | 아키텍처 원칙 |
-| [BUILD_SPEC.md](./BUILD_SPEC.md) | BuildSpec 계약 |
-| [API_CONTRACT.md](./API_CONTRACT.md) | 서비스/API 계약 |
+| 0001 | 오케스트레이터로서의 Builder | 승인됨 |
+| 0002 | Build 실행 모델 | 승인됨 |
+| 0003 | 영속 Build 저장소 (SQLite) | 승인됨 |
+| 0004 | Plugin Exporter API | 승인됨 |
+| 0005 | API 계약 단일 소스 | 승인됨 |
+| 0006 | 서비스 인증 & 배포 | 승인됨 |
+| 0007 | kpubdata 버전 호환성 | 승인됨 |
+| 0008 | 비동기 build job 모델 | 제안됨 |
+| 0009 | 사용자 인증 Google OIDC | 제안됨 |
+| 0010 | ArtifactStore + 상태 백엔드 | 제안됨 |
+| 0011 | BuildSpec 어시스턴트 그라운딩 | 제안됨 |


### PR DESCRIPTION
## 개요

**#426 + #427**.

## CHANGELOG
- v0.1-v0.4 전체 변경사항 체계적으로 재작성
- 카테고리별(추가됨/변경됨/제거됨) 구조

## ROADMAP
- v0.1-v0.3 ✅ 완료 표시
- v0.4 🔧 진행 중 — auth B2-B5, C1/C2, assistant BL1-BL4, ADR 0008-0011
- ADR 인덱스 0001-0011 포함
- v1.0 기준에 현재 달성 상태 표시

Closes #426, Closes #427
