### PR TITLE
feat(validator): split leakage detection for time-series data (#444)

### DIFF
--- a/src/kpubdata_builder/spec/validator.py
+++ b/src/kpubdata_builder/spec/validator.py
@@ -181,6 +181,32 @@ def _split_problems(spec: BuildSpec) -> list[ValidationProblem]:
                 hint="Use 'ratio' or 'key'",
             )
         )
+    # 시계열 데이터 누수 검사 (#444). ratio 모드에서 key가 시간 컬럼이면
+    # 랜덤 셔플이 미래 정보를 train 으로 색는다.
+    _TIME_INDICATORS = (
+        "date",
+        "time",
+        "dt",
+        "year",
+        "month",
+        "day",
+        "hour",
+        "timestamp",
+        "at",
+        "ts",
+    )
+    if split.mode == "ratio" and split.key:
+        key_lower = split.key.lower()
+        if any(ind in key_lower for ind in _TIME_INDICATORS):
+            problems.append(
+                _p(
+                    "time_column_random_split",
+                    "splits",
+                    f"splits.key {split.key!r} looks like a time column but mode is 'ratio' "
+                    "— random split causes time-series data leakage (#444)",
+                    hint="Use mode='key' for temporal splitting",
+                )
+            )
     return problems
 
 

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -234,3 +234,45 @@ def test_validate_spec_skips_license_check_when_not_publishing() -> None:
         publish=False,
     )
     validate_spec(spec)  # 예외 없음
+
+
+def test_validate_spec_warns_time_column_random_split() -> None:
+    """ratio 모드에서 key가 시간 컬럼이면 누수 경고 (#444)."""
+    spec = BuildSpec(
+        dataset_id="dataset.sample",
+        title="Sample",
+        description="desc",
+        sources=_SRC,
+        exports=_EXP,
+        splits=SplitSpec(mode="ratio", ratios={"train": 0.8, "test": 0.2}, key="date"),
+    )
+    with pytest.raises(ValidationError) as exc_info:
+        validate_spec(spec)
+    codes = [p.code for p in (exc_info.value.structured_problems or [])]
+    assert "time_column_random_split" in codes
+
+
+def test_validate_spec_no_warning_for_key_mode_with_time_column() -> None:
+    """key 모드에서 시간 컬럼은 정상 (temporal split, #444 양성)."""
+    spec = BuildSpec(
+        dataset_id="dataset.sample",
+        title="Sample",
+        description="desc",
+        sources=_SRC,
+        exports=_EXP,
+        splits=SplitSpec(mode="key", key="date"),
+    )
+    validate_spec(spec)  # 예외 없음
+
+
+def test_validate_spec_no_warning_for_ratio_without_time_key() -> None:
+    """ratio 모드에서 key가 없거나 시간이 아니면 경고 없음 (#444 양성)."""
+    spec = BuildSpec(
+        dataset_id="dataset.sample",
+        title="Sample",
+        description="desc",
+        sources=_SRC,
+        exports=_EXP,
+        splits=SplitSpec(mode="ratio", ratios={"train": 0.8, "test": 0.2}, key="region"),
+    )
+    validate_spec(spec)  # 예외 없음


### PR DESCRIPTION
Closes #444

## 변경 요약

`_split_problems`에 시계열 데이터 누수 검사를 추가. ratio 모드(랜덤 분할)에서 key가 시간 컬럼(date/time/year/timestamp 등)이면 경고한다.

### 배경
시계열 데이터를 랜덤 분할하면 미래 데이터가 train에 섞여 들어가 모델이 미래를 "예측"하는 데이터 누수가 발생한다. 학습용 데이터셋에서 치명적이다.

### 세부 변경
- **`validator.py._split_problems`** — mode="ratio" + key가 시간 컬럼 휴리스틱(date/time/dt/year/month/day/hour/timestamp/at/ts)에 매칭 → `time_column_random_split` 경고
- key 모드 + 시간 컬럼은 정상 (temporal split) — 경고 없음

## 테스트
`tests/unit/test_validator.py` (신규 3케이스):
- `test_validate_spec_warns_time_column_random_split` — ratio + key="date" → 경고
- `test_validate_spec_no_warning_for_key_mode_with_time_column` — key 모드 + 시간 컬럼 → 통과 (양성)
- `test_validate_spec_no_warning_for_ratio_without_time_key` — ratio + key="region" → 통과 (양성)

## 검증
- pytest: **576 passed** (기존 573 + 신규 3)
- ruff/mypy: pass