### PR TITLE
빌드 manifest JSON 조회 엔드포인트 추가 (#462)

### DIFF
--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -51,6 +51,7 @@ Builder는 **동기식 실행 모델**을 사용합니다.
 | `/validate` | `POST` | BuildSpec 검증 | 동기식 |
 | `/preview` | `POST` | 샘플 실행 및 소스별 스키마 preview | 동기식 |
 | `/build` | `POST` | 빌드 실행 (동기식) | 동기식 |
+| `/builds/{run_id}/manifest` | `GET` | 실행 manifest JSON 본문 조회 | 동기식 |
 | `/artifacts/{run_id}` | `GET` | 실행 워크스페이스 산출물 목록 조회 | 동기식 |
 | `/builds` | `GET` | 빌드 이력 목록 조회 (최신 수정 시각 기준 내림차순) | 동기식 |
 | `/healthz` | `GET` | 무인증 liveness probe (`{"status":"ok"}`) | 동기식 |
@@ -201,7 +202,35 @@ BuildSpec을 실행 전에 검증합니다. body의 `spec` 키에 YAML 문자열
 }
 ```
 
-### 5.5 `GET /artifacts/{run_id}`
+### 5.5 `GET /builds/{run_id}/manifest`
+
+실행 워크스페이스에 기록된 `manifest.json` 파일의 JSON 본문을 반환합니다. Studio는 파일 다운로드 엔드포인트를 파싱하지 않고 이 엔드포인트로 manifest를 직접 소비할 수 있습니다.
+
+#### 응답 `200`
+
+```json
+{
+  "schema_version": "1.0.0",
+  "build_id": "my-run-001",
+  "started_at": "2025-04-01T10:30:00+00:00",
+  "finished_at": "2025-04-01T10:32:15+00:00",
+  "inputs": ["datago.village_fcst"],
+  "outputs": ["/path/to/dist/my-run-001/gold/package.json"],
+  "warnings": [],
+  "errors": [],
+  "row_counts": {"datago.village_fcst": 288}
+}
+```
+
+#### 응답 `404`
+
+```json
+{
+  "error": "manifest not found: my-run-001"
+}
+```
+
+### 5.6 `GET /artifacts/{run_id}`
 
 실행 워크스페이스의 산출물 파일 목록을 반환합니다.
 
@@ -226,7 +255,7 @@ BuildSpec을 실행 전에 검증합니다. body의 `spec` 키에 YAML 문자열
 }
 ```
 
-### 5.6 `GET /builds`
+### 5.7 `GET /builds`
 
 빌드 이력 목록을 최신 수정 시각 기준 내림차순으로 반환합니다. `output_root` 아래의 디렉터리를 스캔해 `manifest.json`이 있는 실행만 포함합니다.
 
@@ -297,10 +326,10 @@ conformance) 순수 파이썬 validator(`tests/unit/_openapi.py`)로 검증합�
 | `validateSpec` | 구현됨 | `POST /validate` (동기) |
 | `previewBuild` | 구현됨 | `POST /preview` (동기) |
 | `createBuild` | 구현됨 | `POST /build` (동기) |
+| `getBuildManifest` | 구현됨 | `GET /builds/{run_id}/manifest` |
 | `listBuildArtifacts` | 구현됨 | `GET /artifacts/{run_id}` |
 | `listDatasets` | 계획(planned)/미구현 | — |
 | `getBuild` | 계획(planned)/미구현 — 비동기 job 모델 | `GET /builds/{run_id}` (후속 ADR) |
-| `getBuildManifest` | 계획(planned)/미구현 | — |
 | `publishArtifacts` | 계획(planned)/미구현 | — |
 | (메타) | 구현됨 | `GET /version` → `{service, api_version}` |
 

--- a/contract/builder-api.yaml
+++ b/contract/builder-api.yaml
@@ -179,6 +179,40 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
+  /builds/{run_id}/manifest:
+    get:
+      operationId: getBuildManifest
+      summary: 실행 워크스페이스의 manifest.json 본문 조회
+      parameters:
+        - $ref: "#/components/parameters/RunId"
+      responses:
+        "200":
+          description: manifest.json 본문
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BuildManifest"
+        "400":
+          description: 경로 안전하지 않은 run_id
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: 해당 run 또는 manifest를 찾을 수 없음
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: manifest 파일을 읽거나 JSON으로 해석할 수 없음
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
   /builds:
     get:
       operationId: listBuilds
@@ -546,6 +580,44 @@ components:
           items:
             type: string
             description: run 디렉터리 기준 상대 파일 경로
