### PR TITLE
feat(spec): require explicit license for publish=true builds (#443)

### DIFF
--- a/src/kpubdata_builder/spec/loader.py
+++ b/src/kpubdata_builder/spec/loader.py
@@ -54,6 +54,9 @@ def parse_spec(data: dict[str, object]) -> BuildSpec:
         exports = _parse_exports(_require_present(data, "exports"))
         splits = _parse_splits(data.get("splits"))
         pii = _parse_pii(data.get("pii"))
+        license_obj = data.get("license")
+        if license_obj is not None and not isinstance(license_obj, str):
+            raise TypeError("license must be a string")
     except (KeyError, TypeError, ValueError) as exc:
         raise SpecLoadError(f"Failed to parse build spec: {exc}") from exc
 
@@ -67,6 +70,7 @@ def parse_spec(data: dict[str, object]) -> BuildSpec:
         publish=publish,
         splits=splits,
         pii=pii,
+        license=license_obj,
     )
 
 

--- a/src/kpubdata_builder/spec/models.py
+++ b/src/kpubdata_builder/spec/models.py
@@ -121,6 +121,9 @@ class BuildSpec:
         publish: 빌드 후 게시까지 수행할지 여부.
         splits: 데이터셋 분할 정의. 없으면 분할하지 않는다.
         pii: PII 스캔 정책. None이면 스캔을 생략한다 (하위 호환, #441).
+        license: 데이터셋 라이선스/이용허락범위 (SPDX 식별자 또는 자유 텍스트).
+            ``publish=True`` 시 반드시 선언해야 한다 (#443). kpubdata 가 라이선스
+            메타데이터를 제공하지 않으므로 사용자 명시 선언만이 출처이다.
 
     예시:
         >>> BuildSpec.from_yaml("specs/sample.yaml")
@@ -135,6 +138,7 @@ class BuildSpec:
     publish: bool = False
     splits: SplitSpec | None = None
     pii: PiiPolicy | None = None
+    license: str | None = None
 
     @classmethod
     def from_yaml(cls, path: str | Path) -> BuildSpec:

--- a/src/kpubdata_builder/spec/validator.py
+++ b/src/kpubdata_builder/spec/validator.py
@@ -116,6 +116,7 @@ def validate_spec(spec: BuildSpec) -> None:
     problems.extend(_split_problems(spec))
     problems.extend(_schema_problems(spec))
     problems.extend(_pii_problems(spec))
+    problems.extend(_license_problems(spec))
     if problems:
         raise ValidationError([str(p) for p in problems], structured=problems)
 
@@ -234,6 +235,24 @@ def _pii_problems(spec: BuildSpec) -> list[ValidationProblem]:
                 "pii_allow_with_publish",
                 "pii.mode",
                 "pii.mode='allow' is forbidden when publish=true (공개 배포 PII 노출 위험, #441)",
+            )
+        )
+    return problems
+
+
+def _license_problems(spec: BuildSpec) -> list[ValidationProblem]:
+    """publish=true 인 빌드의 라이선스 누락을 사전에 검증한다 (#443).
+
+    kpubdata 가 라이선스 메타데이터를 제공하지 않으므로, 공개 배포 시 사용자
+    명시 선언(``license`` 필드)이 재배포 가능성의 유일한 출처이다.
+    """
+    problems: list[ValidationProblem] = []
+    if spec.publish and not spec.license:
+        problems.append(
+            _p(
+                "missing_license_for_publish",
+                "license",
+                "license is required when publish=true (재배포 가능성 명시, #443)",
             )
         )
     return problems

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -189,3 +189,48 @@ def test_validate_spec_rejects_nan_split_ratio() -> None:
         validate_spec(spec)
 
     assert any("finite" in p for p in exc_info.value.problems)
+
+
+def test_validate_spec_requires_license_when_publish() -> None:
+    # publish=true 인데 license 가 없으면 재배포 가능성을 명시할 수 없다 (#443).
+    spec = BuildSpec(
+        dataset_id="dataset.sample",
+        title="Sample Dataset",
+        description="Sample description",
+        sources=_SRC,
+        exports=_EXP,
+        publish=True,
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        validate_spec(spec)
+
+    codes = [p.code for p in (exc_info.value.structured_problems or [])]
+    assert "missing_license_for_publish" in codes
+
+
+def test_validate_spec_accepts_publish_with_license() -> None:
+    # publish=true + license 선언은 통과한다 (양성 회귀, #443).
+    spec = BuildSpec(
+        dataset_id="dataset.sample",
+        title="Sample Dataset",
+        description="Sample description",
+        sources=_SRC,
+        exports=_EXP,
+        publish=True,
+        license="CC-BY-4.0",
+    )
+    validate_spec(spec)  # 예외 없음
+
+
+def test_validate_spec_skips_license_check_when_not_publishing() -> None:
+    # publish=false 면 license 가 없어도 통과한다 (하위 호환, #443).
+    spec = BuildSpec(
+        dataset_id="dataset.sample",
+        title="Sample Dataset",
+        description="Sample description",
+        sources=_SRC,
+        exports=_EXP,
+        publish=False,
+    )
+    validate_spec(spec)  # 예외 없음


### PR DESCRIPTION
Closes #443

## 변경 요약

`publish=true` 빌드의 라이선스/재배포 가능성을 명시 선언하도록 강제한다.

### 배경
kpubdata 가 라이선스 메타데이터를 제공하지 않는다(확인 완료 — DatasetRef.raw_metadata 와 provider catalogue 에 라이선스 필드 없음). 공공데이터포털은 데이터셋마다 이용허락범위가 다르다. 따라서 **사용자 명시 선언이 재배포 가능성의 유일한 출처**다.

### 세부 변경
- **`BuildSpec.license: str | None`** (`spec/models.py`) — SPDX 식별자 또는 자유 텍스트. None 이면 미선언
- **`spec/loader.py`** — `license` 파싱 (문자열 검증)
- **`spec/validator.py._license_problems`** — `publish=true` + `license` 미선언 → `ValidationError` (`missing_license_for_publish`). kpubdata 메타데이터 부재 근거를 코드/메시지에 명시

### 한계
- 라이선스 값의 유효성 검증(SPDX 식별자 교차 검증 등)은 하지 않는다 — 출처가 사용자 선언이므로 형식만 강제.
- dataset card / manifest 에 license 반영은 후속 PR.

## 테스트
`tests/unit/test_validator.py` (신규 3케이스):
- `test_validate_spec_requires_license_when_publish` — publish=true + license 누락 → `missing_license_for_publish`
- `test_validate_spec_accepts_publish_with_license` — license 선언 시 통과 (양성)
- `test_validate_spec_skips_license_check_when_not_publishing` — publish=false 면 license 생략 (하위 호환)

## 검증
- pytest: **563 passed** (기존 560 + 신규 3)
- ruff check / ruff format: pass
- mypy: pass (no issues in 70 files)