### PR TITLE
feat(silver): PII false positive advisory prompt (#447)

### DIFF
--- a/src/kpubdata_builder/stages/silver/pii_advisor.py
+++ b/src/kpubdata_builder/stages/silver/pii_advisor.py
@@ -1,0 +1,66 @@
+"""PII 오탐 문맥 판정 보조 (AI-2, #447).
+
+QG-1(scan_pii)이 검출한 PII 후보 컬럼에 대해 LLM이 오탐 여부 의견을 제시한다.
+LLM은 게이트가 아니다 — 정규식이 차단 권한을 갖고, LLM은 "오탐으로 보인다"는
+의견만 낸다. 최종 해제는 사람이 allow_columns 에 명시한다.
+
+**절대 금지**: LLM이 "괜찮다"고 해서 통과시키는 것. 놓치면 개인정보가 공개된다.
+
+원본 데이터 값은 프롬프트에 포함하지 않는다 — 컬럼명과 종류(kind)만.
+데이터 샘플이 외부로 나가는 것이 아니므로 스크러빙이 불필요하다 (#447).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .pii import PiiFinding
+
+
+@dataclass(frozen=True)
+class PiiAdvisoryResult:
+    """LLM 오탐 판정 결과.
+
+    속성:
+        likely_false_positives: 오탐으로 의심되는 컬럼명 목록 (LLM 의견).
+        raw_response: LLM 원본 응답 (UI 힌트용).
+    """
+
+    likely_false_positives: tuple[str, ...]
+    raw_response: str
+
+
+def build_pii_advisory_prompt(findings: list[PiiFinding]) -> str:
+    """PII 검출 후보를 LLM에 전달해 오탐 여부를 묻는 프롬프트를 구성한다 (#447).
+
+    원본 값은 포함하지 않는다 — 컬럼명과 종류(kind)만. 정규식은 과탐지한다
+    (담당부서명이 인명으로 잡히는 식) — LLM이 문맥으로 오탐을 줄여준다.
+    """
+    if not findings:
+        return ""
+
+    findings_text = "\n".join(
+        f"  - 컬럼 {f.column!r}: 종류={f.kind}, 매칭 수={f.count}"
+        for f in findings
+        if f.column is not None
+    )
+
+    return f"""한국 공공데이터에서 정규식으로 검출된 PII 후보 컬럼 목록이다.
+정규식은 과탐지할 수 있다 — 담당부서명이 인명으로 잡히거나, 코드값이
+주민번호 패턴과 우연히 일치하는 식이다.
+
+각 컬럼이 실제 PII인지 오탐인지 판정해라. 컬럼명의 의미(한국어 축약어 등)를
+근거로 판단한다.
+
+PII 후보:
+{findings_text}
+
+출력 형식: JSON 객체
+{{
+  "likely_false_positives": ["컬럼명1", "컬럼명2"]
+}}
+
+주의: 이 판정은 참고용이다. 최종 결정은 사용자가 한다."""
+
+
+__all__ = ["PiiAdvisoryResult", "build_pii_advisory_prompt"]

--- a/tests/unit/test_pii_advisor.py
+++ b/tests/unit/test_pii_advisor.py
@@ -1,0 +1,36 @@
+"""PII 오탐 보조 테스트 (AI-2, #447)."""
+
+from __future__ import annotations
+
+from kpubdata_builder.stages.silver.pii import PiiFinding
+from kpubdata_builder.stages.silver.pii_advisor import build_pii_advisory_prompt
+
+
+class TestBuildPiiAdvisoryPrompt:
+    def test_empty_findings_returns_empty(self) -> None:
+        assert build_pii_advisory_prompt([]) == ""
+
+    def test_findings_contain_column_names(self) -> None:
+        findings = [
+            PiiFinding(column="OPNR_NM", kind="name", count=1),
+            PiiFinding(column="TELNO", kind="phone", count=3),
+        ]
+        prompt = build_pii_advisory_prompt(findings)
+        assert "OPNR_NM" in prompt
+        assert "TELNO" in prompt
+
+    def test_findings_contain_kinds(self) -> None:
+        findings = [PiiFinding(column="x", kind="rrn", count=2)]
+        prompt = build_pii_advisory_prompt(findings)
+        assert "rrn" in prompt
+
+    def test_prompt_includes_false_positive_instruction(self) -> None:
+        findings = [PiiFinding(column="DEPT_NM", kind="name", count=1)]
+        prompt = build_pii_advisory_prompt(findings)
+        assert "likely_false_positives" in prompt
+
+    def test_none_column_filtered(self) -> None:
+        findings = [PiiFinding(column=None, kind="rrn", count=5)]
+        prompt = build_pii_advisory_prompt(findings)
+        # column이 None인 항목은 프롬프트에서 제외
+        assert prompt.strip() != ""


### PR DESCRIPTION
Closes #447

## 변경 요약
QG-1(scan_pii)이 검출한 PII 후보에 대해 LLM 오탐 판정 프롬프트를 구성한다. LLM은 게이트가 아니다 — 정규식이 차단 권한, LLM은 의견만.

### 세부 변경
- **`pii_advisor.py`** — `build_pii_advisory_prompt(findings) → str`: 컬럼명/종류만 포함(원본 값 미포함), JSON `likely_false_positives` 형식 요청
- **`PiiAdvisoryResult`** dataclass — LLM 응답 파싱 결과

### 보안 (#447)
- 원본 데이터 값 미포함 — 컬럼명과 종류만. 스크러빙 불필요.
- LLM 판정은 UI 힌트만. 정책 변경(allow_columns)은 사용자가 직접.
- **절대 금지**: LLM이 괜찮다고 해서 통과시키는 것.

## 검증
- pytest: 통과 (5 케이스)
- ruff/mypy: pass