### PR TITLE
feat: add Source↔Silver diff and sampling options to /preview (#497)

### DIFF
--- a/contract/builder-api.yaml
+++ b/contract/builder-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: KPubData Builder Service API
-  version: "1.8.0"
+  version: "1.9.0"
   description: >-
     Builder 중심 서비스 계약. BuildSpec 검증, preview, build 실행, artifact 조회,
     계약 버전 조회를 제공한다. CLI와 HTTP service mode(#36)가 동일한 도메인 계약을
@@ -17,7 +17,13 @@ info:
     `evaluated_checks`를 함께 반환해 "0건 평가"와 "애초에 계산된 적 없음"을
     구분한다(#514, additive). v1.7.0은 Silver/Gold read-only `/query`를
     추가한다(#504, additive). v1.8.0은 stable principal별 encrypted Provider
-    credential CRUD와 Provider status/test API를 추가한다(#492, additive).
+    credential CRUD와 Provider status/test API를 추가한다(#492, additive). v1.9.0은
+    `POST /preview`에 Source↔Silver diff와 sample_mode(first/random) 옵션을
+    추가한다(#497, additive — 기존 필드는 유지된다). `limit`의 상한(1000)을
+    새로 도입해 그 이상 값을 요청하면 400을 반환한다(behavioral tightening;
+    이전에는 상한이 없었다). `limit`이 행 수만 제한하므로 wide dataset에서
+    `diffs` 자체가 무제한 커질 수 있어, `diffs`도 별도 상한(1000)으로 자르고
+    `diff_truncated`로 명시한다 — `transform_summary`의 집계는 잘리지 않는다.
 servers:
   - url: http://localhost:8000
     description: 로컬 builder 개발 서버
@@ -1118,7 +1124,25 @@ components:
         limit:
           type: integer
           minimum: 1
+          maximum: 1000
           default: 5
+          description: >-
+            상한 1000은 #497에서 새로 도입됐다(behavioral tightening — v1.8.0
+            이전에는 상한이 없었다). 1000을 넘는 값은 400을 반환한다.
+        sample_mode:
+          type: string
+          enum: [first, random]
+          default: first
+          description: >-
+            "first"는 상위 N행, "random"은 seed 기반 결정적 무작위 N행이다(#497).
+            Source sample과 Silver sample은 항상 같은 행 인덱스를 공유한다 —
+            생략하면 기존 client와 동일하게 상위 N행을 반환한다.
+        seed:
+          type: integer
+          description: >-
+            sample_mode=random일 때 쓰는 결정적 시드(#497). 생략하면 고정
+            기본값을 써서 seed 없이도 재현 가능하다. sample_mode=first에서는
+            무시된다.
 
     BuildRequest:
       type: object
@@ -1323,6 +1347,12 @@ components:
         - total_rows
         - statistics
         - quality_results
+        - source_sample
+        - sample_mode
+        - diff_available
+        - diffs
+        - transform_summary
+        - diff_truncated
       properties:
         source_key:
           type: string
@@ -1363,6 +1393,88 @@ components:
             워크스페이스에 아무것도 쓰지 않으므로 포함하지 않는다.
           items:
             $ref: "#/components/schemas/QualityCheckResult"
+        source_sample:
+          type: array
+          description: >-
+            변환 전 Bronze 원본 sample(#497). diff_available=false여도 최선
+            노력으로 채워질 수 있다(조회 자체가 실패하면 빈 배열).
+          items:
+            type: object
+            additionalProperties:
+              $ref: "#/components/schemas/JsonValue"
+        sample_mode:
+          type: string
+          enum: [first, random]
+          description: 이 응답에 실제로 적용된 sampling 방식.
+        diff_available:
+          type: boolean
+          description: >-
+            source_sample[i]와 sample[i]가 동일 논리 행을 가리킨다고 보장할 수
+            있을 때만 true다(#497). 행 수 불일치, row reorder/filter 가능성,
+            조회 실패 등에서는 false이며 diffs/transform_summary는 빈 값이다.
+            잘못된 index 기반 비교보다 false가 우선이다.
+        diffs:
+          type: array
+          description: >-
+            diff_available=true일 때만 채워지는 셀 단위 변경 목록(#497). limit은
+            행 수만 제한하고 컬럼 수는 제한하지 않으므로, 실제 변경 셀 수가
+            많으면 최대 1000개(MAX_PREVIEW_DIFF_ITEMS)까지만 담긴다 —
+            diff_truncated로 잘렸는지 확인한다.
+          items:
+            $ref: "#/components/schemas/PreviewDiffItem"
+        transform_summary:
+          description: >-
+            diff_available=true일 때만 채워지는 변경 요약(#497). 비교 가능한
+            sample 범위 기준이며 전체 dataset 변화량이 아니다. diffs가
+            diff_truncated로 잘려도 changed_cells/changed_rows는 잘리지 않은
+            실제 합계를 유지한다.
+          oneOf:
+            - $ref: "#/components/schemas/PreviewTransformSummary"
+            - type: "null"
+        diff_truncated:
+          type: boolean
+          description: >-
+            diffs가 MAX_PREVIEW_DIFF_ITEMS(1000) 상한에 걸려 실제 변경 셀 전부를
+            담지 못했으면 true다(#497 sample/diff memory 상한). diffs를 전체
+            diff로 오인하지 않도록 명시한다. diff_available=false면 애초에
+            diff를 시도하지 않았으므로 항상 false다.
+
+    PreviewDiffItem:
+      type: object
+      description: >-
+        Source↔Silver 셀 단위 변경 하나(#497). diff_available=true인 source의
+        diffs에만 등장한다.
+      additionalProperties: false
+      required: [row, column, before, after, transform]
+      properties:
+        row:
+          type: integer
+          minimum: 0
+          description: source_sample/sample 배열 내 0-based 위치(전체 dataset의 절대 행 번호 아님).
+        column:
+          type: string
+        before:
+          $ref: "#/components/schemas/JsonValue"
+        after:
+          $ref: "#/components/schemas/JsonValue"
+        transform:
+          type: [string, "null"]
+          description: >-
+            컬럼에 선언된 캐스팅(schema.casts)이 있을 때만 "cast:{dtype}" 형태로
+            채운다. 알 수 없는 변환은 추측하지 않고 null.
+
+    PreviewTransformSummary:
+      type: object
+      description: 비교 가능한 sample 범위에서 계산한 변경 요약(#497).
+      additionalProperties: false
+      required: [changed_cells, changed_rows]
+      properties:
+        changed_cells:
+          type: integer
+          minimum: 0
+        changed_rows:
+          type: integer
+          minimum: 0
 
     QualityCheckResult:
       type: object

--- a/src/kpubdata_builder/pipeline/__init__.py
+++ b/src/kpubdata_builder/pipeline/__init__.py
@@ -9,18 +9,34 @@ Bronze → Silver → Gold → (Export) → Manifest 흐름을 묶는 orchestrat
     - BuildResult / SourceBuildOutcome: 실행 결과 모델
     - preview_build: 파일 미기록 미리보기 진입점
     - PreviewResult / SourcePreview: 미리보기 결과 모델
+    - PreviewDiffItem / PreviewTransformSummary / SampleMode: Source↔Silver diff·sampling
+      결과 모델 (#497)
 """
 
 from __future__ import annotations
 
 from .context import BuildContext
 from .orchestrator import BuildResult, SourceBuildOutcome, run_build
-from .preview import PreviewResult, SourcePreview, preview_build
+from .preview import (
+    DEFAULT_PREVIEW_SEED,
+    MAX_PREVIEW_DIFF_ITEMS,
+    PreviewDiffItem,
+    PreviewResult,
+    PreviewTransformSummary,
+    SampleMode,
+    SourcePreview,
+    preview_build,
+)
 
 __all__ = [
+    "DEFAULT_PREVIEW_SEED",
+    "MAX_PREVIEW_DIFF_ITEMS",
     "BuildContext",
     "BuildResult",
+    "PreviewDiffItem",
     "PreviewResult",
+    "PreviewTransformSummary",
+    "SampleMode",
     "SourceBuildOutcome",
     "SourcePreview",
     "preview_build",

--- a/src/kpubdata_builder/pipeline/preview.py
+++ b/src/kpubdata_builder/pipeline/preview.py
@@ -9,7 +9,22 @@ Quality/Schema 평가는 orchestrator.run_build와 동일한 공통 evaluator
 대해 다른 판정을 내리는 semantic drift를 만들지 않는다. drift 감지는 하지 않는다
 (persist된 이전 run과 비교해야 하는데 preview는 워크스페이스에 아무것도 쓰지 않는다).
 
+Source↔Silver diff와 sampling (#497): 같은 실행 안에서 Bronze 원본 sample과
+Silver 변환 sample을 같은 행 인덱스로 골라 셀 단위로 비교한다. Bronze→Silver
+경로(normalize/validate)가 행을 filter/reorder하지 않는 현재 구조에서만
+``diff_available=true``이며, 그 전제가 깨지면(행 수 불일치 등) 잘못된 index diff
+대신 ``diff_available=false``로 fail-closed한다.
+
+sample 행 수는 limit(≤ MAX_PREVIEW_LIMIT, service/app.py)으로 제한되지만 컬럼
+수는 어디서도 제한되지 않으므로, wide dataset에서는 셀 단위 diff item 개수가
+여전히 무제한일 수 있다. 그래서 diffs 리스트 자체는 MAX_PREVIEW_DIFF_ITEMS로
+따로 자르고 그 사실을 ``diff_truncated``로 명시한다 — transform_summary의
+집계(changed_cells/changed_rows)는 잘린 뒤에도 정확한 합계를 유지한다.
+
 주요 구성:
+    - SampleMode: "first" | "random" sampling 방식
+    - PreviewDiffItem: 셀 단위 변경 하나
+    - PreviewTransformSummary: 비교 가능한 sample 범위의 변경 요약
     - SourcePreview: 소스별 미리보기 결과
     - PreviewResult: 전체 미리보기 결과
     - preview_build: 미리보기 진입점
@@ -17,15 +32,71 @@ Quality/Schema 평가는 orchestrator.run_build와 동일한 공통 evaluator
 
 from __future__ import annotations
 
+import random
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from typing import Literal
 
 from ..quality import QualityCheckResult, evaluate_quality
-from ..spec import BuildSpec, SourceRef
+from ..spec import BuildSpec, JsonValue, SourceRef
 from ..spec.models import QualityPolicy
 from ..spec.validator import validate_spec
 from ..stages.bronze.build import SourceClient, build_bronze_artifact
 from ..stages.silver.build import build_silver_dataset
+from ..stages.silver.preview import select_preview_rows
 from ..tabular import DEFAULT_PREVIEW_LIMIT, PreviewSlice, SchemaInfo, TableStatistics
+
+SampleMode = Literal["first", "random"]
+_SAMPLE_MODES: tuple[SampleMode, ...] = ("first", "random")
+
+# random sample_mode에서 seed가 생략됐을 때 쓰는 고정 기본값 — "random"이라는
+# 이름과 달리 재현 불가능한 wall-clock 기반 시드를 쓰지 않는다 (#497).
+DEFAULT_PREVIEW_SEED = 0
+
+# diffs 응답의 방어적 상한 (#497). limit(≤ MAX_PREVIEW_LIMIT, service/app.py)은
+# 행 수만 제한하고 컬럼 수는 어디서도 제한하지 않으므로, 셀 단위 diff item 개수는
+# rows × changed_columns로 wide dataset에서는 여전히 무제한일 수 있다. 이 상한은
+# 실제로 materialize해 응답에 싣는 PreviewDiffItem 개수만 자르고, 상한과 같은
+# 값(MAX_PREVIEW_LIMIT)을 재사용해 새 매직넘버를 만들지 않는다 —
+# transform_summary.changed_cells/changed_rows는 잘리지 않은 실제 합계를 유지해
+# "diff 목록은 잘렸지만 집계는 정확하다"는 계약을 지킨다.
+MAX_PREVIEW_DIFF_ITEMS = 1000
+
+
+@dataclass(frozen=True)
+class PreviewDiffItem:
+    """Source↔Silver 셀 단위 변경 하나 (#497).
+
+    속성:
+        row: source_sample/sample 배열 내 0-based 위치. 전체 데이터셋의 절대 행
+            번호가 아니다(둘 다 diff_available=true일 때만 같은 대상을 가리킨다).
+        column: 컬럼명.
+        before: 변환 전(Bronze raw) 값.
+        after: 변환 후(Silver) 값.
+        transform: 컬럼에 선언된 캐스팅(schema.casts)이 있을 때만
+            ``"cast:{dtype}"`` 형태로 채운다. 그 외에는 추측하지 않고 None.
+    """
+
+    row: int
+    column: str
+    before: JsonValue
+    after: JsonValue
+    transform: str | None = None
+
+
+@dataclass(frozen=True)
+class PreviewTransformSummary:
+    """비교 가능한 sample 범위에서 계산한 변경 요약 (#497).
+
+    전체 dataset 변화량이 아니라 이번 preview 응답에 실린 sample 범위 기준이다.
+
+    속성:
+        changed_cells: 값이 달라진 셀 개수.
+        changed_rows: 하나 이상의 셀이 달라진 행 개수.
+    """
+
+    changed_cells: int
+    changed_rows: int
 
 
 @dataclass(frozen=True)
@@ -36,12 +107,26 @@ class SourcePreview:
         source_key: 소스 식별자.
         status: "ok" 또는 "failed".
         schema: 추론된 스키마 요약 (실패 시 빈 SchemaInfo).
-        preview: 상위 N행 미리보기 (실패 시 빈 PreviewSlice).
+        preview: 상위 N행 미리보기 (실패 시 빈 PreviewSlice). sample_mode에 따라
+            상위 N행 또는 결정적 무작위 N행을 담는다.
         statistics: 전체 테이블 기준 통계 (row_count/null_counts/duplicate_rate,
             #440). 스키마 계약 초안(VAL-4)과 품질 게이트(QG-3)의 근거.
         quality_results: 구조화된 Quality/Schema 평가 결과 (#486). Build와 동일한
             evaluator 결과이며, PASS를 포함한 실제로 평가된 check만 담는다.
         error: 실패 시 오류 메시지.
+        source_sample: 변환 전 Bronze 원본 sample (#497). diff_available=false여도
+            최선 노력으로 채워진다(실패 시에는 빈 튜플).
+        sample_mode: 이 응답에 실제로 적용된 sampling 방식.
+        diff_available: source_sample[i]와 preview.rows[i]가 같은 논리 행을
+            가리킨다고 보장할 수 있을 때만 true. 행 수 불일치·조회 실패 등에서는
+            false이며 diffs/transform_summary는 비운다.
+        diffs: diff_available=true일 때만 채워지는 셀 단위 변경 목록. 최대
+            MAX_PREVIEW_DIFF_ITEMS개까지만 담긴다(diff_truncated 참고).
+        transform_summary: diff_available=true일 때만 채워지는 변경 요약.
+            diffs가 잘려도 changed_cells/changed_rows는 잘리지 않은 실제 합계다.
+        diff_truncated: diffs가 MAX_PREVIEW_DIFF_ITEMS 상한에 걸려 실제 변경 셀
+            전부를 담지 못했으면 true. diff_available=false면 항상 false(애초에
+            diff를 시도하지 않았으므로 "잘림"이 아니다).
     """
 
     source_key: str
@@ -51,6 +136,12 @@ class SourcePreview:
     statistics: TableStatistics
     quality_results: tuple[QualityCheckResult, ...] = ()
     error: str | None = None
+    source_sample: tuple[dict[str, JsonValue], ...] = ()
+    sample_mode: SampleMode = "first"
+    diff_available: bool = False
+    diffs: tuple[PreviewDiffItem, ...] = ()
+    transform_summary: PreviewTransformSummary | None = None
+    diff_truncated: bool = False
 
 
 @dataclass(frozen=True)
@@ -74,20 +165,101 @@ def _output_key(source: SourceRef) -> str:
     return source.alias if source.alias else _fetch_key(source)
 
 
+def _select_indices(
+    *, total_rows: int, limit: int, sample_mode: SampleMode, seed: int
+) -> list[int]:
+    """전체 total_rows 중 최대 limit개의 행 인덱스를 오름차순으로 고른다.
+
+    "first": 앞쪽 count개를 그대로 고른다(기존 top-N 동작과 동일).
+    "random": seed로 초기화한 전용 ``random.Random`` 인스턴스로 비복원 추출한다.
+        전역 random 상태를 건드리지 않고, ``range``를 직접 인덱싱하므로 전체
+        데이터셋을 리스트로 복사하거나 셔플하지 않는다(#497 메모리 상한 요건).
+        동일 total_rows/limit/seed면 항상 동일한 결과를 반환한다.
+
+    Source/Silver가 이 함수의 결과를 그대로 공유해서 쓰는 것이 diff 정합성의
+    전제다 — 둘을 독립적으로 sampling하면 다른 행을 고를 수 있다.
+    """
+    count = min(limit, total_rows)
+    if count <= 0:
+        return []
+    if sample_mode == "first":
+        return list(range(count))
+    rng = random.Random(seed)
+    return sorted(rng.sample(range(total_rows), count))
+
+
+def _diff_sample(
+    source_rows: Sequence[dict[str, JsonValue]],
+    transformed_rows: Sequence[dict[str, JsonValue]],
+    *,
+    columns: Sequence[str],
+    casts: Mapping[str, str] | None,
+    max_items: int,
+) -> tuple[tuple[PreviewDiffItem, ...], PreviewTransformSummary, bool]:
+    """정렬됐다고 이미 보장된 두 행 시퀀스를 셀 단위로 비교한다.
+
+    호출자가 ``source_rows[i]``와 ``transformed_rows[i]``가 같은 논리 행을
+    가리킨다고 (diff_available 판정으로) 이미 보장했을 때만 불러야 한다.
+
+    ``columns``는 컬럼 수 제한이 없으므로(#497 sample/diff memory 상한) 실제
+    materialize해 반환하는 diff item은 ``max_items``개로 자르되, 잘린 뒤에도
+    비교 자체는 계속해 ``changed_cells``/``changed_rows``는 항상 전체 sample
+    범위의 정확한 합계를 유지한다 — 집계를 diffs 길이에 종속시키지 않는다.
+
+    반환값: (diffs, transform_summary, truncated). truncated는 실제 변경 셀
+    수가 max_items를 넘어 diffs가 전부를 담지 못했으면 true.
+    """
+    diffs: list[PreviewDiffItem] = []
+    changed_rows = 0
+    changed_cells = 0
+    truncated = False
+    for row_index, (before_row, after_row) in enumerate(
+        zip(source_rows, transformed_rows, strict=True)
+    ):
+        row_changed = False
+        for column in columns:
+            before = before_row.get(column)
+            after = after_row.get(column)
+            if before == after:
+                continue
+            row_changed = True
+            changed_cells += 1
+            if len(diffs) < max_items:
+                transform = f"cast:{casts[column]}" if casts and column in casts else None
+                diffs.append(
+                    PreviewDiffItem(
+                        row=row_index,
+                        column=column,
+                        before=before,
+                        after=after,
+                        transform=transform,
+                    )
+                )
+            else:
+                truncated = True
+        if row_changed:
+            changed_rows += 1
+    summary = PreviewTransformSummary(changed_cells=changed_cells, changed_rows=changed_rows)
+    return tuple(diffs), summary, truncated
+
+
 def _preview_source(
     source: SourceRef,
     *,
     client: SourceClient,
     limit: int,
     quality_policy: QualityPolicy | None,
+    sample_mode: SampleMode,
+    seed: int,
 ) -> SourcePreview:
-    """한 소스를 fetch → Silver(메모리)로 만들어 스키마/샘플/quality 결과를 추출한다."""
+    """한 소스를 fetch → Silver(메모리)로 만들어 스키마/샘플/diff/quality 결과를 추출한다."""
     # fetch_key는 항상 provider.dataset (kpubdata.Client 계약). 표면 키는 alias 우선.
     fetch_key = _fetch_key(source)
     out_key = _output_key(source)
     try:
         required_columns = source.schema.required if source.schema else ()
         column_dtypes = source.schema.dtypes if source.schema else None
+        casts = source.schema.casts if source.schema else None
         bronze = build_bronze_artifact(
             client, source_key=fetch_key, fetch_params=dict(source.params)
         )
@@ -95,7 +267,7 @@ def _preview_source(
             bronze,
             preview_limit=limit,
             required_columns=required_columns,
-            casts=source.schema.casts if source.schema else None,
+            casts=casts,
             column_dtypes=column_dtypes,
         )
         # Build와 동일한 공통 evaluator (#486) — 파일 persist는 하지 않는다.
@@ -106,13 +278,61 @@ def _preview_source(
             required_columns=required_columns,
             column_dtypes=column_dtypes,
         )
+
+        total_rows = silver.statistics.row_count
+        # diff alignment의 진짜 근거는 count가 아니라 현재 Silver 정규화 경로의
+        # row-preserving invariant다: normalize_table()은 records_to_dataframe()
+        # (레코드 순서 그대로 pl.DataFrame 구성) 다음 cast_columns()(같은 행 수를
+        # 유지한 채 값만 캐스팅)만 호출하고, validate_table()은 테이블을 아예
+        # 건드리지 않는다 — 어느 단계도 행을 filter/dedup/reorder하지 않는다
+        # (test_silver.py::TestRowPreservingInvariant#497이 이 불변조건을 회귀
+        # 고정한다). 그 불변조건이 유지되는 한 bronze.raw_records[i]는 항상
+        # silver.table의 i번째 행과 같은 논리적 행이므로, 같은 index list를
+        # 그대로 양쪽에 재사용해도 안전하다.
+        #
+        # 아래 count 비교는 그 불변조건이 "이번 실행에서" 실제로 지켜졌는지
+        # 확인하는 값싼 runtime guard일 뿐, alignment의 근거 자체가 아니다 —
+        # Silver가 향후 dedup/filter를 도입하면 이 코드 경로 자체가 바뀌어야
+        # 하고, 이 guard는 count가 바뀐 경우만 잡아낸다(같은 count로 reorder만
+        # 하는 가상의 미래 변경은 이 guard로 잡지 못하므로 그런 변경을 추가할
+        # 때는 반드시 이 판단을 재검토해야 한다).
+        aligned = bronze.record_count == total_rows
+        indices = _select_indices(
+            total_rows=total_rows, limit=limit, sample_mode=sample_mode, seed=seed
+        )
+
+        source_sample = tuple(bronze.raw_records[i] for i in indices) if aligned else ()
+        transformed_rows = select_preview_rows(silver.table, indices)
+        sample_slice = PreviewSlice(rows=transformed_rows, total_rows=total_rows)
+
+        diff_available = aligned and len(source_sample) == len(transformed_rows)
+        if diff_available:
+            columns = tuple(column.name for column in silver.schema.columns)
+            diffs, transform_summary, diff_truncated = _diff_sample(
+                source_sample,
+                transformed_rows,
+                columns=columns,
+                casts=casts,
+                max_items=MAX_PREVIEW_DIFF_ITEMS,
+            )
+        else:
+            diffs = ()
+            transform_summary = None
+            diff_truncated = False
+
         return SourcePreview(
             source_key=out_key,
             status="ok",
             schema=silver.schema,
-            preview=silver.preview,
+            preview=sample_slice,
             statistics=silver.statistics,
             quality_results=quality_results,
+            source_sample=source_sample,
+            sample_mode=sample_mode,
+            diff_available=diff_available,
+            diffs=diffs,
+            transform_summary=transform_summary,
+            diff_truncated=diff_truncated,
         )
     except Exception as exc:  # 미리보기 실패를 결과로 변환
         return SourcePreview(
@@ -122,6 +342,12 @@ def _preview_source(
             preview=PreviewSlice(rows=(), total_rows=0),
             statistics=TableStatistics(row_count=0, null_counts={}, duplicate_rate=0.0),
             error=str(exc),
+            source_sample=(),
+            sample_mode=sample_mode,
+            diff_available=False,
+            diffs=(),
+            transform_summary=None,
+            diff_truncated=False,
         )
 
 
@@ -130,28 +356,45 @@ def preview_build(
     *,
     client: SourceClient,
     limit: int = DEFAULT_PREVIEW_LIMIT,
+    sample_mode: SampleMode = "first",
+    seed: int = DEFAULT_PREVIEW_SEED,
 ) -> PreviewResult:
-    """각 소스의 스키마와 샘플 행을 산출한다 (파일 미기록).
+    """각 소스의 스키마와 샘플 행, Source↔Silver diff를 산출한다 (파일 미기록).
 
     매개변수:
         spec: 미리볼 빌드 명세.
         client: Bronze fetch에 사용할 kpubdata 호환 클라이언트.
         limit: 미리보기에 포함할 최대 행 수.
+        sample_mode: "first"(상위 N행, 기본값) 또는 "random"(결정적 무작위 N행).
+        seed: sample_mode="random"일 때 쓰는 시드. 동일 입력+동일 seed는 항상
+            동일 sample을 반환한다. sample_mode="first"에서는 쓰이지 않는다.
 
     반환값:
-        PreviewResult: 소스별 스키마/샘플.
+        PreviewResult: 소스별 스키마/샘플/diff.
 
     예외:
-        ValueError: limit이 1보다 작은 경우.
+        ValueError: limit이 1보다 작거나 sample_mode가 "first"/"random"이 아닌 경우.
+        TypeError: seed가 bool을 포함해 int가 아닌 경우.
         ValidationError: spec이 최소 실행 요건을 충족하지 못한 경우. 유효하지 않은
             spec을 부분 실행하거나 빈 결과로 돌려보내지 않고 빠르게 실패시켜
             서비스 레이어와 동일하게 동작하도록 한다 (#193).
     """
     if limit < 1:
         raise ValueError(f"limit must be >= 1, got {limit}")
+    if sample_mode not in _SAMPLE_MODES:
+        raise ValueError(f"sample_mode must be one of {_SAMPLE_MODES}, got {sample_mode!r}")
+    if not isinstance(seed, int) or isinstance(seed, bool):
+        raise TypeError(f"seed must be an int, got {type(seed).__name__}")
     validate_spec(spec)
     previews = tuple(
-        _preview_source(source, client=client, limit=limit, quality_policy=spec.quality)
+        _preview_source(
+            source,
+            client=client,
+            limit=limit,
+            quality_policy=spec.quality,
+            sample_mode=sample_mode,
+            seed=seed,
+        )
         for source in spec.sources
     )
     return PreviewResult(previews=previews)

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -35,7 +35,7 @@ from ..credentials import (
     SQLiteCredentialRepository,
 )
 from ..errors import SpecLoadError, ValidationError
-from ..pipeline import preview_build, run_build
+from ..pipeline import DEFAULT_PREVIEW_SEED, SampleMode, preview_build, run_build
 from ..quality import QualityCheckResult
 from ..query.engine import QueryExecutionError, QueryTimeoutError
 from ..query.models import QueryRequest, QueryStage
@@ -75,6 +75,12 @@ logger = logging.getLogger(__name__)
 _CREDENTIAL_MASTER_KEY_ENV = "KPUBDATA_BUILDER_CREDENTIAL_MASTER_KEY"
 _PROVIDER_TEST_TIMEOUT_ENV = "KPUBDATA_BUILDER_PROVIDER_TEST_TIMEOUT"
 _DEFAULT_PROVIDER_TEST_TIMEOUT = 10.0
+
+# /preview의 limit 방어적 상한 (#497). 기존에는 상한이 없었다 — Preview는 전체
+# dataset을 메모리에 올린 뒤 slice하므로 limit 자체가 fetch량을 줄이지는 않지만,
+# 응답에 실리는 sample/diff 크기는 이 값으로 명확히 bound한다. 값은 stage
+# preview의 기존 상한(MAX_STAGE_PREVIEW_LIMIT, service/stages.py)과 맞췄다.
+MAX_PREVIEW_LIMIT = 1000
 
 
 @runtime_checkable
@@ -237,7 +243,10 @@ def _strip_internal_fields(entries: list[_BuildListEntry]) -> list[_BuildListEnt
 # 1.4.0 -> 1.5.0: Dataset Catalog·Detail·Stage Summary API 추가 (#488, additive).
 # 1.5.0 -> 1.6.0: 구조화된 Quality/Schema Drift 결과, quality history/detail API 추가
 # (#486, additive — 기존 엔드포인트는 변경되지 않는다).
-API_CONTRACT_VERSION = "1.8.0"
+# 1.8.0 -> 1.9.0: POST /preview에 Source↔Silver diff와 sample_mode(first/random)
+# 옵션 추가 (#497, additive — 기존 필드는 유지된다). limit 상한(1000) 신규 도입은
+# behavioral tightening(이전엔 상한 없음) — 그 이상 값은 400.
+API_CONTRACT_VERSION = "1.9.0"
 
 
 @dataclass(frozen=True)
@@ -617,11 +626,19 @@ class BuilderService:
         spec_yaml: str,
         *,
         limit: int = DEFAULT_PREVIEW_LIMIT,
+        sample_mode: str = "first",
+        seed: int = DEFAULT_PREVIEW_SEED,
         principal: Principal | None = None,
     ) -> ServiceResponse:
-        """각 소스의 스키마와 샘플 행을 산출한다 (파일 미기록)."""
-        if limit < 1:
-            return ServiceResponse(400, {"error": "'limit' must be a positive integer"})
+        """각 소스의 스키마와 샘플 행, Source↔Silver diff를 산출한다 (파일 미기록, #497)."""
+        if limit < 1 or limit > MAX_PREVIEW_LIMIT:
+            return ServiceResponse(
+                400, {"error": f"'limit' must be a positive integer up to {MAX_PREVIEW_LIMIT}"}
+            )
+        if sample_mode not in ("first", "random"):
+            return ServiceResponse(400, {"error": "'sample_mode' must be 'first' or 'random'"})
+        if not isinstance(seed, int) or isinstance(seed, bool):
+            return ServiceResponse(400, {"error": "'seed' must be an integer"})
         spec_or_error = self._load_validated(spec_yaml)
         if isinstance(spec_or_error, ServiceResponse):
             return spec_or_error
@@ -643,7 +660,13 @@ class BuilderService:
         except Exception:
             return ServiceResponse(502, {"error": "provider client unavailable"})
         try:
-            result = preview_build(spec_or_error, client=client, limit=limit)
+            result = preview_build(
+                spec_or_error,
+                client=client,
+                limit=limit,
+                sample_mode=cast(SampleMode, sample_mode),
+                seed=seed,
+            )
         finally:
             _close_request_client(client)
         previews: list[JsonValue] = [
@@ -670,6 +693,31 @@ class BuilderService:
                 "quality_results": cast(
                     JsonValue, [_quality_result_to_json(r) for r in p.quality_results]
                 ),
+                "source_sample": list(p.source_sample),
+                "sample_mode": p.sample_mode,
+                "diff_available": p.diff_available,
+                "diffs": cast(
+                    JsonValue,
+                    [
+                        {
+                            "row": d.row,
+                            "column": d.column,
+                            "before": d.before,
+                            "after": d.after,
+                            "transform": d.transform,
+                        }
+                        for d in p.diffs
+                    ],
+                ),
+                "transform_summary": (
+                    {
+                        "changed_cells": p.transform_summary.changed_cells,
+                        "changed_rows": p.transform_summary.changed_rows,
+                    }
+                    if p.transform_summary is not None
+                    else None
+                ),
+                "diff_truncated": p.diff_truncated,
             }
             for p in result.previews
         ]
@@ -1441,16 +1489,43 @@ def dispatch(
         spec = _spec_from_body(body)
         if isinstance(spec, ServiceResponse):
             return spec
-        # limit이 명시되면 양의 정수여야 한다 — 잘못된 값을 조용히 기본값으로 떨어뜨리지 않는다.
+        # limit이 명시되면 양의 정수(상한 이내)여야 한다 — 잘못된 값을 조용히
+        # 기본값으로 떨어뜨리지 않는다.
         if body is not None and "limit" in body:
             limit_value = body["limit"]
             # bool은 int의 하위 타입이지만 limit 의미가 없으므로 거부.
-            if not isinstance(limit_value, int) or isinstance(limit_value, bool) or limit_value < 1:
-                return ServiceResponse(400, {"error": "'limit' must be a positive integer"})
+            if (
+                not isinstance(limit_value, int)
+                or isinstance(limit_value, bool)
+                or limit_value < 1
+                or limit_value > MAX_PREVIEW_LIMIT
+            ):
+                return ServiceResponse(
+                    400,
+                    {"error": f"'limit' must be a positive integer up to {MAX_PREVIEW_LIMIT}"},
+                )
             limit = limit_value
         else:
             limit = DEFAULT_PREVIEW_LIMIT
-        return service.preview(spec, limit=limit, principal=principal)
+        # sample_mode/seed도 같은 원칙: 잘못된 값을 조용히 기본값으로 떨어뜨리지 않는다 (#497).
+        sample_mode = "first"
+        if body is not None and "sample_mode" in body:
+            sample_mode_value = body["sample_mode"]
+            if not isinstance(sample_mode_value, str) or sample_mode_value not in (
+                "first",
+                "random",
+            ):
+                return ServiceResponse(400, {"error": "'sample_mode' must be 'first' or 'random'"})
+            sample_mode = sample_mode_value
+        seed = DEFAULT_PREVIEW_SEED
+        if body is not None and "seed" in body:
+            seed_value = body["seed"]
+            if not isinstance(seed_value, int) or isinstance(seed_value, bool):
+                return ServiceResponse(400, {"error": "'seed' must be an integer"})
+            seed = seed_value
+        return service.preview(
+            spec, limit=limit, sample_mode=sample_mode, seed=seed, principal=principal
+        )
 
     if method == "POST" and path == "/build":
         spec = _spec_from_body(body)

--- a/src/kpubdata_builder/stages/silver/preview.py
+++ b/src/kpubdata_builder/stages/silver/preview.py
@@ -5,15 +5,34 @@
 
 주요 함수:
     - build_preview: pl.DataFrame → PreviewSlice
+    - select_preview_rows: pl.DataFrame → 지정 행 인덱스의 레코드 (#497)
 """
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 import polars as pl
 
+from ...spec import JsonValue
 from ...tabular import DEFAULT_PREVIEW_LIMIT, PreviewSlice, generate_preview
+from ...tabular.convert import dataframe_to_records
 
 
 def build_preview(table: pl.DataFrame, *, limit: int = DEFAULT_PREVIEW_LIMIT) -> PreviewSlice:
     """상위 N행 미리보기 슬라이스를 생성한다."""
     return generate_preview(table, limit=limit)
+
+
+def select_preview_rows(
+    table: pl.DataFrame, indices: Sequence[int]
+) -> tuple[dict[str, JsonValue], ...]:
+    """지정한 행 인덱스의 레코드를 추출한다 (#497).
+
+    sample_mode="random"처럼 상위 N행이 아니라 임의 인덱스의 sample이 필요할 때
+    쓴다. indices의 순서를 그대로 보존하며, polars 타입은 이 함수 밖으로 새지
+    않는다(pipeline 계층은 plain dict만 받는다).
+    """
+    if not indices:
+        return ()
+    return tuple(dataframe_to_records(table[list(indices)]))

--- a/tests/unit/test_preview.py
+++ b/tests/unit/test_preview.py
@@ -1,16 +1,20 @@
-"""Preview(#3): preview_build가 스키마+샘플만 만들고 파일은 쓰지 않는지 검증."""
+"""Preview(#3, #497): preview_build가 스키마+샘플+diff를 만들고 파일은 쓰지 않는지 검증."""
 
 from __future__ import annotations
 
 import builtins
+import random as random_module
 from collections.abc import Iterable
 from pathlib import Path
 
 import pytest
 
+import kpubdata_builder.pipeline.preview as preview_module
 from kpubdata_builder.errors import ValidationError
 from kpubdata_builder.pipeline import PreviewResult, preview_build
 from kpubdata_builder.spec import BuildSpec, ExportTarget, JsonValue, SourceRef
+from kpubdata_builder.spec.models import SchemaContract
+from kpubdata_builder.stages.silver.build import build_silver_dataset
 from kpubdata_builder.tabular import PreviewSlice, SchemaInfo
 
 
@@ -141,3 +145,439 @@ def test_preview_build_rejects_non_positive_limit() -> None:
 
     with pytest.raises(ValueError, match="limit"):
         preview_build(spec, client=client, limit=0)
+
+
+# ---------------------------------------------------------------------------
+# Sampling (#497)
+# ---------------------------------------------------------------------------
+
+
+class TestSampling:
+    def test_default_sample_mode_is_first(self) -> None:
+        spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
+        client = _FakeClient({"datago.apt_trade": [{"id": str(i)} for i in range(10)]})
+
+        result = preview_build(spec, client=client, limit=3)
+
+        preview = result.previews[0]
+        assert preview.sample_mode == "first"
+        assert [row["id"] for row in preview.preview.rows] == ["0", "1", "2"]
+        assert [row["id"] for row in preview.source_sample] == ["0", "1", "2"]
+
+    def test_explicit_first_matches_default(self) -> None:
+        spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
+        client = _FakeClient({"datago.apt_trade": [{"id": str(i)} for i in range(10)]})
+
+        default_result = preview_build(spec, client=client, limit=3)
+        explicit_result = preview_build(spec, client=client, limit=3, sample_mode="first")
+
+        assert default_result.previews[0].preview.rows == explicit_result.previews[0].preview.rows
+        assert default_result.previews[0].source_sample == explicit_result.previews[0].source_sample
+
+    def test_random_mode_is_reproducible_with_same_seed(self) -> None:
+        spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
+        client = _FakeClient({"datago.apt_trade": [{"id": str(i)} for i in range(200)]})
+
+        first = preview_build(spec, client=client, limit=5, sample_mode="random", seed=42)
+        second = preview_build(spec, client=client, limit=5, sample_mode="random", seed=42)
+
+        assert first.previews[0].source_sample == second.previews[0].source_sample
+        assert first.previews[0].preview.rows == second.previews[0].preview.rows
+
+    def test_random_mode_differs_with_different_seed(self) -> None:
+        spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
+        client = _FakeClient({"datago.apt_trade": [{"id": str(i)} for i in range(200)]})
+
+        seed_a = preview_build(spec, client=client, limit=5, sample_mode="random", seed=1)
+        seed_b = preview_build(spec, client=client, limit=5, sample_mode="random", seed=2)
+
+        assert seed_a.previews[0].source_sample != seed_b.previews[0].source_sample
+
+    def test_random_mode_matches_select_indices_algorithm(self) -> None:
+        # 구현이 실제로 random.Random(seed).sample(range(n), k)에 위임하는지,
+        # 전역 random 상태가 아니라 seed에만 의존하는지 화이트박스로 고정한다.
+        spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
+        records = [{"id": str(i)} for i in range(50)]
+        client = _FakeClient({"datago.apt_trade": records})
+
+        result = preview_build(spec, client=client, limit=6, sample_mode="random", seed=7)
+
+        expected_indices = sorted(random_module.Random(7).sample(range(50), 6))
+        expected_ids = [records[i]["id"] for i in expected_indices]
+        assert [row["id"] for row in result.previews[0].source_sample] == expected_ids
+
+    def test_random_mode_does_not_disturb_global_random_state(self) -> None:
+        spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
+        client = _FakeClient({"datago.apt_trade": [{"id": str(i)} for i in range(50)]})
+
+        random_module.seed(1234)
+        before = random_module.random()
+        random_module.seed(1234)
+        preview_build(spec, client=client, limit=5, sample_mode="random", seed=99)
+        after = random_module.random()
+
+        assert before == after
+
+    def test_rejects_invalid_sample_mode(self) -> None:
+        spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
+        client = _FakeClient({"datago.apt_trade": [{"id": "1"}]})
+
+        with pytest.raises(ValueError, match="sample_mode"):
+            preview_build(spec, client=client, sample_mode="shuffle")  # type: ignore[arg-type]
+
+    def test_rejects_non_int_seed(self) -> None:
+        spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
+        client = _FakeClient({"datago.apt_trade": [{"id": "1"}]})
+
+        with pytest.raises(TypeError, match="seed"):
+            preview_build(spec, client=client, sample_mode="random", seed="7")  # type: ignore[arg-type]
+
+    def test_rejects_bool_seed(self) -> None:
+        # bool은 int의 하위 타입이지만 seed 의미가 없다.
+        spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
+        client = _FakeClient({"datago.apt_trade": [{"id": "1"}]})
+
+        with pytest.raises(TypeError, match="seed"):
+            preview_build(spec, client=client, sample_mode="random", seed=True)
+
+    def test_random_sample_bounded_by_total_rows_and_limit(self) -> None:
+        spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
+        client = _FakeClient({"datago.apt_trade": [{"id": str(i)} for i in range(3)]})
+
+        result = preview_build(spec, client=client, limit=10, sample_mode="random", seed=0)
+
+        # total_rows(3)보다 큰 limit(10)을 요청해도 실제 존재하는 행만 반환한다.
+        assert len(result.previews[0].source_sample) == 3
+        assert len(result.previews[0].preview.rows) == 3
+
+
+# ---------------------------------------------------------------------------
+# Diff (#497)
+# ---------------------------------------------------------------------------
+
+
+class TestDiff:
+    def test_no_change_yields_empty_diffs(self) -> None:
+        spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
+        client = _FakeClient(
+            {"datago.apt_trade": [{"id": "1", "label": "a"}, {"id": "2", "label": "b"}]}
+        )
+
+        result = preview_build(spec, client=client, limit=5)
+
+        preview = result.previews[0]
+        assert preview.diff_available is True
+        assert preview.diffs == ()
+        assert preview.transform_summary is not None
+        assert preview.transform_summary.changed_cells == 0
+        assert preview.transform_summary.changed_rows == 0
+        assert preview.diff_truncated is False
+
+    def test_declared_cast_produces_diff_with_transform_label(self) -> None:
+        source = SourceRef(
+            provider="datago",
+            dataset="apt_trade",
+            schema=SchemaContract(casts={"amount": "int"}),
+        )
+        spec = _spec(source)
+        client = _FakeClient(
+            {"datago.apt_trade": [{"id": "1", "amount": "128000"}, {"id": "2", "amount": "50"}]}
+        )
+
+        result = preview_build(spec, client=client, limit=5)
+
+        preview = result.previews[0]
+        assert preview.diff_available is True
+        assert len(preview.diffs) == 2
+        first = preview.diffs[0]
+        assert first.row == 0
+        assert first.column == "amount"
+        assert first.before == "128000"
+        assert first.after == 128000
+        assert first.transform == "cast:int"
+        assert preview.transform_summary is not None
+        assert preview.transform_summary.changed_cells == 2
+        assert preview.transform_summary.changed_rows == 2
+        assert preview.diff_truncated is False
+
+    def test_wide_dataset_truncates_diffs_but_keeps_accurate_summary_end_to_end(self) -> None:
+        # #497 sample/diff memory 상한: limit(행 수)만으로는 wide dataset(컬럼 수多)의
+        # diff item 개수를 막지 못한다 — MAX_PREVIEW_DIFF_ITEMS가 실제로 응답에
+        # 담기는 PreviewDiffItem 개수를 자르고, diff_truncated로 명시하는지 end-to-end로
+        # 확인한다. 1행 × (MAX_PREVIEW_DIFF_ITEMS + 100)컬럼 모두 cast로 변경한다.
+        max_items = preview_module.MAX_PREVIEW_DIFF_ITEMS
+        column_count = max_items + 100
+        columns = [f"c{i}" for i in range(column_count)]
+        casts = dict.fromkeys(columns, "int")
+        source = SourceRef(
+            provider="datago",
+            dataset="apt_trade",
+            schema=SchemaContract(casts=casts),
+        )
+        spec = _spec(source)
+        row = {c: "1" for c in columns}
+        client = _FakeClient({"datago.apt_trade": [row]})
+
+        result = preview_build(spec, client=client, limit=1)
+
+        preview = result.previews[0]
+        assert preview.status == "ok"
+        assert preview.diff_available is True
+        assert len(preview.diffs) == max_items
+        assert preview.diff_truncated is True
+        assert preview.transform_summary is not None
+        assert preview.transform_summary.changed_cells == column_count
+        assert preview.transform_summary.changed_rows == 1
+
+    def test_columns_without_declared_cast_never_produce_a_diff_end_to_end(self) -> None:
+        # 현재 normalize_table()은 casts에 없는 컬럼의 값을 절대 바꾸지 않으므로
+        # (records_to_dataframe()이 원본 값을 그대로 옮긴다), casts에 없는 컬럼은
+        # end-to-end로 diff 자체가 생기지 않는다 — "transform=None" 분기는
+        # _diff_sample() 자체를 직접 검증한다(아래 TestDiffSampleHelper).
+        source = SourceRef(
+            provider="datago",
+            dataset="apt_trade",
+            schema=SchemaContract(casts={"amount": "int"}),
+        )
+        spec = _spec(source)
+        client = _FakeClient({"datago.apt_trade": [{"id": "1", "amount": "1", "label": "x"}]})
+
+        result = preview_build(spec, client=client, limit=5)
+
+        diffs_by_column = {d.column: d for d in result.previews[0].diffs}
+        assert diffs_by_column["amount"].transform == "cast:int"
+        assert "label" not in diffs_by_column
+        assert "id" not in diffs_by_column
+
+
+class TestDiffSampleHelper:
+    """``_diff_sample``을 직접 검증한다 — casts에 없는 컬럼이 바뀌는 상황은 현재
+    Silver 파이프라인(값이 바뀌려면 반드시 declared cast를 거친다)에서는 end-to-end로
+    재현할 수 없으므로, transform=None 분기는 이 pure 함수 레벨에서 고정한다.
+    """
+
+    def test_transform_is_null_when_column_has_no_declared_cast(self) -> None:
+        diffs, summary, truncated = preview_module._diff_sample(
+            [{"note": "before"}],
+            [{"note": "after"}],
+            columns=("note",),
+            casts=None,
+            max_items=preview_module.MAX_PREVIEW_DIFF_ITEMS,
+        )
+
+        assert len(diffs) == 1
+        assert diffs[0].transform is None
+        assert summary.changed_cells == 1
+        assert summary.changed_rows == 1
+        assert truncated is False
+
+    def test_transform_is_null_when_column_not_in_casts_mapping(self) -> None:
+        diffs, _summary, _truncated = preview_module._diff_sample(
+            [{"note": "before", "amount": "1"}],
+            [{"note": "after", "amount": 1}],
+            columns=("note", "amount"),
+            casts={"amount": "int"},
+            max_items=preview_module.MAX_PREVIEW_DIFF_ITEMS,
+        )
+
+        by_column = {d.column: d for d in diffs}
+        assert by_column["note"].transform is None
+        assert by_column["amount"].transform == "cast:int"
+
+    def test_no_change_across_all_rows_yields_zero_summary(self) -> None:
+        diffs, summary, truncated = preview_module._diff_sample(
+            [{"a": 1}, {"a": 2}],
+            [{"a": 1}, {"a": 2}],
+            columns=("a",),
+            casts=None,
+            max_items=preview_module.MAX_PREVIEW_DIFF_ITEMS,
+        )
+
+        assert diffs == ()
+        assert summary.changed_cells == 0
+        assert summary.changed_rows == 0
+        assert truncated is False
+
+    def test_max_items_caps_materialized_diffs_but_keeps_accurate_summary(self) -> None:
+        # #497 sample/diff memory 상한: limit은 행 수만 제한하므로 wide dataset에서
+        # diffs 리스트 자체가 무제한 커질 수 있다 — max_items로 리스트만 자르고,
+        # changed_cells/changed_rows는 잘리지 않은 실제 합계를 유지해야 한다.
+        columns = tuple(f"c{i}" for i in range(10))
+        source_rows = [dict.fromkeys(columns, "before")]
+        transformed_rows = [dict.fromkeys(columns, "after")]
+
+        diffs, summary, truncated = preview_module._diff_sample(
+            source_rows,
+            transformed_rows,
+            columns=columns,
+            casts=None,
+            max_items=4,
+        )
+
+        assert len(diffs) == 4
+        assert truncated is True
+        assert summary.changed_cells == 10  # 잘렸어도 실제 변경 셀 수는 정확하다.
+        assert summary.changed_rows == 1
+
+    def test_max_items_not_exceeded_leaves_truncated_false(self) -> None:
+        columns = ("a", "b")
+        diffs, summary, truncated = preview_module._diff_sample(
+            [{"a": "1", "b": "2"}],
+            [{"a": 1, "b": 2}],
+            columns=columns,
+            casts=None,
+            max_items=2,
+        )
+
+        assert len(diffs) == 2
+        assert truncated is False
+        assert summary.changed_cells == 2
+
+    def test_multiple_changed_cells_across_rows(self) -> None:
+        source = SourceRef(
+            provider="datago",
+            dataset="apt_trade",
+            schema=SchemaContract(casts={"amount": "int", "active": "bool"}),
+        )
+        spec = _spec(source)
+        client = _FakeClient(
+            {
+                "datago.apt_trade": [
+                    {"id": "1", "amount": "100", "active": "true"},
+                    {"id": "2", "amount": "200", "active": "false"},
+                    {"id": "3", "amount": "3", "active": "yes"},
+                ]
+            }
+        )
+
+        result = preview_build(spec, client=client, limit=5)
+
+        preview = result.previews[0]
+        assert preview.diff_available is True
+        # 3행 x 2컬럼(amount, active) 모두 문자열 -> 캐스팅된 값으로 바뀐다.
+        assert preview.transform_summary is not None
+        assert preview.transform_summary.changed_cells == 6
+        assert preview.transform_summary.changed_rows == 3
+        assert {d.column for d in preview.diffs} == {"amount", "active"}
+
+    def test_diff_row_index_is_position_within_sample_not_absolute_row(self) -> None:
+        source = SourceRef(
+            provider="datago",
+            dataset="apt_trade",
+            schema=SchemaContract(casts={"amount": "int"}),
+        )
+        spec = _spec(source)
+        # limit=2이므로 sample에는 0/1번 행만 담기고, diff의 row는 그 배열 내 위치다.
+        client = _FakeClient(
+            {
+                "datago.apt_trade": [
+                    {"id": "1", "amount": "10"},
+                    {"id": "2", "amount": "20"},
+                    {"id": "3", "amount": "30"},
+                ]
+            }
+        )
+
+        result = preview_build(spec, client=client, limit=2)
+
+        rows = {d.row for d in result.previews[0].diffs}
+        assert rows == {0, 1}
+
+    def test_diff_unavailable_when_cast_introduces_nulls(self) -> None:
+        # #188 data-loss guard: 캐스팅이 값을 null로 떨어뜨리면 전체 preview가
+        # 실패 처리되며(#188), diff가 절반만 성공한 것처럼 보이지 않는다 — 이것이
+        # 이 코드베이스에서 "null 변화"가 diff item으로 새는 것을 막는 실제 안전장치다.
+        source = SourceRef(
+            provider="datago",
+            dataset="apt_trade",
+            schema=SchemaContract(casts={"amount": "int"}),
+        )
+        spec = _spec(source)
+        client = _FakeClient(
+            {"datago.apt_trade": [{"id": "1", "amount": "100"}, {"id": "2", "amount": "oops"}]}
+        )
+
+        result = preview_build(spec, client=client, limit=5)
+
+        preview = result.previews[0]
+        assert preview.status == "failed"
+        assert preview.diff_available is False
+        assert preview.diffs == ()
+        assert preview.transform_summary is None
+        assert preview.source_sample == ()
+        assert preview.diff_truncated is False
+
+    def test_diff_unavailable_on_source_fetch_failure(self) -> None:
+        spec = _spec(SourceRef(provider="datago", dataset="missing"))
+        client = _FakeClient({"datago.apt_trade": [{"id": "1"}]})
+
+        result = preview_build(spec, client=client)
+
+        preview = result.previews[0]
+        assert preview.status == "failed"
+        assert preview.diff_available is False
+        assert preview.diffs == ()
+        assert preview.transform_summary is None
+        assert preview.source_sample == ()
+        assert preview.diff_truncated is False
+
+    def test_diff_unavailable_when_row_count_is_not_preserved(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # 오늘의 Silver 경로는 행을 filter/reorder하지 않지만(test_silver.py의
+        # TestRowPreservingInvariant), 그 전제가 깨진 가상의 미래를 시뮬레이션해
+        # count guard가 fail-closed로 동작하는지 검증한다.
+        real_build_silver_dataset = build_silver_dataset
+
+        def _dropping_build_silver_dataset(bronze, **kwargs):  # type: ignore[no-untyped-def]
+            silver = real_build_silver_dataset(bronze, **kwargs)
+            dropped_table = silver.table.head(silver.table.height - 1)
+            return type(silver)(
+                table=dropped_table,
+                schema=silver.schema,
+                statistics=type(silver.statistics)(
+                    row_count=dropped_table.height,
+                    null_counts=silver.statistics.null_counts,
+                    duplicate_rate=silver.statistics.duplicate_rate,
+                ),
+                preview=silver.preview,
+                validation=silver.validation,
+                source_bronze=silver.source_bronze,
+            )
+
+        monkeypatch.setattr(preview_module, "build_silver_dataset", _dropping_build_silver_dataset)
+        spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
+        client = _FakeClient({"datago.apt_trade": [{"id": str(i)} for i in range(5)]})
+
+        result = preview_build(spec, client=client, limit=5)
+
+        preview = result.previews[0]
+        assert preview.status == "ok"  # 실패가 아니라 diff만 안전하게 무효화된다.
+        assert preview.diff_available is False
+        assert preview.diffs == ()
+        assert preview.transform_summary is None
+        assert preview.source_sample == ()
+        assert preview.diff_truncated is False
+        # sample(transformed) 자체는 여전히 채워진다 — diff만 신뢰할 수 없을 뿐.
+        assert len(preview.preview.rows) == 4
+
+
+# ---------------------------------------------------------------------------
+# Regression (#497) — 기존 필드/동작이 보존되는지.
+# ---------------------------------------------------------------------------
+
+
+class TestRegression:
+    def test_existing_fields_unaffected_by_new_sample_mode_param(self) -> None:
+        spec = _spec(SourceRef(provider="datago", dataset="apt_trade"))
+        client = _FakeClient({"datago.apt_trade": [{"id": str(i), "v": i} for i in range(10)]})
+
+        result = preview_build(spec, client=client, limit=3)
+
+        preview = result.previews[0]
+        assert preview.source_key == "datago.apt_trade"
+        assert preview.status == "ok"
+        assert [c.name for c in preview.schema.columns] == ["id", "v"]
+        assert preview.preview.total_rows == 10
+        assert len(preview.preview.rows) == 3
+        assert preview.statistics.row_count == 10

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -8,6 +8,7 @@ import threading
 import urllib.error
 import urllib.request
 from collections.abc import Iterable
+from datetime import date, datetime, timedelta, timezone
 from http.server import HTTPServer
 from pathlib import Path
 from typing import cast
@@ -183,6 +184,64 @@ class TestPreview:
         assert resp.status_code == 200
         assert client.close_calls == 1
 
+    def test_returns_source_sample_and_diff_fields(self, tmp_path: Path) -> None:
+        # #497: 기존 필드(sample/total_rows/statistics)와 함께 신규 필드가 실린다.
+        resp = _service(tmp_path).preview(VALID_SPEC_YAML, limit=2)
+        assert resp.status_code == 200
+        preview = resp.body["previews"][0]
+        assert preview["sample_mode"] == "first"
+        assert preview["diff_available"] is True
+        assert isinstance(preview["source_sample"], list)
+        assert isinstance(preview["diffs"], list)
+        assert preview["transform_summary"] == {"changed_cells": 0, "changed_rows": 0}
+        assert preview["diff_truncated"] is False
+
+    def test_random_sample_mode_is_reproducible_through_service(self, tmp_path: Path) -> None:
+        client = _FakeClient({"datago.air_quality": [{"id": str(i)} for i in range(50)]})
+        service = BuilderService(output_root=tmp_path, client_factory=lambda: client)
+
+        first = service.preview(VALID_SPEC_YAML, limit=5, sample_mode="random", seed=3)
+        second = service.preview(VALID_SPEC_YAML, limit=5, sample_mode="random", seed=3)
+
+        assert first.status_code == second.status_code == 200
+        assert (
+            first.body["previews"][0]["source_sample"]
+            == second.body["previews"][0]["source_sample"]
+        )
+        assert first.body["previews"][0]["sample_mode"] == "random"
+
+    def test_wide_dataset_diffs_are_truncated_over_the_wire(self, tmp_path: Path) -> None:
+        # #497 sample/diff memory 상한: limit(행 수)만으로는 wide dataset의 diff
+        # item 개수를 막지 못하므로, 실제 서비스 응답에서도 diffs가 상한을 지키고
+        # diff_truncated=true를 실어 클라이언트가 전체 diff로 오인하지 않게 한다.
+        from kpubdata_builder.pipeline import MAX_PREVIEW_DIFF_ITEMS
+
+        column_count = MAX_PREVIEW_DIFF_ITEMS + 50
+        columns = [f"c{i}" for i in range(column_count)]
+        spec_yaml = (
+            "dataset_id: dataset.wide\n"
+            "title: Wide Dataset\n"
+            "description: many columns\n"
+            "sources:\n"
+            "  - provider: datago\n"
+            "    dataset: air_quality\n"
+            "    schema:\n"
+            "      casts:\n" + "".join(f"        {c}: int\n" for c in columns) + "exports:\n"
+            "  - kind: jsonl\n"
+            "    output_path: out/data.jsonl\n"
+        )
+        client = _FakeClient({"datago.air_quality": [dict.fromkeys(columns, "1")]})
+        service = BuilderService(output_root=tmp_path, client_factory=lambda: client)
+
+        resp = service.preview(spec_yaml, limit=1)
+
+        assert resp.status_code == 200
+        preview = resp.body["previews"][0]
+        assert preview["diff_available"] is True
+        assert len(preview["diffs"]) == MAX_PREVIEW_DIFF_ITEMS
+        assert preview["diff_truncated"] is True
+        assert preview["transform_summary"]["changed_cells"] == column_count
+
 
 class TestPreviewLimitGuard:
     def test_preview_direct_call_rejects_zero_limit(self, tmp_path: Path) -> None:
@@ -194,6 +253,40 @@ class TestPreviewLimitGuard:
     def test_preview_direct_call_rejects_negative_limit(self, tmp_path: Path) -> None:
         resp = _service(tmp_path).preview(VALID_SPEC_YAML, limit=-5)
         assert resp.status_code == 400
+
+    def test_preview_direct_call_rejects_limit_above_max(self, tmp_path: Path) -> None:
+        # #497: limit 상한(1000) 신규 도입 — 이전엔 상한이 없었다(behavioral tightening).
+        from kpubdata_builder.service.app import MAX_PREVIEW_LIMIT
+
+        resp = _service(tmp_path).preview(VALID_SPEC_YAML, limit=MAX_PREVIEW_LIMIT + 1)
+        assert resp.status_code == 400
+        assert "limit" in str(resp.body.get("error", ""))
+
+    def test_preview_direct_call_accepts_limit_at_max(self, tmp_path: Path) -> None:
+        from kpubdata_builder.service.app import MAX_PREVIEW_LIMIT
+
+        resp = _service(tmp_path).preview(VALID_SPEC_YAML, limit=MAX_PREVIEW_LIMIT)
+        assert resp.status_code == 200
+
+    def test_preview_direct_call_rejects_invalid_sample_mode(self, tmp_path: Path) -> None:
+        resp = _service(tmp_path).preview(VALID_SPEC_YAML, sample_mode="shuffle")
+        assert resp.status_code == 400
+        assert "sample_mode" in str(resp.body.get("error", ""))
+
+    def test_preview_direct_call_rejects_non_int_seed(self, tmp_path: Path) -> None:
+        resp = _service(tmp_path).preview(
+            VALID_SPEC_YAML, sample_mode="random", seed=cast(int, "7")
+        )
+        assert resp.status_code == 400
+        assert "seed" in str(resp.body.get("error", ""))
+
+    def test_preview_direct_call_rejects_bool_seed(self, tmp_path: Path) -> None:
+        # bool은 int의 하위 타입이지만 seed 의미가 없으므로 거부한다.
+        resp = _service(tmp_path).preview(
+            VALID_SPEC_YAML, sample_mode="random", seed=cast(int, True)
+        )
+        assert resp.status_code == 400
+        assert "seed" in str(resp.body.get("error", ""))
 
 
 class TestBuild:
@@ -360,6 +453,97 @@ class TestDispatch:
         )
         assert resp.status_code == 400
 
+    def test_preview_rejects_limit_above_max(self, tmp_path: Path) -> None:
+        # #497: 신규 상한(1000) 도입 — 이전 client가 그 이상을 보내던 관행은 깨진다
+        # (behavioral tightening, 이전엔 상한이 없었다).
+        from kpubdata_builder.service.app import MAX_PREVIEW_LIMIT
+
+        resp = dispatch(
+            _service(tmp_path),
+            "POST",
+            "/preview",
+            {"spec": VALID_SPEC_YAML, "limit": MAX_PREVIEW_LIMIT + 1},
+        )
+        assert resp.status_code == 400
+        assert "limit" in str(resp.body.get("error", ""))
+
+    def test_preview_accepts_limit_at_max(self, tmp_path: Path) -> None:
+        from kpubdata_builder.service.app import MAX_PREVIEW_LIMIT
+
+        resp = dispatch(
+            _service(tmp_path),
+            "POST",
+            "/preview",
+            {"spec": VALID_SPEC_YAML, "limit": MAX_PREVIEW_LIMIT},
+        )
+        assert resp.status_code == 200
+
+    def test_preview_rejects_invalid_sample_mode(self, tmp_path: Path) -> None:
+        resp = dispatch(
+            _service(tmp_path),
+            "POST",
+            "/preview",
+            {"spec": VALID_SPEC_YAML, "sample_mode": "shuffle"},
+        )
+        assert resp.status_code == 400
+        assert "sample_mode" in str(resp.body.get("error", ""))
+
+    def test_preview_rejects_non_string_sample_mode(self, tmp_path: Path) -> None:
+        resp = dispatch(
+            _service(tmp_path),
+            "POST",
+            "/preview",
+            {"spec": VALID_SPEC_YAML, "sample_mode": 1},
+        )
+        assert resp.status_code == 400
+        assert "sample_mode" in str(resp.body.get("error", ""))
+
+    def test_preview_rejects_non_int_seed(self, tmp_path: Path) -> None:
+        resp = dispatch(
+            _service(tmp_path),
+            "POST",
+            "/preview",
+            {"spec": VALID_SPEC_YAML, "sample_mode": "random", "seed": "7"},
+        )
+        assert resp.status_code == 400
+        assert "seed" in str(resp.body.get("error", ""))
+
+    def test_preview_rejects_bool_seed(self, tmp_path: Path) -> None:
+        # bool은 int의 하위 타입이지만 seed로는 거부한다.
+        resp = dispatch(
+            _service(tmp_path),
+            "POST",
+            "/preview",
+            {"spec": VALID_SPEC_YAML, "sample_mode": "random", "seed": True},
+        )
+        assert resp.status_code == 400
+        assert "seed" in str(resp.body.get("error", ""))
+
+    def test_preview_dispatch_passes_sample_mode_and_seed_through(self, tmp_path: Path) -> None:
+        client = _FakeClient({"datago.air_quality": [{"id": str(i)} for i in range(20)]})
+        service = BuilderService(output_root=tmp_path, client_factory=lambda: client)
+
+        resp = dispatch(
+            service,
+            "POST",
+            "/preview",
+            {"spec": VALID_SPEC_YAML, "limit": 3, "sample_mode": "random", "seed": 5},
+        )
+
+        assert resp.status_code == 200
+        assert resp.body["previews"][0]["sample_mode"] == "random"
+        assert len(resp.body["previews"][0]["source_sample"]) == 3
+
+    def test_preview_dispatch_defaults_sample_mode_to_first_when_omitted(
+        self, tmp_path: Path
+    ) -> None:
+        # 기존 client가 sample_mode/seed 없이 호출해도 기존과 동일하게 동작한다.
+        resp = dispatch(
+            _service(tmp_path), "POST", "/preview", {"spec": VALID_SPEC_YAML, "limit": 1}
+        )
+        assert resp.status_code == 200
+        assert resp.body["previews"][0]["sample_mode"] == "first"
+
     def test_build_rejects_non_string_run_id(self, tmp_path: Path) -> None:
         # run_id가 문자열이 아니면 조용히 자동 생성 id로 떨어뜨리지 않고 400 (#185).
         resp = dispatch(
@@ -509,6 +693,139 @@ def http_server_with_auth(
         server.shutdown()
         server.server_close()
         thread.join(timeout=1.0)
+
+
+class TestPreviewWireSerialization:
+    """POST /preview 실제 wire JSON 직렬화를 검증한다 (#497, 계약 섹션 6).
+
+    ``BuilderService.preview()``가 반환하는 dict는 date/datetime 등 파이썬
+    객체를 그대로 담고 있을 수 있어(#440부터의 기존 ``sample`` 필드와 동일한
+    패턴), 실제 HTTP 응답 바이트까지 확인해야 ``service/http.py``의
+    ``json.dumps(default=str)`` 경로가 ``source_sample``/``diffs``에도 올바르게
+    적용되는지 알 수 있다. 별도 serializer를 새로 만들지 않고 기존 경로를
+    그대로 재사용한다.
+    """
+
+    def _post_preview(
+        self, service: BuilderService, spec_yaml: str, **body_extra: object
+    ) -> dict[str, object]:
+        server = HTTPServer(("127.0.0.1", 0), make_handler(service))
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        base_url = f"http://{server.server_address[0]}:{server.server_address[1]}"
+        try:
+            req = urllib.request.Request(
+                f"{base_url}/preview",
+                data=json.dumps({"spec": spec_yaml, **body_extra}).encode("utf-8"),
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=2.0) as response:
+                return cast(dict[str, object], json.loads(response.read()))
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=1.0)
+
+    def test_null_int_float_bool_string_date_and_datetime_survive_the_wire(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("KPUBDATA_BUILDER_DEV_MODE", "true")
+        # casts를 선언하지 않고 raw record에 이미 파이썬 타입 값을 실어, kpubdata
+        # provider가 이미 typed 값을 돌려주는 흔한 경우를 흉내낸다 — records_to_dataframe가
+        # 이 타입들을 그대로 추론해 실어 나른다.
+        row: dict[str, JsonValue] = {
+            "id": "1",
+            "n": None,
+            "count": 3,
+            "ratio": 1.5,
+            "active": True,
+            "label": "seoul",
+            "d": date(2025, 1, 1),  # type: ignore[dict-item]
+            "ts": datetime(2025, 1, 1, 12, 30, 0),  # type: ignore[dict-item]
+        }
+        client = _FakeClient({"datago.air_quality": [row]})
+        service = BuilderService(output_root=tmp_path, client_factory=lambda: client)
+
+        body = self._post_preview(service, VALID_SPEC_YAML, limit=1)
+
+        preview = cast(dict[str, object], cast(list[object], body["previews"])[0])
+        source_row = cast(dict[str, object], cast(list[object], preview["source_sample"])[0])
+        assert source_row["n"] is None
+        assert source_row["count"] == 3
+        assert source_row["ratio"] == 1.5
+        assert source_row["active"] is True
+        assert source_row["label"] == "seoul"
+        # date/naive datetime은 http.py의 json.dumps(default=str)을 거쳐 str()
+        # 형식(공백 구분)의 문자열이 된다 — 기존 sample 필드와 동일 규칙(#497은 이를
+        # 재사용할 뿐 새 규칙을 만들지 않는다).
+        assert source_row["d"] == "2025-01-01"
+        assert source_row["ts"] == "2025-01-01 12:30:00"
+
+        transformed_row = cast(dict[str, object], cast(list[object], preview["sample"])[0])
+        assert transformed_row["d"] == "2025-01-01"
+        assert transformed_row["ts"] == "2025-01-01 12:30:00"
+
+    def test_timezone_aware_datetime_survives_the_wire(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # test_silver.py::test_serializes_timezone_aware_datetime_values_as_iso_strings와
+        # 같은 패턴(직접 aware datetime 값을 실어 polars가 UTC로 정규화하게 한다).
+        monkeypatch.setenv("KPUBDATA_BUILDER_DEV_MODE", "true")
+        kst = timezone(timedelta(hours=9))
+        row: dict[str, JsonValue] = {
+            "id": "1",
+            "tz": datetime(2025, 1, 1, 21, 30, 0, tzinfo=kst),  # type: ignore[dict-item]
+        }
+        client = _FakeClient({"datago.air_quality": [row]})
+        service = BuilderService(output_root=tmp_path, client_factory=lambda: client)
+
+        body = self._post_preview(service, VALID_SPEC_YAML, limit=1)
+
+        preview = cast(dict[str, object], cast(list[object], body["previews"])[0])
+        source_row = cast(dict[str, object], cast(list[object], preview["source_sample"])[0])
+        transformed_row = cast(dict[str, object], cast(list[object], preview["sample"])[0])
+        # source_sample은 bronze raw record를 그대로 노출하므로 원래 KST offset을
+        # 유지하고, Silver(transformed)는 polars가 UTC로 정규화한다 — KST 21:30과
+        # UTC 12:30은 같은 instant이므로 diff는 없지만(값 자체는 동일), 두 표현이
+        # 서로 다른 offset의 str() 문자열로 각자 정확히 직렬화되는지 확인한다.
+        assert source_row["tz"] == "2025-01-01 21:30:00+09:00"
+        assert transformed_row["tz"] == "2025-01-01 12:30:00+00:00"
+
+    def test_diff_before_after_carry_wire_correct_types(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # declared cast로 실제 diff item이 만들어질 때도 before(str)/after(int)가
+        # 각자의 실제 JSON 타입으로 wire에 실린다(#497 diff item 예시와 동일한 형태).
+        monkeypatch.setenv("KPUBDATA_BUILDER_DEV_MODE", "true")
+        spec_yaml = (
+            """
+dataset_id: dataset.sample
+title: Sample Dataset
+description: Sample description
+sources:
+  - provider: datago
+    dataset: air_quality
+    schema:
+      casts:
+        v: int
+exports:
+  - kind: jsonl
+    output_path: out/data.jsonl
+""".strip()
+            + "\n"
+        )
+        client = _FakeClient({"datago.air_quality": [{"id": "1", "v": "128000"}]})
+        service = BuilderService(output_root=tmp_path, client_factory=lambda: client)
+
+        body = self._post_preview(service, spec_yaml, limit=1)
+
+        preview = cast(dict[str, object], cast(list[object], body["previews"])[0])
+        diffs = cast(list[dict[str, object]], preview["diffs"])
+        assert len(diffs) == 1
+        assert diffs[0]["before"] == "128000"
+        assert diffs[0]["after"] == 128000
+        assert diffs[0]["transform"] == "cast:int"
 
 
 class TestHttpAdapter:

--- a/tests/unit/test_service_contract.py
+++ b/tests/unit/test_service_contract.py
@@ -290,6 +290,44 @@ def test_source_preview_schema_covers_success_and_failure_shape() -> None:
     }
 
 
+def test_source_preview_schema_covers_diff_and_sampling_shape() -> None:
+    """#497: source_sample/sample_mode/diff_available/diffs/transform_summary가
+    항상 반환되는 필수 필드로 계약에 고정돼 있는지, PreviewDiffItem이 잘못된
+    index 비교를 만들지 않는다는 계약(transform nullable)을 지키는지 확인한다."""
+    schemas = _load_contract()["components"]["schemas"]
+    preview = schemas["SourcePreview"]
+
+    assert {
+        "source_sample",
+        "sample_mode",
+        "diff_available",
+        "diffs",
+        "transform_summary",
+        "diff_truncated",
+    } <= set(preview["required"])
+    assert preview["properties"]["sample_mode"]["enum"] == ["first", "random"]
+    assert preview["properties"]["diff_available"]["type"] == "boolean"
+    assert preview["properties"]["diffs"]["items"]["$ref"].endswith("/PreviewDiffItem")
+    assert preview["properties"]["diff_truncated"]["type"] == "boolean"
+
+    diff_item = schemas["PreviewDiffItem"]
+    assert set(diff_item["required"]) == {"row", "column", "before", "after", "transform"}
+    assert diff_item["properties"]["transform"]["type"] == ["string", "null"]
+
+    summary = schemas["PreviewTransformSummary"]
+    assert set(summary["required"]) == {"changed_cells", "changed_rows"}
+
+
+def test_preview_request_schema_declares_bounded_limit_and_sample_mode() -> None:
+    """#497: limit 상한(1000, behavioral tightening)과 sample_mode/seed가 계약에 반영됐는지."""
+    preview_request = _load_contract()["components"]["schemas"]["PreviewRequest"]
+
+    assert preview_request["properties"]["limit"]["maximum"] == 1000
+    assert preview_request["properties"]["sample_mode"]["enum"] == ["first", "random"]
+    assert preview_request["properties"]["sample_mode"]["default"] == "first"
+    assert preview_request["properties"]["seed"]["type"] == "integer"
+
+
 # 계약이 기술하는 모든 오퍼레이션은 BuilderService에 실제로 구현돼 있어야 한다.
 # 구현 경로 이름은 계약과 1:1로 일치한다(#226: aspirational 비동기/publish 라우트 제거).
 _IMPLEMENTED_OPERATIONS = {
@@ -793,6 +831,70 @@ class TestResponseConformance:
             _conform_service(tmp_path), "POST", "/preview", {"spec": _CONFORM_SPEC_YAML, "limit": 0}
         )
         assert resp.status_code == 400
+        _assert_conforms(resp, "/preview", "POST")
+
+    def test_preview_400_limit_above_max(self, tmp_path: Path) -> None:
+        # #497: limit 상한(1000) 신규 도입 — behavioral tightening.
+        resp = dispatch(
+            _conform_service(tmp_path),
+            "POST",
+            "/preview",
+            {"spec": _CONFORM_SPEC_YAML, "limit": 1001},
+        )
+        assert resp.status_code == 400
+        _assert_conforms(resp, "/preview", "POST")
+
+    def test_preview_200_random_sample_mode_with_diff(self, tmp_path: Path) -> None:
+        # #497: sample_mode=random + diff가 실제 발생하는 응답도 계약을 만족하는지.
+        resp = dispatch(
+            _conform_service(tmp_path),
+            "POST",
+            "/preview",
+            {"spec": _CONFORM_SPEC_YAML, "limit": 2, "sample_mode": "random", "seed": 1},
+        )
+        assert resp.status_code == 200
+        previews = cast(list[dict[str, JsonValue]], resp.body["previews"])
+        assert previews[0]["sample_mode"] == "random"
+        assert previews[0]["diff_available"] is True
+        _assert_conforms(resp, "/preview", "POST")
+
+    def test_preview_400_bad_sample_mode(self, tmp_path: Path) -> None:
+        resp = dispatch(
+            _conform_service(tmp_path),
+            "POST",
+            "/preview",
+            {"spec": _CONFORM_SPEC_YAML, "sample_mode": "shuffle"},
+        )
+        assert resp.status_code == 400
+        _assert_conforms(resp, "/preview", "POST")
+
+    def test_preview_200_wide_dataset_diff_truncated(self, tmp_path: Path) -> None:
+        # #497 sample/diff memory 상한: diffs가 실제로 잘려도(diff_truncated=true)
+        # 응답이 여전히 계약을 만족하는지 wire-level로 확인한다.
+        from kpubdata_builder.pipeline import MAX_PREVIEW_DIFF_ITEMS
+
+        columns = [f"c{i}" for i in range(MAX_PREVIEW_DIFF_ITEMS + 10)]
+        wide_spec_yaml = (
+            "dataset_id: dataset.wide\n"
+            "title: Wide Conform\n"
+            "description: wide dataset conformance fixture\n"
+            "sources:\n"
+            "  - provider: datago\n"
+            "    dataset: air_quality\n"
+            "    schema:\n"
+            "      casts:\n" + "".join(f"        {c}: int\n" for c in columns) + "exports:\n"
+            "  - kind: jsonl\n"
+            "    output_path: out/data.jsonl\n"
+        )
+        client = _FakeClient({"datago.air_quality": [dict.fromkeys(columns, "1")]})
+        service = BuilderService(output_root=tmp_path, client_factory=lambda: client)
+
+        resp = dispatch(service, "POST", "/preview", {"spec": wide_spec_yaml, "limit": 1})
+
+        assert resp.status_code == 200
+        previews = cast(list[dict[str, JsonValue]], resp.body["previews"])
+        assert len(cast(list[object], previews[0]["diffs"])) == MAX_PREVIEW_DIFF_ITEMS
+        assert previews[0]["diff_truncated"] is True
         _assert_conforms(resp, "/preview", "POST")
 
     def test_build_200_success(self, tmp_path: Path) -> None:

--- a/tests/unit/test_silver.py
+++ b/tests/unit/test_silver.py
@@ -138,6 +138,54 @@ class TestBuildSilverDataset:
             _ = build_silver_dataset(bronze, preview_limit=-1)
 
 
+class TestRowPreservingInvariant:
+    """Bronze→Silver가 행을 filter/dedup/reorder하지 않는다는 불변조건을 고정한다 (#497).
+
+    pipeline.preview의 Source↔Silver diff는 ``bronze.raw_records[i]``와
+    ``silver.table``의 i번째 행이 항상 같은 논리적 행이라는 이 불변조건에
+    의존한다(diff_available 판정의 실제 근거). normalize_table()이
+    records_to_dataframe() → cast_columns()만 호출하고 validate_table()은
+    테이블을 아예 건드리지 않으므로 오늘은 이 불변조건이 성립하지만, 향후 누군가
+    Silver에 dedup/filter/reorder를 추가하면 이 테스트가 깨져서 pipeline/preview.py
+    의 alignment 가정을 재검토하라는 신호를 준다.
+    """
+
+    def test_row_count_is_preserved(self) -> None:
+        records = tuple({"id": str(i), "amount": i * 100} for i in range(50))
+        bronze = _bronze(records)
+
+        dataset = build_silver_dataset(bronze, casts={"amount": "float"})
+
+        assert dataset.table.height == len(records)
+        assert dataset.statistics.row_count == len(records)
+
+    def test_row_order_is_preserved_across_normalize_and_validate(self) -> None:
+        # id를 원본 순서의 지문으로 써서, 캐스팅/검증을 거쳐도 순서가 바뀌지
+        # 않는지 확인한다 — 값이 바뀌어도(#497 diff의 목적) 행의 *위치*는 원본과
+        # 1:1로 대응해야 한다.
+        records = tuple({"id": str(i), "amount": str(i * 100)} for i in range(20))
+        bronze = _bronze(records)
+
+        dataset = build_silver_dataset(
+            bronze,
+            casts={"amount": "int"},
+            required_columns=("id", "amount"),
+            column_dtypes={"amount": "int"},
+        )
+
+        assert dataset.table["id"].to_list() == [r["id"] for r in records]
+        assert dataset.validation.ok is True
+
+    def test_row_order_is_preserved_without_declared_casts(self) -> None:
+        # casts가 전혀 없어도(가장 흔한 preview 경로) 순서 보존은 동일하게 성립한다.
+        records = tuple({"id": str(i), "label": chr(ord("a") + i)} for i in range(10))
+        bronze = _bronze(records)
+
+        dataset = build_silver_dataset(bronze)
+
+        assert dataset.table["id"].to_list() == [r["id"] for r in records]
+
+
 class TestPersistSilverDataset:
     def test_writes_parquet_and_json_sidecars(self, tmp_path: Path) -> None:
         bronze = _bronze(


### PR DESCRIPTION
## 요약
Closes #497

기존 `POST /preview`는 Silver 변환 결과(sample)만 반환하고 원본 Bronze row와
비교할 방법이 없었다. 같은 preview 실행 안에서 Bronze 원본 sample과 Silver
변환 sample을 동일 행 인덱스로 골라 셀 단위로 비교하는 기능을 추가한다.

기존 Preview/Silver/Quality 파이프라인(#485, #486, #488)은 재구현하지 않고
그대로 재사용했다. Preview는 여전히 파일을 persist하지 않는다.

## 변경 사항
- `source_sample`(Bronze 원본), `sample_mode`(first/random), `diff_available`,
  `diffs`(cell-level diff), `transform_summary`를 `/preview` 응답에 추가.
  기존 필드(`sample`/`schema`/`statistics`/`quality_results`)는 값·의미 불변.
- **Sampling**: `sample_mode=first`(기본, 기존과 동일 동작) 또는 `random`
  (`seed` 기반 결정적 무작위 추출, 전역 random 상태 불변경). Source/Silver가
  동일 index list를 공유해 서로 다른 행을 고르는 일이 없도록 설계.
- **Diff alignment**: 현재 Bronze→Silver 정규화 경로(정규화만 하고
  filter/reorder는 하지 않음)의 row-preserving invariant를 근거로
  `diff_available`을 판정하고, 이 불변조건을 회귀 테스트로 고정했다. 행 수
  불일치 등 정합성을 보장할 수 없으면 잘못된 index 비교 대신
  `diff_available=false`로 fail-closed.
- **Diff item cap**: `limit`은 행 수만 제한하므로 wide dataset(컬럼 수 多)에서
  diff item 수가 무제한일 수 있다는 점을 보완해 `MAX_PREVIEW_DIFF_ITEMS`(1000)
  상한과 `diff_truncated` 플래그를 추가. 잘려도 `transform_summary`의
  `changed_cells`/`changed_rows`는 정확한 전체 합계를 유지한다.
- **Limit 상한 신설**: `/preview.limit`에 상한 1000을 새로 도입
  (behavioral tightening, 기존엔 상한 없음) — OpenAPI/서비스 3계층/테스트에 반영.
- `seed`는 bool을 int로 허용하지 않고 400 처리.
- `contract/builder-api.yaml` 갱신(`PreviewDiffItem`, `PreviewTransformSummary`
  등 신규 스키마), `API_CONTRACT_VERSION` 1.8.0 → 1.9.0.

## 보안/계약
- credential 원문, raw provider secret, 절대경로 노출 없음(기존 redaction 로직 재사용).
- sample/diff 응답 크기는 모두 bounded(limit≤1000, diff item≤1000).
- Preview persist 없음, ownership/provider credential 기존 semantics 무변경,
  Quality는 #486 evaluator 결과를 그대로 사용(재판정 없음).
- 기존 client가 신규 필드 없이 호출해도 동일하게 동작(순수 additive 필드 추가).

## 테스트
- `pytest tests/`: 1088 passed / 8 failed / 6 skipped — 실패 8건은 모두 이
  브랜치 변경 전 baseline에서도 동일하게 재현되는 Windows 환경 이슈
  (symlink 권한, `\\?\` UNC 경로, tzdata 패키지 부재로 인한 polars panic)로,
  `#497` 로직과 무관함을 `git stash` 비교로 확인했다.
- `ruff check` / `ruff format --check` / `mypy src`: 모두 통과.