### PR TITLE
feat(spec): quality threshold gate (#446)

### DIFF
--- a/src/kpubdata_builder/pipeline/orchestrator.py
+++ b/src/kpubdata_builder/pipeline/orchestrator.py
@@ -196,6 +196,30 @@ def _run_source_pipeline(
                         ", ".join(f"{f.kind}@{f.column}({f.count})" for f in findings),
                     )
 
+        # 품질 임계 게이트 (#446, QG-3). 기본 warn — 임계 위반 시 로그 경고.
+        if context.spec.quality is not None:
+            qp = context.spec.quality
+            stats = silver.statistics
+            if qp.max_duplicate_rate is not None and stats.duplicate_rate > qp.max_duplicate_rate:
+                logger.warning(
+                    "품질 위반: 중복 행 비율 %.4f > 임계 %.4f (#446)",
+                    stats.duplicate_rate,
+                    qp.max_duplicate_rate,
+                )
+            if qp.min_rows is not None and stats.row_count < qp.min_rows:
+                logger.warning("품질 위반: 행 수 %d < 최소 %d (#446)", stats.row_count, qp.min_rows)
+            for col, max_ratio in qp.max_null_ratio.items():
+                actual_nulls = stats.null_counts.get(col, 0)
+                if stats.row_count > 0:
+                    actual_ratio = actual_nulls / stats.row_count
+                    if actual_ratio > max_ratio:
+                        logger.warning(
+                            "품질 위반: 컬럼 %s null 비율 %.4f > 임계 %.4f (#446)",
+                            col,
+                            actual_ratio,
+                            max_ratio,
+                        )
+
         silver_paths = persist_silver_dataset(
             silver, output_root=context.output_root, run_id=context.run_id
         )

--- a/src/kpubdata_builder/spec/loader.py
+++ b/src/kpubdata_builder/spec/loader.py
@@ -22,6 +22,7 @@ from .models import (
     ExportTarget,
     JsonValue,
     PiiPolicy,
+    QualityPolicy,
     SchemaContract,
     SourceRef,
     SplitSpec,
@@ -57,6 +58,7 @@ def parse_spec(data: dict[str, object]) -> BuildSpec:
         license_obj = data.get("license")
         if license_obj is not None and not isinstance(license_obj, str):
             raise TypeError("license must be a string")
+        quality = _parse_quality(data.get("quality"))
     except (KeyError, TypeError, ValueError) as exc:
         raise SpecLoadError(f"Failed to parse build spec: {exc}") from exc
 
@@ -71,6 +73,7 @@ def parse_spec(data: dict[str, object]) -> BuildSpec:
         splits=splits,
         pii=pii,
         license=license_obj,
+        quality=quality,
     )
 
 
@@ -348,6 +351,35 @@ def _parse_pii(value: object) -> PiiPolicy | None:
         mapping.get("allow_columns", []), field_name="pii.allow_columns"
     )
     return PiiPolicy(mode=mode_obj, allow_columns=allow_columns)
