### PR TITLE
fix(spec): remove dead transforms/normalization_mode fields (#438)

### DIFF
--- a/BUILD_SPEC.md
+++ b/BUILD_SPEC.md
@@ -44,7 +44,6 @@ exports:
 
 | 필드 | 타입 | 설명 |
 | :--- | :--- | :--- |
-| `transforms` | array<string> | 적용 예정인 변환 단계 이름 목록 |
 | `publish` | boolean | 빌드 후 게시까지 수행할지 여부 (기본값: `false`) |
 | `metadata` | object | 산출물에 실을 임의 메타데이터 (문자열 키/값 쌍) |
 | `splits` | object | 데이터셋 분할 정의 |
@@ -82,7 +81,6 @@ sources:
       nx: 55
       ny: 127
     alias: forecast
-    normalization_mode: canonical
 ```
 
 | 필드 | 타입 | 필수 | 설명 |
@@ -91,7 +89,6 @@ sources:
 | `dataset` | string | 예 | provider 내부 dataset 이름 |
 | `params` | object | 아니오 | source 호출 파라미터 (JSON 호환 값) |
 | `alias` | string | 아니오 | 조립 단계에서 사용할 사용자 정의 소스 이름 |
-| `normalization_mode` | string | 아니오 | 정규화 모드 (`canonical` 기본값, `raw` 지원) |
 
 ### 4.5 `exports` (배열)
 
@@ -128,19 +125,7 @@ KPubData Studio에서는 `ExportTarget.format`이라는 필드명을 사용하�
 
 > **참고**: 값 자체는 동일하며, 단지 필드명만 `format` → `kind`로 변환됩니다. Builder API를 직접 호출하는 경우(CLI 등)에는 항상 `kind`를 사용해야 합니다.
 
-### 4.6 `transforms` (optional)
-
-```yaml
-transforms:
-  - normalize_dates
-  - filter_outliers
-```
-
-적용 예정인 변환 단계 이름의 목록입니다.
-
-> 계획(planned)/미구현: `transforms`는 현재 파싱되어 BuildSpec에 보존되지만, 실제 변환 로직은 아직 구현되지 않았습니다.
-
-### 4.7 `publish` (optional)
+### 4.6 `publish` (optional)
 
 ```yaml
 publish: true

--- a/src/kpubdata_builder/spec/loader.py
+++ b/src/kpubdata_builder/spec/loader.py
@@ -36,7 +36,10 @@ def parse_spec(data: dict[str, object]) -> BuildSpec:
         dataset_id = _require_string(data, "dataset_id")
         title = _require_string(data, "title")
         description = _require_string(data, "description")
-        transforms = _parse_string_list(data.get("transforms", []), field_name="transforms")
+        # transforms 필드는 제거됨 (#438). VAL-1 의 sources[].schema.casts 가 대체.
+        # 조용히 무시하지 않고 명시적 에러로 사용자에게 알린다.
+        if "transforms" in data:
+            raise ValueError("'transforms' is removed; use sources[].schema.casts instead (#438)")
         metadata = _parse_string_dict(data.get("metadata", {}), field_name="metadata")
         publish = _parse_bool(data.get("publish", False), field_name="publish")
         sources = _parse_sources(_require_present(data, "sources"))
@@ -51,7 +54,6 @@ def parse_spec(data: dict[str, object]) -> BuildSpec:
         description=description,
         sources=sources,
         exports=exports,
-        transforms=transforms,
         metadata=metadata,
         publish=publish,
         splits=splits,
@@ -206,10 +208,14 @@ def _parse_sources(value: object) -> tuple[SourceRef, ...]:
         params = _parse_json_mapping(
             mapping.get("params", {}), field_name=f"sources[{index}].params"
         )
-        normalization_mode_obj = mapping.get("normalization_mode", "canonical")
+        # normalization_mode 필드는 제거됨 (#438). sources[].schema 가 대체.
+        # 조용히 무시하지 않고 명시적 에러로 알린다.
+        if "normalization_mode" in mapping:
+            raise TypeError(
+                f"sources[{index}].normalization_mode is removed; "
+                "use sources[].schema instead (#438)"
+            )
         alias_obj = mapping.get("alias", "")
-        if not isinstance(normalization_mode_obj, str):
-            raise TypeError(f"sources[{index}].normalization_mode must be a string")
         if not isinstance(alias_obj, str):
             raise TypeError(f"sources[{index}].alias must be a string")
         parsed_sources.append(
@@ -217,7 +223,6 @@ def _parse_sources(value: object) -> tuple[SourceRef, ...]:
                 provider=provider,
                 dataset=dataset,
                 params=params,
-                normalization_mode=normalization_mode_obj,
                 alias=alias_obj,
             )
         )

