### PR TITLE
feat(preview): expose table statistics in /preview response (#440)

### DIFF
--- a/src/kpubdata_builder/pipeline/preview.py
+++ b/src/kpubdata_builder/pipeline/preview.py
@@ -18,7 +18,7 @@ from ..spec import BuildSpec, SourceRef
 from ..spec.validator import validate_spec
 from ..stages.bronze.build import SourceClient, build_bronze_artifact
 from ..stages.silver.build import build_silver_dataset
-from ..tabular import DEFAULT_PREVIEW_LIMIT, PreviewSlice, SchemaInfo
+from ..tabular import DEFAULT_PREVIEW_LIMIT, PreviewSlice, SchemaInfo, TableStatistics
 
 
 @dataclass(frozen=True)
@@ -30,6 +30,8 @@ class SourcePreview:
         status: "ok" 또는 "failed".
         schema: 추론된 스키마 요약 (실패 시 빈 SchemaInfo).
         preview: 상위 N행 미리보기 (실패 시 빈 PreviewSlice).
+        statistics: 전체 테이블 기준 통계 (row_count/null_counts/duplicate_rate,
+            #440). 스키마 계약 초안(VAL-4)과 품질 게이트(QG-3)의 근거.
         error: 실패 시 오류 메시지.
     """
 
@@ -37,6 +39,7 @@ class SourcePreview:
     status: str
     schema: SchemaInfo
     preview: PreviewSlice
+    statistics: TableStatistics
     error: str | None = None
 
 
@@ -87,6 +90,7 @@ def _preview_source(
             status="ok",
             schema=silver.schema,
             preview=silver.preview,
+            statistics=silver.statistics,
         )
     except Exception as exc:  # 미리보기 실패를 결과로 변환
         return SourcePreview(
@@ -94,6 +98,7 @@ def _preview_source(
             status="failed",
             schema=SchemaInfo(),
             preview=PreviewSlice(rows=(), total_rows=0),
+            statistics=TableStatistics(row_count=0, null_counts={}, duplicate_rate=0.0),
             error=str(exc),
         )
 

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -250,6 +250,11 @@ class BuilderService:
                 ],
                 "sample": list(p.preview.rows),
                 "total_rows": p.preview.total_rows,
+                "statistics": {
+                    "row_count": p.statistics.row_count,
+                    "null_counts": dict(p.statistics.null_counts),
+                    "duplicate_rate": p.statistics.duplicate_rate,
+                },
             }
             for p in result.previews
         ]


### PR DESCRIPTION
Closes #440

## 변경 요약

`/preview` 응답에 `TableStatistics{row_count, null_counts, duplicate_rate}`를 노출. 이미 계산되어 있었지만 응답에 없었다. 스키마 계약 초안(VAL-4)과 품질 게이트(QG-3)의 근거 자료.

### 세부 변경
- **`SourcePreview.statistics`** 필드 추가 (`preview.py`) — `TableStatistics` 타입
- **`_preview_source`** 성공 분기에서 `silver.statistics` 전달, 실패 분기에선 빈 통계(`row_count=0`)
- **`/preview` 응답** (`app.py`)에 각 소스마다 `statistics: {row_count, null_counts, duplicate_rate}` 직렬화

## 검증
- pytest: **560 passed** (기존 559 + 1)
- ruff check / ruff format: pass
- mypy: pass (no issues in 70 files)

## 호환성
- 응답에 새 키 추가만 — 기존 소비자(Studio 등)는 무시하면 됨. 계약 버전은 이미 1.3.0(VAL-1).