### PR TITLE
fix: report catalog auth from provider contract

### DIFF
--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -52,6 +52,17 @@ def _close_request_client(client: SourceClient) -> None:
         client.close()
 
 
+def _authenticated_provider_names(client: SourceClient) -> frozenset[str]:
+    authenticated_providers = cast(Client, client).iter_authenticated_providers()
+    return frozenset(provider.name for provider in authenticated_providers)
+
+
+def _requires_service_key(dataset: DatasetRef, auth_provider_names: frozenset[str]) -> bool:
+    return dataset.provider in auth_provider_names or bool(
+        dataset.raw_metadata.get("service_key_param")
+    )
+
+
 def _enforce_ownership() -> bool:
     """run 소유권 강제가 활성화되어 있는지 (#389). 기본 off — 하위 호환."""
     return os.environ.get(_OWNERSHIP_ENV, "").lower() in ("true", "1")
@@ -182,6 +193,7 @@ class BuilderService:
         client = self._client_factory()
         try:
             all_datasets = cast(Client, client).datasets.list()
+            auth_provider_names = _authenticated_provider_names(client)
         except Exception as exc:
             return ServiceResponse(502, {"error": f"catalog unavailable: {exc}"})
         finally:
@@ -199,8 +211,8 @@ class BuilderService:
                     {
                         "name": item.dataset_key,
                         "title": item.name,
-                        "requires_service_key": bool(
-                            getattr(item, "raw_metadata", {}).get("service_key_param")
+                        "requires_service_key": _requires_service_key(
+                            item, auth_provider_names
                         ),
                     }
                     for item in items

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -211,9 +211,7 @@ class BuilderService:
                     {
                         "name": item.dataset_key,
                         "title": item.name,
-                        "requires_service_key": _requires_service_key(
-                            item, auth_provider_names
-                        ),
+                        "requires_service_key": _requires_service_key(item, auth_provider_names),
                     }
                     for item in items
                 ],

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -1215,9 +1215,7 @@ class TestCatalog:
             _FakeCatalogRef("bok", "base_rate", "기준금리"),
             _FakeCatalogRef("krx", "stock", "주식"),
         ]
-        resp = self._service_with_catalog(
-            tmp_path, refs, auth_provider_names=("bok",)
-        ).catalog()
+        resp = self._service_with_catalog(tmp_path, refs, auth_provider_names=("bok",)).catalog()
 
         assert resp.status_code == 200
         providers = cast(list[dict[str, object]], resp.body["providers"])

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -85,14 +85,24 @@ class _FakeClient:
         self,
         data: dict[str, list[dict[str, JsonValue]]],
         catalog_items: list[object] | None = None,
+        auth_provider_names: tuple[str, ...] = (),
     ) -> None:
         self._data = data
         self.datasets = _FakeCatalog(catalog_items)
+        self._auth_provider_names = auth_provider_names
 
     def dataset(self, source_key: str) -> _FakeDataset:
         if source_key not in self._data:
             raise KeyError(f"unknown source: {source_key}")
         return _FakeDataset(self._data[source_key])
+
+    def iter_authenticated_providers(self) -> tuple[object, ...]:
+        return tuple(_FakeProvider(name) for name in self._auth_provider_names)
+
+
+class _FakeProvider:
+    def __init__(self, name: str) -> None:
+        self.name = name
 
 
 class _CloseTrackingClient(_FakeClient):
@@ -1188,8 +1198,14 @@ class _FakeCatalogRef:
 class TestCatalog:
     """catalog 동적 provider 조회 (#436). ADR 0011 — 하드코딩 금지."""
 
-    def _service_with_catalog(self, tmp_path: Path, refs: list[object]) -> BuilderService:
-        client = _FakeClient({}, catalog_items=refs)
+    def _service_with_catalog(
+        self,
+        tmp_path: Path,
+        refs: list[object],
+        *,
+        auth_provider_names: tuple[str, ...] = (),
+    ) -> BuilderService:
+        client = _FakeClient({}, catalog_items=refs, auth_provider_names=auth_provider_names)
         return BuilderService(output_root=tmp_path, client_factory=lambda: client)
 
     def test_catalog_groups_datasets_by_provider(self, tmp_path: Path) -> None:
@@ -1197,8 +1213,11 @@ class TestCatalog:
             _FakeCatalogRef("datago", "air_quality", "대기오염", service_key=True),
             _FakeCatalogRef("datago", "village_fcst", "단기예보"),
             _FakeCatalogRef("bok", "base_rate", "기준금리"),
+            _FakeCatalogRef("krx", "stock", "주식"),
         ]
-        resp = self._service_with_catalog(tmp_path, refs).catalog()
+        resp = self._service_with_catalog(
+            tmp_path, refs, auth_provider_names=("bok",)
+        ).catalog()
 
         assert resp.status_code == 200
         providers = cast(list[dict[str, object]], resp.body["providers"])
@@ -1213,6 +1232,13 @@ class TestCatalog:
         assert aq["requires_service_key"] is True
         vf = next(d for d in datago_datasets if d["name"] == "village_fcst")
         assert vf["requires_service_key"] is False
+
+        bok = next(p for p in providers if p["name"] == "bok")
+        bok_datasets = cast(list[dict[str, object]], bok["datasets"])
+        assert bok_datasets[0]["requires_service_key"] is True
+        krx = next(p for p in providers if p["name"] == "krx")
+        krx_datasets = cast(list[dict[str, object]], krx["datasets"])
+        assert krx_datasets[0]["requires_service_key"] is False
 
     def test_catalog_includes_unlisted_providers(self, tmp_path: Path) -> None:
         """하드코딩 8개에 없는 provider도 동적 조회로 떠야 한다 (#436)."""


### PR DESCRIPTION
## 요약
- `/catalog`의 `requires_service_key`를 dataset-local `service_key_param`만이 아니라 kpubdata provider contract의 authenticated provider set에서도 계산하게 했습니다.
- BOK 같은 provider-level auth dataset은 true, KRX 같은 authless provider는 false로 고정하는 regression을 추가했습니다.
- 현재 public `datasets.list()` 기반 runtime discovery는 유지합니다.

Closes #460

## 검증
- uv run --extra dev python -m pytest
- uv run ruff check .
- uv run --extra dev python -m mypy src

참고: LSP daemon diagnostics는 반복 timeout으로 완료하지 못했습니다. mypy src 검증으로 대체했습니다.