--- a/src/kpubdata_builder/spec/models.py
+++ b/src/kpubdata_builder/spec/models.py
@@ -27,14 +27,12 @@ class SourceRef:
         provider: provider 식별자.
         dataset: dataset 식별자.
         params: list 호출에 전달할 원시 파라미터.
-        normalization_mode: canonical/raw 같은 정규화 모드.
         alias: 조립 단계에서 사용할 사용자 정의 소스 이름.
     """
 
     provider: str
     dataset: str
     params: dict[str, JsonValue] = field(default_factory=dict)
-    normalization_mode: str = "canonical"
     alias: str = ""
 
 
@@ -81,7 +79,6 @@ class BuildSpec:
         description: 빌드 목적과 데이터 설명.
         sources: 입력 소스 목록.
         exports: 출력 대상 목록.
-        transforms: 적용 예정인 변환 단계 이름 목록.
         metadata: 산출물에 실을 임의 메타데이터.
         publish: 빌드 후 게시까지 수행할지 여부.
         splits: 데이터셋 분할 정의. 없으면 분할하지 않는다.
@@ -95,7 +92,6 @@ class BuildSpec:
     description: str
     sources: tuple[SourceRef, ...]
     exports: tuple[ExportTarget, ...]
-    transforms: tuple[str, ...] = ()
     metadata: dict[str, JsonValue] = field(default_factory=dict)
     publish: bool = False
     splits: SplitSpec | None = None

--- a/tests/unit/test_spec.py
+++ b/tests/unit/test_spec.py
@@ -36,7 +36,6 @@ def test_build_spec_instantiation() -> None:
     )
 
     assert spec.dataset_id == "dataset.sample"
-    assert spec.transforms == ()
     assert spec.metadata == {}
     assert spec.publish is False
 
@@ -57,14 +56,12 @@ def test_parse_spec_converts_nested_to_typed_objects() -> None:
 
 
 def test_parse_spec_applies_optional_defaults() -> None:
-    """transforms/metadata/publish default when omitted from YAML."""
+    """metadata/publish default when omitted from YAML."""
     spec = parse_spec(_valid_payload())
 
-    assert spec.transforms == ()
     assert spec.metadata == {}
     assert spec.publish is False
     assert spec.sources[0].params == {}
-    assert spec.sources[0].normalization_mode == "canonical"
     assert spec.sources[0].alias == ""
     assert spec.exports[0].options == {}
 
@@ -72,13 +69,11 @@ def test_parse_spec_applies_optional_defaults() -> None:
 def test_parse_spec_preserves_provided_optionals() -> None:
     """Provided optional fields are carried through unchanged."""
     payload = _valid_payload()
-    payload["transforms"] = ["normalize", "dedupe"]
     payload["metadata"] = {"owner": "kpubdata"}
     payload["publish"] = True
     sources = payload["sources"]
     assert isinstance(sources, list)
     sources[0]["params"] = {"year": 2024}
-    sources[0]["normalization_mode"] = "raw"
     sources[0]["alias"] = "aq"
     exports = payload["exports"]
     assert isinstance(exports, list)
@@ -86,11 +81,9 @@ def test_parse_spec_preserves_provided_optionals() -> None:
 
     spec = parse_spec(payload)
 
-    assert spec.transforms == ("normalize", "dedupe")
     assert spec.metadata == {"owner": "kpubdata"}
     assert spec.publish is True
     assert spec.sources[0].params == {"year": 2024}
-    assert spec.sources[0].normalization_mode == "raw"
     assert spec.sources[0].alias == "aq"
     assert spec.exports[0].options == {"compression": "gzip"}
 
@@ -179,8 +172,6 @@ def test_load_spec_round_trips_from_yaml(tmp_path: Path) -> None:
 dataset_id: dataset.sample
 title: Sample Dataset
 description: Sample description
-transforms:
-  - normalize
 metadata:
   owner: kpubdata
 publish: true
@@ -202,7 +193,6 @@ exports:
     spec = load_spec(spec_path)
 
     assert spec.dataset_id == "dataset.sample"
-    assert spec.transforms == ("normalize",)
     assert spec.metadata == {"owner": "kpubdata"}
     assert spec.publish is True
     assert spec.sources[0].params == {"year": 2024}
@@ -240,3 +230,21 @@ exports:
 
     assert spec.dataset_id == "dataset.sample"
     assert spec.sources[0].provider == "datago"
+
+
+def test_parse_spec_rejects_removed_transforms_field() -> None:
+    """transforms 필드는 제거됨 (#438). 키를 만나면 명시적 에러 (조용히 무시 방지)."""
+    payload = _valid_payload()
+    payload["transforms"] = ["normalize"]
+    with pytest.raises(SpecLoadError, match="transforms"):
+        _ = parse_spec(payload)
+
+
+def test_parse_spec_rejects_removed_normalization_mode_field() -> None:
+    """sources[].normalization_mode 필드는 제거됨 (#438). 키를 만나면 에러."""
+    payload = _valid_payload()
+    sources = payload["sources"]
+    assert isinstance(sources, list)
+    sources[0]["normalization_mode"] = "raw"
+    with pytest.raises(SpecLoadError, match="normalization_mode"):
+        _ = parse_spec(payload)


### PR DESCRIPTION
Closes #438

## 변경 요약

소비처가 0건인 `transforms`(BuildSpec)와 `normalization_mode`(SourceRef) 필드를 제거. VAL-1(#437)의 `sources[].schema.casts`/`schema`가 실제 제어 수단을 제공하므로 함께 정리.

### 배경 (직전 검증 완료)
- `BuildSpec.transforms: tuple[str, ...]` — `models.py:98` 정의, `loader.py:39/54` 파싱만. **소비처 0건**. `BUILD_SPEC.md`는 "적용 예정"이라고 서술
- `SourceRef.normalization_mode: str = "canonical"` — `models.py:37` + `loader.py:209-220` 파싱만. **파이프라인 소비처 없음**

사용자에게 "표준화를 제어할 수 있다"는 잘못된 신호를 주던 필드.

### 세부 변경
- **`models.py`**: `SourceRef.normalization_mode`, `BuildSpec.transforms` 필드 제거 (docstring 포함)
- **`loader.py`**: 두 키를 만나면 **명시적 에러**(`SpecLoadError`/`TypeError` 메시지에 제거 사유 + 대체 안내). 조용히 무시하지 않는다 (#438 본문 요구)
- **`BUILD_SPEC.md`**: Optional 표 transforms 행, sources YAML/표 normalization_mode, 4.6 transforms 섹션 제거

## 테스트

`tests/unit/test_spec.py`:
- 기존 transforms/normalization_mode 검증 4곳 제거 (instantiation/defaults/optionals/yaml round-trip)
- **신규 2케이스**: `test_parse_spec_rejects_removed_transforms_field`, `test_parse_spec_rejects_removed_normalization_mode_field` — 키 만나면 SpecLoadError

## 검증
- pytest: **534 passed** (기존 532 - 제거 4 + 신규 2 + 기존 유지 보정)
- ruff check / ruff format: pass
- mypy: pass (no issues in 70 files)

## 호환성
- 두 필드 모두 소비처가 0건이었으므로 실제 사용자 영향 없음
- 키를 보내는 기존 BuildSpec YAML이 있다면 명확한 에러로 안내 (조용히 무시 대신)