### PR TITLE
feat(silver): PII scan gate with block/warn/allow policy (#441)

### DIFF
--- a/src/kpubdata_builder/pipeline/orchestrator.py
+++ b/src/kpubdata_builder/pipeline/orchestrator.py
@@ -42,6 +42,7 @@ from ..stages.gold.card import build_dataset_card, render_dataset_card
 from ..stages.gold.persist import persist_gold_package
 from ..stages.silver.build import build_silver_dataset
 from ..stages.silver.persist import persist_silver_dataset
+from ..stages.silver.pii import scan_pii
 from .context import BuildContext
 
 logger = logging.getLogger(__name__)
@@ -177,6 +178,24 @@ def _run_source_pipeline(
             # ValidationProblem 객체를 DatasetValidationError가 기대하는 문자열 목록으로 변환 (#261)
             problem_messages = [problem.message for problem in silver.validation.problems]
             raise DatasetValidationError(problem_messages)
+
+        # PII 스캔 게이트 (#441, QG-1). 원본 값은 결과/로그에 담지 않는다.
+        # block: 검출 시 빌드 실패, warn: manifest/로그 경고, allow: 통과.
+        if context.spec.pii is not None:
+            findings = [
+                f for f in scan_pii(silver.table) if f.column not in context.spec.pii.allow_columns
+            ]
+            if findings:
+                if context.spec.pii.mode == "block":
+                    raise DatasetValidationError(
+                        [f"PII 검출({f.kind}) @ {f.column}: {f.count}건" for f in findings]
+                    )
+                if context.spec.pii.mode == "warn":
+                    logger.warning(
+                        "PII 의심 컬럼 (warn): %s",
+                        ", ".join(f"{f.kind}@{f.column}({f.count})" for f in findings),
+                    )
+
         silver_paths = persist_silver_dataset(
             silver, output_root=context.output_root, run_id=context.run_id
         )

--- a/src/kpubdata_builder/spec/loader.py
+++ b/src/kpubdata_builder/spec/loader.py
@@ -17,7 +17,15 @@ from typing import cast
 import yaml
 
 from ..errors import SpecLoadError
-from .models import BuildSpec, ExportTarget, JsonValue, SchemaContract, SourceRef, SplitSpec
+from .models import (
+    BuildSpec,
+    ExportTarget,
+    JsonValue,
+    PiiPolicy,
+    SchemaContract,
+    SourceRef,
+    SplitSpec,
+)
 
 
 def parse_spec(data: dict[str, object]) -> BuildSpec:
@@ -45,6 +53,7 @@ def parse_spec(data: dict[str, object]) -> BuildSpec:
         sources = _parse_sources(_require_present(data, "sources"))
         exports = _parse_exports(_require_present(data, "exports"))
         splits = _parse_splits(data.get("splits"))
+        pii = _parse_pii(data.get("pii"))
     except (KeyError, TypeError, ValueError) as exc:
         raise SpecLoadError(f"Failed to parse build spec: {exc}") from exc
 
@@ -57,6 +66,7 @@ def parse_spec(data: dict[str, object]) -> BuildSpec:
         metadata=metadata,
         publish=publish,
         splits=splits,
+        pii=pii,
     )
 
 
@@ -315,6 +325,25 @@ def _ensure_mapping(value: object, *, field_name: str) -> dict[str, object]:
             raise TypeError(f"{field_name} keys must be strings")
         parsed[key] = item
     return parsed
+
+
+def _parse_pii(value: object) -> PiiPolicy | None:
+    """pii 매핑을 PiiPolicy로 변환한다 (없으면 None, #441).
+
+    mode 는 block(기본)/warn/allow 중 하나. allow_columns 는 오탐 해제용 컬럼 목록.
+    """
+    if value is None:
+        return None
+    mapping = _ensure_mapping(value, field_name="pii")
+    mode_obj = mapping.get("mode", "block")
+    if not isinstance(mode_obj, str):
+        raise TypeError("pii.mode must be a string")
+    if mode_obj not in ("block", "warn", "allow"):
+        raise ValueError(f"pii.mode must be one of block/warn/allow, got {mode_obj!r}")
+    allow_columns = _parse_string_list(
+        mapping.get("allow_columns", []), field_name="pii.allow_columns"
+    )
+    return PiiPolicy(mode=mode_obj, allow_columns=allow_columns)
 
 
 __all__ = [

--- a/src/kpubdata_builder/spec/models.py
+++ b/src/kpubdata_builder/spec/models.py
@@ -94,6 +94,20 @@ class SplitSpec:
 
 
 @dataclass(frozen=True)
+class PiiPolicy:
+    """PII 검출 정책 (#441, QG-1).
+
+    속성:
+        mode: ``"block"``(기본, 검출 시 빌드 실패) | ``"warn"``(manifest 경고만) |
+            ``"allow"``(통과). ``publish=True`` 스펙에서는 ``allow``를 금지한다.
+        allow_columns: 모드와 무관하게 스캔을 건너뛸 컬럼명 목록(오탐 해제용).
+    """
+
+    mode: str = "block"
+    allow_columns: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class BuildSpec:
     """데이터셋 산출물을 위한 선언적 빌드 명세.
 
@@ -106,6 +120,7 @@ class BuildSpec:
         metadata: 산출물에 실을 임의 메타데이터.
         publish: 빌드 후 게시까지 수행할지 여부.
         splits: 데이터셋 분할 정의. 없으면 분할하지 않는다.
+        pii: PII 스캔 정책. None이면 스캔을 생략한다 (하위 호환, #441).
 
     예시:
         >>> BuildSpec.from_yaml("specs/sample.yaml")
@@ -119,6 +134,7 @@ class BuildSpec:
     metadata: dict[str, JsonValue] = field(default_factory=dict)
     publish: bool = False
     splits: SplitSpec | None = None
+    pii: PiiPolicy | None = None
 
     @classmethod
     def from_yaml(cls, path: str | Path) -> BuildSpec:

--- a/src/kpubdata_builder/spec/validator.py
+++ b/src/kpubdata_builder/spec/validator.py
@@ -115,6 +115,7 @@ def validate_spec(spec: BuildSpec) -> None:
             break
     problems.extend(_split_problems(spec))
     problems.extend(_schema_problems(spec))
+    problems.extend(_pii_problems(spec))
     if problems:
         raise ValidationError([str(p) for p in problems], structured=problems)
 
@@ -214,6 +215,27 @@ def _schema_problems(spec: BuildSpec) -> list[ValidationProblem]:
                         hint=f"Use one of: {', '.join(supported)}",
                     )
                 )
+    return problems
+
+
+def _pii_problems(spec: BuildSpec) -> list[ValidationProblem]:
+    """PII 정책의 명백한 위반을 사전에 검증한다 (#441).
+
+    데이터 스캔 자체는 orchestrator 가 silver 이후에 수행한다. 여기서는 정책
+    선언 단계의 위반(publish=true + allow 등)만 잡는다.
+    """
+    problems: list[ValidationProblem] = []
+    if spec.pii is None:
+        return problems
+    # 공개 배포(publish=true) 스펙에서 allow 는 PII 미검출 통과 위험이 있어 금지.
+    if spec.publish and spec.pii.mode == "allow":
+        problems.append(
+            _p(
+                "pii_allow_with_publish",
+                "pii.mode",
+                "pii.mode='allow' is forbidden when publish=true (공개 배포 PII 노출 위험, #441)",
+            )
+        )
     return problems
 
 

--- a/src/kpubdata_builder/stages/silver/pii.py
+++ b/src/kpubdata_builder/stages/silver/pii.py
@@ -1,0 +1,86 @@
+"""PII(개인정보) 스캐너 (#441, QG-1).
+
+Silver 단계 정제 테이블에서 주민등록번호/휴대전화/이메일/사업자등록번호 패턴과
+의심 컬럼명을 결정적으로 검색한다.
+
+보안 원칙 (#441 인수 기준): 검출 내용(원본 값)은 결과에 담지 않고 컬럼명·종류·
+건수만 반환한다. 로그/manifest 에 원본 값이 새어나가는 일이 없어야 한다.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+import polars as pl
+
+# 한국 PII 정규식 — 과탐지 완화를 위해 자릿수/구분자 형태를 요구한다.
+# 주민등록번호: YYMMDD-SXXXXXX (S는 1-4, 성별/국적)
+_RRN = re.compile(r"\b\d{6}-[1-4]\d{6}\b")
+# 휴대전화: 01X(-?)XXXX(-?)XXXX
+_PHONE = re.compile(r"\b01[016789]-?\d{3,4}-?\d{4}\b")
+# 이메일: 로컬@도메인.tld
+_EMAIL = re.compile(r"\b[\w.+-]+@[\w-]+\.[\w.-]+\b")
+# 사업자등록번호: 000-00-00000
+_BRN = re.compile(r"\b\d{3}-\d{2}-\d{5}\b")
+
+_PATTERNS: dict[str, re.Pattern[str]] = {
+    "rrn": _RRN,
+    "phone": _PHONE,
+    "email": _EMAIL,
+    "business_no": _BRN,
+}
+
+# 의심 컬럼명 휴리스틱 (대소문자 무시 부분 일치). 공공데이터 축약형 포함.
+_SUSPECT_PARTS: dict[str, tuple[str, ...]] = {
+    "name": ("NM", "NAME", "성명", "이름"),
+    "phone": ("TEL", "TELNO", "PHONE", "HP", "MOBILE", "연락처"),
+    "addr": ("ADDR", "ADRES", "주소"),
+    "email": ("EMAIL", "이메일"),
+    "rrn": ("RRN", "JUMIN", "주민", "SSN"),
+}
+
+
+@dataclass(frozen=True)
+class PiiFinding:
+    """단일 PII 검출 결과. 원본 값은 절대 담지 않는다 (#441).
+
+    속성:
+        column: 매칭된 컬럼명. None이면 테이블 전체 스캔 결과.
+        kind: rrn/phone/email/business_no/name/addr 중 하나.
+        count: 패턴 매칭 건수. 컬럼명 휴리스틱은 1.
+    """
+
+    column: str | None
+    kind: str
+    count: int
+
+
+def scan_pii(table: pl.DataFrame) -> list[PiiFinding]:
+    """정제 테이블을 PII 패턴 + 컬럼명 휴리스틱으로 스캔한다 (#441).
+
+    원본 값을 결과에 담지 않는다 — 컬럼명·종류·건수만. 호출자는 findings 를
+    manifest warnings 등에 기록할 때도 동일하게 원본 값을 적지 않아야 한다.
+    """
+    findings: list[PiiFinding] = []
+    for column_name in table.columns:
+        series = table.get_column(column_name)
+        # 문자열 컬럼만 패턴 매칭. 비문자열은 컬럼명 휴리스틱만 적용.
+        if series.dtype == pl.Utf8:
+            non_null = series.drop_nulls()
+            for kind, pattern in _PATTERNS.items():
+                if non_null.len() == 0:
+                    continue
+                count = int(non_null.str.contains(pattern.pattern).sum())
+                if count > 0:
+                    findings.append(PiiFinding(column=column_name, kind=kind, count=count))
+        # 컬럼명 휴리스틱 — 한 컬럼당 첫 매칭 종류 하나만.
+        upper = column_name.upper()
+        for kind, parts in _SUSPECT_PARTS.items():
+            if any(part in upper for part in parts):
+                findings.append(PiiFinding(column=column_name, kind=kind, count=1))
+                break
+    return findings
+
+
+__all__ = ["PiiFinding", "scan_pii"]

--- a/tests/unit/test_pii.py
+++ b/tests/unit/test_pii.py
@@ -1,0 +1,76 @@
+"""PII 스캐너 단위 테스트 (#441, QG-1).
+
+패턴(주민번호/휴대전화/이메일/사업자번호), 컬럼명 휴리스틱, 그리고 보안 원칙
+(원본 값 미노출)을 검증한다.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from kpubdata_builder.stages.silver.pii import scan_pii
+
+
+class TestScanPiiPatterns:
+    """패턴 기반 PII 검출."""
+
+    def test_detects_rrn(self) -> None:
+        table = pl.DataFrame({"text": ["900101-1234567", "no pii here"]})
+        findings = scan_pii(table)
+        kinds = [f.kind for f in findings]
+        assert "rrn" in kinds
+        rrn = next(f for f in findings if f.kind == "rrn")
+        assert rrn.count == 1
+        assert rrn.column == "text"
+
+    def test_detects_phone(self) -> None:
+        table = pl.DataFrame({"contact": ["010-1234-5678", "x"]})
+        findings = scan_pii(table)
+        assert "phone" in [f.kind for f in findings]
+
+    def test_detects_email(self) -> None:
+        table = pl.DataFrame({"x": ["user@example.com", "y"]})
+        findings = scan_pii(table)
+        assert "email" in [f.kind for f in findings]
+
+    def test_detects_business_no(self) -> None:
+        table = pl.DataFrame({"biz": ["123-45-67890", "z"]})
+        findings = scan_pii(table)
+        assert "business_no" in [f.kind for f in findings]
+
+    def test_no_pii_returns_empty(self) -> None:
+        table = pl.DataFrame({"a": ["normal text", "more text"]})
+        assert scan_pii(table) == []
+
+    def test_non_string_columns_skip_pattern_scan(self) -> None:
+        """비문자열 컬럼은 패턴 스캔을 건너뛴다 (컬럼명 휴리스틱만 적용)."""
+        table = pl.DataFrame({"value": [1, 2, 3]})
+        assert scan_pii(table) == []
+
+
+class TestScanPiiColumnNameHeuristics:
+    """컬럼명 휴리스틱 — 공공데이터 축약형(NM/TELNO/ADRES 등)."""
+
+    def test_name_column_flagged(self) -> None:
+        table = pl.DataFrame({"OPNR_NM": ["홍길동", "김철수"]})
+        assert "name" in [f.kind for f in scan_pii(table)]
+
+    def test_addr_column_flagged(self) -> None:
+        table = pl.DataFrame({"ROAD_ADRES": ["서울", "부산"]})
+        assert "addr" in [f.kind for f in scan_pii(table)]
+
+    def test_phone_column_flagged(self) -> None:
+        table = pl.DataFrame({"TELNO": ["02-123-4567", "x"]})
+        assert "phone" in [f.kind for f in scan_pii(table)]
+
+
+class TestScanPiiSecurityPrinciple:
+    """검출 결과에 원본 값이 새어나가지 않아야 한다 (#441 보안 원칙)."""
+
+    def test_no_original_values_in_findings(self) -> None:
+        secret = "900101-1234567"
+        table = pl.DataFrame({"x": [secret, "clean"]})
+        findings = scan_pii(table)
+        # findings의 모든 필드(column/kind/count) 직렬화에 원본 값이 없어야
+        serialized = " ".join(f"{f.column}|{f.kind}|{f.count}" for f in findings)
+        assert secret not in serialized


### PR DESCRIPTION
Closes #441

## 변경 요약

Silver 단계에 결정적 PII 스캐너를 추가하고, BuildSpec 의 `pii` 정책 선언으로 게이트(block/warn/allow)를 활성화한다. 공공데이터에 섞여 들어올 수 있는 주민등록번호·휴대전화·이메일·사업자등록번호와 의심 컬럼명을 검출한다.

### 세부 변경
- **`stages/silver/pii.py`** (신규) — `scan_pii(table) → list[PiiFinding]`
  - 패턴: 주민등록번호(YYMMDD-SXXXXXX), 휴대전화(01X-XXXX-XXXX), 이메일, 사업자등록번호(000-00-00000)
  - 컬럼명 휴리스틱: NM/NAME, TEL/TELNO/PHONE, ADDR/ADRES, EMAIL, RRN/JUMIN
  - **보안 원칙**: `PiiFinding{column, kind, count}` 만 반환 — 원본 값은 결과/로그에 담지 않는다
- **`PiiPolicy`** (`spec/models.py`) — `mode: block|warn|allow`, `allow_columns` (오탐 해제). `BuildSpec.pii: PiiPolicy | None` (None이면 스캔 생략, 하위 호환)
- **`spec/loader.py`** — `_parse_pii` (mode/allow_columns 검증)
- **`spec/validator.py`** — `_pii_problems`: `publish=true` + `allow` 금지 (공개 배포 PII 노출 위험)
- **`pipeline/orchestrator.py`** — silver 검증 후 PII 게이트:
  - `block` → `DatasetValidationError` (빌드 실패)
  - `warn` → `logger.warning` (원본 값 미포함 요약)
  - `allow` → 통과
  - `allow_columns` 컬럼은 스캔에서 제외

## 테스트

`tests/unit/test_pii.py` (신규 10케이스):
- 패턴 검출 (rrn/phone/email/business_no/no-pii/비문자열)
- 컬럼명 휴리스틱 (NM/ADRES/TELNO)
- **보안 원칙**: findings 직렬화에 원본 값 없음

## 검증
- pytest: **570 passed** (기존 560 + 신규 10)
- ruff check / ruff format: pass
- mypy: pass (no issues in 71 files)

## 남은 작업 (후속 PR)
- manifest `warnings` 필드에 warn 모드 결과 기록 (현재는 logger.warning 만)
- `allow_columns` 와 패턴/휴리스틱 결과의 상호작용 추가 테스트