### PR TITLE
chore: land PR #510 (BuildSpec snapshots) into main

### DIFF
--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -37,6 +37,7 @@ v0.4 Builder service는 동기식 실행 모델을 유지합니다.
 | BuildSpec 검증 실패 | 문제 목록을 포함한 입력 오류로 처리 |
 | preview source 실패 | HTTP 요청 자체는 성공할 수 있으며, source별 `status`/`error`로 실패를 표현 |
 | build source 실패 | upstream/source 의존 실패로 처리하고 가능한 경우 manifest를 남김 |
+| run별 BuildSpec 조회 | `GET /builds/{run_id}/spec`으로 redaction된 canonical YAML과 그 bytes의 digest를 반환 |
 | 인증 실패 | `401`은 재인증 대상, `403`은 권한 요청 대상, `503`은 JWKS 일시 장애 대상 |
 
 정책과 구현이 다르면 구현 각주를 늘리지 말고 다음 순서로 정리합니다.
@@ -57,6 +58,14 @@ v0.4 Builder service는 동기식 실행 모델을 유지합니다.
   표현합니다.
 - 제거된 `transforms`, top-level `normalization_mode`,
   `sources[].normalization_mode`는 계약 필드가 아니며 파서가 명시적으로 거부합니다.
+- 검증을 통과해 실행을 시작한 spec은 pipeline 진입 전에
+  `{output_root}/{run_id}/buildspec.yaml`에 원자 저장됩니다. legacy run처럼 snapshot이
+  없는 경우 API는 manifest에서 추측·복원하지 않고 unavailable `404`를 반환합니다.
+- snapshot redaction은 범용 매핑의 명시적인 credential 키에만 적용됩니다. inline secret은
+  `<redacted>`로 대체되므로 해당 snapshot만으로 credential이 필요한 실행을 그대로 재실행할
+  수는 없으며, credential은 환경/서비스 설정에서 다시 공급해야 합니다.
+- `spec_digest`는 원본 객체가 아니라 **실제로 저장된 redaction 후 canonical snapshot bytes**의
+  SHA-256입니다. credential 값만 다른 두 spec은 의도적으로 같은 snapshot/digest가 될 수 있습니다.
 
 ## 4. 인증과 CORS
 

--- a/BUILD_SPEC.md
+++ b/BUILD_SPEC.md
@@ -271,6 +271,15 @@ Builder는 최소한 다음 규칙을 검증해야 합니다.
 - BuildSpec은 실행 계획이지 UI 상태 저장 포맷이 아닙니다.
 - exports/publish는 source 정의를 대체하지 않습니다.
 - manifest는 BuildSpec의 결과 기록물이지 입력이 아닙니다.
+- 검증된 실행 입력은 run workspace의 `buildspec.yaml`에 canonical YAML로 저장됩니다.
+  이 snapshot은 결정적 직렬화와 `sha256:<hex>` digest의 기준이며, source pipeline이
+  부분 실패해도 남습니다. 검증 실패 입력은 snapshot으로 기록하지 않습니다.
+- `metadata`, `sources[].params`, `exports[].options` 안의 명시적 credential 키 값은
+  snapshot에서 `<redacted>`로 대체됩니다. 따라서 inline credential이 있던 snapshot은
+  감사·비교용이며, 재실행 시 credential을 환경 또는 서비스 설정에서 다시 공급해야 합니다.
+- `spec_digest`는 **저장된 redaction 후 canonical `buildspec.yaml` bytes**의 SHA-256입니다.
+  따라서 credential 값만 다르고 나머지 spec이 같으면 두 snapshot과 digest도 같을 수 있으며,
+  이는 secret을 digest로 식별하거나 노출하지 않기 위한 의도된 보안 정책입니다.
 
 ## 8. 관련 문서
 

--- a/contract/builder-api.yaml
+++ b/contract/builder-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: KPubData Builder Service API
-  version: "1.3.0"
+  version: "1.4.0"
   description: >-
     Builder 중심 서비스 계약. BuildSpec 검증, preview, build 실행, artifact 조회,
     계약 버전 조회를 제공한다. CLI와 HTTP service mode(#36)가 동일한 도메인 계약을
@@ -208,6 +208,46 @@ paths:
                 $ref: "#/components/schemas/Error"
         "500":
           description: manifest 파일을 읽거나 JSON으로 해석할 수 없음
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /builds/{run_id}/spec:
+    get:
+      operationId: getBuildSpecSnapshot
+      summary: 실행에 사용한 canonical BuildSpec snapshot 조회
+      parameters:
+        - $ref: "#/components/parameters/RunId"
+      responses:
+        "200":
+          description: redaction된 canonical buildspec.yaml 본문과 SHA-256 digest
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BuildSpecSnapshotResponse"
+        "400":
+          description: 경로 안전하지 않은 run_id
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: 해당 run의 소유자가 아님
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: 해당 run이 없거나 legacy run에 snapshot이 없음
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: snapshot 파일을 읽거나 UTF-8로 해석할 수 없음
           content:
             application/json:
               schema:
@@ -744,6 +784,23 @@ components:
           type: [string, "null"]
         created_by:
           type: [string, "null"]
+
+    BuildSpecSnapshotResponse:
+      type: object
+      required: [run_id, spec, spec_digest]
+      additionalProperties: false
+      properties:
+        run_id:
+          type: string
+        spec:
+          type: string
+          description: credential 값이 redaction된 canonical YAML
+        spec_digest:
+          type: string
+          pattern: '^sha256:[0-9a-f]{64}$'
+          description: >-
+            실제 저장된 redaction 후 canonical buildspec.yaml bytes의 SHA-256.
+            credential 값만 다른 spec은 같은 digest가 될 수 있다.
 
     BuildSummary:
       type: object

--- a/src/kpubdata_builder/manifest/writer.py
+++ b/src/kpubdata_builder/manifest/writer.py
@@ -41,6 +41,7 @@ def manifest_writer(manifest: BuildManifest, output_path: Path) -> None:
         ),
         "inputs": list(manifest.inputs),
         "inputs_fingerprint": manifest.inputs_fingerprint,
