### PR TITLE
fix(service): enforce ownership in /builds fallback path (#433)

### DIFF
--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import heapq
 import json
+import logging
 import os
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
@@ -33,6 +34,8 @@ from ..stages.bronze.build import SourceClient
 from ..store import BuildIndex
 from ..tabular import DEFAULT_PREVIEW_LIMIT
 from .auth import AuthError, Principal, authenticate
+
+logger = logging.getLogger(__name__)
 
 _OWNERSHIP_ENV = "ENFORCE_OWNERSHIP"
 
@@ -75,6 +78,21 @@ def _check_ownership(
 
 # Build list entry type for API responses
 _BuildListEntry = dict[str, str | None]
+
+
+def _apply_ownership(
+    entries: list[_BuildListEntry], principal: Principal | None
+) -> list[_BuildListEntry]:
+    """list_builds 응답에서 본인 소유 run만 남긴다 (#433).
+
+    ENFORCE_OWNERSHIP+oidc principal일 때만 필터링. dev/service principal과
+    principal=None은 통과 (관리자 권한 + 하위 호환). 인덱스 분기와 파일시스템
+    폴백 양쪽에서 공통으로 적용해 폴백 경로가 필터를 우회하지 않게 한다.
+    """
+    if not (_enforce_ownership() and principal and principal.kind == "oidc"):
+        return entries
+    return [e for e in entries if e.get("created_by") == principal.label]
+
 
 # Builder API 계약 버전. contract/builder-api.yaml의 info.version과 일치해야 하며
 # (test_service_contract가 강제), 응답에 실어 Studio 같은 소비자가 하위 호환을
@@ -370,27 +388,38 @@ class BuilderService:
         """실행 이력 목록을 최신 완료 시각 기준 내림차순 반환한다.
 
         ADR 0003에 따라 SQLite 인덱스를 우선 조회하고, 인덱스가 없거나
-        비어있으면 파일시스템 스캔으로 폴백한다.
+        비어있으면 파일시스템 스캔으로 폴백한다. ENFORCE_OWNERSHIP+oidc일 때는
+        두 경로 모두 _apply_ownership으로 본인 소유 run만 노출한다 (#433).
         """
         # 인덱스 우선 조회
         try:
             entries = self._build_index.list_builds(limit=limit)
             if entries:
-                if _enforce_ownership() and principal and principal.kind == "oidc":
-                    entries = [e for e in entries if e.created_by == principal.label]
                 index_builds: list[_BuildListEntry] = [
                     {
                         "run_id": entry.run_id,
                         "status": entry.status,
                         "started_at": entry.started_at,
                         "finished_at": entry.finished_at,
+                        "created_by": entry.created_by,
                     }
                     for entry in entries
                 ]
-                return ServiceResponse(200, {"builds": cast(list[JsonValue], index_builds)})
+                return ServiceResponse(
+                    200,
+                    {"builds": cast(list[JsonValue], _apply_ownership(index_builds, principal))},
+                )
         except Exception:
-            # 인덱스 조회 실패 시 폴백
-            pass
+            # 인덱스 조회 실패. ENFORCE_OWNERSHIP+oidc면 타인 run이 폴백으로
+            # 새어나갈 수 있으므로 fail-closed로 빈 배열을 반환한다 (#433).
+            # 일반 모드는 기존대로 파일시스템 폴백으로 진행한다 (ADR 0003).
+            if _enforce_ownership() and principal and principal.kind == "oidc":
+                logger.warning(
+                    "build index query failed; returning empty list "
+                    "(ownership enforced, fail-closed)",
+                    exc_info=True,
+                )
+                return ServiceResponse(200, {"builds": []})
 
         # 폴백: 파일시스템 스캔
         if not self._output_root.exists():
@@ -416,9 +445,13 @@ class BuilderService:
                     "status": "failed" if manifest.get("errors") else "ok",
                     "started_at": manifest.get("started_at"),
                     "finished_at": manifest.get("finished_at"),
+                    "created_by": manifest.get("created_by"),
                 }
             )
-        return ServiceResponse(200, {"builds": cast(list[JsonValue], fs_builds)})
+        return ServiceResponse(
+            200,
+            {"builds": cast(list[JsonValue], _apply_ownership(fs_builds, principal))},
+        )
 
     def _load_validated(self, spec_yaml: str) -> BuildSpec | ServiceResponse:
         """spec_yaml을 파싱·검증하고, 실패 시 오류 ServiceResponse를 반환한다."""

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -14,6 +14,8 @@ from typing import cast
 import pytest
 
 from kpubdata_builder.service import BuilderService, ServiceResponse, dispatch
+from kpubdata_builder.service.app import _OWNERSHIP_ENV
+from kpubdata_builder.service.auth import Principal
 from kpubdata_builder.service.http import _clear_cors_cache, make_handler
 from kpubdata_builder.spec import JsonValue
 
@@ -1037,3 +1039,85 @@ class TestArtifactFileServing:
         # 알 수 없는 확장자 → 기본값
         assert _get_mime_type(tmp_path / "data.unknown") == "application/octet-stream"
         assert _get_mime_type(tmp_path / "data") == "application/octet-stream"
