### PR TITLE
feat(silver): drift cause interpretation advisory prompt (#448)

### DIFF
--- a/src/kpubdata_builder/stages/silver/drift_advisor.py
+++ b/src/kpubdata_builder/stages/silver/drift_advisor.py
@@ -1,0 +1,47 @@
+"""드리프트 원인 해석 (AI-3, #448).
+
+DRIFT-1(detect_drift)이 감지한 드리프트의 원인 가설을 LLM에 요청하는 프롬프트를
+구성한다. 감지는 결정적으로 하고 해석만 LLM이 붙인다.
+
+제안은 알림 메시지에 참고로만 표시된다 — 게이트 판정에 영향을 주지 않는다.
+"""
+
+from __future__ import annotations
+
+from .drift import DriftFinding
+
+
+def build_drift_advisory_prompt(findings: list[DriftFinding]) -> str:
+    """드리프트 감지 결과를 LLM에 전달해 원인 가설을 요청하는 프롬프트 (#448).
+
+    "컬럼명이 바뀐 상류 스키마 변경" vs "새 지역 코드가 추가된 정상 변화"를
+    구분해주면 알림 피로가 줄어든다.
+    """
+    if not findings:
+        return ""
+
+    findings_text = "\n".join(
+        f"  - 종류={f.kind}, 컬럼={f.column or '테이블 전체'}, 상세={f.detail}" for f in findings
+    )
+
+    return f"""한국 공공데이터 파이프라인에서 드리프트가 감지되었다.
+각 드리프트의 원인을 분류하고 설명해라.
+
+드리프트 목록:
+{findings_text}
+
+각 드리프트에 대해 원인을 다음 중 하나로 분류해라:
+- upstream_schema_change: 상류 API가 스키마를 변경
+- data_growth: 정상적인 데이터 증가/감소 (append-only 등)
+- api_error: 일시적 API 오류 또는 부분 응답
+- unknown: 원인 불명
+
+출력 형식: JSON 배열
+[
+  {{"kind": "column_added", "column": "...", "cause": "upstream_schema_change", "explanation": "..."}}
+]
+
+주의: 이 해석은 참고용이다. 게이트 판정에 영향을 주지 않는다."""
+
+
+__all__ = ["build_drift_advisory_prompt"]

--- a/src/kpubdata_builder/stages/silver/drift_advisor.py
+++ b/src/kpubdata_builder/stages/silver/drift_advisor.py
@@ -38,7 +38,12 @@ def build_drift_advisory_prompt(findings: list[DriftFinding]) -> str:
 
 출력 형식: JSON 배열
 [
-  {{"kind": "column_added", "column": "...", "cause": "upstream_schema_change", "explanation": "..."}}
+  {{
+    "kind": "column_added",
+    "column": "...",
+    "cause": "upstream_schema_change",
+    "explanation": "..."
+  }}
 ]
 
 주의: 이 해석은 참고용이다. 게이트 판정에 영향을 주지 않는다."""

--- a/tests/unit/test_drift_advisor.py
+++ b/tests/unit/test_drift_advisor.py
@@ -1,0 +1,32 @@
+"""드리프트 해석 테스트 (AI-3, #448)."""
+
+from __future__ import annotations
+
+from kpubdata_builder.stages.silver.drift import DriftFinding
+from kpubdata_builder.stages.silver.drift_advisor import build_drift_advisory_prompt
+
+
+class TestBuildDriftAdvisoryPrompt:
+    def test_empty_findings_returns_empty(self) -> None:
+        assert build_drift_advisory_prompt([]) == ""
+
+    def test_findings_included_in_prompt(self) -> None:
+        findings = [
+            DriftFinding(kind="column_added", column="new_col", detail="new column"),
+            DriftFinding(kind="dtype_changed", column="amount", detail="Int64 → Float64"),
+        ]
+        prompt = build_drift_advisory_prompt(findings)
+        assert "column_added" in prompt
+        assert "new_col" in prompt
+        assert "dtype_changed" in prompt
+
+    def test_prompt_contains_cause_categories(self) -> None:
+        findings = [DriftFinding(kind="row_count_jump", column=None, detail="100 → 500")]
+        prompt = build_drift_advisory_prompt(findings)
+        assert "upstream_schema_change" in prompt
+        assert "data_growth" in prompt
+
+    def test_prompt_contains_advisory_disclaimer(self) -> None:
+        findings = [DriftFinding(kind="column_removed", column="old_col", detail="gone")]
+        prompt = build_drift_advisory_prompt(findings)
+        assert "참고용" in prompt


### PR DESCRIPTION
Closes #448

## 변경 요약
DRIFT-1(detect_drift)이 감지한 드리프트의 원인 가설을 LLM에 요청하는 프롬프트를 구성한다. 감지는 결정적, 해석만 LLM.

### 세부 변경
- **`drift_advisor.py`** — `build_drift_advisory_prompt(findings) → str`: 드리프트 종류/컬럼/상세를 프롬프트에 포함, 원인 분류(upstream_schema_change/data_growth/api_error/unknown) 요청
- 제안은 알림 메시지에 참고로만 표시 — 게이트 판정에 영향 없음

## 검증
- pytest: 4 케이스 통과
- ruff/mypy: pass