### PR TITLE
fix: collect paginated Bronze records

### DIFF
--- a/src/kpubdata_builder/stages/bronze/build.py
+++ b/src/kpubdata_builder/stages/bronze/build.py
@@ -43,8 +43,7 @@ class SourceDataset(Protocol):
 class PaginatedSourceDataset(SourceDataset, Protocol):
     """kpubdata Dataset.list_all() pagination 계약."""
 
-    def list_all(self, **params: JsonValue) -> Iterable[DatasetResult]:
-        ...
+    def list_all(self, **params: JsonValue) -> Iterable[DatasetResult]: ...
 
 
 class SourceClient(Protocol):

--- a/src/kpubdata_builder/stages/bronze/build.py
+++ b/src/kpubdata_builder/stages/bronze/build.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from datetime import datetime
-from typing import Protocol
+from typing import Protocol, runtime_checkable
 
 from ...spec import JsonValue
 from .models import BronzeArtifact, ProvenanceEvent, require_timezone_aware, utc_now
@@ -36,6 +36,14 @@ class SourceDataset(Protocol):
 
     def list(self, **params: JsonValue) -> DatasetResult:
         """하나의 파라미터 집합에 대해 레코드를 가져온다."""
+        ...
+
+
+@runtime_checkable
+class PaginatedSourceDataset(SourceDataset, Protocol):
+    """kpubdata Dataset.list_all() pagination 계약."""
+
+    def list_all(self, **params: JsonValue) -> Iterable[DatasetResult]:
         ...
 
 
@@ -73,8 +81,13 @@ def build_bronze_artifact(
     require_timezone_aware(resolved_fetched_at, field_name="fetched_at")
 
     dataset = client.dataset(source_key)
-    result = dataset.list(**resolved_params)
-    raw_records = tuple(result.items)
+    if isinstance(dataset, PaginatedSourceDataset):
+        raw_records = tuple(
+            record for batch in dataset.list_all(**resolved_params) for record in batch.items
+        )
+    else:
+        result = dataset.list(**resolved_params)
+        raw_records = tuple(result.items)
     provenance = ProvenanceEvent(
         source_key=source_key,
         fetch_params=resolved_params,

--- a/tests/unit/test_bronze.py
+++ b/tests/unit/test_bronze.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Generator
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -38,10 +39,26 @@ class FakeDataset:
         return FakeResult(items=self.records)
 
 
+class FakePaginatedDataset:
+    def __init__(self, pages: tuple[list[dict[str, JsonValue]], ...]) -> None:
+        self.pages = pages
+        self.list_calls = 0
+        self.list_all_params: dict[str, JsonValue] | None = None
+
+    def list(self, **params: JsonValue) -> DatasetResult:
+        self.list_calls += 1
+        return FakeResult(items=self.pages[0])
+
+    def list_all(self, **params: JsonValue) -> Generator[DatasetResult, None, None]:
+        self.list_all_params = dict(params)
+        for page in self.pages:
+            yield FakeResult(items=page)
+
+
 class FakeClient:
     """dataset 호출 여부를 기록하는 테스트용 클라이언트."""
 
-    def __init__(self, dataset: FakeDataset) -> None:
+    def __init__(self, dataset: SourceDataset) -> None:
         self.dataset_instance = dataset
         self.seen_source_key = ""
 
@@ -112,6 +129,24 @@ def test_build_bronze_artifact_fetches_raw_records_without_transforming() -> Non
         fetch_params={"lawd_cd": "11680", "deal_ymd": "202501"},
         fetched_at=fetched_at,
     )
+
+
+def test_build_bronze_artifact_uses_list_all_when_available() -> None:
+    fetched_at = datetime(2026, 5, 8, 12, 0, tzinfo=timezone.utc)
+    dataset = FakePaginatedDataset(([{"id": "1"}], [{"id": "2"}]))
+    client = FakeClient(dataset)
+
+    artifact = build_bronze_artifact(
+        client,
+        source_key="datago.apt_trade",
+        fetch_params={"page_size": 1},
+        fetched_at=fetched_at,
+    )
+
+    assert dataset.list_calls == 0
+    assert dataset.list_all_params == {"page_size": 1}
+    assert artifact.raw_records == ({"id": "1"}, {"id": "2"})
+    assert artifact.record_count == 2
 
 
 def test_persist_bronze_artifact_writes_jsonl_and_metadata(tmp_path: Path) -> None:

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -32,6 +32,15 @@ class _FakeDataset:
         return _FakeResult(self._items)
 
 
+class _FakePaginatedDataset(_FakeDataset):
+    def __init__(self, pages: tuple[list[dict[str, JsonValue]], ...]) -> None:
+        super().__init__(pages[0])
+        self._pages = pages
+
+    def list_all(self, **_params: JsonValue) -> Iterable[_FakeResult]:
+        return (_FakeResult(page) for page in self._pages)
+
+
 class _FakeClient:
     """source_key → 레코드 매핑을 돌려주는 테스트용 클라이언트."""
 
@@ -42,6 +51,16 @@ class _FakeClient:
         if source_key not in self._data:
             raise KeyError(f"unknown source: {source_key}")
         return _FakeDataset(self._data[source_key])
+
+
+class _FakePaginatedClient:
+    def __init__(self, data: dict[str, tuple[list[dict[str, JsonValue]], ...]]) -> None:
+        self._data = data
+
+    def dataset(self, source_key: str) -> _FakePaginatedDataset:
+        if source_key not in self._data:
+            raise KeyError(f"unknown source: {source_key}")
+        return _FakePaginatedDataset(self._data[source_key])
 
 
 def _spec(*sources: SourceRef) -> BuildSpec:
@@ -356,6 +375,24 @@ def test_run_build_writes_provenance_to_manifest(tmp_path: Path) -> None:
     assert entry["record_count"] == 2
     assert cast(str, entry["data_checksum"]).startswith("sha256:")
     assert cast(str, entry["fetched_at"]).endswith("+00:00")
+
+
+def test_run_build_manifest_counts_all_paginated_records(tmp_path: Path) -> None:
+    spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
+    client = _FakePaginatedClient(
+        {"datago.apt_trade": ([{"id": "1", "amount": 1000}], [{"id": "2", "amount": 2500}])}
+    )
+
+    result = run_build(spec, client=client, output_root=tmp_path, run_id="run1")
+
+    assert result.status == "ok"
+    manifest = cast(
+        dict[str, JsonValue], json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    )
+    row_counts = cast(dict[str, int], manifest["row_counts"])
+    assert row_counts["datago.apt_trade"] == 2
+    provenance = cast(list[dict[str, JsonValue]], manifest["provenance"])
+    assert provenance[0]["record_count"] == 2
 
 
 def test_run_build_rejects_unsafe_run_id(tmp_path: Path) -> None:


### PR DESCRIPTION
## 요약
- Bronze fetch가 `Dataset.list_all()`을 제공하는 kpubdata dataset에서는 모든 batch를 수집하도록 했습니다.
- `list_all()`이 없는 기존 fake/client 계약은 기존 `list()` fallback을 유지합니다.
- Bronze unit regression과 run_build manifest row_count/provenance regression을 추가했습니다.

Closes #461

## 검증
- uv run --extra dev python -m pytest
- uv run ruff check .
- uv run --extra dev python -m mypy src

참고: LSP daemon diagnostics는 반복 timeout으로 완료하지 못했습니다. mypy src 검증으로 대체했습니다.