+
+
+def _parse_quality(value: object) -> QualityPolicy | None:
+    """quality 매핑을 QualityPolicy로 변환한다 (없으면 None, #446).
+
+    max_duplicate_rate/min_rows 는 스칼라, max_null_ratio 는 {컬럼명: 비율} 매핑.
+    """
+    if value is None:
+        return None
+    mapping = _ensure_mapping(value, field_name="quality")
+    max_dup = mapping.get("max_duplicate_rate")
+    if max_dup is not None and (not isinstance(max_dup, (int, float)) or isinstance(max_dup, bool)):
+        raise TypeError("quality.max_duplicate_rate must be a number")
+    min_rows = mapping.get("min_rows")
+    if min_rows is not None and (not isinstance(min_rows, int) or isinstance(min_rows, bool)):
+        raise TypeError("quality.min_rows must be an integer")
+    null_ratio_raw = mapping.get("max_null_ratio", {})
+    if not isinstance(null_ratio_raw, dict):
+        raise TypeError("quality.max_null_ratio must be a mapping")
+    max_null_ratio: dict[str, float] = {}
+    for k, v in cast(dict[object, object], null_ratio_raw).items():
+        if not isinstance(k, str) or not isinstance(v, (int, float)) or isinstance(v, bool):
+            raise TypeError("quality.max_null_ratio entries must be string→number pairs")
+        max_null_ratio[k] = float(v)
+    return QualityPolicy(
+        max_duplicate_rate=float(max_dup) if max_dup is not None else None,
+        max_null_ratio=max_null_ratio,
+        min_rows=min_rows,
+    )
 
 
 __all__ = [

--- a/src/kpubdata_builder/spec/models.py
+++ b/src/kpubdata_builder/spec/models.py
@@ -108,6 +108,24 @@ class PiiPolicy:
 
 
 @dataclass(frozen=True)
+class QualityPolicy:
+    """데이터 품질 임계 정책 (#446, QG-3).
+
+    Silver 통계(row_count/null_counts/duplicate_rate)에 대한 임계. 초과 시
+    위반으로 보고한다(orchestrator 가 warn/fail 처리).
+
+    속성:
+        max_duplicate_rate: 허용 최대 중복 행 비율 (0.0~1.0). 초과 시 위반.
+        max_null_ratio: 컬럼별 허용 최대 null 비율 (``{컬럼명: 비율}``).
+        min_rows: 최소 행 수. 미만 시 위반.
+    """
+
+    max_duplicate_rate: float | None = None
+    max_null_ratio: dict[str, float] = field(default_factory=dict)
+    min_rows: int | None = None
+
+
+@dataclass(frozen=True)
 class BuildSpec:
     """데이터셋 산출물을 위한 선언적 빌드 명세.
 
@@ -124,6 +142,7 @@ class BuildSpec:
         license: 데이터셋 라이선스/이용허락범위 (SPDX 식별자 또는 자유 텍스트).
             ``publish=True`` 시 반드시 선언해야 한다 (#443). kpubdata 가 라이선스
             메타데이터를 제공하지 않으므로 사용자 명시 선언만이 출처이다.
+        quality: 데이터 품질 임계 정책. None이면 검사를 생략한다 (하위 호환, #446).
 
     예시:
         >>> BuildSpec.from_yaml("specs/sample.yaml")
@@ -139,6 +158,7 @@ class BuildSpec:
     splits: SplitSpec | None = None
     pii: PiiPolicy | None = None
     license: str | None = None
+    quality: QualityPolicy | None = None
 
     @classmethod
     def from_yaml(cls, path: str | Path) -> BuildSpec:


### PR DESCRIPTION
Closes #446

## 변경 요약

Silver 통계(duplicate_rate/null_counts/row_count)에 대한 품질 임계 게이트. 이미 계산된 지표를 임계 선언에 연결한다 (기본 warn).

### 세부 변경
- **`QualityPolicy`** (`spec/models.py`) — `max_duplicate_rate: float | None`, `max_null_ratio: dict[str, float]`, `min_rows: int | None`. `BuildSpec.quality: QualityPolicy | None`
- **`spec/loader.py._parse_quality`** — YAML `quality:` 블록 파싱 (타입 검증)
- **`pipeline/orchestrator.py`** — silver 후 PII 게이트 다음에 품질 임계 검사:
  - `max_duplicate_rate` 초과 → `logger.warning`
  - `min_rows` 미만 → `logger.warning`
  - `max_null_ratio[col]` 초과 → `logger.warning` (컬럼별)

### 한계 (후속 PR)
- 현재 warn 전용 (logger.warning). manifest `warnings` 필드 기록은 후속.
- fail 모드(QualityPolicy.mode)는 추후 추가 가능.

## 검증
- pytest: **570 passed** (회귀 보존)
- ruff check / ruff format: pass
- mypy: pass (no issues in 71 files)