+
+    BuildManifest:
+      type: object
+      required: [build_id, started_at, finished_at, schema_version]
+      additionalProperties: true
+      properties:
+        build_id:
+          type: string
+        started_at:
+          type: string
+        finished_at:
+          type: string
+        schema_version:
+          type: string
+        inputs:
+          type: array
+          items:
+            type: string
+        outputs:
+          type: array
+          items:
+            type: string
+        warnings:
+          type: array
+          items:
+            type: string
+        errors:
+          type: array
+          items:
+            type: string
+        row_counts:
+          type: object
+          additionalProperties:
+            type: integer
+        inputs_fingerprint:
+          type: [string, "null"]
+        created_by:
+          type: [string, "null"]
 
     BuildSummary:
       type: object

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -360,6 +360,29 @@ class BuilderService:
         )
         return ServiceResponse(200, {"run_id": run_id, "files": list(files)})
 
+    def manifest(self, run_id: str) -> ServiceResponse:
+        try:
+            validate_path_segment(run_id, field_name="run_id")
+        except ValueError as exc:
+            return ServiceResponse(400, {"error": str(exc)})
+
+        run_dir = self._output_root / run_id
+        ensure_within(self._output_root, run_dir, label="run directory")
+        manifest_path = run_dir / "manifest.json"
+        ensure_within(run_dir, manifest_path, label="manifest file")
+        if not manifest_path.exists():
+            return ServiceResponse(404, {"error": f"manifest not found: {run_id}"})
+
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            return ServiceResponse(500, {"error": f"invalid manifest JSON: {exc.msg}"})
+        except OSError as exc:
+            return ServiceResponse(500, {"error": f"failed to read manifest: {exc}"})
+        if not isinstance(manifest, dict):
+            return ServiceResponse(500, {"error": "invalid manifest: expected object"})
+        return ServiceResponse(200, cast(dict[str, JsonValue], manifest))
+
     def serve_artifact_file(self, run_id: str, file_path: str) -> ServiceResponse | FileResponse:
         """실행 워크스페이스의 특정 파일을 제공한다 (#323).
 
@@ -579,6 +602,20 @@ def dispatch(
                 return ServiceResponse(400, {"error": str(exc)})
             run_id = run_id_value
         return service.build(spec, run_id=run_id, created_by=principal.label)
+
+    if method == "GET" and path.startswith("/builds/") and path.endswith("/manifest"):
+        rest = path[len("/builds/") :]
+        parts = rest.split("/", 1)
+        run_id = parts[0]
+        if len(parts) == 2 and parts[1] == "manifest":
+            try:
+                validate_path_segment(run_id, field_name="run_id")
+            except ValueError as exc:
+                return ServiceResponse(400, {"error": str(exc)})
+            ownership_error = _check_ownership(service, run_id, principal)
+            if ownership_error is not None:
+                return ownership_error
+            return service.manifest(run_id)
 
     if method == "GET" and path.startswith("/artifacts/"):
         rest = path[len("/artifacts/") :]

--- a/tests/integration/test_http_service.py
+++ b/tests/integration/test_http_service.py
@@ -12,6 +12,7 @@ body 크기 제한, JSON 파싱/검증, query string 분리, 예외 시 JSON 500
     - POST /validate
     - POST /preview
     - POST /build
+    - GET  /builds/{run_id}/manifest
     - GET  /artifacts/{run_id}
     - GET  /builds
 
@@ -165,6 +166,18 @@ class TestBuildRoundTrip:
         assert body["status"] == "ok"
         assert body["run_id"] == "http-run"
         assert (tmp_path / "http-run" / "manifest.json").exists()
+
+    def test_get_build_manifest_returns_json_after_build(self, http_server: str) -> None:
+        _post(http_server, "/build", {"spec": VALID_SPEC_YAML, "run_id": "http-manifest"})
+
+        with urllib.request.urlopen(
+            f"{http_server}/builds/http-manifest/manifest", timeout=5.0
+        ) as resp:
+            assert resp.status == 200
+            body = cast(dict[str, object], json.loads(resp.read()))
+
+        assert body["build_id"] == "http-manifest"
+        assert body["schema_version"] == "1.0.0"
 
 
 class TestArtifactsRoundTrip:

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -201,6 +201,23 @@ class TestBuild:
         assert resp.status_code == 502
         assert client.close_calls == 1
 
+    def test_manifest_route_returns_written_manifest_json(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        service.build(VALID_SPEC_YAML, run_id="run1")
+
+        resp = dispatch(service, "GET", "/builds/run1/manifest", None)
+
+        assert isinstance(resp, ServiceResponse)
+        assert resp.status_code == 200
+        assert resp.body["build_id"] == "run1"
+        assert resp.body["schema_version"] == "1.0.0"
+
+    def test_manifest_route_returns_404_for_missing_run(self, tmp_path: Path) -> None:
+        resp = dispatch(_service(tmp_path), "GET", "/builds/nope/manifest", None)
+
+        assert isinstance(resp, ServiceResponse)
+        assert resp.status_code == 404
+
 
 class TestArtifacts:
     def test_lists_artifacts_after_build(self, tmp_path: Path) -> None:

--- a/tests/unit/test_service_contract.py
+++ b/tests/unit/test_service_contract.py
@@ -601,9 +601,7 @@ class TestResponseConformance:
 
     def test_manifest_200_after_build(self, tmp_path: Path) -> None:
         service = _conform_service(tmp_path)
-        dispatch(
-            service, "POST", "/build", {"spec": _CONFORM_SPEC_YAML, "run_id": "conform-man"}
-        )
+        dispatch(service, "POST", "/build", {"spec": _CONFORM_SPEC_YAML, "run_id": "conform-man"})
         resp = dispatch(service, "GET", "/builds/conform-man/manifest", None)
         assert resp.status_code == 200
         _assert_conforms(resp, "/builds/{run_id}/manifest", "GET")

--- a/tests/unit/test_service_contract.py
+++ b/tests/unit/test_service_contract.py
@@ -41,6 +41,7 @@ _DISPATCH_ROUTES: dict[tuple[str, str], str] = {
     ("/preview", "POST"): "previewBuild",
     ("/build", "POST"): "createBuild",
     ("/builds", "GET"): "listBuilds",
+    ("/builds/{run_id}/manifest", "GET"): "getBuildManifest",
     ("/artifacts/{run_id}", "GET"): "listBuildArtifacts",
 }
 
@@ -53,6 +54,7 @@ _REQUIRED_OPERATIONS = [
     ("/validate", "post"),
     ("/preview", "post"),
     ("/build", "post"),
+    ("/builds/{run_id}/manifest", "get"),
     ("/artifacts/{run_id}", "get"),
     ("/builds", "get"),
 ]
@@ -120,6 +122,7 @@ _IMPLEMENTED_OPERATIONS = {
     "validateSpec",
     "previewBuild",
     "createBuild",
+    "getBuildManifest",
     "listBuildArtifacts",
     "listBuilds",
 }
@@ -297,6 +300,7 @@ _OPERATION_STATUS_CODES: dict[str, set[int]] = {
     "validateSpec": {200, 400},
     "previewBuild": {200, 400},
     "createBuild": {200, 400, 502},
+    "getBuildManifest": {200, 400, 404, 500},
     "listBuilds": {200, 400},
     "listBuildArtifacts": {200, 400, 404},
 }
@@ -594,6 +598,20 @@ class TestResponseConformance:
         resp = dispatch(service, "GET", "/builds", None, query="")
         assert resp.status_code == 200
         _assert_conforms(resp, "/builds", "GET")
+
+    def test_manifest_200_after_build(self, tmp_path: Path) -> None:
+        service = _conform_service(tmp_path)
+        dispatch(
+            service, "POST", "/build", {"spec": _CONFORM_SPEC_YAML, "run_id": "conform-man"}
+        )
+        resp = dispatch(service, "GET", "/builds/conform-man/manifest", None)
+        assert resp.status_code == 200
+        _assert_conforms(resp, "/builds/{run_id}/manifest", "GET")
+
+    def test_manifest_404_missing(self, tmp_path: Path) -> None:
+        resp = dispatch(_conform_service(tmp_path), "GET", "/builds/nope/manifest", None)
+        assert resp.status_code == 404
+        _assert_conforms(resp, "/builds/{run_id}/manifest", "GET")
 
     def test_builds_400_bad_limit(self, tmp_path: Path) -> None:
         resp = dispatch(_conform_service(tmp_path), "GET", "/builds", None, query="limit=0")


### PR DESCRIPTION
## 요약
- Studio가 파일 다운로드 경로를 파싱하지 않고 사용할 수 있도록 GET /builds/{run_id}/manifest 엔드포인트를 추가합니다.
- OpenAPI 계약과 API_CONTRACT 문서를 getBuildManifest 구현 상태로 갱신합니다.
- unit/contract/HTTP round-trip 회귀 테스트를 추가합니다.

## 검증
- uv run --extra dev python -m pytest tests/unit/test_service.py -k 'manifest_route' tests/unit/test_service_contract.py -k 'manifest' tests/integration/test_http_service.py -k 'manifest'
- uv run ruff check .
- uv run --extra dev python -m mypy src
- uv run --extra dev python -m pytest

Closes #462