+        "created_by": manifest.created_by,
         "outputs": list(manifest.outputs),
         "warnings": list(manifest.warnings),
         "errors": list(manifest.errors),

--- a/src/kpubdata_builder/pipeline/orchestrator.py
+++ b/src/kpubdata_builder/pipeline/orchestrator.py
@@ -32,7 +32,7 @@ from ..manifest import (
     compute_inputs_fingerprint,
     manifest_writer,
 )
-from ..spec import BuildSpec, ExportTarget, SourceRef
+from ..spec import BuildSpec, ExportTarget, SourceRef, write_buildspec_snapshot
 from ..spec.validator import validate_spec
 from ..stages.bronze.build import SourceClient, build_bronze_artifact
 from ..stages.bronze.models import BronzeArtifact, utc_now
@@ -61,6 +61,18 @@ def _dataset_card_license(spec: BuildSpec) -> str:
         return spec.license
     legacy_license = spec.metadata.get("license")
     return legacy_license if isinstance(legacy_license, str) else ""
+
+
+def _dataset_card_version(spec: BuildSpec) -> str:
+    """metadata.version이 문자열일 때만 사용한다.
+
+    metadata가 ``_parse_json_mapping``으로 임의 JSON 값을 허용하면서, null/숫자/list/dict
+    값을 그대로 ``str()``에 넘기면 ``"None"``·``"{...}"`` 같은 문자열이 dataset card에
+    그대로 노출된다. license와 동일하게 문자열이 아니면 빈 값으로 취급해
+    ``card.version or "unversioned"`` fallback이 정상 동작하게 한다.
+    """
+    version = spec.metadata.get("version")
+    return version if isinstance(version, str) else ""
 
 
 @dataclass(frozen=True)
@@ -95,6 +107,7 @@ class BuildResult:
     status: str
     outcomes: tuple[SourceBuildOutcome, ...]
     manifest_path: Path
+    spec_digest: str
 
 
 def _fetch_source_key(source: SourceRef) -> str:
@@ -308,7 +321,7 @@ def _run_source_pipeline(
             ),
             sample_rows=silver.preview.rows,
             license=_dataset_card_license(context.spec),
-            version=str(context.spec.metadata.get("version", "")),
+            version=_dataset_card_version(context.spec),
         )
         card_path = gold_paths.gold_dir / "README.md"
         _ = card_path.write_text(render_dataset_card(card), encoding="utf-8")
