### PR TITLE
feat(service): add async build idempotency policy

### DIFF
--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -26,6 +26,7 @@ from urllib.parse import parse_qs
 import yaml
 from kpubdata import Client
 from kpubdata.core.models import DatasetRef
+from typing_extensions import assert_never
 
 from ..errors import SpecLoadError, ValidationError
 from ..pipeline import preview_build, run_build
@@ -36,7 +37,7 @@ from ..stages.bronze.build import SourceClient
 from ..store import BuildIndex
 from ..tabular import DEFAULT_PREVIEW_LIMIT
 from .auth import AuthError, Principal, authenticate
-from .jobs import AsyncBuildExecutor
+from .jobs import AsyncBuildExecutor, generate_run_id
 
 logger = logging.getLogger(__name__)
 
@@ -169,11 +170,15 @@ class BuilderService:
         output_root: Path,
         client_factory: Callable[[], SourceClient],
         async_max_workers: int = 10,
+        async_max_queue_size: int = 10,
     ) -> None:
         self._output_root = output_root
         self._client_factory = client_factory
         self._build_index = BuildIndex(output_root)  # #309, ADR 0003
-        self._async_builds = AsyncBuildExecutor(max_workers=async_max_workers)
+        self._async_builds = AsyncBuildExecutor(
+            max_workers=async_max_workers,
+            max_queue_size=async_max_queue_size,
+        )
 
     def version(self) -> ServiceResponse:
         """Builder API 계약 버전을 반환한다 (#209).
@@ -357,16 +362,37 @@ class BuilderService:
         return ServiceResponse(status_code, body)
 
     def submit_build(
-        self, spec_yaml: str, *, run_id: str, created_by: str | None = None
+        self, spec_yaml: str, *, run_id: str | None = None, created_by: str | None = None
     ) -> ServiceResponse:
         """비동기 build job을 큐에 넣고 초기 상태를 반환한다 (#482)."""
-        snapshot = self._async_builds.submit(
+        resolved_run_id = run_id or generate_run_id()
+        if self._build_index.get(resolved_run_id) is not None:
+            return ServiceResponse(
+                409,
+                {
+                    "error": "run_id already completed",
+                    "run_id": resolved_run_id,
+                },
+            )
+        result = self._async_builds.submit(
             spec_yaml=spec_yaml,
-            run_id=run_id,
+            run_id=resolved_run_id,
             created_by=created_by,
             runner=self._run_build_job,
         )
-        return ServiceResponse(202, snapshot.to_body())
+        match result.status:
+            case "accepted":
+                if result.snapshot is None:
+                    raise RuntimeError("accepted async build is missing snapshot")
+                return ServiceResponse(202, result.snapshot.to_body())
+            case "existing":
+                if result.snapshot is None:
+                    raise RuntimeError("existing async build is missing snapshot")
+                return ServiceResponse(200, result.snapshot.to_body())
+            case "queue_full":
+                return ServiceResponse(429, {"error": "async build queue is full"})
+            case unreachable:
+                assert_never(unreachable)
 
     def build_status(self, run_id: str) -> ServiceResponse:
         """active/terminal 비동기 build job 상태를 반환한다 (#482)."""
@@ -648,16 +674,17 @@ def dispatch(
         spec = _spec_from_body(body)
         if isinstance(spec, ServiceResponse):
             return spec
-        if body is None or "run_id" not in body:
-            return ServiceResponse(400, {"error": "'run_id' is required"})
-        run_id_value = body["run_id"]
-        if not isinstance(run_id_value, str) or not run_id_value.strip():
-            return ServiceResponse(400, {"error": "'run_id' must be a non-empty string"})
-        try:
-            validate_path_segment(run_id_value, field_name="run_id")
-        except ValueError as exc:
-            return ServiceResponse(400, {"error": str(exc)})
-        return service.submit_build(spec, run_id=run_id_value, created_by=principal.label)
+        async_run_id: str | None = None
+        if body is not None and "run_id" in body:
+            run_id_value = body["run_id"]
+            if not isinstance(run_id_value, str) or not run_id_value.strip():
+                return ServiceResponse(400, {"error": "'run_id' must be a non-empty string"})
+            try:
+                validate_path_segment(run_id_value, field_name="run_id")
+            except ValueError as exc:
+                return ServiceResponse(400, {"error": str(exc)})
+            async_run_id = run_id_value
+        return service.submit_build(spec, run_id=async_run_id, created_by=principal.label)
 
     if method == "GET" and path.startswith("/builds/") and "/" not in path[len("/builds/") :]:
         run_id = path[len("/builds/") :]

--- a/src/kpubdata_builder/service/jobs.py
+++ b/src/kpubdata_builder/service/jobs.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from threading import Lock
 from typing import TYPE_CHECKING, Literal, Protocol
+from uuid import uuid4
 
 from ..spec import JsonValue
 
@@ -26,6 +27,7 @@ else:
 
 
 BuildJobRunner = Callable[[str, str, str | None], BuildJobResponse]
+SubmitStatus = Literal["accepted", "existing", "queue_full"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -54,6 +56,12 @@ class BuildJobSnapshot:
         if self.error is not None:
             body["error"] = self.error
         return body
+
+
+@dataclass(frozen=True, slots=True)
+class BuildJobSubmitResult:
+    status: SubmitStatus
+    snapshot: BuildJobSnapshot | None = None
 
 
 class AsyncBuildJobRegistry:
@@ -91,6 +99,10 @@ class AsyncBuildJobRegistry:
         with self._lock:
             return self._jobs.get(run_id)
 
+    def queued_count(self) -> int:
+        with self._lock:
+            return sum(1 for job in self._jobs.values() if job.status == "queued")
+
     def _replace(
         self,
         run_id: str,
@@ -117,10 +129,11 @@ class AsyncBuildJobRegistry:
 class AsyncBuildExecutor:
     """고정 크기 worker pool로 build job을 실행한다."""
 
-    def __init__(self, *, max_workers: int) -> None:
+    def __init__(self, *, max_workers: int, max_queue_size: int = 10) -> None:
         self._executor = ThreadPoolExecutor(
             max_workers=max_workers, thread_name_prefix="kpubdata-build"
         )
+        self._max_queue_size = max_queue_size
         self.registry = AsyncBuildJobRegistry()
 
     def submit(
@@ -130,10 +143,15 @@ class AsyncBuildExecutor:
         run_id: str,
         created_by: str | None,
         runner: BuildJobRunner,
-    ) -> BuildJobSnapshot:
+    ) -> BuildJobSubmitResult:
+        existing = self.registry.get(run_id)
+        if existing is not None:
+            return BuildJobSubmitResult(status="existing", snapshot=existing)
+        if self.registry.queued_count() >= self._max_queue_size:
+            return BuildJobSubmitResult(status="queue_full")
         snapshot = self.registry.create(run_id=run_id, created_by=created_by)
         self._executor.submit(self._run, spec_yaml, run_id, created_by, runner)
-        return snapshot
+        return BuildJobSubmitResult(status="accepted", snapshot=snapshot)
 
     def get(self, run_id: str) -> BuildJobSnapshot | None:
         return self.registry.get(run_id)
@@ -169,10 +187,17 @@ def _utc_now_text() -> str:
     return datetime.now(tz=timezone.utc).isoformat()
 
 
+def generate_run_id() -> str:
+    return f"{datetime.now(tz=timezone.utc).strftime('%Y%m%dT%H%M%S%fZ')}-{uuid4().hex[:12]}"
+
+
 __all__ = [
     "AsyncBuildExecutor",
     "AsyncBuildJobRegistry",
+    "BuildJobSubmitResult",
     "BuildJobResponse",
     "BuildJobSnapshot",
     "BuildJobStatus",
+    "SubmitStatus",
+    "generate_run_id",
 ]

--- a/tests/unit/test_service_jobs.py
+++ b/tests/unit/test_service_jobs.py
@@ -6,7 +6,7 @@ import threading
 from collections.abc import Callable, Iterable
 from pathlib import Path
 
-from kpubdata_builder.service import BuilderService, ServiceResponse
+from kpubdata_builder.service import BuilderService, ServiceResponse, dispatch
 from kpubdata_builder.spec import JsonValue
 
 VALID_SPEC_YAML = (
@@ -87,11 +87,13 @@ class _BlockingBuildService(BuilderService):
         output_root: Path,
         entered: threading.Event,
         release: threading.Event,
+        async_max_queue_size: int = 10,
     ) -> None:
         super().__init__(
             output_root=output_root,
             client_factory=lambda: _FakeClient({}),
             async_max_workers=1,
+            async_max_queue_size=async_max_queue_size,
         )
         self._entered = entered
         self._release = release
@@ -182,3 +184,76 @@ class TestAsyncBuildJobs:
 
         status = restarted.build_status("run1")
         assert status.status_code == 404
+
+    def test_duplicate_active_run_id_returns_existing_job(self, tmp_path: Path) -> None:
+        entered = threading.Event()
+        release = threading.Event()
+        service = _BlockingBuildService(output_root=tmp_path, entered=entered, release=release)
+        first = service.submit_build(VALID_SPEC_YAML, run_id="run1", created_by="tester")
+        assert entered.wait(timeout=5)
+
+        second = service.submit_build(VALID_SPEC_YAML, run_id="run1", created_by="tester")
+        release.set()
+
+        assert first.status_code == 202
+        assert second.status_code == 200
+        assert second.body["run_id"] == "run1"
+        assert second.body["status"] == "running"
+
+    def test_duplicate_terminal_run_id_returns_conflict(self, tmp_path: Path) -> None:
+        completed = threading.Event()
+        service = _service(tmp_path, completed)
+        response = service.submit_build(VALID_SPEC_YAML, run_id="run1", created_by="tester")
+        assert response.status_code == 202
+        assert completed.wait(timeout=5)
+
+        duplicate = service.submit_build(VALID_SPEC_YAML, run_id="run1", created_by="tester")
+
+        assert duplicate.status_code == 409
+        assert duplicate.body["run_id"] == "run1"
+
+    def test_post_builds_generates_run_id_when_omitted(self, tmp_path: Path) -> None:
+        completed = threading.Event()
+        service = _service(tmp_path, completed)
+
+        response = dispatch(service, "POST", "/builds", {"spec": VALID_SPEC_YAML})
+        assert isinstance(response, ServiceResponse)
+        assert response.status_code == 202
+        run_id = response.body["run_id"]
+        assert isinstance(run_id, str)
+        assert run_id
+        assert completed.wait(timeout=5)
+
+    def test_queue_full_returns_429(self, tmp_path: Path) -> None:
+        entered = threading.Event()
+        release = threading.Event()
+        service = _BlockingBuildService(
+            output_root=tmp_path,
+            entered=entered,
+            release=release,
+            async_max_queue_size=1,
+        )
+        service.submit_build(VALID_SPEC_YAML, run_id="run1", created_by="tester")
+        assert entered.wait(timeout=5)
+        queued = service.submit_build(VALID_SPEC_YAML, run_id="run2", created_by="tester")
+
+        saturated = service.submit_build(VALID_SPEC_YAML, run_id="run3", created_by="tester")
+        release.set()
+
+        assert queued.status_code == 202
+        assert saturated.status_code == 429
+
+    def test_unsafe_run_id_is_rejected_before_job_creation(self, tmp_path: Path) -> None:
+        completed = threading.Event()
+        service = _service(tmp_path, completed)
+
+        response = dispatch(
+            service,
+            "POST",
+            "/builds",
+            {"spec": VALID_SPEC_YAML, "run_id": "../bad"},
+        )
+
+        assert isinstance(response, ServiceResponse)
+        assert response.status_code == 400
+        assert service.build_status("bad").status_code == 404


### PR DESCRIPTION
## Summary
- Add #483 async submission policy on top of #482.
- Return existing active job snapshots for duplicate `run_id` submissions.
- Reject completed/terminal duplicate `run_id`s with deterministic `409`.
- Generate safe run IDs when `POST /builds` omits `run_id`.
- Add a bounded queued-job cap with `429` backpressure response.

## Boundaries
- Does not implement cancellation semantics (#481).
- Does not update OpenAPI SSOT (#480).

## Validation
- `uv run --frozen ruff check src/kpubdata_builder/service/jobs.py src/kpubdata_builder/service/app.py tests/unit/test_service_jobs.py`
- `uv run --frozen mypy src`
- `uv run --frozen pytest tests/unit/test_service_jobs.py tests/unit/test_service.py`
- `uv run --frozen pytest` (701 passed, 1 existing deprecation warning)
- `GIT_MASTER=1 git diff --check`

Closes #483.