### PR TITLE
ci: harden scheduled dataset workflows (#377)

### DIFF
--- a/.github/workflows/publish-dataset.yml
+++ b/.github/workflows/publish-dataset.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: string
         default: "--local-only"
+      timeout_minutes:
+        description: 퍼블리시 잡 제한 시간(분)
+        required: false
+        type: number
+        default: 60
     secrets:
       KPUBDATA_DATAGO_API_KEY:
         required: false
@@ -45,6 +50,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout_minutes || 60 }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/scheduled-air-quality.yml
+++ b/.github/workflows/scheduled-air-quality.yml
@@ -6,12 +6,43 @@ on:
     - cron: "15 */2 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: scheduled-air-quality
+  cancel-in-progress: false
+
 jobs:
   air-quality:
     uses: ./.github/workflows/publish-dataset.yml
+    permissions:
+      contents: read
+    concurrency:
+      group: scheduled-air-quality-publish
+      cancel-in-progress: false
     with:
       mode: ""
       config: scripts/configs/air_quality.yaml
+      timeout_minutes: 45
     secrets:
       KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
+  notify-failure:
+    needs: [air-quality]
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Create freshness incident issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW: ${{ github.workflow }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue create \
+            --title "[Freshness] ${WORKFLOW} failed" \
+            --body "Scheduled dataset publish failed.\n\nRun: ${RUN_URL}\n\nFollow DATA_FRESHNESS.md escalation policy before re-running or backfilling."

--- a/.github/workflows/scheduled-dur.yml
+++ b/.github/workflows/scheduled-dur.yml
@@ -6,84 +6,172 @@ on:
     - cron: "0 1 * * 6"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: scheduled-dur
+  cancel-in-progress: false
+
 jobs:
   dur-usjnt-taboo:
     uses: ./.github/workflows/publish-dataset.yml
+    permissions:
+      contents: read
+    concurrency:
+      group: scheduled-dur-usjnt-taboo
+      cancel-in-progress: false
     with:
       mode: ""
       config: scripts/configs/dur_usjnt_taboo.yaml
+      timeout_minutes: 60
     secrets:
       KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   dur-pregnancy-taboo:
     uses: ./.github/workflows/publish-dataset.yml
+    permissions:
+      contents: read
+    concurrency:
+      group: scheduled-dur-pregnancy-taboo
+      cancel-in-progress: false
     with:
       mode: ""
       config: scripts/configs/dur_pregnancy_taboo.yaml
+      timeout_minutes: 60
     secrets:
       KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   dur-age-taboo:
     uses: ./.github/workflows/publish-dataset.yml
+    permissions:
+      contents: read
+    concurrency:
+      group: scheduled-dur-age-taboo
+      cancel-in-progress: false
     with:
       mode: ""
       config: scripts/configs/dur_age_taboo.yaml
+      timeout_minutes: 60
     secrets:
       KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   dur-older-adult-caution:
     uses: ./.github/workflows/publish-dataset.yml
+    permissions:
+      contents: read
+    concurrency:
+      group: scheduled-dur-older-adult-caution
+      cancel-in-progress: false
     with:
       mode: ""
       config: scripts/configs/dur_older_adult_caution.yaml
+      timeout_minutes: 60
     secrets:
       KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   dur-dosage-caution:
     uses: ./.github/workflows/publish-dataset.yml
+    permissions:
+      contents: read
+    concurrency:
+      group: scheduled-dur-dosage-caution
+      cancel-in-progress: false
     with:
       mode: ""
       config: scripts/configs/dur_dosage_caution.yaml
+      timeout_minutes: 60
     secrets:
       KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   dur-medication-period-caution:
     uses: ./.github/workflows/publish-dataset.yml
+    permissions:
+      contents: read
+    concurrency:
+      group: scheduled-dur-medication-period-caution
+      cancel-in-progress: false
     with:
       mode: ""
       config: scripts/configs/dur_medication_period_caution.yaml
+      timeout_minutes: 60
     secrets:
       KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   dur-efficacy-duplication:
     uses: ./.github/workflows/publish-dataset.yml
+    permissions:
+      contents: read
+    concurrency:
+      group: scheduled-dur-efficacy-duplication
+      cancel-in-progress: false
     with:
       mode: ""
       config: scripts/configs/dur_efficacy_duplication.yaml
+      timeout_minutes: 60
     secrets:
       KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   dur-product-info:
     uses: ./.github/workflows/publish-dataset.yml
+    permissions:
+      contents: read
+    concurrency:
+      group: scheduled-dur-product-info
+      cancel-in-progress: false
     with:
       mode: ""
       config: scripts/configs/dur_product_info.yaml
+      timeout_minutes: 60
     secrets:
       KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   dur-er-tablet-split-caution:
     uses: ./.github/workflows/publish-dataset.yml
+    permissions:
+      contents: read
+    concurrency:
+      group: scheduled-dur-er-tablet-split-caution
+      cancel-in-progress: false
     with:
       mode: ""
       config: scripts/configs/dur_er_tablet_split_caution.yaml
+      timeout_minutes: 60
     secrets:
       KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
+  notify-failure:
+    needs:
+      - dur-usjnt-taboo
+      - dur-pregnancy-taboo
+      - dur-age-taboo
+      - dur-older-adult-caution
+      - dur-dosage-caution
+      - dur-medication-period-caution
+      - dur-efficacy-duplication
+      - dur-product-info
+      - dur-er-tablet-split-caution
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Create freshness incident issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW: ${{ github.workflow }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue create \
+            --title "[Freshness] ${WORKFLOW} failed" \
+            --body "Scheduled dataset publish failed.\n\nRun: ${RUN_URL}\n\nFollow DATA_FRESHNESS.md escalation policy before re-running or backfilling."

--- a/.github/workflows/scheduled-real-estate.yml
+++ b/.github/workflows/scheduled-real-estate.yml
@@ -6,21 +6,58 @@ on:
     - cron: "30 0 1-10 * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: scheduled-real-estate
+  cancel-in-progress: false
+
 jobs:
   apt-trade:
     uses: ./.github/workflows/publish-dataset.yml
+    permissions:
+      contents: read
+    concurrency:
+      group: scheduled-real-estate-apt-trade
+      cancel-in-progress: false
     with:
       mode: ""
       config: scripts/configs/seoul_apartment_trades.yaml
+      timeout_minutes: 60
     secrets:
       KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   apt-rent:
     uses: ./.github/workflows/publish-dataset.yml
+    permissions:
+      contents: read
+    concurrency:
+      group: scheduled-real-estate-apt-rent
+      cancel-in-progress: false
     with:
       mode: ""
       config: scripts/configs/seoul_apartment_rent.yaml
+      timeout_minutes: 60
     secrets:
       KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
+  notify-failure:
+    needs: [apt-trade, apt-rent]
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Create freshness incident issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW: ${{ github.workflow }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue create \
+            --title "[Freshness] ${WORKFLOW} failed" \
+            --body "Scheduled dataset publish failed.\n\nRun: ${RUN_URL}\n\nFollow DATA_FRESHNESS.md escalation policy before re-running or backfilling."

--- a/.github/workflows/scheduled-tourism.yml
+++ b/.github/workflows/scheduled-tourism.yml
@@ -6,39 +6,88 @@ on:
     - cron: "0 2 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: scheduled-tourism
+  cancel-in-progress: false
+
 jobs:
   tour-area:
     uses: ./.github/workflows/publish-dataset.yml
+    permissions:
+      contents: read
+    concurrency:
+      group: scheduled-tourism-tour-area
+      cancel-in-progress: false
     with:
       mode: ""
       config: scripts/configs/tour_kor_area.yaml
+      timeout_minutes: 60
     secrets:
       KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   tour-location:
     uses: ./.github/workflows/publish-dataset.yml
+    permissions:
+      contents: read
+    concurrency:
+      group: scheduled-tourism-tour-location
+      cancel-in-progress: false
     with:
       mode: ""
       config: scripts/configs/tour_kor_location.yaml
+      timeout_minutes: 60
     secrets:
       KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   tour-keyword:
     uses: ./.github/workflows/publish-dataset.yml
+    permissions:
+      contents: read
+    concurrency:
+      group: scheduled-tourism-tour-keyword
+      cancel-in-progress: false
     with:
       mode: ""
       config: scripts/configs/tour_kor_keyword.yaml
+      timeout_minutes: 60
     secrets:
       KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   tour-festival:
     uses: ./.github/workflows/publish-dataset.yml
+    permissions:
+      contents: read
+    concurrency:
+      group: scheduled-tourism-tour-festival
+      cancel-in-progress: false
     with:
       mode: ""
       config: scripts/configs/tour_kor_festival.yaml
+      timeout_minutes: 60
     secrets:
       KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
+  notify-failure:
+    needs: [tour-area, tour-location, tour-keyword, tour-festival]
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Create freshness incident issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW: ${{ github.workflow }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue create \
+            --title "[Freshness] ${WORKFLOW} failed" \
+            --body "Scheduled dataset publish failed.\n\nRun: ${RUN_URL}\n\nFollow DATA_FRESHNESS.md escalation policy before re-running or backfilling."

--- a/.github/workflows/scheduled-weather.yml
+++ b/.github/workflows/scheduled-weather.yml
@@ -6,21 +6,58 @@ on:
     - cron: "20 */3 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: scheduled-weather
+  cancel-in-progress: false
+
 jobs:
   village-forecast:
     uses: ./.github/workflows/publish-dataset.yml
+    permissions:
+      contents: read
+    concurrency:
+      group: scheduled-weather-village-forecast
+      cancel-in-progress: false
     with:
       mode: ""
       config: scripts/configs/weather_village_fcst.yaml
+      timeout_minutes: 45
     secrets:
       KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   ultra-short-term:
     uses: ./.github/workflows/publish-dataset.yml
+    permissions:
+      contents: read
+    concurrency:
+      group: scheduled-weather-ultra-short-term
+      cancel-in-progress: false
     with:
       mode: ""
       config: scripts/configs/weather_ultra_srt_ncst.yaml
+      timeout_minutes: 45
     secrets:
       KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
+  notify-failure:
+    needs: [village-forecast, ultra-short-term]
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Create freshness incident issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW: ${{ github.workflow }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue create \
+            --title "[Freshness] ${WORKFLOW} failed" \
+            --body "Scheduled dataset publish failed.\n\nRun: ${RUN_URL}\n\nFollow DATA_FRESHNESS.md escalation policy before re-running or backfilling."

--- a/DATA_FRESHNESS.md
+++ b/DATA_FRESHNESS.md
@@ -52,3 +52,13 @@
 - API 호출 수 (일일 한도 대비 %)
 - Push된 파일 크기 / row count
 - 실패 시 자동 retry (최대 2회), 이후 Slack/issue 알림
+
+## GitHub Actions 운영 가드레일
+
+- 모든 `scheduled-*.yml`은 `permissions: contents: read`를 기본값으로 두고, 실패 알림 job에만 `issues: write`를 부여한다.
+- append-only 데이터셋(대기오염/날씨)은 `concurrency.cancel-in-progress: false`로 이전 실행을 취소하지 않고 직렬화해 중복 append와 부분 publish를 피한다.
+- 데이터셋 publish job은 reusable workflow의 `timeout_minutes` 입력으로 45~60분 제한을 둔다. 긴 backfill은 scheduled workflow가 아니라 `workflow_dispatch`로 별도 실행한다.
+- scheduled workflow가 실패하면 `[Freshness] <workflow> failed` 이슈가 생성되며, run URL을 기준으로 원인 확인 후 backfill 여부를 결정한다.
+- GitHub는 저장소 활동이 60일 이상 없으면 scheduled workflow를 비활성화할 수 있다. 월 1회 이상 수동 `workflow_dispatch` 또는 운영 변경 PR로 schedule 활성 상태를 확인한다.
+- `KPUBDATA_DATAGO_API_KEY`, `HF_TOKEN`, Kaggle credentials는 GitHub Environment 보호 규칙 아래에서 관리하고, 분기별 로테이션 결과를 운영 이슈에 기록한다.
+- Kaggle scheduled publish는 현재 비활성이다. dataset config에 `kaggle_slug`가 있고 Environment에 `KAGGLE_USERNAME`/`KAGGLE_KEY`가 등록된 데이터셋만 별도 scheduled workflow에서 활성화한다.


### PR DESCRIPTION
## Summary
- add caller-controlled timeout_minutes to the reusable dataset publish workflow
- add explicit permissions and concurrency serialization to all scheduled dataset workflows
- create freshness incident issues when scheduled publishes fail
- document scheduled workflow guardrails, 60-day inactivity checks, secret rotation, and Kaggle schedule governance

Closes #377

## Verification
- python3 YAML parse for scheduled-*.yml and publish-dataset.yml
- GIT_MASTER=1 git diff --check origin/main...HEAD
- docs/workflow diff review