### PR TITLE
fix(service): resolve catalog providers dynamically via kpubdata Client API (#436)

### DIFF
--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -24,6 +24,8 @@ from typing import cast
 from urllib.parse import parse_qs
 
 import yaml
+from kpubdata import Client
+from kpubdata.core.models import DatasetRef
 
 from ..errors import SpecLoadError, ValidationError
 from ..pipeline import preview_build, run_build
@@ -159,45 +161,45 @@ class BuilderService:
         )
 
     def catalog(self) -> ServiceResponse:
-        """사용 가능한 provider/dataset 카탈로그를 반환한다 (#416, BL2).
+        """사용 가능한 provider/dataset 카탈로그를 반환한다 (#416, BL2, #436).
 
-        kpubdata Client의 catalog에서 provider별 dataset 목록을 구성한다.
-        시크릿 값은 노출하지 않고 필요 여부만 표시한다.
+        kpubdata Client의 공개 ``datasets.list()`` 로 모든 데이터셋을 조회한 뒤
+        provider별로 그룹화한다 (ADR 0011 — Builder가 provider 목록을
+        하드코딩하지 않는다). 이전에는 ``getattr(client, "_catalog")`` private
+        접근 + 8개 provider 하드코딩 튜플을 써서 kpubdata에 provider가 추가돼도
+        카탈로그에 안 떴다 (#436). 시크릿 값은 노출하지 않고 필요 여부만 표시한다.
         """
         try:
-            client = self._client_factory()
-            cat = getattr(client, "_catalog", None)
-            if cat is None:
-                return ServiceResponse(502, {"error": "catalog unavailable: client has no catalog"})
-            providers_data: list[JsonValue] = []
-            for provider_name in (
-                "datago",
-                "bok",
-                "law",
-                "seoul",
-                "kosis",
-                "lofin",
-                "localdata",
-                "semas",
-            ):
-                try:
-                    items = cat.list(provider=provider_name)
-                    datasets: list[JsonValue] = [
-                        {
-                            "name": item.dataset_key,
-                            "title": item.name,
-                            "requires_service_key": bool(
-                                getattr(item, "raw_metadata", {}).get("service_key_param")
-                            ),
-                        }
-                        for item in items
-                    ]
-                    providers_data.append({"name": provider_name, "datasets": datasets})
-                except Exception:
-                    continue
-            return ServiceResponse(200, {"providers": providers_data})
+            # client_factory는 SourceClient(Protocol)을 반환타입으로 선언하지만
+            # catalog는 kpubdata.Client의 공개 datasets API를 쓴다. 런타임엔 항상
+            # kpubdata.Client이므로 cast로 타입을 확정한다 (#436).
+            client = cast(Client, self._client_factory())
+            all_datasets = client.datasets.list()
         except Exception as exc:
             return ServiceResponse(502, {"error": f"catalog unavailable: {exc}"})
+
+        # provider별 그룹화 (등록 순서 보존 위해 dict 사용).
+        grouped: dict[str, list[DatasetRef]] = {}
+        for ds in all_datasets:
+            grouped.setdefault(ds.provider, []).append(ds)
+
+        providers_data: list[JsonValue] = [
+            {
+                "name": provider_name,
+                "datasets": [
+                    {
+                        "name": item.dataset_key,
+                        "title": item.name,
+                        "requires_service_key": bool(
+                            getattr(item, "raw_metadata", {}).get("service_key_param")
+                        ),
+                    }
+                    for item in items
+                ],
+            }
+            for provider_name, items in grouped.items()
+        ]
+        return ServiceResponse(200, {"providers": providers_data})
 
     def validate(self, spec_yaml: str) -> ServiceResponse:
         """BuildSpec을 파싱·검증한다."""

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -60,6 +60,18 @@ class _FakeResult:
         return self._items
 
 
+class _FakeCatalog:
+    """``client.datasets`` 흉내 — DatasetRef 목록을 provider 필터로 반환."""
+
+    def __init__(self, items: list[object] | None = None) -> None:
+        self._items = items or []
+
+    def list(self, *, provider: str | None = None) -> list[object]:
+        if provider is None:
+            return self._items
+        return [i for i in self._items if getattr(i, "provider", None) == provider]
+
+
 class _FakeDataset:
     def __init__(self, items: list[dict[str, JsonValue]]) -> None:
         self._items = items
@@ -69,8 +81,13 @@ class _FakeDataset:
 
 
 class _FakeClient:
-    def __init__(self, data: dict[str, list[dict[str, JsonValue]]]) -> None:
+    def __init__(
+        self,
+        data: dict[str, list[dict[str, JsonValue]]],
+        catalog_items: list[object] | None = None,
+    ) -> None:
         self._data = data
+        self.datasets = _FakeCatalog(catalog_items)
 
     def dataset(self, source_key: str) -> _FakeDataset:
         if source_key not in self._data:
@@ -1121,3 +1138,72 @@ class TestOwnershipEnforcement:
         builds = cast(list[dict[str, object]], resp.body["builds"])
         run_ids = [cast(str, b["run_id"]) for b in builds]
         assert "runA" in run_ids
+
+
+class _FakeCatalogRef:
+    """DatasetRef 흉내 — catalog() 가 접근하는 속성만 노출."""
+
+    def __init__(
+        self, provider: str, dataset_key: str, name: str, *, service_key: bool = False
+    ) -> None:
+        self.provider = provider
+        self.dataset_key = dataset_key
+        self.name = name
+        self.raw_metadata: dict[str, object] = (
+            {"service_key_param": "serviceKey"} if service_key else {}
+        )
+
+
+class TestCatalog:
+    """catalog 동적 provider 조회 (#436). ADR 0011 — 하드코딩 금지."""
+
+    def _service_with_catalog(self, tmp_path: Path, refs: list[object]) -> BuilderService:
+        client = _FakeClient({}, catalog_items=refs)
+        return BuilderService(output_root=tmp_path, client_factory=lambda: client)
+
+    def test_catalog_groups_datasets_by_provider(self, tmp_path: Path) -> None:
+        refs = [
+            _FakeCatalogRef("datago", "air_quality", "대기오염", service_key=True),
+            _FakeCatalogRef("datago", "village_fcst", "단기예보"),
+            _FakeCatalogRef("bok", "base_rate", "기준금리"),
+        ]
+        resp = self._service_with_catalog(tmp_path, refs).catalog()
+
+        assert resp.status_code == 200
+        providers = cast(list[dict[str, object]], resp.body["providers"])
+        names = [cast(str, p["name"]) for p in providers]
+        assert "datago" in names
+        assert "bok" in names
+
+        datago = next(p for p in providers if p["name"] == "datago")
+        datago_datasets = cast(list[dict[str, object]], datago["datasets"])
+        assert len(datago_datasets) == 2
+        aq = next(d for d in datago_datasets if d["name"] == "air_quality")
+        assert aq["requires_service_key"] is True
+        vf = next(d for d in datago_datasets if d["name"] == "village_fcst")
+        assert vf["requires_service_key"] is False
+
+    def test_catalog_includes_unlisted_providers(self, tmp_path: Path) -> None:
+        """하드코딩 8개에 없는 provider도 동적 조회로 떠야 한다 (#436)."""
+        refs = [_FakeCatalogRef("newprovider", "new_ds", "새 데이터셋")]
+        resp = self._service_with_catalog(tmp_path, refs).catalog()
+
+        assert resp.status_code == 200
+        providers = cast(list[dict[str, object]], resp.body["providers"])
+        names = [cast(str, p["name"]) for p in providers]
+        assert "newprovider" in names
+
+    def test_catalog_empty_when_no_datasets(self, tmp_path: Path) -> None:
+        resp = self._service_with_catalog(tmp_path, []).catalog()
+        assert resp.status_code == 200
+        assert resp.body["providers"] == []
+
+    def test_catalog_returns_502_when_client_raises(self, tmp_path: Path) -> None:
+        class _BrokenClient:
+            @property
+            def datasets(self) -> object:
+                raise RuntimeError("client init failed")
+
+        service = BuilderService(output_root=tmp_path, client_factory=lambda: _BrokenClient())
+        resp = service.catalog()
+        assert resp.status_code == 502


### PR DESCRIPTION
Closes #436

## 변경 요약

`BuilderService.catalog()` 가 provider 목록을 하드코딩하지 않고 kpubdata Client의 공개 ``datasets.list()`` API에서 동적으로 유도하도록 재작성. ADR 0011 준수.

### 세부 변경
- **하드코딩 8개 provider 튜플 제거** — `("datago","bok","law","seoul","kosis","lofin","localdata","semas")` 제거. kpubdata에 provider가 추가돼도 자동으로 카탈로그에 뜸
- **private 속성 접근 제거** — `getattr(client, "_catalog", None)` 대신 공개 `client.datasets.list()` 사용. private 속성명 변경 시 502로 죽던 회귀 위험 제거
- **provider별 그룹화** — `datasets.list()` 결과를 `ds.provider` 기준으로 dict 그룹화 (등록 순서 보존)
- **`cast(Client, ...)`** — `client_factory` 반환 타입이 `SourceClient(Protocol)`이라 `datasets` 속성이 타입에 없지만, 런타임엔 항상 `kpubdata.Client`이므로 cast로 확정

## 테스트

`tests/unit/test_service.py::TestCatalog` (신규 4케이스):
- `test_catalog_groups_datasets_by_provider` — provider별 그룹화 + `requires_service_key` 플래그
- `test_catalog_includes_unlisted_providers` — 하드코딩 8개에 없는 `newprovider`도 동적 조회로 떠야 함 (#436 핵심)
- `test_catalog_empty_when_no_datasets` — 빈 카탈로그
- `test_catalog_returns_502_when_client_raises` — client.datasets 접근 예외 시 502

`_FakeClient` 확장: `_FakeCatalog` + `catalog_items` 인자 추가.

## 검증
- pytest: **74 passed** (기존 70 + 신규 4)
- ruff check / ruff format: pass
- mypy: pass (no issues in 70 files)