### PR TITLE
feat(spec): add source schema contract and wire Silver validation gate (#437)

### DIFF
--- a/contract/builder-api.yaml
+++ b/contract/builder-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: KPubData Builder Service API
-  version: "1.2.0"
+  version: "1.3.0"
   description: >-
     Builder 중심 서비스 계약. BuildSpec 검증, preview, build 실행, artifact 조회,
     계약 버전 조회를 제공한다. CLI와 HTTP service mode(#36)가 동일한 도메인 계약을

--- a/src/kpubdata_builder/pipeline/orchestrator.py
+++ b/src/kpubdata_builder/pipeline/orchestrator.py
@@ -165,7 +165,12 @@ def _run_source_pipeline(
             params=source.params,
         )
 
-        silver = build_silver_dataset(bronze)
+        silver = build_silver_dataset(
+            bronze,
+            required_columns=source.schema.required if source.schema else (),
+            casts=source.schema.casts if source.schema else None,
+            column_dtypes=source.schema.dtypes if source.schema else None,
+        )
         # 검증에 실패한 Silver 데이터셋이 Gold/패키징으로 흘러가지 않도록 소스를
         # 실패 처리한다. 검증은 더 이상 권고용이 아니라 게이트다 (#189).
         if not silver.validation.ok:

--- a/src/kpubdata_builder/pipeline/preview.py
+++ b/src/kpubdata_builder/pipeline/preview.py
@@ -75,7 +75,13 @@ def _preview_source(
         bronze = build_bronze_artifact(
             client, source_key=fetch_key, fetch_params=dict(source.params)
         )
-        silver = build_silver_dataset(bronze, preview_limit=limit)
+        silver = build_silver_dataset(
+            bronze,
+            preview_limit=limit,
+            required_columns=source.schema.required if source.schema else (),
+            casts=source.schema.casts if source.schema else None,
+            column_dtypes=source.schema.dtypes if source.schema else None,
+        )
         return SourcePreview(
             source_key=out_key,
             status="ok",

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -99,7 +99,7 @@ def _apply_ownership(
 # Builder API 계약 버전. contract/builder-api.yaml의 info.version과 일치해야 하며
 # (test_service_contract가 강제), 응답에 실어 Studio 같은 소비자가 하위 호환을
 # 협상할 수 있게 한다 (#209).
-API_CONTRACT_VERSION = "1.2.0"
+API_CONTRACT_VERSION = "1.3.0"
 
 
 @dataclass(frozen=True)

--- a/src/kpubdata_builder/spec/loader.py
+++ b/src/kpubdata_builder/spec/loader.py
@@ -17,7 +17,7 @@ from typing import cast
 import yaml
 
 from ..errors import SpecLoadError
-from .models import BuildSpec, ExportTarget, JsonValue, SourceRef, SplitSpec
+from .models import BuildSpec, ExportTarget, JsonValue, SchemaContract, SourceRef, SplitSpec
 
 
 def parse_spec(data: dict[str, object]) -> BuildSpec:
@@ -212,6 +212,8 @@ def _parse_sources(value: object) -> tuple[SourceRef, ...]:
             raise TypeError(f"sources[{index}].normalization_mode must be a string")
         if not isinstance(alias_obj, str):
             raise TypeError(f"sources[{index}].alias must be a string")
+        schema_obj = mapping.get("schema")
+        schema = _parse_schema(schema_obj, prefix=prefix) if schema_obj is not None else None
         parsed_sources.append(
             SourceRef(
                 provider=provider,
@@ -219,9 +221,31 @@ def _parse_sources(value: object) -> tuple[SourceRef, ...]:
                 params=params,
                 normalization_mode=normalization_mode_obj,
                 alias=alias_obj,
+                schema=schema,
             )
         )
     return tuple(parsed_sources)
+
+
+def _parse_schema(value: object, *, prefix: str) -> SchemaContract:
+    """sources[].schema 매핑을 SchemaContract로 변환한다 (#437).
+
+    required/dtypes/casts 세 필드를 파싱한다. dtype/cast 값은 문자열이어야 하고,
+    실제 polars dtype 으로 해석 가능한지는 validator.py 가 검증한다 (로더는 구조만).
+    """
+    mapping = _ensure_mapping(value, field_name=f"{prefix}.schema")
+    required = _parse_string_list(
+        mapping.get("required", []), field_name=f"{prefix}.schema.required"
+    )
+    dtypes = cast(
+        dict[str, str],
+        _parse_string_dict(mapping.get("dtypes", {}), field_name=f"{prefix}.schema.dtypes"),
+    )
+    casts = cast(
+        dict[str, str],
+        _parse_string_dict(mapping.get("casts", {}), field_name=f"{prefix}.schema.casts"),
+    )
+    return SchemaContract(required=required, dtypes=dtypes, casts=casts)
 
 
 def _parse_exports(value: object) -> tuple[ExportTarget, ...]:

--- a/src/kpubdata_builder/spec/models.py
+++ b/src/kpubdata_builder/spec/models.py
@@ -20,6 +20,28 @@ JsonValue: TypeAlias = JsonPrimitive | list["JsonValue"] | dict[str, "JsonValue"
 
 
 @dataclass(frozen=True)
+class SchemaContract:
+    """소스 스키마 계약 — Silver 검증/정규화 규칙 (#437).
+
+    BuildSpec 의 ``sources[].schema`` 선언이 이 모델로 파싱되고,
+    orchestrator/preview 가 build_silver_dataset 의 인자로 전달한다.
+    이전까지는 게이트가 존재했지만 통과 조건이 없었다 (항상 ok).
+
+    속성:
+        required: 필수 컬럼 목록. validate_table 의 required_columns 로 전달.
+        dtypes: 컬럼별 기대 dtype (문자열, ``_NAMED_DTYPES`` 키). validate_table 의
+            column_dtypes 로 전달.
+        casts: 정규화 시 적용할 컬럼별 캐스팅 (문자열). normalize_table 의 casts 로
+            전달. 캐스팅으로 인한 null 손실은 audit=True 로 감지돼 TabularError 로
+            표면화된다 (#188).
+    """
+
+    required: tuple[str, ...] = ()
+    dtypes: dict[str, str] = field(default_factory=dict)
+    casts: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
 class SourceRef:
     """kpubdata의 정규화된 소스 쿼리를 가리키는 참조.
 
@@ -29,6 +51,7 @@ class SourceRef:
         params: list 호출에 전달할 원시 파라미터.
         normalization_mode: canonical/raw 같은 정규화 모드.
         alias: 조립 단계에서 사용할 사용자 정의 소스 이름.
+        schema: 소스 스키마 계약. None 이면 Silver 검증을 생략한다 (하위 호환, #437).
     """
 
     provider: str
@@ -36,6 +59,7 @@ class SourceRef:
     params: dict[str, JsonValue] = field(default_factory=dict)
     normalization_mode: str = "canonical"
     alias: str = ""
+    schema: SchemaContract | None = None
 
 
 @dataclass(frozen=True)

--- a/src/kpubdata_builder/spec/validator.py
+++ b/src/kpubdata_builder/spec/validator.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 
 from ..errors import ValidationError
 from ..exporters import EXPORTER_REGISTRY
+from ..tabular.polars_helpers import _NAMED_DTYPES
 from .models import BuildSpec
 
 
@@ -113,6 +114,7 @@ def validate_spec(spec: BuildSpec) -> None:
             )
             break
     problems.extend(_split_problems(spec))
+    problems.extend(_schema_problems(spec))
     if problems:
         raise ValidationError([str(p) for p in problems], structured=problems)
 
@@ -177,6 +179,41 @@ def _split_problems(spec: BuildSpec) -> list[ValidationProblem]:
                 hint="Use 'ratio' or 'key'",
             )
         )
+    return problems
+
+
+def _schema_problems(spec: BuildSpec) -> list[ValidationProblem]:
+    """sources[].schema 계약 자체의 유효성을 검증한다 (#437).
+
+    dtypes/casts 의 문자열이 ``_NAMED_DTYPES`` 키로 해석 가능한지 확인한다.
+    로더(loader._parse_schema)는 구조만 검사하고, 여기서 의미를 검사한다 —
+    알 수 없는 dtype 문자열이 런타임(정규화/검증)에서야 실패하는 것을 막는다.
+    """
+    problems: list[ValidationProblem] = []
+    supported = sorted(_NAMED_DTYPES)
+    for i, source in enumerate(spec.sources):
+        if source.schema is None:
+            continue
+        for col, dtype in source.schema.dtypes.items():
+            if dtype.lower() not in _NAMED_DTYPES:
+                problems.append(
+                    _p(
+                        "unknown_dtype",
+                        f"sources[{i}].schema.dtypes.{col}",
+                        f"unknown dtype {dtype!r} for column {col!r}",
+                        hint=f"Use one of: {', '.join(supported)}",
+                    )
+                )
+        for col, cast in source.schema.casts.items():
+            if cast.lower() not in _NAMED_DTYPES:
+                problems.append(
+                    _p(
+                        "unknown_cast_dtype",
+                        f"sources[{i}].schema.casts.{col}",
+                        f"unknown cast dtype {cast!r} for column {col!r}",
+                        hint=f"Use one of: {', '.join(supported)}",
+                    )
+                )
     return problems
 
 

--- a/tests/unit/test_schema_contract.py
+++ b/tests/unit/test_schema_contract.py
@@ -1,0 +1,149 @@
+"""소스 스키마 계약 검증 테스트 (#437, VAL-1).
+
+BuildSpec 의 ``sources[].schema`` 선언이 (1) 로더에서 SchemaContract로 파싱되고,
+(2) validator 가 unknown dtype/cast 를 거부하며, (3) Silver 검증 게이트가
+required/dtype 위반을 잡아내는지 검증한다. 이전까지는 게이트가 존재했지만
+통과 조건이 없었다 (orchestrator 가 인자를 안 넘겨 항상 ok).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kpubdata_builder.errors import ValidationError
+from kpubdata_builder.spec import parse_spec
+from kpubdata_builder.spec.validator import validate_spec
+from kpubdata_builder.stages.bronze.models import BronzeArtifact, utc_now
+from kpubdata_builder.stages.silver.build import build_silver_dataset
+
+_BASE_SOURCE = {"provider": "datago", "dataset": "air_quality"}
+_BASE_EXPORTS = [{"kind": "jsonl", "output_path": "o.jsonl"}]
+
+
+def _spec(sources: list[dict[str, object]]) -> object:
+    return parse_spec(
+        {
+            "dataset_id": "ds",
+            "title": "t",
+            "description": "d",
+            "sources": sources,
+            "exports": _BASE_EXPORTS,
+        }
+    )
+
+
+class TestSchemaContractParsing:
+    """loader._parse_schema → SchemaContract (#437)."""
+
+    def test_parse_required_dtypes_casts(self) -> None:
+        spec = _spec(
+            [
+                {
+                    **_BASE_SOURCE,
+                    "schema": {
+                        "required": ["base_date", "nx"],
+                        "dtypes": {"nx": "int64", "base_date": "string"},
+                        "casts": {"nx": "int64"},
+                    },
+                }
+            ]
+        )
+        schema = spec.sources[0].schema
+        assert schema is not None
+        assert schema.required == ("base_date", "nx")
+        assert schema.dtypes == {"nx": "int64", "base_date": "string"}
+        assert schema.casts == {"nx": "int64"}
+
+    def test_schema_none_when_not_declared(self) -> None:
+        """schema 미선언 시 None — 하위 호환 (#437 인수 기준)."""
+        spec = _spec([{**_BASE_SOURCE}])
+        assert spec.sources[0].schema is None
+
+    def test_schema_partial_fields(self) -> None:
+        """일부 필드만 선언해도 파싱된다 (기본값 빈 컬렉션)."""
+        spec = _spec([{**_BASE_SOURCE, "schema": {"required": ["x"]}}])
+        schema = spec.sources[0].schema
+        assert schema is not None
+        assert schema.required == ("x",)
+        assert schema.dtypes == {}
+        assert schema.casts == {}
+
+
+class TestSchemaContractValidation:
+    """validator._schema_problems — unknown dtype/cast 거부 (#437)."""
+
+    def test_rejects_unknown_dtype(self) -> None:
+        spec = _spec([{**_BASE_SOURCE, "schema": {"dtypes": {"nx": "NotARealDtype"}}}])
+        with pytest.raises(ValidationError) as exc:
+            validate_spec(spec)
+        codes = [p.code for p in (exc.value.structured_problems or [])]
+        assert "unknown_dtype" in codes
+
+    def test_rejects_unknown_cast(self) -> None:
+        spec = _spec([{**_BASE_SOURCE, "schema": {"casts": {"nx": "BogusType"}}}])
+        with pytest.raises(ValidationError) as exc:
+            validate_spec(spec)
+        codes = [p.code for p in (exc.value.structured_problems or [])]
+        assert "unknown_cast_dtype" in codes
+
+    def test_accepts_known_dtypes(self) -> None:
+        """_NAMED_DTYPES 키(int64/string/float64 등)는 통과."""
+        spec = _spec(
+            [
+                {
+                    **_BASE_SOURCE,
+                    "schema": {
+                        "required": ["x"],
+                        "dtypes": {"x": "string"},
+                        "casts": {"x": "int64"},
+                    },
+                }
+            ]
+        )
+        validate_spec(spec)  # 예외 없음
+
+
+class TestSchemaContractEnforcement:
+    """build_silver_dataset 인자 전달 → Silver 검증 게이트 활성화 (#437).
+
+    orchestrator/preview 가 source.schema 를 required_columns/casts/column_dtypes
+    로 넘기므로, 이제 게이트가 실제로 동작한다.
+    """
+
+    @staticmethod
+    def _bronze(records: list[dict[str, object]]) -> BronzeArtifact:
+        return BronzeArtifact(
+            source_key="test",
+            raw_records=records,
+            fetch_params={},
+            fetched_at=utc_now(),
+            provenance=None,
+        )
+
+    def test_required_missing_fails_validation(self) -> None:
+        """required 컬럼이 실제 테이블에 없으면 검증 실패 (#437)."""
+        bronze = self._bronze([{"a": 1}, {"a": 2}])
+        silver = build_silver_dataset(bronze, required_columns=("missing_col",))
+        assert not silver.validation.ok
+        codes = [p.code for p in silver.validation.problems]
+        assert "missing_column" in codes
+
+    def test_dtype_mismatch_fails_validation(self) -> None:
+        """선언 dtype과 실제가 다르면 검증 실패 (#437)."""
+        bronze = self._bronze([{"a": 1}])
+        silver = build_silver_dataset(bronze, column_dtypes={"a": "string"})
+        assert not silver.validation.ok
+        codes = [p.code for p in silver.validation.problems]
+        assert "dtype_mismatch" in codes
+
+    def test_matching_contract_passes(self) -> None:
+        """계약이 실제와 일치하면 ok=True (양성)."""
+        bronze = self._bronze([{"a": 1}, {"a": 2}])
+        silver = build_silver_dataset(bronze, required_columns=("a",), column_dtypes={"a": "int64"})
+        assert silver.validation.ok
+
+    def test_no_contract_backward_compat(self) -> None:
+        """인자 미전달(계약 None) 시 기존 동작 — 항상 ok (하위 호환)."""
+        bronze = self._bronze([{"a": 1}])
+        silver = build_silver_dataset(bronze)
+        assert silver.validation.ok


### PR DESCRIPTION
Closes #437

## 변경 요약

BuildSpec 의 `sources[].schema` 선언을 통해 Silver 검증 게이트를 활성화한다 (VAL-1, "목적의 핵심"). 이전까지는 게이트가 존재했지만 orchestrator가 인자를 안 넘겨 통과 조건이 없었다 (항상 ok).

### 세부 변경
- **`SchemaContract` dataclass** (`spec/models.py`) — `required`/`dtypes`/`casts` 필드. `SourceRef.schema: SchemaContract | None` (None이면 기존 동작, 하위 호환)
- **`loader._parse_schema`** — YAML `sources[].schema` 블록을 SchemaContract로 파싱 (로더는 구조만)
- **`validator._schema_problems`** — `dtypes`/`casts` 값이 `_NAMED_DTYPES` 키로 해석 가능한지 검증 (unknown dtype/cast 거부, 코드 `unknown_dtype`/`unknown_cast_dtype`)
- **orchestrator/preview 배선** — `build_silver_dataset(bronze)` → `source.schema` 의 `required`/`dtypes`/`casts`를 `required_columns`/`column_dtypes`/`casts`로 전달. 미리보기와 빌드 검증 결과 일치
- **계약 버전 1.2.0 → 1.3.0** (`app.py:API_CONTRACT_VERSION`, `contract/builder-api.yaml`)

### 사용 예시
```yaml
sources:
  - provider: datago
    dataset: village_fcst
    schema:
      required: [base_date, nx, ny]
      dtypes:
        base_date: String
        nx: Int64
      casts:
        nx: Int64
```

## 테스트

`tests/unit/test_schema_contract.py` (신규 10케이스):
- **파싱 (3)** — required/dtypes/casts 파싱, schema 미선언 시 None (하위 호환), 부분 필드
- **검증 (3)** — unknown dtype/cast 거부, known dtype 통과
- **게이트 활성화 (4)** — required 누락/dtype 불일치 검증 실패, 일치 시 통과, 계약 없으면 항상 ok (하위 호환)

## 검증
- pytest: **542 passed** (기존 532 + 신규 10)
- ruff check / ruff format: pass
- mypy: pass (no issues in 70 files)

## 인수 기준 (#437)
- [x] 계약 미선언 시 기존 동작 (하위 호환)
- [x] `required` 컬럼 없는 소스 → Silver 검증 실패 (orchestrator가 DatasetValidationError로 변환)
- [x] dtype 불일치 → 실패
- [x] `casts` 선언 시 정규화 적용 (normalize_table, null 손실 시 TabularError #188)
- [x] 미리보기와 빌드 검증 결과 일치 (동일 인자 전달)

> BUILD_SPEC.md 문서 갱신은 후속 PR에서 진행 (이 PR은 코드 계약에 집중).