@@ -395,6 +408,11 @@ def run_build(
     # spec이 단계 깊숙이 들어가 cryptic 에러로 터지므로, 단계 진입 전에 막는다 (#212).
     validate_spec(spec)
     context = BuildContext.create(spec, output_root=output_root, run_id=run_id)
+    # 검증된 실제 실행 입력을 pipeline보다 먼저 고정한다. 이후 source 단계가 실패해도
+    # run 감사 정보는 남고, validation 실패 입력은 snapshot으로 기록되지 않는다.
+    _, spec_digest = write_buildspec_snapshot(
+        spec, output_root=context.output_root, run_id=context.run_id
+    )
 
     def _worker(source: SourceRef) -> _SourcePipelineResult:
         return _run_source_pipeline(source, client=client, context=context)
@@ -452,4 +470,5 @@ def run_build(
         status=status,
         outcomes=outcomes,
         manifest_path=manifest_path,
+        spec_digest=spec_digest,
     )

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -30,6 +30,7 @@ from kpubdata.core.models import DatasetRef
 from ..errors import SpecLoadError, ValidationError
 from ..pipeline import preview_build, run_build
 from ..spec import BuildSpec, JsonValue, parse_spec
+from ..spec.serializer import BUILDSPEC_SNAPSHOT_FILENAME, compute_spec_digest
 from ..spec.validator import validate_spec
 from ..stages._path_safety import ensure_within, validate_path_segment
 from ..stages.bronze.build import SourceClient
@@ -99,6 +100,15 @@ def _check_ownership(
     return ServiceResponse(403, {"error": "forbidden: not run owner"})
 
 
+def _check_run_exists(service: BuilderService, run_id: str) -> ServiceResponse | None:
+    """snapshot 파일을 읽지 않고 run workspace 존재 여부만 확인한다."""
+    run_dir = service._output_root / run_id
+    ensure_within(service._output_root, run_dir, label="run directory")
+    if run_dir.is_dir():
+        return None
+    return ServiceResponse(404, {"error": f"run not found: {run_id}"})
+
+
 # Build list entry type for API responses
 _BuildListEntry = dict[str, str | None]
 
@@ -120,7 +130,7 @@ def _apply_ownership(
 # Builder API 계약 버전. contract/builder-api.yaml의 info.version과 일치해야 하며
 # (test_service_contract가 강제), 응답에 실어 Studio 같은 소비자가 하위 호환을
 # 협상할 수 있게 한다 (#209).
-API_CONTRACT_VERSION = "1.3.0"
+API_CONTRACT_VERSION = "1.4.0"
 
 
 @dataclass(frozen=True)
@@ -345,6 +355,7 @@ class BuilderService:
                 status=result.status,  # type: ignore[arg-type]
                 started_at=started_at,
                 finished_at=finished_at,
+                spec_digest=result.spec_digest,
                 created_by=manifest_data.get("created_by"),
             )
         except Exception:
@@ -392,6 +403,38 @@ class BuilderService:
         if not isinstance(manifest, dict):
             return ServiceResponse(500, {"error": "invalid manifest: expected object"})
         return ServiceResponse(200, cast(dict[str, JsonValue], manifest))
+
+    def spec(self, run_id: str) -> ServiceResponse:
+        """run에서 실제 사용한 canonical BuildSpec snapshot과 digest를 반환한다."""
+        try:
+            validate_path_segment(run_id, field_name="run_id")
+        except ValueError as exc:
+            return ServiceResponse(400, {"error": str(exc)})
+
+        run_dir = self._output_root / run_id
+        ensure_within(self._output_root, run_dir, label="run directory")
+        if not run_dir.is_dir():
+            return ServiceResponse(404, {"error": f"run not found: {run_id}"})
+
+        snapshot_path = run_dir / BUILDSPEC_SNAPSHOT_FILENAME
+        ensure_within(run_dir, snapshot_path, label="BuildSpec snapshot")
+        if not snapshot_path.is_file():
+            return ServiceResponse(
+                404, {"error": f"BuildSpec snapshot unavailable for run: {run_id}"}
+            )
+        try:
+            payload = snapshot_path.read_bytes()
+            spec_text = payload.decode("utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            return ServiceResponse(500, {"error": f"failed to read BuildSpec snapshot: {exc}"})
+        return ServiceResponse(
+            200,
+            {
+                "run_id": run_id,
+                "spec": spec_text,
+                "spec_digest": compute_spec_digest(payload),
+            },
+        )
 
     def serve_artifact_file(self, run_id: str, file_path: str) -> ServiceResponse | FileResponse:
         """실행 워크스페이스의 특정 파일을 제공한다 (#323).
@@ -626,6 +669,20 @@ def dispatch(
             if ownership_error is not None:
                 return ownership_error
             return service.manifest(run_id)
+
+    if method == "GET" and path.startswith("/builds/") and path.endswith("/spec"):
+        run_id = path[len("/builds/") : -len("/spec")]
+        try:
+            validate_path_segment(run_id, field_name="run_id")
+        except ValueError as exc:
+            return ServiceResponse(400, {"error": str(exc)})
+        existence_error = _check_run_exists(service, run_id)
+        if existence_error is not None:
+            return existence_error
+        ownership_error = _check_ownership(service, run_id, principal)
+        if ownership_error is not None:
+            return ownership_error
+        return service.spec(run_id)
 
     if method == "GET" and path.startswith("/artifacts/"):
         rest = path[len("/artifacts/") :]

--- a/src/kpubdata_builder/spec/__init__.py
+++ b/src/kpubdata_builder/spec/__init__.py
@@ -13,17 +13,31 @@ from __future__ import annotations
 
 from .loader import load_spec, parse_spec
 from .models import BuildSpec, ExportTarget, JsonPrimitive, JsonValue, SourceRef, SplitSpec
+from .serializer import (
+    BUILDSPEC_SNAPSHOT_FILENAME,
+    canonical_spec_mapping,
+    compute_spec_digest,
+    serialize_spec,
+    serialize_spec_bytes,
+    write_buildspec_snapshot,
+)
 from .template import load_template, render_template
 
 __all__ = [
     "BuildSpec",
+    "BUILDSPEC_SNAPSHOT_FILENAME",
     "ExportTarget",
     "JsonPrimitive",
     "JsonValue",
     "SourceRef",
     "SplitSpec",
+    "canonical_spec_mapping",
+    "compute_spec_digest",
     "load_spec",
     "load_template",
     "parse_spec",
     "render_template",
+    "serialize_spec",
+    "serialize_spec_bytes",
+    "write_buildspec_snapshot",
 ]

--- a/src/kpubdata_builder/spec/serializer.py
+++ b/src/kpubdata_builder/spec/serializer.py
@@ -1,0 +1,192 @@
+"""Run별 재현성 감사를 위한 canonical BuildSpec 직렬화와 snapshot 저장."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import os
+import tempfile
+from pathlib import Path
+from typing import cast
+
+import yaml
+
+from ..stages._path_safety import ensure_within, validate_path_segment
+from .models import BuildSpec, JsonValue
+
+BUILDSPEC_SNAPSHOT_FILENAME = "buildspec.yaml"
+REDACTED_VALUE = "<redacted>"
+
+# BuildSpec에는 별도 credential 모델이 없고 자유 형식 JSON 매핑만 있다. 따라서
+# 부분 문자열 추측 대신, 실제로 credential 값에 쓰이는 명시적 키만 redaction한다.
+_SECRET_FIELD_NAMES = frozenset(
+    {
+        "access_token",
+        "accesstoken",
+        "api_key",
+        "apikey",
+        "authorization",
+        "bearer_token",
+        "bearertoken",
+        "client_secret",
+        "clientsecret",
+        "password",
+        "refresh_token",
+        "refreshtoken",
+        "secret",
+        "service_key",
+        "servicekey",
+        "token",
+        # 이 저장소가 실제 credential 환경변수/헤더 이름으로 사용하는 키.
+        "hf_token",
+        "kaggle_key",
+        "kpubdata_builder_api_key",
+        "kpubdata_datago_api_key",
+        "x_api_key",
+    }
+)
+
+
+def _normalized_key(key: str) -> str:
+    return key.casefold().replace("-", "_")
+
+
+def _canonical_json(value: JsonValue) -> JsonValue:
+    """JSON 값을 key 순서와 secret redaction이 고정된 값으로 복사한다."""
+    if isinstance(value, dict):
+        result: dict[str, JsonValue] = {}
+        for key in sorted(value):
+            item = value[key]
+            result[key] = (
+                REDACTED_VALUE
+                if _normalized_key(key) in _SECRET_FIELD_NAMES
+                else _canonical_json(item)
+            )
+        return result
+    if isinstance(value, list):
+        return [_canonical_json(item) for item in value]
+    return value
+
+
+def canonical_spec_mapping(spec: BuildSpec) -> dict[str, JsonValue]:
+    """BuildSpec을 필드 순서와 optional 기본값이 고정된 JSON 호환 매핑으로 만든다."""
+    sources: list[JsonValue] = []
+    for source in spec.sources:
+        schema: JsonValue = None
+        if source.schema is not None:
+            schema = {
+                "required": list(source.schema.required),
+                "dtypes": _canonical_json(cast(JsonValue, source.schema.dtypes)),
+                "casts": _canonical_json(cast(JsonValue, source.schema.casts)),
+            }
+        sources.append(
+            {
+                "provider": source.provider,
+                "dataset": source.dataset,
+                "params": _canonical_json(source.params),
+                "alias": source.alias,
+                "schema": schema,
+            }
+        )
+
+    exports: list[JsonValue] = [
+        {
+            "kind": target.kind,
+            "output_path": target.output_path,
+            "options": _canonical_json(target.options),
+        }
+        for target in spec.exports
+    ]
+
+    splits: JsonValue = None
+    if spec.splits is not None:
+        splits = {
+            "mode": spec.splits.mode,
+            "ratios": _canonical_json(cast(JsonValue, spec.splits.ratios)),
+            "key": spec.splits.key,
+            "seed": spec.splits.seed,
+        }
+
+    pii: JsonValue = None
+    if spec.pii is not None:
+        pii = {"mode": spec.pii.mode, "allow_columns": list(spec.pii.allow_columns)}
+
+    quality: JsonValue = None
+    if spec.quality is not None:
+        quality = {
+            "max_duplicate_rate": spec.quality.max_duplicate_rate,
+            "max_null_ratio": _canonical_json(cast(JsonValue, spec.quality.max_null_ratio)),
+            "min_rows": spec.quality.min_rows,
+        }
+
+    return {
+        "dataset_id": spec.dataset_id,
+        "title": spec.title,
+        "description": spec.description,
+        "sources": sources,
+        "exports": exports,
+        "metadata": _canonical_json(spec.metadata),
+        "publish": spec.publish,
+        "splits": splits,
+        "pii": pii,
+        "license": spec.license,
+        "quality": quality,
+    }
+
+
+def serialize_spec(spec: BuildSpec) -> str:
+    """BuildSpec을 결정적인 canonical UTF-8 YAML 문자열로 직렬화한다."""
+    return yaml.safe_dump(
+        canonical_spec_mapping(spec),
+        allow_unicode=True,
+        default_flow_style=False,
+        sort_keys=False,
+        width=4096,
+    )
+
+
+def serialize_spec_bytes(spec: BuildSpec) -> bytes:
+    """실제 snapshot에 기록할 canonical bytes를 반환한다."""
+    return serialize_spec(spec).encode("utf-8")
+
+
+def compute_spec_digest(payload: bytes) -> str:
+    """canonical snapshot bytes의 SHA-256 digest를 반환한다."""
+    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+
+def write_buildspec_snapshot(
+    spec: BuildSpec, *, output_root: Path, run_id: str
+) -> tuple[Path, str]:
+    """canonical BuildSpec을 run workspace에 원자적으로 기록하고 digest를 반환한다."""
+    validate_path_segment(run_id, field_name="run_id")
+    run_dir = output_root / run_id
+    ensure_within(output_root, run_dir, label="run directory")
+    snapshot_path = run_dir / BUILDSPEC_SNAPSHOT_FILENAME
+    ensure_within(run_dir, snapshot_path, label="BuildSpec snapshot")
+    payload = serialize_spec_bytes(spec)
+
+    run_dir.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=run_dir, prefix=".buildspec_", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_name, snapshot_path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+    return snapshot_path, compute_spec_digest(payload)
+
+
+__all__ = [
+    "BUILDSPEC_SNAPSHOT_FILENAME",
+    "REDACTED_VALUE",
+    "canonical_spec_mapping",
+    "compute_spec_digest",
+    "serialize_spec",
+    "serialize_spec_bytes",
+    "write_buildspec_snapshot",
+]

--- a/src/kpubdata_builder/store/build_index.py
+++ b/src/kpubdata_builder/store/build_index.py
@@ -303,9 +303,11 @@ def rebuild_index(output_root: Path) -> int:
             finished_at = manifest.get("finished_at")
             snapshot_path = run_dir / BUILDSPEC_SNAPSHOT_FILENAME
             try:
+                # is_file()은 symlink를 따라가므로, 워크스페이스 밖 파일을
+                # 해시하는 것을 막기 위해 symlink는 명시적으로 거부한다.
                 spec_digest = (
                     compute_spec_digest(snapshot_path.read_bytes())
-                    if snapshot_path.is_file()
+                    if snapshot_path.is_file() and not snapshot_path.is_symlink()
                     else None
                 )
             except OSError:

--- a/src/kpubdata_builder/store/build_index.py
+++ b/src/kpubdata_builder/store/build_index.py
@@ -271,6 +271,8 @@ def rebuild_index(output_root: Path) -> int:
     """
     import json
 
+    from ..spec.serializer import BUILDSPEC_SNAPSHOT_FILENAME, compute_spec_digest
+
     if not output_root.exists():
         return 0
 
@@ -299,12 +301,22 @@ def rebuild_index(output_root: Path) -> int:
             status = "failed" if manifest.get("errors") else "ok"
             started_at = manifest.get("started_at")
             finished_at = manifest.get("finished_at")
+            snapshot_path = run_dir / BUILDSPEC_SNAPSHOT_FILENAME
+            try:
+                spec_digest = (
+                    compute_spec_digest(snapshot_path.read_bytes())
+                    if snapshot_path.is_file()
+                    else None
+                )
+            except OSError:
+                spec_digest = None
 
             index.insert_or_replace(
                 run_id=run_dir.name,
                 status=status,  # type: ignore[arg-type]
                 started_at=started_at,
                 finished_at=finished_at,
+                spec_digest=spec_digest,
                 created_by=manifest.get("created_by"),
             )
             count += 1

--- a/tests/unit/test_build_index.py
+++ b/tests/unit/test_build_index.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -217,6 +218,74 @@ class TestRebuildIndex:
         # run_id로 정렬 확인 (finished_at DESC)
         assert builds[0].run_id == "run2"
         assert builds[1].run_id == "run1"
+
+    def test_rebuild_indexes_digest_from_snapshot_bytes(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run1"
+        run_dir.mkdir()
+        (run_dir / "manifest.json").write_text(
+            json.dumps({"started_at": "a", "finished_at": "b"}), encoding="utf-8"
+        )
+        payload = b"dataset_id: d\n"
+        (run_dir / "buildspec.yaml").write_bytes(payload)
+
+        assert rebuild_index(tmp_path) == 1
+
+        entry = BuildIndex(tmp_path).get("run1")
+        assert entry is not None
+        assert entry.spec_digest == f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+    def test_rebuild_keeps_legacy_snapshot_digest_null(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "legacy"
+        run_dir.mkdir()
+        (run_dir / "manifest.json").write_text("{}", encoding="utf-8")
+
+        assert rebuild_index(tmp_path) == 1
+        entry = BuildIndex(tmp_path).get("legacy")
+        assert entry is not None
+        assert entry.spec_digest is None
+
+    def test_rebuild_isolates_empty_corrupt_and_unreadable_snapshots(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        payloads: dict[str, bytes | None] = {
+            "normal": b"dataset_id: normal\n",
+            "empty": b"",
+            "invalid-utf8": b"\xff\xfe\x00",
+            "unreadable": b"dataset_id: unreadable\n",
+        }
+        for run_id, payload in payloads.items():
+            run_dir = tmp_path / run_id
+            run_dir.mkdir()
+            (run_dir / "manifest.json").write_text("{}", encoding="utf-8")
+            if payload is not None:
+                (run_dir / "buildspec.yaml").write_bytes(payload)
+
+        original_read_bytes = Path.read_bytes
+
+        def read_bytes_or_fail(path: Path) -> bytes:
+            if path == tmp_path / "unreadable" / "buildspec.yaml":
+                raise PermissionError("snapshot unreadable")
+            return original_read_bytes(path)
+
+        monkeypatch.setattr(Path, "read_bytes", read_bytes_or_fail)
+
+        assert rebuild_index(tmp_path) == len(payloads)
+
+        index = BuildIndex(tmp_path)
+        normal = index.get("normal")
+        empty = index.get("empty")
+        invalid = index.get("invalid-utf8")
+        unreadable = index.get("unreadable")
+        assert normal is not None
+        assert empty is not None
+        assert invalid is not None
+        assert unreadable is not None
+        assert normal.spec_digest == f"sha256:{hashlib.sha256(payloads['normal']).hexdigest()}"
+        assert empty.spec_digest == f"sha256:{hashlib.sha256(b'').hexdigest()}"
+        assert invalid.spec_digest == (
+            f"sha256:{hashlib.sha256(payloads['invalid-utf8']).hexdigest()}"
+        )
+        assert unreadable.spec_digest is None
 
     def test_rebuild_replaces_existing_index(self, tmp_path: Path) -> None:
         """rebuild는 기존 인덱스를 삭제하고 다시 생성한다."""

--- a/tests/unit/test_build_index.py
+++ b/tests/unit/test_build_index.py
@@ -244,6 +244,22 @@ class TestRebuildIndex:
         assert entry is not None
         assert entry.spec_digest is None
 
+    def test_rebuild_skips_symlinked_snapshot(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run1"
+        run_dir.mkdir()
+        (run_dir / "manifest.json").write_text(
+            json.dumps({"started_at": "a", "finished_at": "b"}), encoding="utf-8"
+        )
+        outside = tmp_path / "outside.yaml"
+        outside.write_bytes(b"dataset_id: evil\n")
+        (run_dir / "buildspec.yaml").symlink_to(outside)
+
+        assert rebuild_index(tmp_path) == 1
+
+        entry = BuildIndex(tmp_path).get("run1")
+        assert entry is not None
+        assert entry.spec_digest is None
+
     def test_rebuild_isolates_empty_corrupt_and_unreadable_snapshots(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/test_buildspec_snapshot.py
+++ b/tests/unit/test_buildspec_snapshot.py
@@ -1,0 +1,208 @@
+"""Run별 canonical BuildSpec snapshot 계약 검증 (#487)."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import replace
+from pathlib import Path
+from typing import cast
+
+import pytest
+import yaml
+
+import kpubdata_builder.spec.serializer as serializer
+from kpubdata_builder.spec import (
+    BuildSpec,
+    ExportTarget,
+    SourceRef,
+    compute_spec_digest,
+    parse_spec,
+    serialize_spec,
+    serialize_spec_bytes,
+    write_buildspec_snapshot,
+)
+from kpubdata_builder.spec.models import PiiPolicy, QualityPolicy, SchemaContract, SplitSpec
+
+
+def _complete_spec() -> BuildSpec:
+    return BuildSpec(
+        dataset_id="dataset.contract",
+        title="계약 데이터",
+        description="모든 optional field",
+        sources=(
+            SourceRef(
+                provider="datago",
+                dataset="air_quality",
+                params={"nested": {"z": 1, "a": [True, None]}, "page": 1},
+                alias="air",
+                schema=SchemaContract(
+                    required=("id",), dtypes={"id": "string"}, casts={"value": "float64"}
+                ),
+            ),
+        ),
+        exports=(
+            ExportTarget(
+                kind="jsonl",
+                output_path="out/data.jsonl",
+                options={"indent": 2, "flags": ["a", "b"]},
+            ),
+        ),
+        metadata={"coverage": {"year": 2026, "note": None}, "public": True},
+        publish=False,
+        splits=SplitSpec(mode="ratio", ratios={"train": 0.8, "test": 0.2}, seed=7),
+        pii=PiiPolicy(mode="warn", allow_columns=("contact_hint",)),
+        license="CC-BY-4.0",
+        quality=QualityPolicy(
+            max_duplicate_rate=0.01, max_null_ratio={"value": 0.05}, min_rows=100
+        ),
+    )
+
+
+def _parse_yaml(text: str) -> BuildSpec:
+    raw = yaml.safe_load(text)
+    assert isinstance(raw, dict)
+    return parse_spec(cast(dict[str, object], raw))
+
+
+def test_minimal_and_complete_spec_round_trip() -> None:
+    minimal = BuildSpec(
+        dataset_id="d",
+        title="t",
+        description="desc",
+        sources=(SourceRef(provider="p", dataset="s"),),
+        exports=(ExportTarget(kind="jsonl", output_path="data.jsonl"),),
+    )
+
+    assert _parse_yaml(serialize_spec(minimal)) == minimal
+    assert _parse_yaml(serialize_spec(_complete_spec())) == _complete_spec()
+
+
+def test_serialization_is_deterministic_for_nested_mapping_order() -> None:
+    first = _complete_spec()
+    second = replace(first, metadata={"public": True, "coverage": {"note": None, "year": 2026}})
+
+    assert first == second
+    assert serialize_spec_bytes(first) == serialize_spec_bytes(second)
+    assert compute_spec_digest(serialize_spec_bytes(first)) == compute_spec_digest(
+        serialize_spec_bytes(second)
+    )
+
+
+def test_secret_redaction_is_exact_and_recursive() -> None:
+    spec = _complete_spec()
+    source = spec.sources[0]
+    redacted = replace(
+        spec,
+        sources=(
+            replace(
+                source,
+                params={
+                    "api_key": "plain-api-secret",
+                    "apiKey": "plain-camel-api-secret",
+                    "service_key": "plain-service-secret",
+                    "nested": [
+                        {
+                            "serviceKey": "plain-camel-service-secret",
+                            "access_token": "plain-access-token",
+                        },
+                        {"refresh_token": "plain-refresh-token"},
+                    ],
+                    "monkey": "keep-me",
+                    "token_count": 3,
+                },
+            ),
+        ),
+        exports=(
+            replace(
+                spec.exports[0],
+                options={
+                    "client_secret": "plain-client-secret",
+                    "Authorization": "plain-authorization",
+                },
+            ),
+        ),
+        metadata={
+            "password": "plain-password",
+            "HF_TOKEN": "plain-hf-token",
+            "KAGGLE_KEY": "plain-kaggle-key",
+            "KPUBDATA_DATAGO_API_KEY": "plain-datago-key",
+            "KPUBDATA_BUILDER_API_KEY": "plain-builder-key",
+            "bearer_token": "plain-bearer-token",
+            "key": "business-key",
+        },
+    )
+
+    text = serialize_spec(redacted)
+
+    assert "plain-api-secret" not in text
+    plaintext_secrets = (
+        "plain-api-secret",
+        "plain-camel-api-secret",
+        "plain-service-secret",
+        "plain-camel-service-secret",
+        "plain-access-token",
+        "plain-refresh-token",
+        "plain-client-secret",
+        "plain-authorization",
+        "plain-password",
+        "plain-hf-token",
+        "plain-kaggle-key",
+        "plain-datago-key",
+        "plain-builder-key",
+        "plain-bearer-token",
+    )
+    assert all(secret not in text for secret in plaintext_secrets)
+    assert text.count("<redacted>") == len(plaintext_secrets)
+    assert "keep-me" in text
+    assert "business-key" in text
+    assert "token_count: 3" in text
+    # credential-bearing snapshot은 의도적으로 원본과 동일한 round-trip을 제공하지 않는다.
+    assert _parse_yaml(text) != redacted
+
+
+def test_specs_differing_only_by_secret_share_redacted_snapshot_digest() -> None:
+    first = replace(
+        _complete_spec(),
+        metadata={"api_key": "first-secret", "label": "same-public-value"},
+    )
+    second = replace(
+        first,
+        metadata={"api_key": "second-secret", "label": "same-public-value"},
+    )
+
+    first_payload = serialize_spec_bytes(first)
+    second_payload = serialize_spec_bytes(second)
+
+    assert first_payload == second_payload
+    assert compute_spec_digest(first_payload) == compute_spec_digest(second_payload)
+
+
+def test_snapshot_bytes_and_digest_are_identical(tmp_path: Path) -> None:
+    path, digest = write_buildspec_snapshot(_complete_spec(), output_root=tmp_path, run_id="r1")
+    payload = path.read_bytes()
+
+    assert path == tmp_path / "r1" / "buildspec.yaml"
+    assert payload == serialize_spec_bytes(_complete_spec())
+    assert digest == f"sha256:{hashlib.sha256(payload).hexdigest()}"
+    changed_payload = serialize_spec_bytes(replace(_complete_spec(), title="변경된 제목"))
+    assert compute_spec_digest(changed_payload) != digest
+
+
+def test_snapshot_write_is_atomic_and_cleans_temp_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail_replace(_source: str, _destination: Path) -> None:
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(serializer.os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="replace failed"):
+        write_buildspec_snapshot(_complete_spec(), output_root=tmp_path, run_id="r1")
+
+    assert not (tmp_path / "r1" / "buildspec.yaml").exists()
+    assert list((tmp_path / "r1").glob(".buildspec_*.tmp")) == []
+
+
+def test_snapshot_rejects_unsafe_run_id(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="run_id"):
+        write_buildspec_snapshot(_complete_spec(), output_root=tmp_path, run_id="../escape")

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -235,6 +235,22 @@ def test_manifest_writer_emits_schema_version(tmp_path: Path) -> None:
     assert payload["schema_version"] == MANIFEST_SCHEMA_VERSION
 
 
+def test_manifest_writer_emits_existing_created_by_as_additive_field(tmp_path: Path) -> None:
+    manifest = BuildManifest(
+        build_id="build-owner",
+        started_at=datetime(2026, 5, 26, 1, 0, 0, tzinfo=timezone.utc),
+        finished_at=datetime(2026, 5, 26, 1, 0, 0, tzinfo=timezone.utc),
+        created_by="oidc:user@example.com",
+    )
+    output_path = tmp_path / "manifest.json"
+
+    manifest_writer(manifest, output_path)
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["created_by"] == "oidc:user@example.com"
+    assert payload["schema_version"] == MANIFEST_SCHEMA_VERSION == "1.0.0"
+
+
 def test_capture_build_environment_reports_python_and_builder_version() -> None:
     env = capture_build_environment()
     # builder는 설치되어 있으므로 실제 버전을, kpubdata도 의존성이므로 버전 문자열을 가진다.

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -9,10 +9,11 @@ from typing import cast
 
 import polars as pl
 import pytest
+import yaml
 
 import kpubdata_builder.pipeline.orchestrator as orchestrator
 from kpubdata_builder.pipeline import BuildContext, BuildResult, run_build
-from kpubdata_builder.spec import BuildSpec, ExportTarget, JsonValue, SourceRef
+from kpubdata_builder.spec import BuildSpec, ExportTarget, JsonValue, SourceRef, parse_spec
 
 
 class _FakeResult:
@@ -101,6 +102,7 @@ def test_run_build_executes_full_pipeline_and_writes_workspace(tmp_path: Path) -
 
     # run workspace 디렉터리 구조
     run_dir = tmp_path / "run1"
+    assert (run_dir / "buildspec.yaml").is_file()
     assert (run_dir / "bronze").is_dir()
     assert (run_dir / "silver").is_dir()
     assert (run_dir / "gold").is_dir()
@@ -215,6 +217,65 @@ def test_run_build_dataset_card_uses_canonical_license_with_legacy_fallback(
     assert f"## License\n\n{expected}\n" in text
     if unexpected is not None:
         assert unexpected not in text
+
+
+def test_run_build_snapshot_round_trip_preserves_legacy_license_fallback(
+    tmp_path: Path,
+) -> None:
+    """serializer는 legacy metadata.license를 top-level로 승격하지 않는다 (#487).
+
+    snapshot에는 metadata가 그대로 보존되므로, snapshot을 다시 parse해서 재실행해도
+    ``_dataset_card_license``의 legacy fallback으로 동일한 license가 나와야 한다 —
+    canonical spec의 license 표현과 dataset card 렌더링이 재현 가능함을 검증한다.
+    """
+    spec = BuildSpec(
+        dataset_id="apt_trade",
+        title="Apartment Trades",
+        description="seoul apartment trades",
+        sources=(SourceRef(provider="datago", dataset="apt_trade"),),
+        exports=(ExportTarget(kind="jsonl", output_path="data.jsonl"),),
+        metadata={"license": "KOGL Type 1"},
+    )
+    client = _FakeClient({"datago.apt_trade": [{"id": "1"}]})
+
+    first = run_build(spec, client=client, output_root=tmp_path, run_id="run1")
+    assert first.status == "ok"
+
+    snapshot_text = (tmp_path / "run1" / "buildspec.yaml").read_text(encoding="utf-8")
+    reparsed = parse_spec(cast(dict[str, object], yaml.safe_load(snapshot_text)))
+    assert reparsed.license is None
+    assert reparsed.metadata["license"] == "KOGL Type 1"
+
+    second = run_build(reparsed, client=client, output_root=tmp_path, run_id="run2")
+    assert second.status == "ok"
+    readme = tmp_path / "run2" / "gold" / "datago.apt_trade" / "README.md"
+    assert "## License\n\nKOGL Type 1\n" in readme.read_text(encoding="utf-8")
+
+
+def test_run_build_dataset_card_ignores_non_string_metadata_version(tmp_path: Path) -> None:
+    """metadata.version이 null/숫자/list/dict이면 문자열화하지 않고 unversioned로 렌더링한다 (#487).
+
+    metadata가 JsonValue로 넓어지면서 ``str(None) == "None"``이 그대로 카드에 노출되던
+    회귀를 막는다.
+    """
+    spec = BuildSpec(
+        dataset_id="apt_trade",
+        title="Apartment Trades",
+        description="seoul apartment trades",
+        sources=(SourceRef(provider="datago", dataset="apt_trade"),),
+        exports=(ExportTarget(kind="jsonl", output_path="data.jsonl"),),
+        metadata={"version": None},
+    )
+    client = _FakeClient({"datago.apt_trade": [{"id": "1"}]})
+
+    result = run_build(spec, client=client, output_root=tmp_path, run_id="run1")
+
+    assert result.status == "ok"
+    text = (tmp_path / "run1" / "gold" / "datago.apt_trade" / "README.md").read_text(
+        encoding="utf-8"
+    )
+    assert "## Version\n\nunversioned" in text
+    assert "None" not in text
 
 
 def test_run_build_does_not_forward_arbitrary_metadata_to_exporters(
@@ -575,3 +636,13 @@ def test_run_build_validates_spec_before_running(tmp_path: Path) -> None:
 
     # fail-fast: manifest나 워크스페이스가 생성되지 않는다.
     assert not (tmp_path / "run1").exists()
+
+
+def test_run_build_keeps_snapshot_when_source_pipeline_fails(tmp_path: Path) -> None:
+    spec = _spec(SourceRef(provider="datago", dataset="missing"))
+
+    result = run_build(spec, client=_FakeClient({}), output_root=tmp_path, run_id="failed-run")
+
+    assert result.status == "failed"
+    assert (tmp_path / "failed-run" / "buildspec.yaml").is_file()
+    assert result.spec_digest.startswith("sha256:")

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import threading
 import urllib.error
@@ -13,6 +14,7 @@ from typing import cast
 
 import pytest
 
+import kpubdata_builder.service.app as app_module
 from kpubdata_builder.service import BuilderService, ServiceResponse, dispatch
 from kpubdata_builder.service.app import _OWNERSHIP_ENV
 from kpubdata_builder.service.auth import Principal
@@ -1341,3 +1343,76 @@ class TestRunIdRouteValidation:
         # ENFORCE_OWNERSHIP off(기본) → 200
         resp = dispatch(service, "GET", "/artifacts/run1", None)
         assert resp.status_code == 200
+
+
+class TestBuildSpecSnapshot:
+    """GET /builds/{run_id}/spec의 조회·보안·legacy 정책 (#487)."""
+
+    def test_owner_reads_snapshot_and_index_digest_matches(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        build = dispatch(service, "POST", "/build", {"spec": VALID_SPEC_YAML, "run_id": "spec-run"})
+        assert build.status_code == 200
+
+        response = dispatch(service, "GET", "/builds/spec-run/spec", None)
+
+        assert response.status_code == 200
+        snapshot = (tmp_path / "spec-run" / "buildspec.yaml").read_bytes()
+        expected = f"sha256:{hashlib.sha256(snapshot).hexdigest()}"
+        assert response.body == {
+            "run_id": "spec-run",
+            "spec": snapshot.decode("utf-8"),
+            "spec_digest": expected,
+        }
+        entry = service._build_index.get("spec-run")
+        assert entry is not None
+        assert entry.spec_digest == expected
+
+    def test_unknown_and_legacy_run_return_404(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        assert dispatch(service, "GET", "/builds/unknown/spec", None).status_code == 404
+
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        (legacy / "manifest.json").write_text("{}", encoding="utf-8")
+        response = dispatch(service, "GET", "/builds/legacy/spec", None)
+        assert response.status_code == 404
+        assert "unavailable" in str(response.body["error"])
+
+    @pytest.mark.parametrize("run_id", ["..", "../escape", "bad%2Fsegment"])
+    def test_invalid_run_id_returns_400(self, tmp_path: Path, run_id: str) -> None:
+        response = dispatch(_service(tmp_path), "GET", f"/builds/{run_id}/spec", None)
+        assert response.status_code == 400
+
+    def test_another_owner_receives_403(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(_OWNERSHIP_ENV, "true")
+        service = _service(tmp_path)
+        monkeypatch.setattr(
+            app_module, "authenticate", lambda **_kwargs: Principal(kind="oidc", identifier="a")
+        )
+        build = dispatch(service, "POST", "/build", {"spec": VALID_SPEC_YAML, "run_id": "owned"})
+        assert build.status_code == 200
+
+        monkeypatch.setattr(
+            app_module, "authenticate", lambda **_kwargs: Principal(kind="oidc", identifier="b")
+        )
+        response = dispatch(service, "GET", "/builds/owned/spec", None)
+        assert response.status_code == 403
+
+        # ownership 거부 시 snapshot reader까지 도달하지 않는다.
+        monkeypatch.setattr(Path, "read_bytes", lambda _path: pytest.fail("snapshot read leaked"))
+        response = dispatch(service, "GET", "/builds/owned/spec", None)
+        assert response.status_code == 403
+
+    def test_unknown_run_returns_404_before_ownership(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(_OWNERSHIP_ENV, "true")
+        monkeypatch.setattr(
+            app_module, "authenticate", lambda **_kwargs: Principal(kind="oidc", identifier="a")
+        )
+
+        response = dispatch(_service(tmp_path), "GET", "/builds/unknown/spec", None)
+
+        assert response.status_code == 404

--- a/tests/unit/test_service_contract.py
+++ b/tests/unit/test_service_contract.py
@@ -44,6 +44,7 @@ _DISPATCH_ROUTES: dict[tuple[str, str], str] = {
     ("/build", "POST"): "createBuild",
     ("/builds", "GET"): "listBuilds",
     ("/builds/{run_id}/manifest", "GET"): "getBuildManifest",
+    ("/builds/{run_id}/spec", "GET"): "getBuildSpecSnapshot",
     ("/artifacts/{run_id}", "GET"): "listBuildArtifacts",
 }
 
@@ -57,6 +58,7 @@ _REQUIRED_OPERATIONS = [
     ("/preview", "post"),
     ("/build", "post"),
     ("/builds/{run_id}/manifest", "get"),
+    ("/builds/{run_id}/spec", "get"),
     ("/artifacts/{run_id}", "get"),
     ("/builds", "get"),
 ]
@@ -245,6 +247,7 @@ _IMPLEMENTED_OPERATIONS = {
     "previewBuild",
     "createBuild",
     "getBuildManifest",
+    "getBuildSpecSnapshot",
     "listBuildArtifacts",
     "listBuilds",
 }
@@ -423,6 +426,7 @@ _OPERATION_STATUS_CODES: dict[str, set[int]] = {
     "previewBuild": {200, 400},
     "createBuild": {200, 400, 502},
     "getBuildManifest": {200, 400, 404, 500},
+    "getBuildSpecSnapshot": {200, 400, 403, 404, 500},
     "listBuilds": {200, 400},
     "listBuildArtifacts": {200, 400, 404},
 }
@@ -752,6 +756,18 @@ class TestResponseConformance:
         resp = dispatch(_conform_service(tmp_path), "GET", "/builds/nope/manifest", None)
         assert resp.status_code == 404
         _assert_conforms(resp, "/builds/{run_id}/manifest", "GET")
+
+    def test_spec_200_after_build(self, tmp_path: Path) -> None:
+        service = _conform_service(tmp_path)
+        dispatch(service, "POST", "/build", {"spec": _CONFORM_SPEC_YAML, "run_id": "spec-ok"})
+        resp = dispatch(service, "GET", "/builds/spec-ok/spec", None)
+        assert resp.status_code == 200
+        _assert_conforms(resp, "/builds/{run_id}/spec", "GET")
+
+    def test_spec_404_missing(self, tmp_path: Path) -> None:
+        resp = dispatch(_conform_service(tmp_path), "GET", "/builds/nope/spec", None)
+        assert resp.status_code == 404
+        _assert_conforms(resp, "/builds/{run_id}/spec", "GET")
 
     def test_builds_400_bad_limit(self, tmp_path: Path) -> None:
         resp = dispatch(_conform_service(tmp_path), "GET", "/builds", None, query="limit=0")


### PR DESCRIPTION
PR #510 was mistakenly merged into its stacked base branch instead of main. This PR lands the same content (persist canonical BuildSpec snapshots + symlink rejection fix + tests) into main. cc: #487