### PR TITLE
feat(service): add async build job registry

### DIFF
--- a/src/kpubdata_builder/cli.py
+++ b/src/kpubdata_builder/cli.py
@@ -380,6 +380,7 @@ def _run_serve(*, output_dir: str, host: str, port: int, max_workers: int | None
     service = BuilderService(
         output_root=Path(output_dir),
         client_factory=_create_client,
+        async_max_workers=max_workers,
     )
     # 장시간 실행 명령이므로 시작 로그가 파이프 버퍼링에 갈리지 않도록 즉시 flush한다.
     print(

--- a/src/kpubdata_builder/service/__init__.py
+++ b/src/kpubdata_builder/service/__init__.py
@@ -12,12 +12,16 @@ from __future__ import annotations
 
 from .app import API_CONTRACT_VERSION, BuilderService, FileResponse, ServiceResponse, dispatch
 from .http import make_handler, serve
+from .jobs import AsyncBuildExecutor, BuildJobSnapshot, BuildJobStatus
 
 __all__ = [
     "API_CONTRACT_VERSION",
     "BuilderService",
     "FileResponse",
     "ServiceResponse",
+    "AsyncBuildExecutor",
+    "BuildJobSnapshot",
+    "BuildJobStatus",
     "dispatch",
     "make_handler",
     "serve",

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -36,6 +36,7 @@ from ..stages.bronze.build import SourceClient
 from ..store import BuildIndex
 from ..tabular import DEFAULT_PREVIEW_LIMIT
 from .auth import AuthError, Principal, authenticate
+from .jobs import AsyncBuildExecutor
 
 logger = logging.getLogger(__name__)
 
@@ -167,10 +168,12 @@ class BuilderService:
         *,
         output_root: Path,
         client_factory: Callable[[], SourceClient],
+        async_max_workers: int = 10,
     ) -> None:
         self._output_root = output_root
         self._client_factory = client_factory
         self._build_index = BuildIndex(output_root)  # #309, ADR 0003
+        self._async_builds = AsyncBuildExecutor(max_workers=async_max_workers)
 
     def version(self) -> ServiceResponse:
         """Builder API 계약 버전을 반환한다 (#209).
@@ -352,6 +355,34 @@ class BuilderService:
             pass
 
         return ServiceResponse(status_code, body)
+
+    def submit_build(
+        self, spec_yaml: str, *, run_id: str, created_by: str | None = None
+    ) -> ServiceResponse:
+        """비동기 build job을 큐에 넣고 초기 상태를 반환한다 (#482)."""
+        snapshot = self._async_builds.submit(
+            spec_yaml=spec_yaml,
+            run_id=run_id,
+            created_by=created_by,
+            runner=self._run_build_job,
+        )
+        return ServiceResponse(202, snapshot.to_body())
+
+    def build_status(self, run_id: str) -> ServiceResponse:
+        """active/terminal 비동기 build job 상태를 반환한다 (#482)."""
+        try:
+            validate_path_segment(run_id, field_name="run_id")
+        except ValueError as exc:
+            return ServiceResponse(400, {"error": str(exc)})
+        snapshot = self._async_builds.get(run_id)
+        if snapshot is None:
+            return ServiceResponse(404, {"error": f"build job not found: {run_id}"})
+        return ServiceResponse(200, snapshot.to_body())
+
+    def _run_build_job(
+        self, spec_yaml: str, run_id: str, created_by: str | None
+    ) -> ServiceResponse:
+        return self.build(spec_yaml, run_id=run_id, created_by=created_by)
 
     def artifacts(self, run_id: str) -> ServiceResponse:
         """실행 워크스페이스의 산출물 파일 목록을 반환한다."""
@@ -612,6 +643,25 @@ def dispatch(
                 return ServiceResponse(400, {"error": str(exc)})
             run_id = run_id_value
         return service.build(spec, run_id=run_id, created_by=principal.label)
+
+    if method == "POST" and path == "/builds":
+        spec = _spec_from_body(body)
+        if isinstance(spec, ServiceResponse):
+            return spec
+        if body is None or "run_id" not in body:
+            return ServiceResponse(400, {"error": "'run_id' is required"})
+        run_id_value = body["run_id"]
+        if not isinstance(run_id_value, str) or not run_id_value.strip():
+            return ServiceResponse(400, {"error": "'run_id' must be a non-empty string"})
+        try:
+            validate_path_segment(run_id_value, field_name="run_id")
+        except ValueError as exc:
+            return ServiceResponse(400, {"error": str(exc)})
+        return service.submit_build(spec, run_id=run_id_value, created_by=principal.label)
+
+    if method == "GET" and path.startswith("/builds/") and "/" not in path[len("/builds/") :]:
+        run_id = path[len("/builds/") :]
+        return service.build_status(run_id)
 
     if method == "GET" and path.startswith("/builds/") and path.endswith("/manifest"):
         rest = path[len("/builds/") :]

--- a/src/kpubdata_builder/service/jobs.py
+++ b/src/kpubdata_builder/service/jobs.py
@@ -1,0 +1,178 @@
+"""비동기 build job 레지스트리와 bounded worker 실행기 (#482)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from threading import Lock
+from typing import TYPE_CHECKING, Literal, Protocol
+
+from ..spec import JsonValue
+
+BuildJobStatus = Literal["queued", "running", "cancelling", "succeeded", "failed", "cancelled"]
+
+
+if TYPE_CHECKING:
+    from .app import ServiceResponse as BuildJobResponse
+else:
+
+    class BuildJobResponse(Protocol):
+        """BuilderService 응답 중 job 실행기가 필요한 구조."""
+
+        status_code: int
+        body: dict[str, JsonValue]
+
+
+BuildJobRunner = Callable[[str, str, str | None], BuildJobResponse]
+
+
+@dataclass(frozen=True, slots=True)
+class BuildJobSnapshot:
+    """외부에 노출 가능한 build job 상태 스냅샷."""
+
+    run_id: str
+    status: BuildJobStatus
+    created_at: str
+    updated_at: str
+    created_by: str | None = None
+    response: dict[str, JsonValue] | None = None
+    error: str | None = None
+
+    def to_body(self) -> dict[str, JsonValue]:
+        body: dict[str, JsonValue] = {
+            "run_id": self.run_id,
+            "status": self.status,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+        if self.created_by is not None:
+            body["created_by"] = self.created_by
+        if self.response is not None:
+            body["response"] = self.response
+        if self.error is not None:
+            body["error"] = self.error
+        return body
+
+
+class AsyncBuildJobRegistry:
+    """프로세스 메모리에만 유지되는 active/terminal job 레지스트리."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._jobs: dict[str, BuildJobSnapshot] = {}
+
+    def create(self, *, run_id: str, created_by: str | None) -> BuildJobSnapshot:
+        now = _utc_now_text()
+        snapshot = BuildJobSnapshot(
+            run_id=run_id,
+            status="queued",
+            created_at=now,
+            updated_at=now,
+            created_by=created_by,
+        )
+        with self._lock:
+            self._jobs[run_id] = snapshot
+        return snapshot
+
+    def mark_running(self, run_id: str) -> BuildJobSnapshot:
+        return self._replace(run_id, status="running")
+
+    def mark_succeeded(self, run_id: str, response: dict[str, JsonValue]) -> BuildJobSnapshot:
+        return self._replace(run_id, status="succeeded", response=response)
+
+    def mark_failed(
+        self, run_id: str, *, response: dict[str, JsonValue] | None = None, error: str | None = None
+    ) -> BuildJobSnapshot:
+        return self._replace(run_id, status="failed", response=response, error=error)
+
+    def get(self, run_id: str) -> BuildJobSnapshot | None:
+        with self._lock:
+            return self._jobs.get(run_id)
+
+    def _replace(
+        self,
+        run_id: str,
+        *,
+        status: BuildJobStatus,
+        response: dict[str, JsonValue] | None = None,
+        error: str | None = None,
+    ) -> BuildJobSnapshot:
+        with self._lock:
+            current = self._jobs[run_id]
+            updated = BuildJobSnapshot(
+                run_id=current.run_id,
+                status=status,
+                created_at=current.created_at,
+                updated_at=_utc_now_text(),
+                created_by=current.created_by,
+                response=response,
+                error=error,
+            )
+            self._jobs[run_id] = updated
+            return updated
+
+
+class AsyncBuildExecutor:
+    """고정 크기 worker pool로 build job을 실행한다."""
+
+    def __init__(self, *, max_workers: int) -> None:
+        self._executor = ThreadPoolExecutor(
+            max_workers=max_workers, thread_name_prefix="kpubdata-build"
+        )
+        self.registry = AsyncBuildJobRegistry()
+
+    def submit(
+        self,
+        *,
+        spec_yaml: str,
+        run_id: str,
+        created_by: str | None,
+        runner: BuildJobRunner,
+    ) -> BuildJobSnapshot:
+        snapshot = self.registry.create(run_id=run_id, created_by=created_by)
+        self._executor.submit(self._run, spec_yaml, run_id, created_by, runner)
+        return snapshot
+
+    def get(self, run_id: str) -> BuildJobSnapshot | None:
+        return self.registry.get(run_id)
+
+    def shutdown(self) -> None:
+        self._executor.shutdown(wait=False, cancel_futures=True)
+
+    def _run(
+        self,
+        spec_yaml: str,
+        run_id: str,
+        created_by: str | None,
+        runner: BuildJobRunner,
+    ) -> None:
+        self.registry.mark_running(run_id)
+        try:
+            response = runner(spec_yaml, run_id, created_by)
+        except RuntimeError as exc:
+            self.registry.mark_failed(run_id, error=str(exc))
+            return
+        if response.status_code < 400:
+            self.registry.mark_succeeded(run_id, response=response.body)
+            return
+        error = response.body.get("error")
+        self.registry.mark_failed(
+            run_id,
+            response=response.body,
+            error=error if isinstance(error, str) else "build failed",
+        )
+
+
+def _utc_now_text() -> str:
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+__all__ = [
+    "AsyncBuildExecutor",
+    "AsyncBuildJobRegistry",
+    "BuildJobResponse",
+    "BuildJobSnapshot",
+    "BuildJobStatus",
+]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -430,6 +430,7 @@ def test_publish_kaggle_end_to_end(
         # --output-dir가 BuilderService.output_root로 올바르게 전달되는지 확인한다 (#249 review).
         assert isinstance(service, BuilderService)
         captured_kwargs["output_root"] = service._output_root
+        captured_kwargs["async_max_workers"] = service._async_builds._executor._max_workers
 
     monkeypatch.setattr(http_module, "serve", fake_serve)
 
@@ -452,6 +453,7 @@ def test_publish_kaggle_end_to_end(
         "host": "0.0.0.0",
         "port": 9123,
         "max_workers": 10,
+        "async_max_workers": 10,
         "output_root": tmp_path,
     }
     assert "serving kpubdata-builder" in out

--- a/tests/unit/test_service_jobs.py
+++ b/tests/unit/test_service_jobs.py
@@ -1,0 +1,184 @@
+"""비동기 build job 서비스 동작 검증 (#482)."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable, Iterable
+from pathlib import Path
+
+from kpubdata_builder.service import BuilderService, ServiceResponse
+from kpubdata_builder.spec import JsonValue
+
+VALID_SPEC_YAML = (
+    """
+dataset_id: dataset.sample
+title: Sample Dataset
+description: Sample description
+sources:
+  - provider: datago
+    dataset: air_quality
+exports:
+  - kind: jsonl
+    output_path: out/data.jsonl
+""".strip()
+    + "\n"
+)
+
+
+class _FakeResult:
+    def __init__(self, items: list[dict[str, JsonValue]]) -> None:
+        self._items = items
+
+    @property
+    def items(self) -> Iterable[dict[str, JsonValue]]:
+        return self._items
+
+
+class _FakeDataset:
+    def __init__(self, items: list[dict[str, JsonValue]]) -> None:
+        self._items = items
+
+    def list(self, **params: JsonValue) -> _FakeResult:
+        return _FakeResult(self._items)
+
+
+class _FakeClient:
+    def __init__(self, data: dict[str, list[dict[str, JsonValue]]]) -> None:
+        self._data = data
+
+    def dataset(self, source_key: str) -> _FakeDataset:
+        if source_key not in self._data:
+            raise KeyError(f"unknown source: {source_key}")
+        return _FakeDataset(self._data[source_key])
+
+
+ClientFactory = Callable[[], _FakeClient]
+
+
+class _ObservedBuildService(BuilderService):
+    def __init__(
+        self,
+        *,
+        output_root: Path,
+        client_factory: ClientFactory,
+        completed: threading.Event,
+        async_max_workers: int = 1,
+    ) -> None:
+        super().__init__(
+            output_root=output_root,
+            client_factory=client_factory,
+            async_max_workers=async_max_workers,
+        )
+        self._completed = completed
+
+    def build(
+        self, spec_yaml: str, *, run_id: str | None = None, created_by: str | None = None
+    ) -> ServiceResponse:
+        try:
+            return super().build(spec_yaml, run_id=run_id, created_by=created_by)
+        finally:
+            self._completed.set()
+
+
+class _BlockingBuildService(BuilderService):
+    def __init__(
+        self,
+        *,
+        output_root: Path,
+        entered: threading.Event,
+        release: threading.Event,
+    ) -> None:
+        super().__init__(
+            output_root=output_root,
+            client_factory=lambda: _FakeClient({}),
+            async_max_workers=1,
+        )
+        self._entered = entered
+        self._release = release
+
+    def _run_build_job(
+        self, spec_yaml: str, run_id: str, created_by: str | None
+    ) -> ServiceResponse:
+        self._entered.set()
+        self._release.wait(timeout=5)
+        return ServiceResponse(200, {"status": "ok", "run_id": run_id})
+
+
+def _service(tmp_path: Path, completed: threading.Event) -> _ObservedBuildService:
+    client = _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}]})
+    return _ObservedBuildService(
+        output_root=tmp_path,
+        client_factory=lambda: client,
+        completed=completed,
+        async_max_workers=1,
+    )
+
+
+class TestAsyncBuildJobs:
+    def test_second_job_stays_queued_when_single_worker_is_busy(self, tmp_path: Path) -> None:
+        entered = threading.Event()
+        release = threading.Event()
+        service = _BlockingBuildService(output_root=tmp_path, entered=entered, release=release)
+
+        first = service.submit_build(VALID_SPEC_YAML, run_id="run1", created_by="tester")
+        assert first.status_code == 202
+        assert entered.wait(timeout=5)
+        second = service.submit_build(VALID_SPEC_YAML, run_id="run2", created_by="tester")
+
+        first_status = service.build_status("run1")
+        second_status = service.build_status("run2")
+        release.set()
+        assert first_status.body["status"] == "running"
+        assert second.status_code == 202
+        assert second_status.body["status"] == "queued"
+
+    def test_successful_async_build_writes_manifest_and_index(self, tmp_path: Path) -> None:
+        completed = threading.Event()
+        service = _service(tmp_path, completed)
+
+        response = service.submit_build(VALID_SPEC_YAML, run_id="run1", created_by="tester")
+        assert response.status_code == 202
+        assert completed.wait(timeout=5)
+
+        status = service.build_status("run1")
+        entry = service._build_index.get("run1")
+        assert status.body["status"] == "succeeded"
+        assert (tmp_path / "run1" / "manifest.json").exists()
+        assert entry is not None
+        assert entry.status == "ok"
+
+    def test_failed_async_build_records_failed_terminal_status(self, tmp_path: Path) -> None:
+        completed = threading.Event()
+        service = _ObservedBuildService(
+            output_root=tmp_path,
+            client_factory=lambda: _FakeClient({}),
+            completed=completed,
+            async_max_workers=1,
+        )
+
+        response = service.submit_build(VALID_SPEC_YAML, run_id="run1", created_by="tester")
+        assert response.status_code == 202
+        assert completed.wait(timeout=5)
+
+        status = service.build_status("run1")
+        entry = service._build_index.get("run1")
+        assert status.body["status"] == "failed"
+        assert entry is not None
+        assert entry.status == "failed"
+
+    def test_active_registry_is_empty_after_service_restart(self, tmp_path: Path) -> None:
+        entered = threading.Event()
+        release = threading.Event()
+        service = _BlockingBuildService(output_root=tmp_path, entered=entered, release=release)
+        service.submit_build(VALID_SPEC_YAML, run_id="run1", created_by="tester")
+        assert entered.wait(timeout=5)
+
+        restarted = BuilderService(
+            output_root=tmp_path,
+            client_factory=lambda: _FakeClient({"datago.air_quality": []}),
+            async_max_workers=1,
+        )
+        release.set()
+
+        status = restarted.build_status("run1")
+        assert status.status_code == 404


### PR DESCRIPTION
## Summary
- Add an in-memory async build job registry and bounded ThreadPoolExecutor foundation for ADR 0008 / #482.
- Add callable `POST /builds` submission and `GET /builds/{run_id}` status routing while leaving OpenAPI SSOT updates for #480.
- Wire CLI `serve --max-workers` into async build worker capacity so HTTP and build worker limits stay aligned.
- Cover queued/running/succeeded/failed transitions and restart-empty active registry behavior.

## Boundaries
- Does not implement cancellation semantics (#481).
- Does not implement idempotent duplicate submission/backpressure policy (#483).
- Does not update OpenAPI contract (#480).

## Validation
- `uv run --frozen ruff check src/kpubdata_builder/cli.py src/kpubdata_builder/service/jobs.py src/kpubdata_builder/service/app.py src/kpubdata_builder/service/__init__.py tests/unit/test_cli.py tests/unit/test_service_jobs.py`
- `uv run --frozen mypy src`
- `uv run --frozen pytest tests/unit/test_cli.py tests/unit/test_service.py tests/unit/test_service_jobs.py`
- `uv run --frozen pytest` (696 passed, 1 existing deprecation warning)
- `GIT_MASTER=1 git diff --check`

Closes #482.