### PR TITLE
fix: run BuildSpec exports during build

### DIFF
--- a/src/kpubdata_builder/pipeline/export.py
+++ b/src/kpubdata_builder/pipeline/export.py
@@ -1,0 +1,29 @@
+"""GoldPackage export plan 실행을 담당한다."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..artifact import ArtifactDataset
+from ..exporters import get_exporter
+from ..spec import JsonValue
+from ..stages.gold import GoldPackage
+
+
+def export_gold_package(package: GoldPackage, *, output_dir: Path) -> tuple[Path, ...]:
+    """GoldPackage의 export target을 파일/디렉터리 산출물로 기록한다."""
+    artifact = ArtifactDataset(
+        records=tuple(_json_record(row) for row in package.table.to_dicts()),
+        schema={name: str(dtype) for name, dtype in package.table.schema.items()},
+        metadata=package.metadata,
+        provenance=(package.source_silver,),
+        statistics={"row_count": package.table.height},
+    )
+    return tuple(
+        get_exporter(target.kind).export(artifact, target, output_dir).output_path
+        for target in package.export_plan.targets
+    )
+
+
+def _json_record(row: dict[str, JsonValue]) -> dict[str, JsonValue]:
+    return dict(row)

--- a/src/kpubdata_builder/pipeline/orchestrator.py
+++ b/src/kpubdata_builder/pipeline/orchestrator.py
@@ -6,8 +6,6 @@ BuildSpec의 각 소스를 Bronze → Silver → Gold 순서로 실행하고, �
 부분 성공 정책(BUILD_STATE.md): 소스 중 하나라도 실패하면 전체 상태는 failed로
 기록하되, 성공한 소스의 산출물과 실패 정보를 매니페스트에 함께 남긴다.
 
-Export 단계 연결은 stage-aware exporter 도입(#28/v0.2) 시점으로 연기한다.
-
 주요 구성:
     - SourceBuildOutcome: 소스별 실행 결과
     - BuildResult: 전체 실행 결과
@@ -44,6 +42,7 @@ from ..stages.silver.build import build_silver_dataset
 from ..stages.silver.persist import persist_silver_dataset
 from ..stages.silver.pii import scan_pii
 from .context import BuildContext
+from .export import export_gold_package
 
 logger = logging.getLogger(__name__)
 
@@ -213,6 +212,7 @@ def _run_source_pipeline(
             silver,
             dataset_name=output_key,
             exports=context.spec.exports,
+            metadata={"title": context.spec.title, "description": context.spec.description},
             splits_spec=context.spec.splits,
         )
         gold_paths = persist_gold_package(
@@ -225,6 +225,8 @@ def _run_source_pipeline(
             gold_paths.package_path,
             *gold_paths.splits_paths.values(),
         )
+        export_paths = export_gold_package(gold, output_dir=gold_paths.gold_dir)
+        _record_output_paths(outputs, *export_paths)
 
         card = build_dataset_card(
             title=context.spec.title,

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -110,6 +110,35 @@ def test_run_build_executes_full_pipeline_and_writes_workspace(tmp_path: Path) -
     ]
 
 
+def test_run_build_executes_export_targets(tmp_path: Path) -> None:
+    spec = BuildSpec(
+        dataset_id="apt_trade",
+        title="Apartment Trades",
+        description="seoul apartment trades",
+        sources=(SourceRef(provider="datago", dataset="apt_trade"),),
+        exports=(
+            ExportTarget(kind="jsonl", output_path="exports/data.jsonl"),
+            ExportTarget(kind="markdown", output_path="exports/README.md"),
+        ),
+    )
+    client = _FakeClient({"datago.apt_trade": [{"id": "1", "amount": 1000}]})
+
+    result = run_build(spec, client=client, output_root=tmp_path, run_id="run1")
+
+    assert result.status == "ok"
+    gold_dir = tmp_path / "run1" / "gold" / "datago.apt_trade"
+    jsonl_path = gold_dir / "exports" / "data.jsonl"
+    markdown_path = gold_dir / "exports" / "README.md"
+    assert jsonl_path.read_text(encoding="utf-8") == '{"amount": 1000, "id": "1"}\n'
+    assert "# Apartment Trades" in markdown_path.read_text(encoding="utf-8")
+    manifest = cast(
+        dict[str, JsonValue], json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    )
+    outputs = cast(list[str], manifest["outputs"])
+    assert str(jsonl_path) in outputs
+    assert str(markdown_path) in outputs
+
+
 def test_run_build_writes_dataset_card_readme(tmp_path: Path) -> None:
     # 성공한 빌드의 gold 디렉터리에 dataset card README.md가 생성되는지 검증한다 (#37).
     spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))

--- a/tests/unit/test_pipeline_export.py
+++ b/tests/unit/test_pipeline_export.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+
+from kpubdata_builder.pipeline.export import export_gold_package
+from kpubdata_builder.spec import ExportTarget
+from kpubdata_builder.stages.gold import ExportPlan, GoldPackage
+
+
+def test_export_gold_package_executes_registered_targets(tmp_path: Path) -> None:
+    package = GoldPackage(
+        dataset_name="apt_trade",
+        table=pl.DataFrame([{"id": "1", "amount": 1000}]),
+        export_plan=ExportPlan(
+            targets=(ExportTarget(kind="jsonl", output_path="exports/data.jsonl"),)
+        ),
+        source_silver="datago.apt_trade",
+        metadata={"title": "Apartment Trades"},
+    )
+
+    paths = export_gold_package(package, output_dir=tmp_path)
+
+    output_path = tmp_path / "exports" / "data.jsonl"
+    assert paths == (output_path,)
+    assert output_path.read_text(encoding="utf-8") == '{"amount": 1000, "id": "1"}\n'


### PR DESCRIPTION
## 요약
- GoldPackage export plan을 실행하는 pipeline export helper를 추가했습니다.
- run_build가 Gold persist 이후 등록된 exporter를 호출하고 생성된 경로를 manifest outputs에 기록하게 했습니다.
- JSONL/Markdown export가 실제 Gold workspace에 생성되는 regression test를 추가했습니다.

Closes #458

## 검증
- uv run --extra dev python -m pytest
- uv run ruff check .
- uv run --extra dev python -m mypy src
- uv run --extra dev python -m mypy src/kpubdata_builder/pipeline/export.py src/kpubdata_builder/pipeline/orchestrator.py tests/unit/test_pipeline.py tests/unit/test_pipeline_export.py

참고: LSP daemon diagnostics는 반복 timeout으로 완료하지 못했습니다. mypy strict 검증으로 대체했습니다.