### PR TITLE
fix: close request-scoped Builder clients

### DIFF
--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -20,7 +20,7 @@ import os
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import cast
+from typing import Protocol, cast, runtime_checkable
 from urllib.parse import parse_qs
 
 import yaml
@@ -40,6 +40,16 @@ from .auth import AuthError, Principal, authenticate
 logger = logging.getLogger(__name__)
 
 _OWNERSHIP_ENV = "ENFORCE_OWNERSHIP"
+
+
+@runtime_checkable
+class _CloseableClient(Protocol):
+    def close(self) -> None: ...
+
+
+def _close_request_client(client: SourceClient) -> None:
+    if isinstance(client, _CloseableClient):
+        client.close()
 
 
 def _enforce_ownership() -> bool:
@@ -169,14 +179,13 @@ class BuilderService:
         접근 + 8개 provider 하드코딩 튜플을 써서 kpubdata에 provider가 추가돼도
         카탈로그에 안 떴다 (#436). 시크릿 값은 노출하지 않고 필요 여부만 표시한다.
         """
+        client = self._client_factory()
         try:
-            # client_factory는 SourceClient(Protocol)을 반환타입으로 선언하지만
-            # catalog는 kpubdata.Client의 공개 datasets API를 쓴다. 런타임엔 항상
-            # kpubdata.Client이므로 cast로 타입을 확정한다 (#436).
-            client = cast(Client, self._client_factory())
-            all_datasets = client.datasets.list()
+            all_datasets = cast(Client, client).datasets.list()
         except Exception as exc:
             return ServiceResponse(502, {"error": f"catalog unavailable: {exc}"})
+        finally:
+            _close_request_client(client)
 
         # provider별 그룹화 (등록 순서 보존 위해 dict 사용).
         grouped: dict[str, list[DatasetRef]] = {}
@@ -233,7 +242,11 @@ class BuilderService:
         if isinstance(spec_or_error, ServiceResponse):
             return spec_or_error
 
-        result = preview_build(spec_or_error, client=self._client_factory(), limit=limit)
+        client = self._client_factory()
+        try:
+            result = preview_build(spec_or_error, client=client, limit=limit)
+        finally:
+            _close_request_client(client)
         previews: list[JsonValue] = [
             {
                 "source_key": p.source_key,
@@ -275,13 +288,17 @@ class BuilderService:
         if isinstance(spec_or_error, ServiceResponse):
             return spec_or_error
 
-        result = run_build(
-            spec_or_error,
-            client=self._client_factory(),
-            output_root=self._output_root,
-            run_id=run_id,
-            created_by=created_by,
-        )
+        client = self._client_factory()
+        try:
+            result = run_build(
+                spec_or_error,
+                client=client,
+                output_root=self._output_root,
+                run_id=run_id,
+                created_by=created_by,
+            )
+        finally:
+            _close_request_client(client)
         outcomes: list[JsonValue] = [
             {
                 "source_key": outcome.source_key,

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -95,6 +95,19 @@ class _FakeClient:
         return _FakeDataset(self._data[source_key])
 
 
+class _CloseTrackingClient(_FakeClient):
+    def __init__(
+        self,
+        data: dict[str, list[dict[str, JsonValue]]],
+        catalog_items: list[object] | None = None,
+    ) -> None:
+        super().__init__(data, catalog_items=catalog_items)
+        self.close_calls = 0
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
 def _service(tmp_path: Path) -> BuilderService:
     client = _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}, {"id": "2", "v": 20}]})
     return BuilderService(output_root=tmp_path, client_factory=lambda: client)
@@ -149,6 +162,15 @@ class TestPreview:
         files = [p.name for p in tmp_path.iterdir() if not p.name.startswith("_builds")]
         assert files == []
 
+    def test_preview_closes_request_client(self, tmp_path: Path) -> None:
+        client = _CloseTrackingClient({"datago.air_quality": [{"id": "1", "v": 10}]})
+        service = BuilderService(output_root=tmp_path, client_factory=lambda: client)
+
+        resp = service.preview(VALID_SPEC_YAML)
+
+        assert resp.status_code == 200
+        assert client.close_calls == 1
+
 
 class TestPreviewLimitGuard:
     def test_preview_direct_call_rejects_zero_limit(self, tmp_path: Path) -> None:
@@ -169,6 +191,15 @@ class TestBuild:
         assert resp.body["status"] == "ok"
         assert resp.body["run_id"] == "run1"
         assert (tmp_path / "run1" / "manifest.json").exists()
+
+    def test_build_closes_request_client_when_source_fails(self, tmp_path: Path) -> None:
+        client = _CloseTrackingClient({})
+        service = BuilderService(output_root=tmp_path, client_factory=lambda: client)
+
+        resp = service.build(VALID_SPEC_YAML, run_id="run1")
+
+        assert resp.status_code == 502
+        assert client.close_calls == 1
 
 
 class TestArtifacts:
@@ -1197,6 +1228,39 @@ class TestCatalog:
         resp = self._service_with_catalog(tmp_path, []).catalog()
         assert resp.status_code == 200
         assert resp.body["providers"] == []
+
+    def test_catalog_closes_request_client(self, tmp_path: Path) -> None:
+        client = _CloseTrackingClient(
+            {}, catalog_items=[_FakeCatalogRef("datago", "air_quality", "대기오염")]
+        )
+        service = BuilderService(output_root=tmp_path, client_factory=lambda: client)
+
+        resp = service.catalog()
+
+        assert resp.status_code == 200
+        assert client.close_calls == 1
+
+    def test_catalog_closes_request_client_when_catalog_fails(self, tmp_path: Path) -> None:
+        class _BrokenCatalogClient:
+            close_calls = 0
+
+            @property
+            def datasets(self) -> object:
+                raise RuntimeError("catalog failed")
+
+            def dataset(self, source_key: str) -> _FakeDataset:
+                raise KeyError(source_key)
+
+            def close(self) -> None:
+                self.close_calls += 1
+
+        client = _BrokenCatalogClient()
+        service = BuilderService(output_root=tmp_path, client_factory=lambda: client)
+
+        resp = service.catalog()
+
+        assert resp.status_code == 502
+        assert client.close_calls == 1
 
     def test_catalog_returns_502_when_client_raises(self, tmp_path: Path) -> None:
         class _BrokenClient:


### PR DESCRIPTION
## 요약
- catalog/preview/build에서 `client_factory()`로 만든 요청 scope client를 지역 변수로 잡고 `finally`에서 닫도록 했습니다.
- `close()`를 제공하지 않는 테스트 fake/호환 client는 그대로 동작하도록 runtime-checkable protocol로 닫기 가능 여부만 확인합니다.
- catalog success/failure, preview success, build source failure에서 close 호출 regression test를 추가했습니다.

Closes #459

## 검증
- uv run --extra dev python -m pytest
- uv run ruff check .
- uv run --extra dev python -m mypy src

참고: LSP daemon diagnostics는 반복 timeout으로 완료하지 못했습니다. mypy src 검증으로 대체했습니다.