### PR TITLE
fix(service): validate run_id before ownership check in /artifacts route (#439)

### DIFF
--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -562,6 +562,13 @@ def dispatch(
         rest = path[len("/artifacts/") :]
         parts = rest.split("/", 1)
         run_id = parts[0]
+        # run_id를 소유권 검사보다 먼저 검증 (#439). _read_manifest_created_by 가
+        # 검증 없이 경로를 조립하므로 "../" 등 unsafe 세그먼트가 _check_ownership
+        # 보다 먼저 도달해야 한다.
+        try:
+            validate_path_segment(run_id, field_name="run_id")
+        except ValueError as exc:
+            return ServiceResponse(400, {"error": str(exc)})
         ownership_error = _check_ownership(service, run_id, principal)
         if ownership_error is not None:
             return ownership_error

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -1207,3 +1207,32 @@ class TestCatalog:
         service = BuilderService(output_root=tmp_path, client_factory=lambda: _BrokenClient())
         resp = service.catalog()
         assert resp.status_code == 502
+
+
+class TestRunIdRouteValidation:
+    """/artifacts/{run_id} 라우트가 run_id를 소유권 검사보다 먼저 검증 (#439).
+
+    _read_manifest_created_by 가 URL에서 온 run_id로 검증 없이 경로를 조립하므로,
+    "../" 등 unsafe 세그먼트가 _check_ownership 보다 먼저 validate_path_segment
+    에 도달해야 한다.
+    """
+
+    def test_unsafe_run_id_returns_400_before_ownership(self, tmp_path: Path) -> None:
+        """unsafe run_id(``..``)는 _check_ownership 전에 400 (#439)."""
+        resp = dispatch(_service(tmp_path), "GET", "/artifacts/../bad", None)
+        assert resp.status_code == 400
+        err = str(resp.body.get("error", "")).lower()
+        assert "run_id" in err or "safe" in err
+
+    def test_blank_run_id_returns_400(self, tmp_path: Path) -> None:
+        resp = dispatch(_service(tmp_path), "GET", "/artifacts/", None)
+        assert resp.status_code == 400
+        assert "run_id" in str(resp.body.get("error", "")).lower()
+
+    def test_safe_run_id_still_reaches_ownership_check(self, tmp_path: Path) -> None:
+        """safe run_id는 validate 통과 후 artifacts(또는 소유권 검사)로 (#439 양성)."""
+        service = _service(tmp_path)
+        service.build(VALID_SPEC_YAML, run_id="run1")
+        # ENFORCE_OWNERSHIP off(기본) → 200
+        resp = dispatch(service, "GET", "/artifacts/run1", None)
+        assert resp.status_code == 200


### PR DESCRIPTION
Closes #439

## 변경 요약

`/artifacts/{run_id}` 라우트가 run_id를 `_check_ownership` 보다 먼저 `validate_path_segment` 로 검증하도록 순서 조정.

### 배경
`_read_manifest_created_by` (app.py:47)가 URL에서 온 run_id로 검증 없이 경로를 조립한다:
```python
manifest_path = service._output_root / run_id / "manifest.json"
```
`serve_artifact_file`/`artifacts`는 `validate_path_segment` 를 쓰지만, `_check_ownership` 이 그보다 먼저 실행돼 `_read_manifest_created_by` 가 unsafe 세그먼트에 도달할 수 있었다.

### 세부 변경
- dispatch의 `/artifacts/` 라우트에서 run_id 추출 직후 `validate_path_segment(run_id, field_name="run_id")` 호출
- 검증 실패 시 400 반환, 이후 `_check_ownership` → `serve_artifact_file`/`artifacts` (기존 흐름 유지)
- 실질 피해는 제한적(읽기 실패 → None → 403)이지만, 경로 안전 헬퍼를 우회하는 코드 경로를 제거해 회귀 위험 감소

## 테스트

`tests/unit/test_service.py::TestRunIdRouteValidation` (신규 3케이스):
- `test_unsafe_run_id_returns_400_before_ownership` — `/artifacts/../bad` → 400 (#439 핵심)
- `test_blank_run_id_returns_400` — `/artifacts/` (빈 run_id) → 400
- `test_safe_run_id_still_reaches_ownership_check` — safe run_id는 통과 후 정상 처리 (양성 회귀)

## 검증
- pytest: **73 passed** (기존 70 + 신규 3)
- ruff check / ruff format: pass
- mypy: pass (no issues in 70 files)