### PR TITLE
ci: publish Docker images to GHCR (#376)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,12 +16,22 @@ on:
       - ".github/workflows/docker.yml"
   push:
     branches: [main]
+    tags:
+      - "v*"
     paths:
       - "Dockerfile"
       - "docker-entrypoint.sh"
+      - ".dockerignore"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "src/**"
+      - ".github/workflows/docker.yml"
+  workflow_dispatch:
 
 permissions:
   contents: read
+  packages: write
+  id-token: write
 
 concurrency:
   group: docker-${{ github.workflow }}-${{ github.ref }}
@@ -29,11 +39,75 @@ concurrency:
 
 jobs:
   build:
-    name: docker build
+    name: docker build and scan
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
+
       - name: Build serve image
-        run: docker build -t kpubdata-builder:ci .
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
+        with:
+          context: .
+          load: true
+          tags: kpubdata-builder:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Trivy image scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+        with:
+          image-ref: kpubdata-builder:ci
+          severity: CRITICAL,HIGH
+          exit-code: "1"
+          ignore-unfixed: true
+
+  publish:
+    name: publish GHCR image
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event_name != 'pull_request' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
+        with:
+          images: ghcr.io/yeongseon/kpubdata-builder
+          tags: |
+            type=ref,event=tag
+            type=ref,event=branch
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and publish image
+        id: build-publish
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          sbom: true
+          provenance: mode=max
+
+      - name: Print image digest
+        run: echo "Published ghcr.io/yeongseon/kpubdata-builder@${{ steps.build-publish.outputs.digest }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,8 @@ RUN if [ -z "${EXTRAS}" ]; then \
     else \
       _flags=""; for _e in ${EXTRAS}; do _flags="$_flags --extra $_e"; done; \
       uv sync --no-sources $_flags; \
-    fi
+    fi; \
+    rm -rf /root/.cache/uv /bin/uv /bin/uvx
 
 # 빌드 산출물(아티팩트·매니페스트) 영속 볼륨의 기본 위치.
 RUN mkdir -p /data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "polars>=1.0,<2",
   "pyyaml>=6.0,<7",
   "typing_extensions>=4.5,<5",
+  "urllib3>=2.7.0,<3",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -729,7 +729,7 @@ wheels = [
 [[package]]
 name = "kpubdata"
 version = "0.5.0"
-source = { editable = "/home/dahyeon/GitHub/kpubdata" }
+source = { editable = "../kpubdata" }
 dependencies = [
     { name = "httpx" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
@@ -766,6 +766,7 @@ dependencies = [
     { name = "polars" },
     { name = "pyyaml" },
     { name = "typing-extensions" },
+    { name = "urllib3" },
 ]
 
 [package.optional-dependencies]
@@ -804,7 +805,7 @@ requires-dist = [
     { name = "huggingface-hub", marker = "extra == 'huggingface'", specifier = ">=0.23,<2" },
     { name = "huggingface-hub", marker = "extra == 'publish'", specifier = ">=0.23,<2" },
     { name = "kaggle", marker = "extra == 'publish'", specifier = ">=1.6,<2" },
-    { name = "kpubdata", editable = "/home/dahyeon/GitHub/kpubdata" },
+    { name = "kpubdata", editable = "../kpubdata" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6,<2" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9,<10" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10,<3" },
@@ -818,6 +819,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5,<1" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "typing-extensions", specifier = ">=4.5,<5" },
+    { name = "urllib3", specifier = ">=2.7.0,<3" },
     { name = "xmltodict", marker = "extra == 'publish'", specifier = ">=0.13,<2" },
 ]
 provides-extras = ["docs", "parquet", "huggingface", "auth", "publish", "dev"]
@@ -1755,11 +1757,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- switch Docker CI to buildx with GitHub Actions cache
- validate PR images with Trivy on CRITICAL/HIGH severities
- publish multi-arch GHCR images on main/tag/workflow_dispatch with SHA, branch/tag, and latest tags
- enable SBOM and max provenance attestations for published images

Closes #376

## Verification
- python3 YAML parse for .github/workflows/docker.yml
- GIT_MASTER=1 git diff --check origin/main...HEAD
- workflow diff review