+
+
+class TestOwnershipEnforcement:
+    """ENFORCE_OWNERSHIP 회귀: 인덱스 폴백 시에도 소유권이 강제되어야 한다 (#433).
+
+    list_builds의 SQLite 인덱스 분기에만 소유권 필터가 있고, 파일시스템 폴백에는
+    없어 ENFORCE_OWNERSHIP=true 여도 타인의 run_id가 노출되는 버그 회귀 테스트.
+    ADR 0003이 폴백을 정상 동작 모드로 설계하므로 예외 상황이 아님.
+    """
+
+    def _build_as(self, service: BuilderService, run_id: str, created_by: str) -> None:
+        """created_by를 명시적으로 기록하며 빌드 (테스트 단순화용 주입)."""
+        dispatch(
+            service,
+            "POST",
+            "/build",
+            {"spec": VALID_SPEC_YAML, "run_id": run_id},
+        )
+        mpath = service._output_root / run_id / "manifest.json"
+        data = json.loads(mpath.read_text(encoding="utf-8"))
+        data["created_by"] = created_by
+        mpath.write_text(json.dumps(data), encoding="utf-8")
+
+    def test_fallback_filters_other_owners_when_index_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """인덱스가 비었을 때 폴백이 다른 사용자의 run을 노출하면 안 된다 (#433)."""
+        monkeypatch.setenv(_OWNERSHIP_ENV, "true")
+        service = _service(tmp_path)
+        self._build_as(service, "runA", "oidc:userA")
+        monkeypatch.setattr(service._build_index, "list_builds", lambda limit: [])
+
+        user_b = Principal(kind="oidc", identifier="userB")
+        resp = service.list_builds(principal=user_b)
+
+        assert resp.status_code == 200
+        builds = cast(list[dict[str, object]], resp.body["builds"])
+        run_ids = [cast(str, b["run_id"]) for b in builds]
+        assert "runA" not in run_ids, (
+            "폴백 경로가 다른 사용자의 run_id를 노출함 — 소유권 필터 누락 (#433)"
+        )
+
+    def test_fallback_filters_other_owners_when_index_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """인덱스 조회가 예외로 실패해도 폴백은 소유권을 강제해야 한다 (#433).
+
+        SQLite 잠금 경합 등으로 list_builds가 예외를 던질 때, ENFORCE_OWNERSHIP+
+        oidc 조합이면 타인 run이 폴백으로 새어나가면 안 됨 (fail-closed).
+        """
+        monkeypatch.setenv(_OWNERSHIP_ENV, "true")
+        service = _service(tmp_path)
+        self._build_as(service, "runA", "oidc:userA")
+
+        def _raise(_limit: int) -> list:
+            raise RuntimeError("simulated sqlite lock contention")
+
+        monkeypatch.setattr(service._build_index, "list_builds", _raise)
+
+        user_b = Principal(kind="oidc", identifier="userB")
+        resp = service.list_builds(principal=user_b)
+
+        assert resp.status_code == 200
+        builds = cast(list[dict[str, object]], resp.body["builds"])
+        run_ids = [cast(str, b["run_id"]) for b in builds]
+        assert "runA" not in run_ids
+
+    def test_owner_sees_own_run_in_fallback(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """소유자 본인은 폴백에서도 자신의 run을 볼 수 있어야 한다 (양성 회귀)."""
+        monkeypatch.setenv(_OWNERSHIP_ENV, "true")
+        service = _service(tmp_path)
+        self._build_as(service, "runA", "oidc:userA")
+        monkeypatch.setattr(service._build_index, "list_builds", lambda limit: [])
+
+        user_a = Principal(kind="oidc", identifier="userA")
+        resp = service.list_builds(principal=user_a)
+
+        builds = cast(list[dict[str, object]], resp.body["builds"])
+        run_ids = [cast(str, b["run_id"]) for b in builds]
+        assert "runA" in run_ids


### PR DESCRIPTION
Closes #433

## 변경 요약

`BuilderService.list_builds`의 파일시스템 폴백 경로가 소유권 필터를 우회하던 P0 보안 버그 수정.

- `_apply_ownership(entries, principal)` 헬퍼 추가 — 인덱스 분기와 폴백 양쪽에서 공통 적용
- 폴백 `fs_builds` 항목에 `created_by` 추출 (`manifest.get("created_by")`)
- `except Exception`이 `ENFORCE_OWNERSHIP`+oidc 조합일 때 **fail-closed** (빈 배열 + warning 로그). 일반 모드는 기존대로 폴백으로 진행 (ADR 0003)
- `dev`/`service` principal과 `principal=None`은 기존 동작 유지 (하위 호환)

## 회귀 테스트

`tests/unit/test_service.py::TestOwnershipEnforcement` 3케이스:
- `test_fallback_filters_other_owners_when_index_empty` — 인덱스가 비었을 때 타인 run 필터
- `test_fallback_filters_other_owners_when_index_raises` — 인덱스 예외 시 fail-closed
- `test_owner_sees_own_run_in_fallback` — 소유자 양성 (본인 run은 폴백에서도 조회)

## 품질 게이트
- pytest: **73 passed** (기존 회귀 보존 + 3 신규)
- ruff check / ruff format: pass
- mypy: pass (no issues in 70 files)