### PR TITLE
fix(deps): raise pyjwt floor to >=2.9 for issuer list support (#434)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,10 @@ docs = [
 ]
 parquet = ["pyarrow>=15,<26"]
 huggingface = ["huggingface-hub>=0.23,<2"]
-auth = ["pyjwt[crypto]>=2.8,<3"]
+# PyJWT 2.9+ 부터 issuer=list 지원 (#434). auth.py:_verify_bearer_token 이
+# list(=여러 issuer)를 jwt.decode(issuer=...)로 넘기므로, 하한을 되돌리면
+# 2.8.x 환경에서 모든 토큰이 InvalidIssuerError 로 거부된다.
+auth = ["pyjwt[crypto]>=2.9,<3"]
 publish = ["huggingface-hub>=0.23,<2", "xmltodict>=0.13,<2", "kaggle>=1.6,<2"]
 dev = [
   "build>=1.2,<2",
@@ -56,7 +59,7 @@ dev = [
   "ruff>=0.5,<1",
   "types-PyYAML>=6.0",
   # auth extra를 dev에 포함해 CI(mypy/ruff/pytest)에서 항상 타입 체크 가능 (#385).
-  "pyjwt[crypto]>=2.8,<3",
+  "pyjwt[crypto]>=2.9,<3",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/tests/unit/test_oidc_auth.py
+++ b/tests/unit/test_oidc_auth.py
@@ -370,3 +370,19 @@ class TestJwksDiscovery:
         monkeypatch.delenv("OIDC_JWKS_URL", raising=False)
         with pytest.raises(RuntimeError, match="OIDC_ISSUER"):
             auth_module._oidc_jwks_url()
+
+
+def test_pyjwt_supports_issuer_list() -> None:
+    """pyjwt >=2.9만 issuer=list 지원 (#434). auth.py:_verify_bearer_token 참조.
+
+    auth.py 가 ``jwt.decode(..., issuer=_oidc_issuers())`` 로 list를 넘기는데,
+    2.8.x 는 ``payload["iss"] != issuer`` 단순 비교라 모든 토큰이 거부된다.
+    하한을 ``>=2.9`` 로 올린 것(#434)을 설치 환경에서 재확인한다 (#431 교집합 패턴).
+    """
+    import jwt
+
+    parts = jwt.__version__.split(".")
+    major, minor = int(parts[0]), int(parts[1])
+    assert (major, minor) >= (2, 9), (
+        f"pyjwt {jwt.__version__} < 2.9 — issuer list 미지원, auth.py 가 깨짐 (#434)"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -729,7 +729,7 @@ wheels = [
 [[package]]
 name = "kpubdata"
 version = "0.5.0"
-source = { editable = "../kpubdata" }
+source = { editable = "/home/dahyeon/GitHub/kpubdata" }
 dependencies = [
     { name = "httpx" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
@@ -775,6 +775,7 @@ auth = [
 dev = [
     { name = "build" },
     { name = "mypy" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -803,13 +804,14 @@ requires-dist = [
     { name = "huggingface-hub", marker = "extra == 'huggingface'", specifier = ">=0.23,<2" },
     { name = "huggingface-hub", marker = "extra == 'publish'", specifier = ">=0.23,<2" },
     { name = "kaggle", marker = "extra == 'publish'", specifier = ">=1.6,<2" },
-    { name = "kpubdata", editable = "../kpubdata" },
+    { name = "kpubdata", editable = "/home/dahyeon/GitHub/kpubdata" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6,<2" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9,<10" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10,<3" },
     { name = "polars", specifier = ">=1.0,<2" },
     { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=15,<26" },
-    { name = "pyjwt", extras = ["crypto"], marker = "extra == 'auth'", specifier = ">=2.8,<3" },
+    { name = "pyjwt", extras = ["crypto"], marker = "extra == 'auth'", specifier = ">=2.9,<3" },
+    { name = "pyjwt", extras = ["crypto"], marker = "extra == 'dev'", specifier = ">=2.9,<3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2,<10" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5,<8" },
     { name = "pyyaml", specifier = ">=6.0,<7" },


### PR DESCRIPTION
Closes #434

## 변경 요약

`pyproject.toml`의 pyjwt 하한을 `>=2.8` → `>=2.9` 로 상향 (auth + dev 양쪽).

`auth.py:_verify_bearer_token` 이 `jwt.decode(..., issuer=_oidc_issuers())` 로 **list**를 넘기는데, PyJWT 2.8.x는 `payload["iss"] != issuer` 단순 비교라 list를 지원하지 않는다. 2.8.x가 resolver에 풀리면 모든 토큰이 `InvalidIssuerError` 로 거부되고, 응답이 `invalid token: InvalidIssuerError` 라 설정 오류/버전 불일치 구분이 안 된다.

## 세부 변경
- `auth = ["pyjwt[crypto]>=2.9,<3"]` (+ 되돌리면 깨지는 이유 코멘트)
- `dev` 의존성도 동일하게 `>=2.9`
- `uv.lock` 갱신 — pyjwt specifier `>=2.9,<3` (auth + dev)

## 테스트

`tests/unit/test_oidc_auth.py::test_pyjwt_supports_issuer_list` (신규, #431 교집합 패턴):
- 설치된 pyjwt 버전이 `(2, 9)` 이상인지 단언. CI 환경에서 하한 회귀 감지.

## 검증
- pytest: **22 passed** (기존 21 + 신규 1)
- ruff check / ruff format: pass
- mypy: pass (no issues in 70 files)

## PyJWT changelog 인용 (PR 작성자 메모)

PyJWT 2.9.0 release notes — "Allow ``issuer`` to be a sequence of strings" (PR #938). 본 PR의 하한 근거.