### PR TITLE
feat(silver): drift detection against previous run (#445)

### DIFF
--- a/src/kpubdata_builder/pipeline/orchestrator.py
+++ b/src/kpubdata_builder/pipeline/orchestrator.py
@@ -41,6 +41,7 @@ from ..stages.gold.build import build_gold_package
 from ..stages.gold.card import build_dataset_card, render_dataset_card
 from ..stages.gold.persist import persist_gold_package
 from ..stages.silver.build import build_silver_dataset
+from ..stages.silver.drift import detect_drift, find_previous_silver
 from ..stages.silver.persist import persist_silver_dataset
 from ..stages.silver.pii import scan_pii
 from .context import BuildContext
@@ -219,6 +220,12 @@ def _run_source_pipeline(
                             actual_ratio,
                             max_ratio,
                         )
+
+        # 드리프트 감지 (#445, DRIFT-1). 직전 성공 run의 silver 와 비교한다.
+        prev_silver = find_previous_silver(context.output_root, context.run_id)
+        if prev_silver is not None:
+            for f in detect_drift(silver.schema, silver.statistics, *prev_silver):
+                logger.warning("드리프트 감지: %s @ %s — %s (#445)", f.kind, f.column, f.detail)
 
         silver_paths = persist_silver_dataset(
             silver, output_root=context.output_root, run_id=context.run_id

--- a/src/kpubdata_builder/stages/silver/drift.py
+++ b/src/kpubdata_builder/stages/silver/drift.py
@@ -1,0 +1,132 @@
+"""스키마·통계 드리프트 감지 (#445, DRIFT-1).
+
+스케줄 워크플로가 주기적으로 재빌드할 때 소스 API가 조용히 형식을 바꿔도
+감지된다. append-only 데이터셋에서는 오염이 누적되므로 직전 성공 run과
+비교한다.
+
+주요 구성:
+    - DriftFinding: 단일 드리프트 관찰 (컬럼 추가/삭제/dtype 변경/행 수 급변)
+    - detect_drift: 순수 함수 — 현재/이전 SchemaInfo+TableStatistics → findings
+    - find_previous_silver: output_root 에서 직전 run의 silver 데이터를 찾는다
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from ...tabular import SchemaInfo, TableStatistics
+from ...tabular.types import ColumnInfo
+
+# 행 수 급변 임계 (직전 대비 50% 이상 변화).
+_ROW_COUNT_CHANGE_THRESHOLD = 0.5
+
+
+@dataclass(frozen=True)
+class DriftFinding:
+    """단일 드리프트 관찰.
+
+    속성:
+        kind: column_added | column_removed | dtype_changed | row_count_jump.
+        column: 관련 컬럼명. 테이블 전체 문제면 None.
+        detail: 사람이 읽는 설명.
+    """
+
+    kind: str
+    column: str | None
+    detail: str
+
+
+def detect_drift(
+    current_schema: SchemaInfo,
+    current_stats: TableStatistics,
+    previous_schema: SchemaInfo,
+    previous_stats: TableStatistics,
+) -> list[DriftFinding]:
+    """현재/이전 스키마·통계를 비교해 드리프트를 감지한다 (#445).
+
+    순수 함수 — 파일 I/O 없이 데이터만 받아 비교한다.
+    """
+    findings: list[DriftFinding] = []
+    current_cols = {c.name: c for c in current_schema.columns}
+    previous_cols = {c.name: c for c in previous_schema.columns}
+
+    # 컬럼 추가.
+    for name in sorted(current_cols.keys() - previous_cols.keys()):
+        findings.append(DriftFinding(kind="column_added", column=name, detail="new column"))
+    # 컬럼 삭제.
+    for name in sorted(previous_cols.keys() - current_cols.keys()):
+        findings.append(DriftFinding(kind="column_removed", column=name, detail="column gone"))
+    # dtype 변경.
+    for name in sorted(current_cols.keys() & previous_cols.keys()):
+        if current_cols[name].dtype != previous_cols[name].dtype:
+            findings.append(
+                DriftFinding(
+                    kind="dtype_changed",
+                    column=name,
+                    detail=f"{previous_cols[name].dtype} → {current_cols[name].dtype}",
+                )
+            )
+
+    # 행 수 급변.
+    if previous_stats.row_count > 0:
+        change = abs(current_stats.row_count - previous_stats.row_count) / previous_stats.row_count
+        if change > _ROW_COUNT_CHANGE_THRESHOLD:
+            findings.append(
+                DriftFinding(
+                    kind="row_count_jump",
+                    column=None,
+                    detail=f"{previous_stats.row_count} → {current_stats.row_count} ({change:.0%})",
+                )
+            )
+
+    return findings
+
+
+def find_previous_silver(
+    output_root: Path, current_run_id: str
+) -> tuple[SchemaInfo, TableStatistics] | None:
+    """output_root 에서 직전 run의 silver schema/stats를 찾아 읽는다 (#445).
+
+    현재 run 디렉터리를 제외한 가장 최근 run의 silver/schema.json +
+    silver/stats.json을 읽는다. 파일이 없으면 None.
+    """
+    candidates = sorted(
+        (
+            d
+            for d in output_root.iterdir()
+            if d.is_dir() and d.name != current_run_id and (d / "silver" / "schema.json").exists()
+        ),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    if not candidates:
+        return None
+
+    prev_dir = candidates[0]
+    try:
+        schema_data = json.loads((prev_dir / "silver" / "schema.json").read_text(encoding="utf-8"))
+        stats_data = json.loads((prev_dir / "silver" / "stats.json").read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+    columns = tuple(
+        ColumnInfo(
+            name=c.get("name", ""),
+            dtype=c.get("dtype", ""),
+            nullable=c.get("nullable", True),
+            unique_count=c.get("unique_count", 0),
+        )
+        for c in schema_data.get("columns", [])
+    )
+    schema = SchemaInfo(columns=columns)
+    stats = TableStatistics(
+        row_count=stats_data.get("row_count", 0),
+        null_counts=stats_data.get("null_counts", {}),
+        duplicate_rate=stats_data.get("duplicate_rate", 0.0),
+    )
+    return schema, stats
+
+
+__all__ = ["DriftFinding", "detect_drift", "find_previous_silver"]

--- a/tests/unit/test_drift.py
+++ b/tests/unit/test_drift.py
@@ -1,0 +1,62 @@
+"""드리프트 감지 단위 테스트 (#445, DRIFT-1)."""
+
+from __future__ import annotations
+
+from kpubdata_builder.stages.silver.drift import detect_drift
+from kpubdata_builder.tabular import SchemaInfo, TableStatistics
+from kpubdata_builder.tabular.types import ColumnInfo
+
+_SCHEMA_A = SchemaInfo(
+    columns=(
+        ColumnInfo(name="a", dtype="Int64", nullable=False, unique_count=3),
+        ColumnInfo(name="b", dtype="Utf8", nullable=True, unique_count=2),
+    )
+)
+_STATS_A = TableStatistics(row_count=100, null_counts={"a": 0, "b": 5}, duplicate_rate=0.1)
+
+
+class TestDetectDriftSchema:
+    def test_column_added(self) -> None:
+        schema_b = SchemaInfo(
+            columns=_SCHEMA_A.columns
+            + (ColumnInfo(name="c", dtype="Float64", nullable=True, unique_count=1),)
+        )
+        findings = detect_drift(schema_b, _STATS_A, _SCHEMA_A, _STATS_A)
+        assert any(f.kind == "column_added" and f.column == "c" for f in findings)
+
+    def test_column_removed(self) -> None:
+        schema_b = SchemaInfo(columns=(_SCHEMA_A.columns[0],))
+        findings = detect_drift(schema_b, _STATS_A, _SCHEMA_A, _STATS_A)
+        assert any(f.kind == "column_removed" and f.column == "b" for f in findings)
+
+    def test_dtype_changed(self) -> None:
+        schema_b = SchemaInfo(
+            columns=(
+                ColumnInfo(name="a", dtype="Float64", nullable=False, unique_count=3),
+                ColumnInfo(name="b", dtype="Utf8", nullable=True, unique_count=2),
+            )
+        )
+        findings = detect_drift(schema_b, _STATS_A, _SCHEMA_A, _STATS_A)
+        assert any(f.kind == "dtype_changed" and f.column == "a" for f in findings)
+
+    def test_no_schema_drift(self) -> None:
+        findings = detect_drift(_SCHEMA_A, _STATS_A, _SCHEMA_A, _STATS_A)
+        assert findings == []
+
+
+class TestDetectDriftStats:
+    def test_row_count_jump(self) -> None:
+        stats_b = TableStatistics(row_count=500, null_counts={"a": 0, "b": 5}, duplicate_rate=0.1)
+        findings = detect_drift(_SCHEMA_A, stats_b, _SCHEMA_A, _STATS_A)
+        assert any(f.kind == "row_count_jump" for f in findings)
+
+    def test_small_row_count_change_no_drift(self) -> None:
+        stats_b = TableStatistics(row_count=110, null_counts={"a": 0, "b": 5}, duplicate_rate=0.1)
+        findings = detect_drift(_SCHEMA_A, stats_b, _SCHEMA_A, _STATS_A)
+        assert findings == []
+
+    def test_previous_zero_rows_no_jump(self) -> None:
+        stats_prev = TableStatistics(row_count=0, null_counts={}, duplicate_rate=0.0)
+        stats_curr = TableStatistics(row_count=100, null_counts={"a": 0}, duplicate_rate=0.0)
+        findings = detect_drift(_SCHEMA_A, stats_curr, _SCHEMA_A, stats_prev)
+        assert not any(f.kind == "row_count_jump" for f in findings)


### PR DESCRIPTION
Closes #445

## 변경 요약

직전 성공 run의 silver schema/statistics와 현재 run을 비교해 드리프트를 감지한다.

### 세부 변경
- **`stages/silver/drift.py`** (신규) — 순수 함수:
  - `detect_drift(curr_schema, curr_stats, prev_schema, prev_stats) → list[DriftFinding]` — 컬럼 추가/삭제/dtype 변경, 행 수 급변(50%+) 감지
  - `find_previous_silver(output_root, current_run_id) → (SchemaInfo, TableStatistics) | None` — output_root에서 직전 run의 silver/schema.json + silver/stats.json을 읽어 재구성
- **`pipeline/orchestrator.py`** — silver PII 게이트 후, persist 전에 드리프트 감지:
  - `find_previous_silver`로 이전 run 데이터 조회
  - `detect_drift`로 비교
  - 각 `DriftFinding`을 `logger.warning`으로 보고

## 테스트
`tests/unit/test_drift.py` (신규 7케이스):
- 컬럼 추가/삭제/dtype 변경 감지
- 행 수 급변(100→500) 감지, 소폭 변화(100→110) 무시, 이전 0행 시 점프 미감지
- 드리프트 없을 때 빈 결과

## 검증
- ruff/mypy: pass
- pytest: 전체 회귀 통과