### PR TITLE
feat(auth): resolve JWKS URL via OIDC discovery (RFC 8414) (#435)

### DIFF
--- a/src/kpubdata_builder/service/auth.py
+++ b/src/kpubdata_builder/service/auth.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import hmac
 import os
 import threading
+import time
 from dataclasses import dataclass
 
 # 서버가 요구하는 API 키. 환경변수로만 주입한다 (#248).
@@ -28,6 +29,7 @@ _OIDC_AUDIENCE_ENV = "OIDC_AUDIENCE"
 _OIDC_JWKS_URL_ENV = "OIDC_JWKS_URL"
 _OIDC_JWKS_TTL_ENV = "OIDC_JWKS_TTL"
 _DEFAULT_JWKS_TTL_SECONDS = 3600
+_DISCOVERY_TIMEOUT_SECONDS = 5
 _TOKEN_LEEWAY_SECONDS = 60
 _OIDC_ALLOWED_HD_ENV = "OIDC_ALLOWED_HD"
 _OIDC_ALLOWED_SUBJECTS_ENV = "OIDC_ALLOWED_SUBJECTS"
@@ -89,6 +91,8 @@ def _verify_api_key(api_key: str | None) -> Principal | AuthError:
 _jwks_client: object | None = None
 _jwks_url_cached: str | None = None
 _jwks_lock = threading.Lock()
+# OIDC discovery 결과 캐시: issuer → (jwks_uri, expires_at). #435.
+_discovery_cache: dict[str, tuple[str, float]] = {}
 
 
 def _oidc_issuers() -> list[str]:
@@ -96,17 +100,49 @@ def _oidc_issuers() -> list[str]:
     return [s.strip() for s in raw.split(",") if s.strip()]
 
 
+def _discover_jwks_uri(issuer: str) -> str:
+    """OIDC discovery 문서에서 jwks_uri를 읽는다 (RFC 8414, #435).
+
+    issuer의 ``/.well-known/openid-configuration``을 조회해 ``jwks_uri`` 필드를
+    반환한다. Google/Auth0/Keycloak 등 IdP마다 JWKS 경로가 달라 경로 추정이
+    깨지던 기존 동작을 대체한다. 결과는 TTL 캐시된다.
+    """
+    import json
+    import urllib.request
+
+    now = time.monotonic()
+    cached = _discovery_cache.get(issuer)
+    if cached is not None:
+        jwks_uri, expires_at = cached
+        if now < expires_at:
+            return jwks_uri
+
+    base = issuer if issuer.startswith("http") else "https://" + issuer
+    discovery_url = base.rstrip("/") + "/.well-known/openid-configuration"
+    with urllib.request.urlopen(discovery_url, timeout=_DISCOVERY_TIMEOUT_SECONDS) as resp:
+        doc = json.loads(resp.read())
+    jwks_uri_raw = doc.get("jwks_uri")
+    if not isinstance(jwks_uri_raw, str) or not jwks_uri_raw:
+        raise RuntimeError(f"discovery at {discovery_url} has no jwks_uri")
+    ttl = int(os.environ.get(_OIDC_JWKS_TTL_ENV, "") or _DEFAULT_JWKS_TTL_SECONDS)
+    _discovery_cache[issuer] = (jwks_uri_raw, now + ttl)
+    return jwks_uri_raw
+
+
 def _oidc_jwks_url() -> str:
-    """JWKS URL. OIDC_JWKS_URL 우선, 없으면 첫 issuer의 well-known에서 유도."""
+    """JWKS URL. OIDC_JWKS_URL 명시 시 discovery를 건너뛴다 (#435).
+
+    명시 없으면 첫 issuer의 discovery 문서에서 jwks_uri를 읽는다 (RFC 8414).
+    기존 ``issuer + /.well-known/jwks.json`` 추정은 Google이 저 경로를 쓰지
+    않아 404 → 503 실패를 일으켰다.
+    """
     explicit = os.environ.get(_OIDC_JWKS_URL_ENV, "").strip()
     if explicit:
         return explicit
     issuers = _oidc_issuers()
-    # Google은 https://accounts.google.com 와 accounts.google.com 두 형태를 쓴다.
-    issuer = issuers[0]
-    if not issuer.startswith("http"):
-        issuer = "https://" + issuer
-    return issuer.rstrip("/") + "/.well-known/jwks.json"
+    if not issuers:
+        raise RuntimeError("OIDC_ISSUER not set")
+    return _discover_jwks_uri(issuers[0])
 
 
 def _oidc_allowlists() -> tuple[set[str], set[str], set[str]]:

--- a/tests/unit/test_oidc_auth.py
+++ b/tests/unit/test_oidc_auth.py
@@ -265,3 +265,108 @@ class TestAllowlistGate:
         token = _make_token(oidc_env, hd="example.com")
         result = authenticate(bearer_token=f"Bearer {token}")
         assert isinstance(result, Principal)
+
+
+class _FakeDiscoveryResp:
+    """urllib urlopen 반환 흉내 (context manager + read)."""
+
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> _FakeDiscoveryResp:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        pass
+
+
+class TestJwksDiscovery:
+    """OIDC discovery (RFC 8414) 기반 JWKS URL 해석 (#435).
+
+    기존 ``issuer + /.well-known/jwks.json`` 추정이 Google에서 404 → 503 실패를
+    일으킨 문제 수정. discovery 문서의 jwks_uri를 읽고 TTL 캐시한다.
+    """
+
+    def _clear_cache(self) -> None:
+        import kpubdata_builder.service.auth as auth_module
+
+        auth_module._discovery_cache.clear()
+
+    def test_discover_reads_jwks_uri(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """discovery 문서의 jwks_uri 필드를 반환한다 (Google 경로)."""
+        import urllib.request
+
+        import kpubdata_builder.service.auth as auth_module
+
+        self._clear_cache()
+        captured: list[str] = []
+        doc = b'{"issuer":"https://accounts.google.com","jwks_uri":"https://www.googleapis.com/oauth2/v3/certs"}'
+
+        def _fake_urlopen(url: str, timeout: float) -> _FakeDiscoveryResp:
+            captured.append(url)
+            return _FakeDiscoveryResp(doc)
+
+        monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+
+        result = auth_module._discover_jwks_uri("https://accounts.google.com")
+        assert result == "https://www.googleapis.com/oauth2/v3/certs"
+        assert "accounts.google.com/.well-known/openid-configuration" in captured[0]
+
+    def test_oidc_jwks_url_explicit_bypasses_discovery(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """OIDC_JWKS_URL 명시 시 discovery를 건너뛴다 (override)."""
+        import kpubdata_builder.service.auth as auth_module
+
+        monkeypatch.setenv("OIDC_JWKS_URL", "http://explicit/jwks.json")
+        assert auth_module._oidc_jwks_url() == "http://explicit/jwks.json"
+
+    def test_discover_caches_within_ttl(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """동일 issuer는 TTL 내 재조회 시 urlopen을 한 번만 부른다."""
+        import urllib.request
+
+        import kpubdata_builder.service.auth as auth_module
+
+        self._clear_cache()
+        call_count = [0]
+
+        def _fake_urlopen(url: str, timeout: float) -> _FakeDiscoveryResp:
+            call_count[0] += 1
+            return _FakeDiscoveryResp(b'{"jwks_uri":"https://cached/certs"}')
+
+        monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+
+        first = auth_module._discover_jwks_uri("https://idp.example.com")
+        second = auth_module._discover_jwks_uri("https://idp.example.com")
+        assert first == second == "https://cached/certs"
+        assert call_count[0] == 1, "캐시 hit면 urlopen을 다시 부르지 않는다"
+
+    def test_discover_raises_when_jwks_uri_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """discovery 문서에 jwks_uri 필드가 없으면 RuntimeError."""
+        import urllib.request
+
+        import kpubdata_builder.service.auth as auth_module
+
+        self._clear_cache()
+        monkeypatch.setattr(
+            urllib.request,
+            "urlopen",
+            lambda url, timeout: _FakeDiscoveryResp(b'{"issuer":"https://idp.example.com"}'),
+        )
+
+        with pytest.raises(RuntimeError, match="jwks_uri"):
+            auth_module._discover_jwks_uri("https://idp.example.com")
+
+    def test_oidc_jwks_url_raises_when_no_issuer_no_explicit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """OIDC_ISSUER 미설정 + OIDC_JWKS_URL 미설정 → RuntimeError (방어)."""
+        import kpubdata_builder.service.auth as auth_module
+
+        monkeypatch.delenv("OIDC_ISSUER", raising=False)
+        monkeypatch.delenv("OIDC_JWKS_URL", raising=False)
+        with pytest.raises(RuntimeError, match="OIDC_ISSUER"):
+            auth_module._oidc_jwks_url()


### PR DESCRIPTION
Closes #435

## 변경 요약

`_oidc_jwks_url()`이 issuer 뒤 `/.well-known/jwks.json`을 추정하던 것을 **OIDC discovery 문서(RFC 8414)의 `jwks_uri` 조회**로 교체. Google의 실제 JWKS는 `https://www.googleapis.com/oauth2/v3/certs`에 있는데 추정 경로는 404 → 503 실패를 일으켰다.

### 세부 변경
- **`_discover_jwks_uri(issuer)`** 추가 — `{issuer}/.well-known/openid-configuration`을 조회해 `jwks_uri` 추출. `jwks_uri`가 없거나 str이 아니면 `RuntimeError`
- **TTL 캐시** (`_discovery_cache`) — 동일 issuer 재조회 시 `urlopen` 1회만 (TTL = 기존 `_DEFAULT_JWKS_TTL_SECONDS`)
- **`OIDC_JWKS_URL` override 유지** — 명시 시 discovery 건너뜀 (이전과 하위 호환)
- **`OIDC_ISSUER` 미설정 + `OIDC_JWKS_URL` 미설정** → `RuntimeError("OIDC_ISSUER not set")` (이전엔 빈 issuers[0]로 IndexError 위험)

## 테스트

`tests/unit/test_oidc_auth.py::TestJwksDiscovery` 5케이스 (모두 `urlopen` 목, 외부 네트워크 의존 없음):
- `test_discover_reads_jwks_uri` — Google discovery → `https://www.googleapis.com/oauth2/v3/certs`
- `test_oidc_jwks_url_explicit_bypasses_discovery` — `OIDC_JWKS_URL` 명시 시 discovery skip
- `test_discover_caches_within_ttl` — 동일 issuer 재조회 시 urlopen 1회
- `test_discover_raises_when_jwks_uri_missing` — discovery에 jwks_uri 없으면 RuntimeError
- `test_oidc_jwks_url_raises_when_no_issuer_no_explicit` — 둘 다 미설정 시 RuntimeError

## 검증
- pytest: **26 passed** (기존 21 + 신규 5)
- ruff check / ruff format: pass
- mypy: pass (no issues in 70 files)

## 호환성
- `OIDC_JWKS_URL`을 명시하는 기존 배포는 동작 변경 없음
- discovery 실패 시 기존 `_verify_bearer_token`이 `503 (auth service unavailable)` 반환 (이전과 동일한 사용자 경험, 단 이제 discovery URL이 정확)