### PR TITLE
feat(monitoring): add system and build statistics API (#516)

### DIFF
--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -187,6 +187,62 @@ v0.4 Builder service는 동기식 실행 모델을 유지합니다.
 - 특정 신규 IdP 채택이나 email/password 로그인은 이 절의 범위가 아닙니다 — 향후 IdP
   결정(#515)과 무관하게 stable owner identity 계산 방식이 먼저 확정된 것입니다.
 
+### System Resource·Build Statistics API (#516)
+
+`GET /monitoring/summary`, `GET /monitoring/builds`는 Studio Monitoring 화면에
+필요한 시스템/집계 observability를 제공합니다. Run 단위 이벤트(#496)는 별도
+범위입니다.
+
+- **"모른다"와 "0"을 구분합니다.** 측정된 적 없는 값은 `0`/`healthy`로 위장하지 않고
+  `null`과 `available`/`partial`/`unavailable`(quality.py가 이미 정의한 어휘를
+  재사용)로 표현합니다.
+- **Aggregate status**(`MonitoringSummaryResponse.status`): required subsystem
+  (`api`/`queue`/`workers`/`artifact_store`)의 `availability`로부터 계산되는
+  deterministic 판정입니다. 넷 모두 `available`이면 `healthy`, 하나라도
+  `partial`/`unavailable`이면 `degraded`입니다. latency SLA threshold(예:
+  p95 100ms/500ms/1s)는 근거(ADR/config)가 없어 사용하지 않습니다 —
+  `sample_count=0`/`p95_latency_ms=null` 자체나 `queue`/`workers`의 실제 0건은
+  degraded 근거가 아닙니다(availability가 실제로 `unavailable`/`partial`일 때만
+  degraded). Provider 상태(#492)는 optional이라 이 판정에 포함되지 않습니다.
+- **Builder API 상태**: `dispatch()` 실행 시간을 최근 최대 1000개 요청의 bounded
+  ring buffer로 기록하고 nearest-rank(보간 없음) 방식으로 p95를 계산합니다.
+  `sample_count=0`이면 `p95_latency_ms=null`입니다. Healthy/Degraded 같은 latency
+  임계값 판정은 근거(ADR/config)가 없어 발명하지 않았습니다 — raw
+  `sample_count`/`p95_latency_ms`만 제공합니다.
+- **Queue/Worker**: async build 실행 모델은 `AsyncBuildExecutor`/
+  `AsyncBuildJobRegistry`(#511/#513)로 구현되어 있고 `BuilderService`가 항상
+  생성해 `POST /builds`(비동기) 제출에 사용합니다. `queue`/`workers`는 이
+  실행기의 read-only snapshot(`AsyncBuildExecutor.stats()`)을 그대로 반영하므로
+  정상 runtime에서는 항상 `availability: available`입니다. `waiting`은
+  status=`queued`, `running`은 status=`running`인 active job 수이고
+  `total = waiting + running`입니다 — registry가 계속 보존하는 terminal
+  (`succeeded`/`failed`/`cancelled`) job 이력은 섞지 않습니다. `workers.active`는
+  `running`과 같고(worker 하나가 job 하나를 실행), `workers.capacity`는 실행기
+  생성 시 보존한 `max_workers`이며 `ThreadPoolExecutor`의 private field를 직접
+  읽지 않습니다. `workers.utilization`은 `active / capacity`(0.0~1.0)입니다.
+  `availability: unavailable`은 (현재는 도달하지 않는) 진짜 async 미지원 구성을
+  위한 fallback으로만 남겨두며, 그때만 나머지 필드가 `null`입니다 — "0건"과
+  "확인 불가"를 구분합니다. `BoundedThreadingHTTPServer`의
+  `ThreadPoolExecutor`(#253)는 이것과 무관한 HTTP 연결 동시성 상한입니다.
+- **Artifact Store**: `output_root` 폴더가 존재한다는 사실만으로 `available`로
+  간주하지 않습니다 — BuildIndex 쿼리도 성공해야 `available`입니다. `last_write_at`은
+  BuildIndex에 기록된 가장 최근 성공(`ok`) 빌드의 `finished_at`에서만 얻으며, 성공
+  기록이 없으면 `available`이되 `null`입니다(0건과 확인 불가를 구분). 절대 파일시스템
+  경로는 노출하지 않습니다.
+- **Build 통계**(`/monitoring/builds`): timezone은 UTC, bucket 경계는
+  `[start, end)` 반열린, bucket 기준 timestamp는 `finished_at`(BuildIndex는 완료된
+  빌드만 기록, ADR 0003)입니다. 현재 `window=24h`/`bucket=hour`만 지원하며 다른
+  값은 400입니다. malformed timestamp(파싱 실패, NULL 포함)는 집계에서 제외되고
+  `excluded_count`에 반영되며 전체 `availability`는 `partial`이 됩니다(BuildIndex
+  쿼리 자체 실패는 `unavailable`, 정상 집계 결과 0건은 `available`).
+- **Provider 상태**는 요청마다 실제 네트워크 프로브를 유발하므로(#492) 이번 버전의
+  Monitoring 응답에는 포함되지 않습니다.
+- **Ownership**: 시스템 aggregate(`api`/`queue`/`workers`/`artifact_store`)는 개별
+  run의 dataset/owner/credential 정보를 포함하지 않아 필터링이 필요 없습니다.
+  `/monitoring/builds`의 버킷 집계와 recent runs는 `ENFORCE_OWNERSHIP`+oidc
+  principal일 때 `principal_owns()`로 필터링해 다른 사용자의 run이 섞이지
+  않습니다(#505와 동일 정책).
+
 ## 4. 인증과 CORS
 
 브라우저 클라이언트(Studio 등)와의 연동을 위해 CORS는 default-deny입니다.

--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -206,7 +206,11 @@ v0.4 Builder service는 동기식 실행 모델을 유지합니다.
   degraded). Provider 상태(#492)는 optional이라 이 판정에 포함되지 않습니다.
 - **Builder API 상태**: `dispatch()` 실행 시간을 최근 최대 1000개 요청의 bounded
   ring buffer로 기록하고 nearest-rank(보간 없음) 방식으로 p95를 계산합니다.
-  `sample_count=0`이면 `p95_latency_ms=null`입니다. Healthy/Degraded 같은 latency
+  `sample_count=0`이면 `p95_latency_ms=null`입니다. collector 자체가 손상되어
+  표본을 읽을 수 없으면(#527) `availability=unavailable` +
+  `sample_count=null` + `p95_latency_ms=null`입니다 — "정상 무표본"과 "측정
+  불가"를 같은 값으로 뭉개지 않으며, 이 subsystem 실패가 원 요청이나
+  monitoring 응답 자체를 실패시키지 않습니다. Healthy/Degraded 같은 latency
   임계값 판정은 근거(ADR/config)가 없어 발명하지 않았습니다 — raw
   `sample_count`/`p95_latency_ms`만 제공합니다.
 - **Queue/Worker**: async build 실행 모델은 `AsyncBuildExecutor`/
@@ -234,14 +238,21 @@ v0.4 Builder service는 동기식 실행 모델을 유지합니다.
   빌드만 기록, ADR 0003)입니다. 현재 `window=24h`/`bucket=hour`만 지원하며 다른
   값은 400입니다. malformed timestamp(파싱 실패, NULL 포함)는 집계에서 제외되고
   `excluded_count`에 반영되며 전체 `availability`는 `partial`이 됩니다(BuildIndex
-  쿼리 자체 실패는 `unavailable`, 정상 집계 결과 0건은 `available`).
+  쿼리 자체 실패는 `unavailable`, 정상 집계 결과 0건은 `available`). bucket 카운트
+  wire 필드는 `total`/`success`/`failed`/`cancelled`입니다 — 내부 BuildIndex
+  status 값 `ok`는 그대로 두고(변경 없음) 외부 Monitoring API 필드 이름만
+  `success`로 매핑합니다(#527).
 - **Provider 상태**는 요청마다 실제 네트워크 프로브를 유발하므로(#492) 이번 버전의
   Monitoring 응답에는 포함되지 않습니다.
 - **Ownership**: 시스템 aggregate(`api`/`queue`/`workers`/`artifact_store`)는 개별
   run의 dataset/owner/credential 정보를 포함하지 않아 필터링이 필요 없습니다.
   `/monitoring/builds`의 버킷 집계와 recent runs는 `ENFORCE_OWNERSHIP`+oidc
-  principal일 때 `principal_owns()`로 필터링해 다른 사용자의 run이 섞이지
-  않습니다(#505와 동일 정책).
+  principal일 때 `principal_owns()`(#505)와 동일한 정책으로 필터링해 다른
+  사용자의 run이 섞이지 않습니다. bucket 집계는 window 전체를 먼저 가져온 뒤
+  필터링해도 손실이 없지만, `recent_runs`는 고정 10건 LIMIT이 걸린 조회라 필터를
+  LIMIT **이전에** SQL에서 적용합니다(`BuildIndex.list_recent_owned`, #527) —
+  그렇지 않으면 다른 principal의 최신 run들이 LIMIT을 다 채워 요청자 본인의
+  recent run이 빠질 수 있습니다.
 
 ## 4. 인증과 CORS
 

--- a/BOUNDARY.md
+++ b/BOUNDARY.md
@@ -26,6 +26,7 @@
 | Publish | 원격 게시 수행, 성공/실패 기록 | publish 요청, 결과 표시 |
 | Query | Silver/Gold table resolve, read-only 실행, limit/timeout | SQL 명시 실행 요청, result preview 표시 |
 | Provider credential | owner_id별 encrypted-at-rest 저장, server default fallback, 요청별 client 격리, status/test | credential 입력 UX, masked/configured/status 표시 |
+| Monitoring(#516) | latency/queue/worker/artifact 상태 측정, BuildIndex 기반 build 통계 집계, availability 판정 | Monitoring 대시보드 렌더링, 폴링 |
 
 ## 4. Studio가 해서는 안 되는 일
 
@@ -41,6 +42,8 @@ Studio는 다음을 구현하거나 소유하면 안 됩니다.
 - Polars 외 별도 canonical transform engine 도입
 - raw Provider credential을 browser storage나 Studio backend의 정본으로 보관
 - Builder의 owner_id 또는 credential resolution 우선순위를 재구현
+- Builder가 `unavailable`/`partial`로 보고한 Monitoring 값을 임의로 `healthy`/`0`으로
+  대체해 표시
 
 ## 5. 허용되는 Studio 역할
 

--- a/contract/builder-api.yaml
+++ b/contract/builder-api.yaml
@@ -2300,11 +2300,15 @@ components:
     MonitoringApiStatus:
       type: object
       description: >-
-        Builder API 요청 처리 latency 상태. 이 응답이 생성된다는 사실 자체가
-        API가 응답 중임을 증명하므로 availability는 항상 available이다.
-        Healthy/Degraded 같은 latency 임계값 판정은 근거(ADR/config)가 없어
-        이번 버전에서 발명하지 않는다 — raw sample_count/p95_latency_ms만
-        제공한다.
+        Builder API 요청 처리 latency 상태. availability=available은 latency
+        collector(ring buffer)가 정상적으로 표본을 읽어낼 수 있었다는 뜻이며,
+        collector 자체가 손상되어 표본을 읽을 수 없으면(#527) unavailable +
+        sample_count=null + p95_latency_ms=null이다 — "정상 무표본"
+        (available + sample_count=0 + p95_latency_ms=null)과 "측정 불가"를
+        같은 값으로 뭉개지 않는다. 이 subsystem 실패는 원 요청이나 이
+        monitoring 응답 자체를 실패시키지 않는다. Healthy/Degraded 같은
+        latency 임계값 판정은 근거(ADR/config)가 없어 이번 버전에서 발명하지
+        않는다 — raw sample_count/p95_latency_ms만 제공한다.
       required: [availability, sample_count, p95_latency_ms]
       additionalProperties: false
       properties:
@@ -2312,12 +2316,16 @@ components:
           type: string
           enum: [available, partial, unavailable]
         sample_count:
-          type: integer
+          type: [integer, "null"]
           minimum: 0
-          description: 최근 최대 1000개 요청 ring buffer에 현재 보관된 표본 수.
+          description: >-
+            최근 최대 1000개 요청 ring buffer에 현재 보관된 표본 수.
+            availability가 unavailable이면(collector 실패) null.
         p95_latency_ms:
           type: [number, "null"]
-          description: sample_count가 0이면 null. nearest-rank 방식(보간 없음)으로 계산.
+          description: >-
+            sample_count가 0이거나 availability가 unavailable이면 null.
+            nearest-rank 방식(보간 없음)으로 계산.
 
     MonitoringQueueStatus:
       type: object
@@ -2425,8 +2433,12 @@ components:
 
     MonitoringBuildBucket:
       type: object
-      description: "[bucket_start, bucket_end) 반열린 구간의 build 카운트 (UTC)."
-      required: [bucket_start, bucket_end, total, ok, failed, cancelled]
+      description: >-
+        [bucket_start, bucket_end) 반열린 구간의 build 카운트 (UTC). success는
+        내부 BuildIndex status "ok"를 외부 wire 명명으로 매핑한 값이다(#527) —
+        내부 BuildIndex status vocabulary(ok/failed/cancelled) 자체는 바뀌지
+        않는다.
+      required: [bucket_start, bucket_end, total, success, failed, cancelled]
       additionalProperties: false
       properties:
         bucket_start:
@@ -2438,7 +2450,7 @@ components:
         total:
           type: integer
           minimum: 0
-        ok:
+        success:
           type: integer
           minimum: 0
         failed:

--- a/contract/builder-api.yaml
+++ b/contract/builder-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: KPubData Builder Service API
-  version: "1.9.0"
+  version: "1.10.0"
   description: >-
     Builder 중심 서비스 계약. BuildSpec 검증, preview, build 실행, artifact 조회,
     계약 버전 조회를 제공한다. CLI와 HTTP service mode(#36)가 동일한 도메인 계약을
@@ -24,6 +24,20 @@ info:
     이전에는 상한이 없었다). `limit`이 행 수만 제한하므로 wide dataset에서
     `diffs` 자체가 무제한 커질 수 있어, `diffs`도 별도 상한(1000)으로 자르고
     `diff_truncated`로 명시한다 — `transform_summary`의 집계는 잘리지 않는다.
+    v1.10.0은 `GET /monitoring/summary`와 `GET /monitoring/builds`를
+    추가한다(#516, additive — 기존 엔드포인트는 변경되지 않는다). Studio
+    Monitoring 화면을 위한 시스템/집계 observability만 다루며 Run 단위 이벤트는
+    별도(#496)다. Async build queue/worker 상태는 기존
+    `AsyncBuildExecutor`/`AsyncBuildJobRegistry`(#511/#513)의 read-only
+    snapshot을 반영한다 — 정상 Builder runtime에서는 `availability: available`
+    이며 실제 0건과 `unavailable`을 구분한다. Builder API latency는
+    healthy/degraded 임계값 근거가 없어 판정 없이 raw
+    `sample_count`/`p95_latency_ms`만 제공한다. 대신
+    `MonitoringSummaryResponse.status`(`healthy`/`degraded`)는 required
+    subsystem(`api`/`queue`/`workers`/`artifact_store`)의 availability로부터
+    계산되는 deterministic aggregate이며 latency threshold는 사용하지 않는다.
+    Provider 상태는 요청마다 네트워크 프로브를 유발하므로(#492) 이번
+    버전에서는 응답에도, aggregate status 판정에도 포함하지 않는다.
 servers:
   - url: http://localhost:8000
     description: 로컬 builder 개발 서버
@@ -752,6 +766,68 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+
+  /monitoring/summary:
+    get:
+      operationId: getMonitoringSummary
+      summary: Builder API/Queue/Worker/Artifact Store 시스템 상태 요약 (#516)
+      description: >-
+        시스템 aggregate만 반환하며 개별 run의 dataset/owner/credential 정보는
+        포함하지 않는다. Async build queue/worker(#511/#513)는 이 서비스가 항상
+        생성하는 AsyncBuildExecutor의 read-only snapshot을 반영하므로 항상
+        `availability: available`이다(#516). Provider 상태는 네트워크 프로브를
+        유발하므로 이번 버전에서는 포함하지 않는다.
+      responses:
+        "200":
+          description: 시스템 상태 요약
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MonitoringSummaryResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /monitoring/builds:
+    get:
+      operationId: getMonitoringBuilds
+      summary: 시간대별 build 통계와 recent runs (#516)
+      description: >-
+        BuildIndex(ADR 0003) 기반 파생 집계. timezone은 UTC이며 bucket 경계는
+        `[start, end)` 반열린이다. bucket 기준 timestamp는 `finished_at`이다.
+        ENFORCE_OWNERSHIP+oidc principal일 때는 본인이 접근 가능한 run만
+        집계·노출한다(#505).
+      parameters:
+        - name: window
+          in: query
+          required: false
+          description: "집계 기간. 현재 24h만 지원 (기본값: 24h)"
+          schema:
+            type: string
+            enum: [24h]
+            default: 24h
+        - name: bucket
+          in: query
+          required: false
+          description: "집계 단위. 현재 hour만 지원 (기본값: hour)"
+          schema:
+            type: string
+            enum: [hour]
+            default: hour
+      responses:
+        "200":
+          description: build 통계와 recent runs
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MonitoringBuildsResponse"
+        "400":
+          description: 지원하지 않는 window/bucket 값
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
 
 components:
   securitySchemes:
@@ -2216,3 +2292,208 @@ components:
         sample_available:
           type: boolean
           enum: [false]
+
+    # ---------------------------------------------------------------------
+    # Monitoring API (#516)
+    # ---------------------------------------------------------------------
+
+    MonitoringApiStatus:
+      type: object
+      description: >-
+        Builder API 요청 처리 latency 상태. 이 응답이 생성된다는 사실 자체가
+        API가 응답 중임을 증명하므로 availability는 항상 available이다.
+        Healthy/Degraded 같은 latency 임계값 판정은 근거(ADR/config)가 없어
+        이번 버전에서 발명하지 않는다 — raw sample_count/p95_latency_ms만
+        제공한다.
+      required: [availability, sample_count, p95_latency_ms]
+      additionalProperties: false
+      properties:
+        availability:
+          type: string
+          enum: [available, partial, unavailable]
+        sample_count:
+          type: integer
+          minimum: 0
+          description: 최근 최대 1000개 요청 ring buffer에 현재 보관된 표본 수.
+        p95_latency_ms:
+          type: [number, "null"]
+          description: sample_count가 0이면 null. nearest-rank 방식(보간 없음)으로 계산.
+
+    MonitoringQueueStatus:
+      type: object
+      description: >-
+        Async build queue 상태(#516). AsyncBuildExecutor/AsyncBuildJobRegistry
+        (#511/#513)의 read-only snapshot을 반영하며, 이 서비스는 항상
+        AsyncBuildExecutor를 생성하므로 정상 runtime에서는 항상
+        availability: available이다. waiting/running=0은 "대기/실행 중인 job이
+        실제로 없다"는 뜻이며, availability가 unavailable일 때만(예: async
+        build를 지원하지 않는 구성) 나머지 필드가 null이다 — "0건"과 "확인
+        불가"를 구분한다. total = waiting + running이며 terminal
+        (succeeded/failed/cancelled) job 이력은 포함하지 않는다.
+      required: [availability, waiting, running, total]
+      additionalProperties: false
+      properties:
+        availability:
+          type: string
+          enum: [available, partial, unavailable]
+        waiting:
+          type: [integer, "null"]
+          description: status=queued인 active job 수. unavailable이면 null.
+        running:
+          type: [integer, "null"]
+          description: status=running인 active job 수. unavailable이면 null.
+        total:
+          type: [integer, "null"]
+          description: waiting + running. unavailable이면 null.
+
+    MonitoringWorkerStatus:
+      type: object
+      description: >-
+        Async build worker pool 상태(#516). 근거는 MonitoringQueueStatus와
+        동일 — AsyncBuildExecutor가 항상 생성되므로 정상 runtime에서는 항상
+        availability: available이다. utilization은 0.0~1.0 ratio다(퍼센트
+        아님). unavailable일 때만 나머지 필드가 null이다.
+      required: [availability, active, capacity, utilization]
+      additionalProperties: false
+      properties:
+        availability:
+          type: string
+          enum: [available, partial, unavailable]
+        active:
+          type: [integer, "null"]
+          description: 현재 running job 수. unavailable이면 null.
+        capacity:
+          type: [integer, "null"]
+          description: >-
+            AsyncBuildExecutor 생성 시 지정한 max_workers. unavailable이면
+            null.
+        utilization:
+          type: [number, "null"]
+          description: >-
+            active / capacity ratio, 0.0~1.0. capacity가 0보다 클 때만 계산되며
+            unavailable이면 null(0.0으로 위장하지 않는다).
+
+    MonitoringArtifactStatus:
+      type: object
+      description: >-
+        Artifact Store 상태. output_root 폴더가 존재한다는 사실만으로
+        available로 간주하지 않는다 — BuildIndex 쿼리도 성공해야 available이다.
+        절대 파일시스템 경로는 노출하지 않는다.
+      required: [availability, last_write_at]
+      additionalProperties: false
+      properties:
+        availability:
+          type: string
+          enum: [available, partial, unavailable]
+        last_write_at:
+          type: [string, "null"]
+          format: date-time
+          description: >-
+            BuildIndex에 기록된 가장 최근 성공(ok) 빌드의 완료 시각. 성공 기록이
+            없으면 available이되 null(0건과 확인 불가를 구분).
+
+    MonitoringSummaryResponse:
+      type: object
+      description: >-
+        Studio Monitoring 화면용 시스템 상태 요약 (#516). Provider 상태는
+        요청마다 네트워크 프로브를 유발하므로(#492) 이번 버전에서는 포함하지
+        않는다.
+      required: [generated_at, status, api, queue, workers, artifact_store]
+      additionalProperties: false
+      properties:
+        generated_at:
+          type: string
+          format: date-time
+        status:
+          type: string
+          enum: [healthy, degraded]
+          description: >-
+            required subsystem(api/queue/workers/artifact_store) availability로부터
+            계산되는 deterministic aggregate status. 넷 모두 available이면
+            healthy, 하나라도 partial/unavailable이면 degraded. latency
+            threshold(SLA)는 사용하지 않으며 sample_count=0/p95_latency_ms=null
+            자체는 degraded 근거가 아니다. Provider status(#492, optional)는
+            이 판정에 포함되지 않는다.
+        api:
+          $ref: "#/components/schemas/MonitoringApiStatus"
+        queue:
+          $ref: "#/components/schemas/MonitoringQueueStatus"
+        workers:
+          $ref: "#/components/schemas/MonitoringWorkerStatus"
+        artifact_store:
+          $ref: "#/components/schemas/MonitoringArtifactStatus"
+
+    MonitoringBuildBucket:
+      type: object
+      description: "[bucket_start, bucket_end) 반열린 구간의 build 카운트 (UTC)."
+      required: [bucket_start, bucket_end, total, ok, failed, cancelled]
+      additionalProperties: false
+      properties:
+        bucket_start:
+          type: string
+          format: date-time
+        bucket_end:
+          type: string
+          format: date-time
+        total:
+          type: integer
+          minimum: 0
+        ok:
+          type: integer
+          minimum: 0
+        failed:
+          type: integer
+          minimum: 0
+        cancelled:
+          type: integer
+          minimum: 0
+
+    MonitoringRecentRun:
+      type: object
+      description: Monitoring 화면용 최소 run 요약. dataset_id/owner_id/error 등은 노출하지 않는다.
+      required: [run_id, status, started_at, finished_at]
+      additionalProperties: false
+      properties:
+        run_id:
+          type: string
+        status:
+          type: string
+          enum: [ok, failed, cancelled]
+        started_at:
+          type: [string, "null"]
+        finished_at:
+          type: [string, "null"]
+
+    MonitoringBuildsResponse:
+      type: object
+      description: >-
+        window/bucket별 build 통계(#516). timezone은 UTC. bucket 기준
+        timestamp는 finished_at. excluded_count는 malformed timestamp로 집계에서
+        제외된 행 수이며, 0보다 크면 availability는 partial이다.
+      required: [window, bucket, availability, excluded_count, buckets, recent_runs]
+      additionalProperties: false
+      properties:
+        window:
+          type: string
+          enum: [24h]
+        bucket:
+          type: string
+          enum: [hour]
+        availability:
+          type: string
+          enum: [available, partial, unavailable]
+          description: >-
+            available: 집계 성공(0건이어도 유효). partial: BuildIndex 쿼리는
+            성공했지만 malformed timestamp로 일부 행이 제외됨. unavailable:
+            BuildIndex 쿼리 자체가 실패함(buckets는 빈 배열).
+        excluded_count:
+          type: integer
+          minimum: 0
+        buckets:
+          type: array
+          items:
+            $ref: "#/components/schemas/MonitoringBuildBucket"
+        recent_runs:
+          type: array
+          items:
+            $ref: "#/components/schemas/MonitoringRecentRun"

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -18,8 +18,10 @@ import inspect
 import json
 import logging
 import os
+import time
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Protocol, cast, runtime_checkable
 from urllib.parse import parse_qs, unquote
@@ -54,6 +56,7 @@ from ..stages.bronze.build import SourceClient
 from ..store import BuildIndex
 from ..tabular import DEFAULT_PREVIEW_LIMIT
 from . import datasets as datasets_service
+from . import monitoring as monitoring_service
 from . import ownership as ownership_module
 from . import quality as quality_service
 from . import stages as stages_service
@@ -246,7 +249,11 @@ def _strip_internal_fields(entries: list[_BuildListEntry]) -> list[_BuildListEnt
 # 1.8.0 -> 1.9.0: POST /preview에 Source↔Silver diff와 sample_mode(first/random)
 # 옵션 추가 (#497, additive — 기존 필드는 유지된다). limit 상한(1000) 신규 도입은
 # behavioral tightening(이전엔 상한 없음) — 그 이상 값은 400.
-API_CONTRACT_VERSION = "1.9.0"
+# 1.9.0 -> 1.10.0: GET /monitoring/summary, GET /monitoring/builds 추가 (#516,
+# additive — 기존 엔드포인트는 변경되지 않는다). Async build queue/worker는 이
+# 저장소에 아직 구현되어 있지 않아(ADR 0008 Proposed) availability=unavailable로
+# 명시적으로 보고한다.
+API_CONTRACT_VERSION = "1.10.0"
 
 
 @dataclass(frozen=True)
@@ -319,6 +326,9 @@ class BuilderService:
         self._output_root = output_root
         self._client_factory = client_factory
         self._build_index = BuildIndex(output_root)  # #309, ADR 0003
+        # Monitoring API용 bounded latency recorder (#516). dispatch()가 매 요청
+        # 처리 시간을 기록한다 — 인스턴스별로 분리해 테스트 간 상태가 섞이지 않는다.
+        self._latency_recorder = monitoring_service.LatencyRecorder()
         self._query_service = query_service or QueryService()
         repository = credential_repository or _credential_repository_from_env(output_root)
         self._credential_resolver = CredentialResolver(repository)
@@ -1218,6 +1228,107 @@ class BuilderService:
             },
         )
 
+    def monitoring_summary(self) -> ServiceResponse:
+        """Builder API/Queue/Worker/Artifact Store 시스템 상태 요약 (#516).
+
+        시스템 aggregate만 담으며 개별 run의 dataset/owner/credential 정보는
+        포함하지 않는다 — ownership 필터링이 필요 없다. Provider status(#492)는
+        요청마다 실제 네트워크 프로브를 유발하므로 이번 PR에서는 포함하지 않는다.
+        """
+        api = monitoring_service.api_status(self._latency_recorder)
+        queue = monitoring_service.queue_status(self._async_builds)
+        workers = monitoring_service.worker_status(self._async_builds)
+        artifact_store = monitoring_service.artifact_store_status(
+            self._output_root, self._build_index
+        )
+        status = monitoring_service.aggregate_status(
+            api=api, queue=queue, workers=workers, artifact_store=artifact_store
+        )
+        generated_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        return ServiceResponse(
+            200,
+            {
+                "generated_at": generated_at,
+                "status": status,
+                "api": {
+                    "availability": api.availability,
+                    "sample_count": api.sample_count,
+                    "p95_latency_ms": api.p95_latency_ms,
+                },
+                "queue": {
+                    "availability": queue.availability,
+                    "waiting": queue.waiting,
+                    "running": queue.running,
+                    "total": queue.total,
+                },
+                "workers": {
+                    "availability": workers.availability,
+                    "active": workers.active,
+                    "capacity": workers.capacity,
+                    "utilization": workers.utilization,
+                },
+                "artifact_store": {
+                    "availability": artifact_store.availability,
+                    "last_write_at": artifact_store.last_write_at,
+                },
+            },
+        )
+
+    def monitoring_builds(
+        self, *, window: str, bucket: str, principal: Principal | None = None
+    ) -> ServiceResponse:
+        """window/bucket별 build 통계와 recent runs를 반환한다 (#516).
+
+        ENFORCE_OWNERSHIP+oidc principal일 때는 본인이 접근 가능한 run만
+        집계·노출한다(#505) — 다른 principal의 run metadata가 새는 side
+        channel이 되지 않는다.
+        """
+        validated_window = monitoring_service.validate_window(window)
+        if validated_window is None:
+            return ServiceResponse(400, {"error": f"unsupported window: {window!r} (only '24h')"})
+        validated_bucket = monitoring_service.validate_bucket(bucket)
+        if validated_bucket is None:
+            return ServiceResponse(400, {"error": f"unsupported bucket: {bucket!r} (only 'hour')"})
+
+        stats = monitoring_service.build_statistics(
+            self._build_index,
+            window=validated_window,
+            bucket=validated_bucket,
+            principal=principal,
+            enforce_ownership=_enforce_ownership(),
+        )
+        buckets: list[JsonValue] = [
+            {
+                "bucket_start": b.bucket_start,
+                "bucket_end": b.bucket_end,
+                "total": b.total,
+                "ok": b.ok,
+                "failed": b.failed,
+                "cancelled": b.cancelled,
+            }
+            for b in stats.buckets
+        ]
+        recent_runs: list[JsonValue] = [
+            {
+                "run_id": r.run_id,
+                "status": r.status,
+                "started_at": r.started_at,
+                "finished_at": r.finished_at,
+            }
+            for r in stats.recent_runs
+        ]
+        return ServiceResponse(
+            200,
+            {
+                "window": stats.window,
+                "bucket": stats.bucket,
+                "availability": stats.availability,
+                "excluded_count": stats.excluded_count,
+                "buckets": buckets,
+                "recent_runs": recent_runs,
+            },
+        )
+
     def list_run_stages(self, run_id: str) -> ServiceResponse:
         """run에 알려진 모든 source의 Bronze/Silver/Gold 상태를 반환한다 (#488).
 
@@ -1381,6 +1492,33 @@ def _parse_limit_query(query: str, *, default: int = 50) -> int | ServiceRespons
 
 
 def dispatch(
+    service: BuilderService,
+    method: str,
+    path: str,
+    body: Mapping[str, JsonValue] | None,
+    query: str = "",
+    *,
+    api_key: str | None = None,
+    bearer_token: str | None = None,
+) -> ServiceResponse | FileResponse:
+    """``_dispatch_impl``을 호출하고 처리 시간을 Monitoring latency 표본으로
+    기록한다 (#516).
+
+    타이밍은 라우팅+인증+비즈니스 로직 전체를 감싼다(HTTP 소켓 I/O는 제외 —
+    그건 http.py 계층). metric 기록 실패가 요청 실패로 전파되지 않도록
+    ``LatencyRecorder.record``가 이미 내부적으로 예외를 흡수한다.
+    """
+    started = time.perf_counter()
+    try:
+        return _dispatch_impl(
+            service, method, path, body, query, api_key=api_key, bearer_token=bearer_token
+        )
+    finally:
+        elapsed_ms = (time.perf_counter() - started) * 1000
+        service._latency_recorder.record(elapsed_ms)
+
+
+def _dispatch_impl(
     service: BuilderService,
     method: str,
     path: str,
@@ -1718,6 +1856,15 @@ def dispatch(
                 return ServiceResponse(400, {"error": "'limit' must be a positive integer"})
             limit = limit_value
         return service.list_builds(limit=limit, principal=principal)
+
+    if method == "GET" and path == "/monitoring/summary":
+        return service.monitoring_summary()
+
+    if method == "GET" and path == "/monitoring/builds":
+        query_params = parse_qs(query)
+        window = query_params.get("window", ["24h"])[-1]
+        bucket = query_params.get("bucket", ["hour"])[-1]
+        return service.monitoring_builds(window=window, bucket=bucket, principal=principal)
 
     return ServiceResponse(404, {"error": f"not found: {method} {path}"})
 

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -250,9 +250,12 @@ def _strip_internal_fields(entries: list[_BuildListEntry]) -> list[_BuildListEnt
 # 옵션 추가 (#497, additive — 기존 필드는 유지된다). limit 상한(1000) 신규 도입은
 # behavioral tightening(이전엔 상한 없음) — 그 이상 값은 400.
 # 1.9.0 -> 1.10.0: GET /monitoring/summary, GET /monitoring/builds 추가 (#516,
-# additive — 기존 엔드포인트는 변경되지 않는다). Async build queue/worker는 이
-# 저장소에 아직 구현되어 있지 않아(ADR 0008 Proposed) availability=unavailable로
-# 명시적으로 보고한다.
+# additive — 기존 엔드포인트는 변경되지 않는다). Async build queue/worker는
+# 기존 AsyncBuildExecutor/AsyncBuildJobRegistry(#511/#513)의 read-only
+# snapshot을 반영하며, 정상 runtime에서는 availability=available이다.
+# MonitoringSummaryResponse.status(healthy/degraded)는 required subsystem
+# availability로부터 계산되는 deterministic aggregate다(latency threshold
+# 미사용).
 API_CONTRACT_VERSION = "1.10.0"
 
 
@@ -1302,7 +1305,9 @@ class BuilderService:
                 "bucket_start": b.bucket_start,
                 "bucket_end": b.bucket_end,
                 "total": b.total,
-                "ok": b.ok,
+                # wire 계약은 success/failed/cancelled다(#527) — 내부 BuildIndex
+                # status 값 "ok"는 그대로 두고 외부 필드 이름만 매핑한다.
+                "success": b.success,
                 "failed": b.failed,
                 "cancelled": b.cancelled,
             }

--- a/src/kpubdata_builder/service/jobs.py
+++ b/src/kpubdata_builder/service/jobs.py
@@ -64,6 +64,14 @@ class BuildJobSubmitResult:
     snapshot: BuildJobSnapshot | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class AsyncBuildJobCounts:
+    """``snapshot_counts()``가 단일 lock scope에서 집계한 active job 수 (#516)."""
+
+    queued: int
+    running: int
+
+
 class AsyncBuildJobRegistry:
     """프로세스 메모리에만 유지되는 active/terminal job 레지스트리."""
 
@@ -103,6 +111,27 @@ class AsyncBuildJobRegistry:
         with self._lock:
             return sum(1 for job in self._jobs.values() if job.status == "queued")
 
+    def snapshot_counts(self) -> AsyncBuildJobCounts:
+        """queued/running job 수를 단일 lock scope에서 일관되게 집계한다 (#516).
+
+        ``queued_count()`` 같은 개별 메서드를 서로 다른 시점에 호출해 조합하면
+        그 사이의 상태 전이(queued -> running)로 모순된 snapshot이 만들어질 수
+        있다 — monitoring은 반드시 이 메서드처럼 하나의 lock 안에서 계산한
+        값을 써야 한다. terminal(succeeded/failed/cancelled) job은 registry가
+        메모리에 계속 보존하지만 이 snapshot에는 포함하지 않는다 — Monitoring이
+        보여줘야 하는 건 현재 workload이지 terminal history가 아니다. mutable
+        ``_jobs`` dict 자체는 절대 외부에 노출하지 않는다.
+        """
+        with self._lock:
+            queued = 0
+            running = 0
+            for job in self._jobs.values():
+                if job.status == "queued":
+                    queued += 1
+                elif job.status == "running":
+                    running += 1
+        return AsyncBuildJobCounts(queued=queued, running=running)
+
     def _replace(
         self,
         run_id: str,
@@ -126,6 +155,20 @@ class AsyncBuildJobRegistry:
             return updated
 
 
+@dataclass(frozen=True, slots=True)
+class AsyncBuildStats:
+    """Monitoring API(#516)가 소비하는 async build 실행기 raw 집계.
+
+    ``queued``/``running``/``capacity`` raw 값만 담는다 — ``total``/``active``/
+    ``utilization`` 같은 파생값과 availability 판정은 ``service/monitoring.py``의
+    책임이다.
+    """
+
+    queued: int
+    running: int
+    capacity: int
+
+
 class AsyncBuildExecutor:
     """고정 크기 worker pool로 build job을 실행한다."""
 
@@ -133,8 +176,23 @@ class AsyncBuildExecutor:
         self._executor = ThreadPoolExecutor(
             max_workers=max_workers, thread_name_prefix="kpubdata-build"
         )
+        # ThreadPoolExecutor._max_workers 같은 private field를 외부(monitoring)가
+        # 직접 읽지 않도록 capacity를 생성 시점에 명시적으로 보존한다 (#516).
+        self._max_workers = max_workers
         self._max_queue_size = max_queue_size
         self.registry = AsyncBuildJobRegistry()
+
+    def stats(self) -> AsyncBuildStats:
+        """monitoring용 read-only aggregate snapshot (#516).
+
+        registry의 mutable internal job dict는 노출하지 않고, 단일 lock scope
+        에서 얻은 queued/running 집계(``registry.snapshot_counts()``)와 worker
+        pool capacity만 반환한다. 이 호출 자체는 job 상태를 변경하지 않는다.
+        """
+        counts = self.registry.snapshot_counts()
+        return AsyncBuildStats(
+            queued=counts.queued, running=counts.running, capacity=self._max_workers
+        )
 
     def submit(
         self,
@@ -193,7 +251,9 @@ def generate_run_id() -> str:
 
 __all__ = [
     "AsyncBuildExecutor",
+    "AsyncBuildJobCounts",
     "AsyncBuildJobRegistry",
+    "AsyncBuildStats",
     "BuildJobSubmitResult",
     "BuildJobResponse",
     "BuildJobSnapshot",

--- a/src/kpubdata_builder/service/monitoring.py
+++ b/src/kpubdata_builder/service/monitoring.py
@@ -67,13 +67,19 @@ class LatencyRecorder:
             # metric collection 실패가 요청 실패로 전파되면 안 된다 (#516).
             pass
 
-    def snapshot(self) -> tuple[int, float | None]:
-        """``(sample_count, p95_latency_ms)``를 반환한다. 표본이 없으면 p95는 None."""
+    def snapshot(self) -> tuple[int, float | None] | None:
+        """``(sample_count, p95_latency_ms)``를 반환한다. 표본이 없으면 p95는 None.
+
+        collector 자체가 실패하면(lock 손상 등) ``None``을 반환한다(#527) —
+        "정상 무표본"(``(0, None)``)과 "측정 subsystem 실패"를 같은 값으로
+        뭉개지 않기 위함이며, 이 실패가 예외로 전파되지도 않는다(호출자인
+        ``api_status()``가 ``None``을 ``unavailable``로 구분해 매핑한다).
+        """
         try:
             with self._lock:
                 samples = list(self._samples)
         except Exception:
-            return 0, None
+            return None
         return _p95(samples)
 
 
@@ -94,19 +100,29 @@ def _p95(samples: list[float]) -> tuple[int, float | None]:
 @dataclass(frozen=True)
 class ApiStatus:
     availability: Availability
-    sample_count: int
+    sample_count: int | None
     p95_latency_ms: float | None
 
 
 def api_status(recorder: LatencyRecorder) -> ApiStatus:
     """Builder API 상태를 반환한다.
 
-    이 함수가 호출된다는 사실 자체가 프로세스가 응답 중임을 증명하므로
-    availability는 항상 ``available``이다. Healthy/Degraded 같은 latency
-    임계값 판정은 근거(ADR/config)가 없어 이번 PR에서 발명하지 않는다 — raw
-    ``sample_count``/``p95_latency_ms``만 제공한다.
+    ``dispatch()``가 실행되어 이 함수가 호출된다는 사실 자체는 프로세스가
+    응답 중임을 증명하지만, latency collector(``LatencyRecorder``) 자체가
+    손상되어 표본을 읽을 수 없는 경우(#527)까지 ``available``로 위장하지
+    않는다 — ``recorder.snapshot()``이 ``None``을 반환하면(collector 실패)
+    ``unavailable`` + ``sample_count=None`` + ``p95_latency_ms=None``이고,
+    정상적으로 무표본이면(``(0, None)``) ``available`` + ``sample_count=0`` +
+    ``p95_latency_ms=None``이다 — "0표본"과 "측정 불가"를 구분한다. 이
+    subsystem 판정 실패는 원 요청(dispatch)이나 이 monitoring 요청 자체를
+    실패시키지 않는다(``snapshot()``이 예외를 전파하지 않으므로). Healthy/
+    Degraded 같은 latency 임계값 판정은 근거(ADR/config)가 없어 이번 PR에서
+    발명하지 않는다 — raw ``sample_count``/``p95_latency_ms``만 제공한다.
     """
-    sample_count, p95 = recorder.snapshot()
+    snapshot = recorder.snapshot()
+    if snapshot is None:
+        return ApiStatus(availability="unavailable", sample_count=None, p95_latency_ms=None)
+    sample_count, p95 = snapshot
     return ApiStatus(availability="available", sample_count=sample_count, p95_latency_ms=p95)
 
 
@@ -224,10 +240,18 @@ def aggregate_status(
 
 @dataclass(frozen=True)
 class BuildBucket:
+    """시간 bucket당 build 카운트 (#516 wire 계약: total/success/failed/cancelled).
+
+    ``success``는 ``BuildIndex``/``BuildEntry.status``의 내부 값 ``"ok"``를
+    외부 Monitoring API 명명으로 매핑한 것이다(#527) — 내부 BuildIndex status
+    vocabulary(``ok``/``failed``/``cancelled``)는 그대로 두고, 이 wire 필드
+    이름만 계약에 맞춘다.
+    """
+
     bucket_start: str
     bucket_end: str
     total: int
-    ok: int
+    success: int
     failed: int
     cancelled: int
 
@@ -288,18 +312,32 @@ def _isoformat_z(dt: datetime) -> str:
     return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+def _should_enforce_ownership(principal: Principal | None, *, enforce: bool) -> bool:
+    """ownership 필터를 적용해야 하는지 판정한다 (#516, #505).
+
+    ``app._apply_ownership``/``datasets.filter_ownership``과 동일한 정책 —
+    ENFORCE_OWNERSHIP+oidc principal일 때만 필터링하며, dev/service/None은
+    관리자 권한으로 통과한다. ``_filter_ownership``(Python 사후 필터)와
+    ``BuildIndex.list_recent_owned``(SQL push-down, #527) 양쪽이 이 판정을
+    공유해 정책이 어긋나지 않게 한다.
+    """
+    return enforce and principal is not None and principal.kind == "oidc"
+
+
 def _filter_ownership(
     entries: list[BuildEntry], principal: Principal | None, *, enforce: bool
 ) -> list[BuildEntry]:
     """BuildEntry 목록에 기존 ownership 정책을 적용한다 (#516, #505).
 
-    ``app._apply_ownership``/``datasets.filter_ownership``과 동일한 정책 —
-    ENFORCE_OWNERSHIP+oidc principal일 때만 필터링하며, dev/service/None은
-    관리자 권한으로 통과한다. Monitoring 집계·recent runs가 다른 principal의
-    run metadata를 노출하는 side channel이 되지 않도록 한다.
+    Monitoring 집계·recent runs가 다른 principal의 run metadata를 노출하는
+    side channel이 되지 않도록 한다. bucket 집계(``raw_entries``)처럼 이미
+    전체 window를 로드한 뒤라 LIMIT 손실 우려가 없는 경우에만 쓴다 —
+    LIMIT이 걸린 recent runs 조회는 대신 ``BuildIndex.list_recent_owned``로
+    필터를 먼저 SQL에서 적용한다(#527, 아래 ``build_statistics`` 참조).
     """
-    if not (enforce and principal is not None and principal.kind == "oidc"):
+    if not _should_enforce_ownership(principal, enforce=enforce):
         return entries
+    assert principal is not None  # _should_enforce_ownership이 이미 보장
     return [
         e
         for e in entries
@@ -324,6 +362,13 @@ def build_statistics(
     - BuildIndex 쿼리 자체가 실패하면 ``unavailable`` (buckets 비어있음).
     - 쿼리는 성공했지만 malformed timestamp로 일부 행이 제외되면 ``partial``.
     - 쿼리 성공 + 제외 없음이면 ``available`` (0건이어도 유효한 available).
+
+    recent runs는 ``_RECENT_RUNS_LIMIT``(10)으로 bounded된 조회다. ownership을
+    강제해야 하면(#505) 그 필터를 LIMIT **이전에** SQL에서 적용한다(#527) —
+    먼저 전역 최신 10건을 가져온 뒤 Python에서 걸러내면, 다른 principal의
+    최신 run들이 LIMIT을 다 채워 정작 요청자 본인의 recent run이 잘릴 수
+    있다. bucket 집계(``raw_entries``)는 이미 window 전체를 LIMIT 없이
+    가져오므로 이 문제가 없어 기존처럼 사후(Python) 필터링한다.
     """
     current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
     window_seconds = _SUPPORTED_WINDOWS[window]
@@ -333,7 +378,15 @@ def build_statistics(
 
     try:
         raw_entries = build_index.list_between(_isoformat_z(window_start), _isoformat_z(window_end))
-        recent_entries = build_index.list_builds(limit=_RECENT_RUNS_LIMIT)
+        if _should_enforce_ownership(principal, enforce=enforce_ownership):
+            assert principal is not None  # _should_enforce_ownership이 이미 보장
+            recent_entries = build_index.list_recent_owned(
+                limit=_RECENT_RUNS_LIMIT,
+                principal_owner_id=principal.owner_id,
+                principal_label=principal.label,
+            )
+        else:
+            recent_entries = build_index.list_builds(limit=_RECENT_RUNS_LIMIT)
     except Exception:
         return BuildStatistics(
             window=window,
@@ -345,7 +398,10 @@ def build_statistics(
         )
 
     scoped_entries = _filter_ownership(raw_entries, principal, enforce=enforce_ownership)
-    scoped_recent = _filter_ownership(recent_entries, principal, enforce=enforce_ownership)
+    # recent_entries는 이미 위에서 필요 시 SQL push-down으로 걸러졌다(#527) —
+    # 여기서 다시 Python 필터를 적용하지 않는다(중복도 아니고, LIMIT이 이미
+    # 걸린 뒤라 손실을 되돌릴 수도 없다).
+    scoped_recent = recent_entries
 
     bucket_count = window_seconds // bucket_seconds
     bucket_starts = [
@@ -378,7 +434,8 @@ def build_statistics(
             bucket_start=_isoformat_z(start),
             bucket_end=_isoformat_z(start + timedelta(seconds=bucket_seconds)),
             total=counters[_isoformat_z(start)]["total"],
-            ok=counters[_isoformat_z(start)]["ok"],
+            # 내부 BuildIndex status "ok" -> 외부 wire 필드 "success" (#527).
+            success=counters[_isoformat_z(start)]["ok"],
             failed=counters[_isoformat_z(start)]["failed"],
             cancelled=counters[_isoformat_z(start)]["cancelled"],
         )

--- a/src/kpubdata_builder/service/monitoring.py
+++ b/src/kpubdata_builder/service/monitoring.py
@@ -1,0 +1,423 @@
+"""System Resource·Build Statistics 조회 로직 (#516).
+
+Studio Monitoring 화면에 필요한 Builder API/Queue/Worker/Artifact Store 상태와
+BuildIndex 기반 시간대별 build 통계를 제공한다. Run 단위 이벤트는 #496이
+담당하며 이 모듈은 시스템/집계 observability만 다룬다.
+
+핵심 원칙("없는 상태를 만들어내지 말 것"):
+    - 측정된 적 없는 값은 0/healthy 등으로 위장하지 않고 ``null``/``unavailable``로
+      표현한다.
+    - ``Availability`` vocabulary는 ``quality.py``가 이미 정의한 것을 그대로
+      재사용한다(``available``/``partial``/``unavailable``).
+
+Async build 실행 모델(queued/running worker pool)은 ``jobs.AsyncBuildExecutor``/
+``AsyncBuildJobRegistry``(#511/#513)로 이미 구현되어 있고 ``BuilderService``가
+항상 생성해 사용한다 — queue/worker 상태는 그 실행기의 read-only snapshot을
+그대로 반영한다. 존재하지 않는 실행기를 흉내 내 값을 위장하지도, 실행기가
+없는 구성을 새로 만들지도 않는다.
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Literal
+
+from ..store import BuildEntry, BuildIndex
+from .auth import Principal, principal_owns
+from .jobs import AsyncBuildExecutor
+from .quality import Availability
+
+# Latency 표본은 시간창이 아니라 최근 최대 N개 요청의 고정 크기 ring buffer다
+# (#516) — 메모리 상한이 목적이며 "지난 X분" 같은 시간 기반 window가 아니다.
+_LATENCY_WINDOW_SIZE = 1000
+
+# recent runs는 Monitoring 카드용 미리보기이므로 /builds처럼 클라이언트가
+# limit을 조정하게 하지 않고 작은 고정 개수만 노출한다 (#516).
+_RECENT_RUNS_LIMIT = 10
+
+BuildBucketWindow = Literal["24h"]
+BuildBucketGranularity = Literal["hour"]
+
+_SUPPORTED_WINDOWS: dict[str, int] = {"24h": 24 * 3600}
+_SUPPORTED_BUCKETS: dict[str, int] = {"hour": 3600}
+
+
+class LatencyRecorder:
+    """Bounded, thread-safe in-memory Builder API 요청 latency 기록기 (#516).
+
+    ``dispatch()`` 전체 실행 시간(라우팅+인증+비즈니스 로직)을 ms 단위로
+    기록한다. 실제 HTTP 소켓 I/O는 포함하지 않는다(그건 http.py 계층).
+    """
+
+    def __init__(self, *, max_samples: int = _LATENCY_WINDOW_SIZE) -> None:
+        self._samples: deque[float] = deque(maxlen=max_samples)
+        self._lock = threading.Lock()
+
+    def record(self, latency_ms: float) -> None:
+        """표본을 기록한다. 실패해도 예외를 전파하지 않는다(#516 요구사항)."""
+        try:
+            with self._lock:
+                self._samples.append(latency_ms)
+        except Exception:
+            # metric collection 실패가 요청 실패로 전파되면 안 된다 (#516).
+            pass
+
+    def snapshot(self) -> tuple[int, float | None]:
+        """``(sample_count, p95_latency_ms)``를 반환한다. 표본이 없으면 p95는 None."""
+        try:
+            with self._lock:
+                samples = list(self._samples)
+        except Exception:
+            return 0, None
+        return _p95(samples)
+
+
+def _p95(samples: list[float]) -> tuple[int, float | None]:
+    """nearest-rank 방식으로 p95를 계산한다 (#516, 보간 없음).
+
+    ``rank = clamp(ceil(0.95 * n), 1, n)`` 을 오름차순 정렬된 표본의 1-indexed
+    순위로 사용한다. 예: n=1 -> rank=1(그 표본 자체), n=20 -> rank=19.
+    """
+    n = len(samples)
+    if n == 0:
+        return 0, None
+    ordered = sorted(samples)
+    rank = max(1, min(math.ceil(0.95 * n), n))
+    return n, ordered[rank - 1]
+
+
+@dataclass(frozen=True)
+class ApiStatus:
+    availability: Availability
+    sample_count: int
+    p95_latency_ms: float | None
+
+
+def api_status(recorder: LatencyRecorder) -> ApiStatus:
+    """Builder API 상태를 반환한다.
+
+    이 함수가 호출된다는 사실 자체가 프로세스가 응답 중임을 증명하므로
+    availability는 항상 ``available``이다. Healthy/Degraded 같은 latency
+    임계값 판정은 근거(ADR/config)가 없어 이번 PR에서 발명하지 않는다 — raw
+    ``sample_count``/``p95_latency_ms``만 제공한다.
+    """
+    sample_count, p95 = recorder.snapshot()
+    return ApiStatus(availability="available", sample_count=sample_count, p95_latency_ms=p95)
+
+
+@dataclass(frozen=True)
+class QueueStatus:
+    availability: Availability
+    waiting: int | None
+    running: int | None
+    total: int | None
+
+
+@dataclass(frozen=True)
+class WorkerStatus:
+    availability: Availability
+    active: int | None
+    capacity: int | None
+    utilization: float | None
+
+
+def queue_status(async_builds: AsyncBuildExecutor) -> QueueStatus:
+    """Async build queue 상태 (#516).
+
+    ``BuilderService``가 항상 생성하는 ``AsyncBuildExecutor``(#511/#513)의
+    read-only snapshot(``stats()``)을 그대로 반영한다 — 이 서비스에서 async
+    build는 항상 지원되므로 availability는 항상 ``available``이다.
+    ``total``은 ``waiting + running``이다(terminal succeeded/failed/cancelled
+    history는 workload 상태가 아니므로 섞지 않는다 — registry가 이들을 메모리에
+    계속 보존하더라도 ``stats()``가 이미 제외한다).
+    """
+    stats = async_builds.stats()
+    return QueueStatus(
+        availability="available",
+        waiting=stats.queued,
+        running=stats.running,
+        total=stats.queued + stats.running,
+    )
+
+
+def worker_status(async_builds: AsyncBuildExecutor) -> WorkerStatus:
+    """Async build worker pool 상태. 근거는 ``queue_status`` 문서 참조 (#516).
+
+    ``active``는 현재 running job 수(워커 하나가 job 하나를 실행하므로
+    running == active), ``capacity``는 실행기 생성 시 보존한 ``max_workers``다.
+    ``ThreadPoolExecutor``의 private field는 직접 읽지 않는다 —
+    ``AsyncBuildExecutor.stats()``가 이미 capacity를 노출한다.
+    """
+    stats = async_builds.stats()
+    utilization = (stats.running / stats.capacity) if stats.capacity > 0 else 0.0
+    return WorkerStatus(
+        availability="available",
+        active=stats.running,
+        capacity=stats.capacity,
+        utilization=utilization,
+    )
+
+
+@dataclass(frozen=True)
+class ArtifactStoreStatus:
+    availability: Availability
+    last_write_at: str | None
+
+
+def artifact_store_status(output_root: Path, build_index: BuildIndex) -> ArtifactStoreStatus:
+    """Artifact Store 상태 (#516).
+
+    폴더 존재만으로 healthy로 간주하지 않는다 — ``output_root``가 디렉터리로
+    접근 가능하고 BuildIndex 쿼리도 성공해야 ``available``이다.
+    ``last_write_at``은 BuildIndex에 실제로 기록된 가장 최근 성공(``ok``) 빌드의
+    ``finished_at``에서만 얻는다(성공 기록이 없으면 ``available``이되 ``null``
+    — "0건"과 "확인 불가"를 구분).
+    """
+    if not output_root.exists() or not output_root.is_dir():
+        return ArtifactStoreStatus(availability="unavailable", last_write_at=None)
+    try:
+        last_write_at = build_index.latest_successful_finished_at()
+    except Exception:
+        return ArtifactStoreStatus(availability="unavailable", last_write_at=None)
+    return ArtifactStoreStatus(availability="available", last_write_at=last_write_at)
+
+
+MonitoringAggregateStatus = Literal["healthy", "degraded"]
+
+
+def aggregate_status(
+    *,
+    api: ApiStatus,
+    queue: QueueStatus,
+    workers: WorkerStatus,
+    artifact_store: ArtifactStoreStatus,
+) -> MonitoringAggregateStatus:
+    """Required subsystem availability로부터 deterministic aggregate status를 판정한다 (#516).
+
+    latency threshold(SLA)는 근거(ADR/config)가 없어 사용하지 않는다 —
+    ``sample_count=0``/``p95_latency_ms=None``은 startup/무표본 상태일 수 있으므로
+    그 자체로는 degraded 근거가 아니다(``api.availability``만 본다). Provider
+    status는 #516에서 optional이라 이 판정에 포함하지 않는다(호출자가 아예
+    전달하지 않는다).
+
+    required subsystem(api/queue/workers/artifact_store) availability가 모두
+    ``available``이면 ``healthy``, 하나라도 ``partial``/``unavailable``이면
+    ``degraded``. queue/workers의 실제 0(waiting/running/active=0)은
+    availability와 무관한 값이므로 이 판정에 영향을 주지 않는다 — availability
+    자체가 unavailable일 때만 degraded로 반영된다.
+    """
+    required_availabilities = (
+        api.availability,
+        queue.availability,
+        workers.availability,
+        artifact_store.availability,
+    )
+    if all(availability == "available" for availability in required_availabilities):
+        return "healthy"
+    return "degraded"
+
+
+@dataclass(frozen=True)
+class BuildBucket:
+    bucket_start: str
+    bucket_end: str
+    total: int
+    ok: int
+    failed: int
+    cancelled: int
+
+
+@dataclass(frozen=True)
+class RecentRun:
+    run_id: str
+    status: str
+    started_at: str | None
+    finished_at: str | None
+
+
+@dataclass(frozen=True)
+class BuildStatistics:
+    window: str
+    bucket: str
+    availability: Availability
+    excluded_count: int
+    buckets: tuple[BuildBucket, ...]
+    recent_runs: tuple[RecentRun, ...]
+
+
+def validate_window(window: str) -> BuildBucketWindow | None:
+    """지원하는 window 값이면 그대로, 아니면 None (#516 — 범위를 넓히지 않음)."""
+    return "24h" if window == "24h" else None
+
+
+def validate_bucket(bucket: str) -> BuildBucketGranularity | None:
+    """지원하는 bucket 값이면 그대로, 아니면 None (#516 — 범위를 넓히지 않음)."""
+    return "hour" if bucket == "hour" else None
+
+
+def _parse_iso_utc(value: str | None) -> datetime | None:
+    """ISO 8601 문자열을 UTC ``datetime``으로 파싱한다. 실패/None이면 None.
+
+    malformed/legacy timestamp를 조용히 포함시키지 않기 위한 엄격한 검증 —
+    파싱 실패 행은 호출자가 ``excluded_count``로 집계해 partial 판정에 반영한다.
+    """
+    if not value:
+        return None
+    try:
+        text = value[:-1] + "+00:00" if value.endswith("Z") else value
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _bucket_start(dt: datetime, bucket_seconds: int) -> datetime:
+    epoch_seconds = int(dt.timestamp())
+    floored = (epoch_seconds // bucket_seconds) * bucket_seconds
+    return datetime.fromtimestamp(floored, tz=timezone.utc)
+
+
+def _isoformat_z(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _filter_ownership(
+    entries: list[BuildEntry], principal: Principal | None, *, enforce: bool
+) -> list[BuildEntry]:
+    """BuildEntry 목록에 기존 ownership 정책을 적용한다 (#516, #505).
+
+    ``app._apply_ownership``/``datasets.filter_ownership``과 동일한 정책 —
+    ENFORCE_OWNERSHIP+oidc principal일 때만 필터링하며, dev/service/None은
+    관리자 권한으로 통과한다. Monitoring 집계·recent runs가 다른 principal의
+    run metadata를 노출하는 side channel이 되지 않도록 한다.
+    """
+    if not (enforce and principal is not None and principal.kind == "oidc"):
+        return entries
+    return [
+        e
+        for e in entries
+        if principal_owns(created_by=e.created_by, owner_id=e.owner_id, principal=principal)
+    ]
+
+
+def build_statistics(
+    build_index: BuildIndex,
+    *,
+    window: BuildBucketWindow,
+    bucket: BuildBucketGranularity,
+    principal: Principal | None,
+    enforce_ownership: bool,
+    now: datetime | None = None,
+) -> BuildStatistics:
+    """window/bucket에 따른 build 통계와 recent runs를 집계한다 (#516).
+
+    timezone: UTC. bucket 경계는 ``[start, end)`` 반열린. bucket 기준
+    timestamp는 ``finished_at``(BuildIndex는 완료된 빌드만 기록, ADR 0003).
+
+    - BuildIndex 쿼리 자체가 실패하면 ``unavailable`` (buckets 비어있음).
+    - 쿼리는 성공했지만 malformed timestamp로 일부 행이 제외되면 ``partial``.
+    - 쿼리 성공 + 제외 없음이면 ``available`` (0건이어도 유효한 available).
+    """
+    current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    window_seconds = _SUPPORTED_WINDOWS[window]
+    bucket_seconds = _SUPPORTED_BUCKETS[bucket]
+    window_end = _bucket_start(current, bucket_seconds) + timedelta(seconds=bucket_seconds)
+    window_start = window_end - timedelta(seconds=window_seconds)
+
+    try:
+        raw_entries = build_index.list_between(_isoformat_z(window_start), _isoformat_z(window_end))
+        recent_entries = build_index.list_builds(limit=_RECENT_RUNS_LIMIT)
+    except Exception:
+        return BuildStatistics(
+            window=window,
+            bucket=bucket,
+            availability="unavailable",
+            excluded_count=0,
+            buckets=(),
+            recent_runs=(),
+        )
+
+    scoped_entries = _filter_ownership(raw_entries, principal, enforce=enforce_ownership)
+    scoped_recent = _filter_ownership(recent_entries, principal, enforce=enforce_ownership)
+
+    bucket_count = window_seconds // bucket_seconds
+    bucket_starts = [
+        window_start + timedelta(seconds=i * bucket_seconds) for i in range(bucket_count)
+    ]
+    counters: dict[str, dict[str, int]] = {
+        _isoformat_z(start): {"total": 0, "ok": 0, "failed": 0, "cancelled": 0}
+        for start in bucket_starts
+    }
+
+    excluded_count = 0
+    for entry in scoped_entries:
+        parsed = _parse_iso_utc(entry.finished_at)
+        if parsed is None:
+            excluded_count += 1
+            continue
+        key = _isoformat_z(_bucket_start(parsed, bucket_seconds))
+        counter = counters.get(key)
+        if counter is None:
+            # window 쿼리 자체가 [start,end)로 한정하므로 정상적으로는 발생하지
+            # 않지만, 경계 근처 부동소수/파싱 편차에 대비한 방어적 처리.
+            excluded_count += 1
+            continue
+        counter["total"] += 1
+        if entry.status in ("ok", "failed", "cancelled"):
+            counter[entry.status] += 1
+
+    buckets = tuple(
+        BuildBucket(
+            bucket_start=_isoformat_z(start),
+            bucket_end=_isoformat_z(start + timedelta(seconds=bucket_seconds)),
+            total=counters[_isoformat_z(start)]["total"],
+            ok=counters[_isoformat_z(start)]["ok"],
+            failed=counters[_isoformat_z(start)]["failed"],
+            cancelled=counters[_isoformat_z(start)]["cancelled"],
+        )
+        for start in bucket_starts
+    )
+    recent_runs = tuple(
+        RecentRun(
+            run_id=e.run_id, status=e.status, started_at=e.started_at, finished_at=e.finished_at
+        )
+        for e in scoped_recent
+    )
+
+    availability: Availability = "partial" if excluded_count > 0 else "available"
+    return BuildStatistics(
+        window=window,
+        bucket=bucket,
+        availability=availability,
+        excluded_count=excluded_count,
+        buckets=buckets,
+        recent_runs=recent_runs,
+    )
+
+
+__all__ = [
+    "ApiStatus",
+    "ArtifactStoreStatus",
+    "BuildBucket",
+    "BuildStatistics",
+    "LatencyRecorder",
+    "MonitoringAggregateStatus",
+    "QueueStatus",
+    "RecentRun",
+    "WorkerStatus",
+    "aggregate_status",
+    "api_status",
+    "artifact_store_status",
+    "build_statistics",
+    "queue_status",
+    "validate_bucket",
+    "validate_window",
+    "worker_status",
+]

--- a/src/kpubdata_builder/store/build_index.py
+++ b/src/kpubdata_builder/store/build_index.py
@@ -273,6 +273,73 @@ class BuildIndex:
             for row in cur
         ]
 
+    def list_between(self, start_iso: str, end_iso: str) -> list[BuildEntry]:
+        """``[start_iso, end_iso)`` 반열린 구간에 완료된 빌드를 오름차순으로 반환한다 (#516).
+
+        ``finished_at``이 문자열 비교로 구간 안에 드는 행에 더해 ``finished_at``이
+        NULL인 행도 함께 반환한다 — SQL에서는 어느 구간에 속하는지 판정할 수 없는
+        값이므로 침묵하며 제외하지 않고 호출자에게 넘겨 malformed로 셀 수 있게
+        한다(#516 partial 판정). ISO 8601 UTC(``Z`` suffix, zero-padded) 형식이면
+        문자열 정렬이 시각 정렬과 일치하지만, 그 형식을 벗어나면서 문자열 정렬상
+        구간 밖으로 벗어나는 극단적인 legacy 값은 이 쿼리 자체에서 걸러질 수 있다
+        — 실제 배포에서 malformed 값은 대체로 같은 날짜 prefix를 공유하는 손상된
+        ISO 문자열(NULL 포함)이라 이 한계는 좁다. ``idx_builds_finished_at``
+        인덱스를 활용해 테이블 전체를 로드하지 않는다.
+
+        Args:
+            start_iso: 구간 시작(포함), ISO 8601 UTC 문자열.
+            end_iso: 구간 끝(제외), ISO 8601 UTC 문자열.
+
+        Returns:
+            BuildEntry 목록 (finished_at 오름차순, NULL은 먼저 온다).
+        """
+        cur = self._conn.execute(
+            """
+            SELECT run_id, status, started_at, finished_at, spec_digest, error, created_by,
+                   dataset_id, owner_id
+            FROM builds
+            WHERE finished_at IS NULL OR (finished_at >= ? AND finished_at < ?)
+            ORDER BY finished_at ASC
+            """,
+            (start_iso, end_iso),
+        )
+        return [
+            BuildEntry(
+                run_id=row[0],
+                status=cast(BuildStatus, row[1]),
+                started_at=row[2],
+                finished_at=row[3],
+                spec_digest=row[4],
+                error=row[5],
+                created_by=row[6],
+                dataset_id=row[7],
+                owner_id=row[8],
+            )
+            for row in cur
+        ]
+
+    def latest_successful_finished_at(self) -> str | None:
+        """가장 최근 성공(``status='ok'``) 빌드의 ``finished_at``을 반환한다 (#516).
+
+        Artifact Store의 ``last_write_at`` 근거로 쓰인다 — 실제 성공한 빌드가
+        artifact를 기록했다는 확실한 증거만 반환하며, 성공 기록이 없으면
+        ``None``이다("모른다"를 임의 값으로 채우지 않는다). ``idx_builds_finished_at``
+        인덱스를 활용하는 bounded 쿼리다.
+
+        Returns:
+            ISO 8601 문자열 또는 성공 기록이 없으면 None.
+        """
+        cur = self._conn.execute(
+            """
+            SELECT finished_at FROM builds
+            WHERE status = 'ok' AND finished_at IS NOT NULL
+            ORDER BY finished_at DESC
+            LIMIT 1
+            """
+        )
+        row = cur.fetchone()
+        return cast(str | None, row[0]) if row is not None else None
+
     def get(self, run_id: str) -> BuildEntry | None:
         """특정 빌드를 조회한다.
 

--- a/src/kpubdata_builder/store/build_index.py
+++ b/src/kpubdata_builder/store/build_index.py
@@ -273,6 +273,75 @@ class BuildIndex:
             for row in cur
         ]
 
+    def list_recent_owned(
+        self, *, limit: int, principal_owner_id: str | None, principal_label: str
+    ) -> list[BuildEntry]:
+        """principal 소유 build만 최신 완료 순으로 최대 ``limit``개 반환한다 (#527).
+
+        ownership 필터를 Python에서 전체 결과에 사후 적용하기 전에 LIMIT을
+        걸면(예: 전역 최신 10건을 먼저 가져온 뒤 필터링), 다른 principal의
+        최신 run들이 LIMIT을 다 채워 본인의 recent run이 잘릴 수 있다 — 이
+        메서드는 필터를 SQL WHERE로 LIMIT보다 먼저 적용해 그 문제를 없앤다.
+
+        정책은 ``service.auth.principal_owns()``(#505)와 정확히 동일해야
+        한다:
+
+        - 레코드와 principal 양쪽 모두 ``owner_id``가 있으면 그 값을 비교한다
+          (``principal_owner_id``가 아닌 경우에만).
+        - 그 외(레코드에 ``owner_id``가 없거나 principal에 ``owner_id``가
+          없음)에는 ``created_by == principal_label``로 폴백한다.
+        - 어느 쪽도 매치하지 않으면 제외한다(fail-closed) — SQL의 NULL 비교는
+          자연히 조건을 만족시키지 않으므로 별도 처리가 필요 없다.
+
+        Args:
+            limit: 반환할 최대 빌드 수.
+            principal_owner_id: 요청 principal의 canonical stable owner_id.
+                ``None``이면(legacy/owner_id 미설정 principal) 레코드
+                ``owner_id``와 무관하게 항상 ``created_by`` 비교로 폴백한다
+                (``principal_owns()``와 동일).
+            principal_label: 요청 principal의 legacy 비교용 label
+                (``Principal.label``).
+
+        Returns:
+            BuildEntry 목록 (finished_at 내림차순, 최대 limit개).
+        """
+        if principal_owner_id is not None:
+            sql = """
+                SELECT run_id, status, started_at, finished_at, spec_digest, error, created_by,
+                       dataset_id, owner_id
+                FROM builds
+                WHERE (owner_id IS NOT NULL AND owner_id = ?)
+                   OR (owner_id IS NULL AND created_by = ?)
+                ORDER BY finished_at DESC
+                LIMIT ?
+            """
+            params: tuple[object, ...] = (principal_owner_id, principal_label, limit)
+        else:
+            sql = """
+                SELECT run_id, status, started_at, finished_at, spec_digest, error, created_by,
+                       dataset_id, owner_id
+                FROM builds
+                WHERE created_by = ?
+                ORDER BY finished_at DESC
+                LIMIT ?
+            """
+            params = (principal_label, limit)
+        cur = self._conn.execute(sql, params)
+        return [
+            BuildEntry(
+                run_id=row[0],
+                status=cast(BuildStatus, row[1]),
+                started_at=row[2],
+                finished_at=row[3],
+                spec_digest=row[4],
+                error=row[5],
+                created_by=row[6],
+                dataset_id=row[7],
+                owner_id=row[8],
+            )
+            for row in cur
+        ]
+
     def list_between(self, start_iso: str, end_iso: str) -> list[BuildEntry]:
         """``[start_iso, end_iso)`` 반열린 구간에 완료된 빌드를 오름차순으로 반환한다 (#516).
 

--- a/tests/unit/test_build_index.py
+++ b/tests/unit/test_build_index.py
@@ -309,6 +309,141 @@ class TestBuildIndexOwnerId:
         assert index.list_by_dataset("dataset.sample")[0].owner_id == "oidc:deadbeef"
 
 
+class TestListRecentOwned:
+    """``list_recent_owned`` (#527) — ownership 필터를 LIMIT 이전에 SQL에서
+
+    적용해, 다른 principal의 최신 run들이 LIMIT을 채워 요청자 본인의 recent
+    run이 잘리지 않게 한다. 정책은 ``service.auth.principal_owns()``(#505)와
+    정확히 동일해야 한다.
+    """
+
+    def test_owner_id_match_takes_priority(self, tmp_path: Path) -> None:
+        index = BuildIndex(tmp_path)
+        index.insert_or_replace(
+            run_id="mine",
+            status="ok",
+            started_at=None,
+            finished_at="2025-01-01T10:00:00Z",
+            created_by="oidc:otherLabel",  # label은 다르지만 owner_id가 일치.
+            owner_id="oidc:deadbeef",
+        )
+        entries = index.list_recent_owned(
+            limit=10, principal_owner_id="oidc:deadbeef", principal_label="oidc:userA"
+        )
+        assert [e.run_id for e in entries] == ["mine"]
+
+    def test_legacy_created_by_fallback_when_record_owner_id_missing(self, tmp_path: Path) -> None:
+        """레코드에 owner_id가 없는 legacy run은 created_by로 폴백해 매치한다."""
+        index = BuildIndex(tmp_path)
+        index.insert_or_replace(
+            run_id="legacy-mine",
+            status="ok",
+            started_at=None,
+            finished_at="2025-01-01T10:00:00Z",
+            created_by="oidc:userA",
+            owner_id=None,
+        )
+        entries = index.list_recent_owned(
+            limit=10, principal_owner_id="oidc:deadbeef", principal_label="oidc:userA"
+        )
+        assert [e.run_id for e in entries] == ["legacy-mine"]
+
+    def test_principal_without_owner_id_always_falls_back_to_created_by(
+        self, tmp_path: Path
+    ) -> None:
+        """principal에 owner_id가 없으면 레코드 owner_id 유무와 무관하게 created_by로 비교한다."""
+        index = BuildIndex(tmp_path)
+        index.insert_or_replace(
+            run_id="has-owner-id",
+            status="ok",
+            started_at=None,
+            finished_at="2025-01-01T10:00:00Z",
+            created_by="oidc:userA",
+            owner_id="oidc:deadbeef",  # 레코드엔 owner_id가 있지만 principal엔 없다.
+        )
+        entries = index.list_recent_owned(
+            limit=10, principal_owner_id=None, principal_label="oidc:userA"
+        )
+        assert [e.run_id for e in entries] == ["has-owner-id"]
+
+    def test_no_match_is_excluded_fail_closed(self, tmp_path: Path) -> None:
+        index = BuildIndex(tmp_path)
+        index.insert_or_replace(
+            run_id="theirs",
+            status="ok",
+            started_at=None,
+            finished_at="2025-01-01T10:00:00Z",
+            created_by="oidc:userB",
+            owner_id="oidc:otherhash",
+        )
+        entries = index.list_recent_owned(
+            limit=10, principal_owner_id="oidc:deadbeef", principal_label="oidc:userA"
+        )
+        assert entries == []
+
+    def test_no_created_by_no_owner_id_is_excluded(self, tmp_path: Path) -> None:
+        """created_by/owner_id 둘 다 없는 레코드는 어떤 principal과도 매치하지 않는다."""
+        index = BuildIndex(tmp_path)
+        index.insert_or_replace(
+            run_id="anonymous",
+            status="ok",
+            started_at=None,
+            finished_at="2025-01-01T10:00:00Z",
+            created_by=None,
+            owner_id=None,
+        )
+        entries = index.list_recent_owned(
+            limit=10, principal_owner_id="oidc:deadbeef", principal_label="oidc:userA"
+        )
+        assert entries == []
+
+    def test_filter_applied_before_limit_so_own_older_run_is_not_crowded_out(
+        self, tmp_path: Path
+    ) -> None:
+        """다른 사용자의 최신 run 10건보다 내 run이 오래돼도 LIMIT에 밀려 잘리지 않는다 (#527)."""
+        index = BuildIndex(tmp_path)
+        index.insert_or_replace(
+            run_id="mine-old",
+            status="ok",
+            started_at=None,
+            finished_at="2025-01-01T00:00:00Z",  # 다른 사용자 run 10건보다 모두 오래됨.
+            created_by="oidc:userA",
+            owner_id="oidc:deadbeef",
+        )
+        for i in range(10):
+            index.insert_or_replace(
+                run_id=f"theirs-{i:02d}",
+                status="ok",
+                started_at=None,
+                finished_at=f"2025-01-02T{i:02d}:00:00Z",  # 전부 내 run보다 최신.
+                created_by="oidc:userB",
+                owner_id="oidc:otherhash",
+            )
+        entries = index.list_recent_owned(
+            limit=10, principal_owner_id="oidc:deadbeef", principal_label="oidc:userA"
+        )
+        assert [e.run_id for e in entries] == ["mine-old"]
+
+    def test_limit_is_respected_after_filtering(self, tmp_path: Path) -> None:
+        index = BuildIndex(tmp_path)
+        for i in range(15):
+            index.insert_or_replace(
+                run_id=f"mine-{i:02d}",
+                status="ok",
+                started_at=None,
+                finished_at=f"2025-01-01T{i:02d}:00:00Z",
+                created_by="oidc:userA",
+                owner_id="oidc:deadbeef",
+            )
+        entries = index.list_recent_owned(
+            limit=10, principal_owner_id="oidc:deadbeef", principal_label="oidc:userA"
+        )
+        assert len(entries) == 10
+        # finished_at 내림차순 — 가장 최근 10건(09~14가 아니라 05~14)이어야 한다.
+        assert entries[0].run_id == "mine-14"
+        assert entries[-1].run_id == "mine-05"
+
+
 class TestRebuildIndex:
     """rebuild_index 함수 테스트."""
 

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -197,9 +197,24 @@ class TestLatencyRecorder:
 
         monkeypatch.setattr(recorder, "_lock", _BrokenLock())
         recorder.record(10.0)  # 예외를 던지지 않아야 한다.
-        sample_count, p95 = recorder.snapshot()
-        assert sample_count == 0
-        assert p95 is None
+
+    def test_snapshot_failure_returns_none_not_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """collector 실패는 (0, None)이 아니라 None으로 구분된다 (#527).
+
+        (0, None)은 "정상 무표본"이고, None은 "측정 자체가 불가"다 — 이 둘을
+        같은 값으로 뭉개면 api_status()가 항상 available로 위장하게 된다.
+        """
+        recorder = LatencyRecorder()
+
+        class _BrokenLock:
+            def __enter__(self) -> None:
+                raise RuntimeError("simulated lock failure")
+
+            def __exit__(self, *exc: object) -> None:
+                return None
+
+        monkeypatch.setattr(recorder, "_lock", _BrokenLock())
+        assert recorder.snapshot() is None  # 예외를 던지지 않되, (0, None)도 아니다.
 
 
 class TestApiStatus:
@@ -216,6 +231,23 @@ class TestApiStatus:
         assert status.availability == "available"
         assert status.sample_count == 1
         assert status.p95_latency_ms == 5.0
+
+    def test_unavailable_when_collector_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """collector 실패(#527)는 available+0으로 위장하지 않고 unavailable+null+null이다."""
+        recorder = LatencyRecorder()
+
+        class _BrokenLock:
+            def __enter__(self) -> None:
+                raise RuntimeError("simulated lock failure")
+
+            def __exit__(self, *exc: object) -> None:
+                return None
+
+        monkeypatch.setattr(recorder, "_lock", _BrokenLock())
+        status = api_status(recorder)
+        assert status.availability == "unavailable"
+        assert status.sample_count is None
+        assert status.p95_latency_ms is None
 
 
 # =============================================================================
@@ -521,7 +553,10 @@ class TestArtifactStoreStatus:
 
 
 def _api(
-    *, availability: Availability = "available", sample_count: int = 0, p95: float | None = None
+    *,
+    availability: Availability = "available",
+    sample_count: int | None = 0,
+    p95: float | None = None,
 ) -> ApiStatus:
     return ApiStatus(availability=availability, sample_count=sample_count, p95_latency_ms=p95)
 
@@ -581,6 +616,16 @@ class TestAggregateStatus:
             queue=_queue(),
             workers=_workers(),
             artifact_store=_artifact(availability="unavailable", last_write_at=None),
+        )
+        assert status == "degraded"
+
+    def test_api_unavailable_is_degraded(self) -> None:
+        """api collector 실패(#527)로 availability=unavailable이면 aggregate도 degraded."""
+        status = aggregate_status(
+            api=_api(availability="unavailable", sample_count=None, p95=None),
+            queue=_queue(),
+            workers=_workers(),
+            artifact_store=_artifact(),
         )
         assert status == "degraded"
 
@@ -671,7 +716,7 @@ class TestBuildStatistics:
         assert all(b.total == 0 for b in stats.buckets)
         assert stats.recent_runs == ()
 
-    def test_counts_ok_failed_cancelled_in_correct_bucket(self, tmp_path: Path) -> None:
+    def test_counts_success_failed_cancelled_in_correct_bucket(self, tmp_path: Path) -> None:
         index = BuildIndex(tmp_path)
         index.insert_or_replace(
             run_id="ok-1", status="ok", started_at=None, finished_at="2026-08-15T09:15:00Z"
@@ -693,7 +738,8 @@ class TestBuildStatistics:
         )
         bucket_09 = next(b for b in stats.buckets if b.bucket_start == "2026-08-15T09:00:00Z")
         assert bucket_09.total == 3
-        assert bucket_09.ok == 1
+        # 내부 BuildIndex status "ok"는 wire 필드 "success"로 매핑된다 (#527).
+        assert bucket_09.success == 1
         assert bucket_09.failed == 1
         assert bucket_09.cancelled == 1
         assert bucket_09.bucket_end == "2026-08-15T10:00:00Z"
@@ -829,6 +875,43 @@ class TestBuildStatistics:
         assert run_ids == {"mine"}
         total = sum(b.total for b in stats.buckets)
         assert total == 1
+
+    def test_recent_run_survives_limit_when_older_than_other_users_runs(
+        self, tmp_path: Path
+    ) -> None:
+        """#527: 다른 사용자의 최신 run 10건이 있어도 그보다 오래된 내 recent run이
+
+        ownership 필터 이전에 걸린 전역 LIMIT(10)에 밀려 잘리지 않는다 —
+        필터가 LIMIT보다 먼저 SQL에서 적용돼야 한다(``BuildIndex.list_recent_owned``).
+        """
+        index = BuildIndex(tmp_path)
+        index.insert_or_replace(
+            run_id="mine-old",
+            status="ok",
+            started_at=None,
+            finished_at="2020-01-01T00:00:00Z",  # 아래 다른 사용자 run 10건보다 모두 오래됨.
+            created_by="oidc:userA",
+        )
+        for i in range(10):
+            index.insert_or_replace(
+                run_id=f"theirs-{i:02d}",
+                status="ok",
+                started_at=None,
+                finished_at=f"2026-08-15T{i:02d}:00:00Z",  # 전부 mine-old보다 최신.
+                created_by="oidc:userB",
+            )
+        principal = Principal(kind="oidc", identifier="userA")
+        stats = build_statistics(
+            index,
+            window="24h",
+            bucket="hour",
+            principal=principal,
+            enforce_ownership=True,
+            now=_NOW,
+        )
+        run_ids = {r.run_id for r in stats.recent_runs}
+        assert "mine-old" in run_ids
+        assert "theirs-00" not in run_ids
 
     def test_ownership_not_filtered_when_enforcement_off(self, tmp_path: Path) -> None:
         index = BuildIndex(tmp_path)

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -1,0 +1,968 @@
+"""Monitoring API 단위 테스트 (#516).
+
+``service/monitoring.py``의 순수 로직(latency/p95, queue/worker, artifact
+store, build 통계 집계)과 dispatch 레벨 ownership 격리를 검증한다.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Iterable
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from kpubdata_builder.service import BuilderService, dispatch
+from kpubdata_builder.service.auth import Principal
+from kpubdata_builder.service.jobs import AsyncBuildExecutor
+from kpubdata_builder.service.monitoring import (
+    ApiStatus,
+    ArtifactStoreStatus,
+    LatencyRecorder,
+    QueueStatus,
+    WorkerStatus,
+    aggregate_status,
+    api_status,
+    artifact_store_status,
+    build_statistics,
+    queue_status,
+    validate_bucket,
+    validate_window,
+    worker_status,
+)
+from kpubdata_builder.service.ownership import _OWNERSHIP_ENV
+from kpubdata_builder.service.quality import Availability
+from kpubdata_builder.spec import JsonValue
+from kpubdata_builder.store import BuildIndex
+
+VALID_SPEC_YAML = (
+    """
+dataset_id: dataset.sample
+title: Sample Dataset
+description: Sample description
+sources:
+  - provider: datago
+    dataset: air_quality
+exports:
+  - kind: jsonl
+    output_path: out/data.jsonl
+""".strip()
+    + "\n"
+)
+
+
+class _FakeResult:
+    def __init__(self, items: list[dict[str, JsonValue]]) -> None:
+        self._items = items
+
+    @property
+    def items(self) -> Iterable[dict[str, JsonValue]]:
+        return self._items
+
+
+class _FakeCatalog:
+    def __init__(self, items: list[object] | None = None) -> None:
+        self._items = items or []
+
+    def list(self, *, provider: str | None = None) -> list[object]:
+        return self._items
+
+
+class _FakeDataset:
+    def __init__(self, items: list[dict[str, JsonValue]]) -> None:
+        self._items = items
+
+    def list(self, **params: JsonValue) -> _FakeResult:
+        return _FakeResult(self._items)
+
+
+class _FakeClient:
+    """service.build()이 요구하는 최소 SourceClient 흉내."""
+
+    datasets = _FakeCatalog()
+
+    def __init__(self, data: dict[str, list[dict[str, JsonValue]]]) -> None:
+        self._data = data
+
+    def dataset(self, dataset_id: str) -> _FakeDataset:
+        return _FakeDataset(self._data.get(dataset_id, []))
+
+    def close(self) -> None:
+        pass
+
+
+def _service(tmp_path: Path) -> BuilderService:
+    client = _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}]})
+    return BuilderService(output_root=tmp_path, client_factory=lambda: client)
+
+
+def _build_as(service: BuilderService, run_id: str, created_by: str) -> None:
+    dispatch(service, "POST", "/build", {"spec": VALID_SPEC_YAML, "run_id": run_id})
+    import json
+
+    mpath = service._output_root / run_id / "manifest.json"
+    data = json.loads(mpath.read_text(encoding="utf-8"))
+    data["created_by"] = created_by
+    mpath.write_text(json.dumps(data), encoding="utf-8")
+
+
+# =============================================================================
+# LatencyRecorder / p95
+# =============================================================================
+
+
+class TestLatencyRecorder:
+    def test_no_samples_reports_zero_count_and_null_p95(self) -> None:
+        recorder = LatencyRecorder()
+        sample_count, p95 = recorder.snapshot()
+        assert sample_count == 0
+        assert p95 is None
+
+    def test_single_sample(self) -> None:
+        recorder = LatencyRecorder()
+        recorder.record(42.0)
+        sample_count, p95 = recorder.snapshot()
+        assert sample_count == 1
+        assert p95 == 42.0
+
+    def test_p95_nearest_rank_boundary(self) -> None:
+        # n=20, rank = ceil(0.95*20) = 19 -> 1-indexed 19번째(오름차순) = 값 19.
+        recorder = LatencyRecorder()
+        for value in range(1, 21):
+            recorder.record(float(value))
+        sample_count, p95 = recorder.snapshot()
+        assert sample_count == 20
+        assert p95 == 19.0
+
+    def test_p95_unsorted_input_still_correct(self) -> None:
+        recorder = LatencyRecorder()
+        for value in [50.0, 10.0, 30.0, 20.0, 40.0]:
+            recorder.record(value)
+        # n=5, rank=ceil(0.95*5)=5 -> 오름차순 5번째(최댓값) = 50.
+        sample_count, p95 = recorder.snapshot()
+        assert sample_count == 5
+        assert p95 == 50.0
+
+    def test_bounded_ring_buffer_evicts_oldest(self) -> None:
+        recorder = LatencyRecorder(max_samples=3)
+        for value in [1.0, 2.0, 3.0, 4.0]:
+            recorder.record(value)
+        sample_count, p95 = recorder.snapshot()
+        # 최근 3개만 남는다: [2, 3, 4]. rank=ceil(0.95*3)=3 -> 최댓값 4.
+        assert sample_count == 3
+        assert p95 == 4.0
+
+    def test_concurrent_record_and_snapshot_is_safe(self) -> None:
+        recorder = LatencyRecorder(max_samples=10_000)
+        errors: list[BaseException] = []
+
+        def _writer(n: int) -> None:
+            try:
+                for i in range(n):
+                    recorder.record(float(i))
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        def _reader() -> None:
+            try:
+                for _ in range(50):
+                    recorder.snapshot()
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=_writer, args=(200,)) for _ in range(4)]
+        threads += [threading.Thread(target=_reader) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        sample_count, _ = recorder.snapshot()
+        assert sample_count == 800  # 4 writer * 200 (bounded 10_000이므로 소실 없음)
+
+    def test_record_failure_does_not_raise(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """metric 기록 실패가 요청 실패로 전파되면 안 된다 (#516)."""
+        recorder = LatencyRecorder()
+
+        class _BrokenLock:
+            def __enter__(self) -> None:
+                raise RuntimeError("simulated lock failure")
+
+            def __exit__(self, *exc: object) -> None:
+                return None
+
+        monkeypatch.setattr(recorder, "_lock", _BrokenLock())
+        recorder.record(10.0)  # 예외를 던지지 않아야 한다.
+        sample_count, p95 = recorder.snapshot()
+        assert sample_count == 0
+        assert p95 is None
+
+
+class TestApiStatus:
+    def test_available_with_no_samples(self) -> None:
+        status = api_status(LatencyRecorder())
+        assert status.availability == "available"
+        assert status.sample_count == 0
+        assert status.p95_latency_ms is None
+
+    def test_available_with_samples(self) -> None:
+        recorder = LatencyRecorder()
+        recorder.record(5.0)
+        status = api_status(recorder)
+        assert status.availability == "available"
+        assert status.sample_count == 1
+        assert status.p95_latency_ms == 5.0
+
+
+# =============================================================================
+# Queue / Worker — 실제 AsyncBuildExecutor/Registry(#511/#513)의 read-only
+# snapshot을 반영한다 (#516). 항상 생성되는 실행기이므로 available이 정상이다.
+# =============================================================================
+
+
+class _StubResponse:
+    """AsyncBuildExecutor.submit()이 요구하는 최소 BuildJobResponse 흉내."""
+
+    def __init__(self, status_code: int = 200, body: dict[str, JsonValue] | None = None) -> None:
+        self.status_code = status_code
+        self.body: dict[str, JsonValue] = body or {}
+
+
+def _blocking_runner(entered: threading.Event, release: threading.Event):  # type: ignore[no-untyped-def]
+    """runner가 실행 중임을 ``entered``로 알리고 ``release``까지 대기한다.
+
+    큐/워커 상태를 결정론적으로 관찰하기 위해 job을 원하는 시점에 "running"
+    상태로 묶어두는 테스트 헬퍼(#516).
+    """
+
+    def _runner(spec_yaml: str, run_id: str, created_by: str | None) -> _StubResponse:
+        entered.set()
+        release.wait(timeout=5)
+        return _StubResponse(200, {"run_id": run_id})
+
+    return _runner
+
+
+def _wait_for_terminal(executor: AsyncBuildExecutor, run_id: str, *, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        snapshot = executor.get(run_id)
+        if snapshot is not None and snapshot.status in ("succeeded", "failed", "cancelled"):
+            return
+        time.sleep(0.01)
+    raise AssertionError(f"job {run_id} did not reach terminal status within {timeout}s")
+
+
+class TestQueueWorkerStatus:
+    def test_no_jobs_is_available_with_zero_counts(self) -> None:
+        executor = AsyncBuildExecutor(max_workers=3, max_queue_size=10)
+        try:
+            queue = queue_status(executor)
+            workers = worker_status(executor)
+        finally:
+            executor.shutdown()
+        assert queue.availability == "available"
+        assert queue.waiting == 0
+        assert queue.running == 0
+        assert queue.total == 0
+        assert workers.availability == "available"
+        assert workers.active == 0
+        assert workers.capacity == 3
+        assert workers.utilization == 0.0
+
+    def test_queued_job_is_reflected_in_waiting(self) -> None:
+        entered = threading.Event()
+        release = threading.Event()
+        executor = AsyncBuildExecutor(max_workers=1, max_queue_size=10)
+        try:
+            executor.submit(
+                spec_yaml="spec",
+                run_id="run-blocking",
+                created_by=None,
+                runner=_blocking_runner(entered, release),
+            )
+            assert entered.wait(timeout=5)
+            executor.submit(
+                spec_yaml="spec",
+                run_id="run-queued",
+                created_by=None,
+                runner=_blocking_runner(threading.Event(), threading.Event()),
+            )
+            queue = queue_status(executor)
+            workers = worker_status(executor)
+            release.set()
+        finally:
+            executor.shutdown()
+        assert queue.availability == "available"
+        assert queue.waiting == 1
+        assert queue.running == 1
+        assert queue.total == 2
+        assert workers.active == 1
+        assert workers.capacity == 1
+        assert workers.utilization == 1.0
+
+    def test_running_job_is_reflected_in_running_and_active(self) -> None:
+        entered = threading.Event()
+        release = threading.Event()
+        executor = AsyncBuildExecutor(max_workers=1, max_queue_size=10)
+        try:
+            executor.submit(
+                spec_yaml="spec",
+                run_id="run-1",
+                created_by=None,
+                runner=_blocking_runner(entered, release),
+            )
+            assert entered.wait(timeout=5)
+            queue = queue_status(executor)
+            workers = worker_status(executor)
+            release.set()
+        finally:
+            executor.shutdown()
+        assert queue.waiting == 0
+        assert queue.running == 1
+        assert queue.total == 1
+        assert workers.active == 1
+
+    def test_succeeded_and_failed_terminal_jobs_excluded_from_active(self) -> None:
+        executor = AsyncBuildExecutor(max_workers=2, max_queue_size=10)
+        try:
+
+            def _succeed(spec_yaml: str, run_id: str, created_by: str | None) -> _StubResponse:
+                return _StubResponse(200, {"run_id": run_id})
+
+            def _fail(spec_yaml: str, run_id: str, created_by: str | None) -> _StubResponse:
+                raise RuntimeError("simulated build failure")
+
+            executor.submit(spec_yaml="spec", run_id="run-ok", created_by=None, runner=_succeed)
+            executor.submit(spec_yaml="spec", run_id="run-failed", created_by=None, runner=_fail)
+            _wait_for_terminal(executor, "run-ok")
+            _wait_for_terminal(executor, "run-failed")
+
+            queue = queue_status(executor)
+            workers = worker_status(executor)
+        finally:
+            executor.shutdown()
+        assert queue.waiting == 0
+        assert queue.running == 0
+        assert queue.total == 0
+        assert workers.active == 0
+        assert executor.get("run-ok") is not None  # registry는 terminal job도 보존한다.
+        assert executor.get("run-failed") is not None
+
+    def test_capacity_matches_configured_max_workers(self) -> None:
+        executor = AsyncBuildExecutor(max_workers=7, max_queue_size=10)
+        try:
+            workers = worker_status(executor)
+        finally:
+            executor.shutdown()
+        assert workers.capacity == 7
+
+    def test_utilization_is_active_over_capacity_ratio(self) -> None:
+        entered_a = threading.Event()
+        entered_b = threading.Event()
+        release = threading.Event()
+        executor = AsyncBuildExecutor(max_workers=4, max_queue_size=10)
+        try:
+            executor.submit(
+                spec_yaml="spec",
+                run_id="run-a",
+                created_by=None,
+                runner=_blocking_runner(entered_a, release),
+            )
+            executor.submit(
+                spec_yaml="spec",
+                run_id="run-b",
+                created_by=None,
+                runner=_blocking_runner(entered_b, release),
+            )
+            assert entered_a.wait(timeout=5)
+            assert entered_b.wait(timeout=5)
+            workers = worker_status(executor)
+            release.set()
+        finally:
+            executor.shutdown()
+        assert workers.active == 2
+        assert workers.capacity == 4
+        assert workers.utilization == 0.5
+
+    def test_monitoring_read_does_not_mutate_job_state(self) -> None:
+        entered = threading.Event()
+        release = threading.Event()
+        executor = AsyncBuildExecutor(max_workers=1, max_queue_size=10)
+        try:
+            executor.submit(
+                spec_yaml="spec",
+                run_id="run-1",
+                created_by=None,
+                runner=_blocking_runner(entered, release),
+            )
+            assert entered.wait(timeout=5)
+            before = executor.get("run-1")
+            queue_status(executor)
+            worker_status(executor)
+            after = executor.get("run-1")
+            release.set()
+        finally:
+            executor.shutdown()
+        assert before is not None and after is not None
+        assert before.status == after.status == "running"
+        assert before.updated_at == after.updated_at
+
+    def test_snapshot_thread_safety_under_concurrent_submits_and_reads(self) -> None:
+        release = threading.Event()
+        executor = AsyncBuildExecutor(max_workers=4, max_queue_size=200)
+        errors: list[BaseException] = []
+
+        def _submitter(i: int) -> None:
+            try:
+                executor.submit(
+                    spec_yaml="spec",
+                    run_id=f"run-{i}",
+                    created_by=None,
+                    runner=_blocking_runner(threading.Event(), release),
+                )
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        def _reader() -> None:
+            try:
+                for _ in range(50):
+                    queue = queue_status(executor)
+                    workers = worker_status(executor)
+                    assert queue.total == (queue.waiting or 0) + (queue.running or 0)
+                    assert (workers.active or 0) <= (workers.capacity or 0)
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=_submitter, args=(i,)) for i in range(20)]
+        threads += [threading.Thread(target=_reader) for _ in range(4)]
+        try:
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+            release.set()
+        finally:
+            executor.shutdown()
+        assert not errors
+
+
+# =============================================================================
+# Artifact Store
+# =============================================================================
+
+
+class TestArtifactStoreStatus:
+    def test_missing_output_root_is_unavailable(self, tmp_path: Path) -> None:
+        missing = tmp_path / "does-not-exist"
+        index = BuildIndex(tmp_path)  # index는 tmp_path에, output_root만 없는 경로로.
+        status = artifact_store_status(missing, index)
+        assert status.availability == "unavailable"
+        assert status.last_write_at is None
+
+    def test_available_with_no_successful_builds_yet(self, tmp_path: Path) -> None:
+        index = BuildIndex(tmp_path)
+        status = artifact_store_status(tmp_path, index)
+        assert status.availability == "available"
+        assert status.last_write_at is None  # 0건이지 확인 불가가 아님.
+
+    def test_available_with_last_write_evidence(self, tmp_path: Path) -> None:
+        index = BuildIndex(tmp_path)
+        index.insert_or_replace(
+            run_id="run-1",
+            status="ok",
+            started_at="2026-08-15T01:00:00Z",
+            finished_at="2026-08-15T01:05:00Z",
+        )
+        status = artifact_store_status(tmp_path, index)
+        assert status.availability == "available"
+        assert status.last_write_at == "2026-08-15T01:05:00Z"
+
+    def test_failed_only_builds_do_not_count_as_write_evidence(self, tmp_path: Path) -> None:
+        index = BuildIndex(tmp_path)
+        index.insert_or_replace(
+            run_id="run-1",
+            status="failed",
+            started_at="2026-08-15T01:00:00Z",
+            finished_at="2026-08-15T01:05:00Z",
+        )
+        status = artifact_store_status(tmp_path, index)
+        assert status.availability == "available"
+        assert status.last_write_at is None
+
+    def test_index_query_failure_is_unavailable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        index = BuildIndex(tmp_path)
+        monkeypatch.setattr(
+            index,
+            "latest_successful_finished_at",
+            lambda: (_ for _ in ()).throw(RuntimeError("simulated sqlite failure")),
+        )
+        status = artifact_store_status(tmp_path, index)
+        assert status.availability == "unavailable"
+        assert status.last_write_at is None
+
+    def test_no_absolute_path_leaks_into_status(self, tmp_path: Path) -> None:
+        index = BuildIndex(tmp_path)
+        status = artifact_store_status(tmp_path, index)
+        rendered = f"{status.availability}{status.last_write_at}"
+        assert str(tmp_path) not in rendered
+
+
+# =============================================================================
+# Aggregate status (#516 최종 점검) — required subsystem availability로부터
+# healthy/degraded를 판정한다. latency threshold는 절대 쓰지 않는다.
+# =============================================================================
+
+
+def _api(
+    *, availability: Availability = "available", sample_count: int = 0, p95: float | None = None
+) -> ApiStatus:
+    return ApiStatus(availability=availability, sample_count=sample_count, p95_latency_ms=p95)
+
+
+def _queue(
+    *, availability: Availability = "available", waiting: int | None = 0, running: int | None = 0
+) -> QueueStatus:
+    total = None if waiting is None or running is None else waiting + running
+    return QueueStatus(availability=availability, waiting=waiting, running=running, total=total)
+
+
+def _workers(
+    *, availability: Availability = "available", active: int | None = 0, capacity: int | None = 10
+) -> WorkerStatus:
+    utilization = None if active is None or capacity is None or capacity == 0 else active / capacity
+    return WorkerStatus(
+        availability=availability, active=active, capacity=capacity, utilization=utilization
+    )
+
+
+def _artifact(
+    *, availability: Availability = "available", last_write_at: str | None = None
+) -> ArtifactStoreStatus:
+    return ArtifactStoreStatus(availability=availability, last_write_at=last_write_at)
+
+
+class TestAggregateStatus:
+    def test_all_available_is_healthy(self) -> None:
+        status = aggregate_status(
+            api=_api(), queue=_queue(), workers=_workers(), artifact_store=_artifact()
+        )
+        assert status == "healthy"
+
+    def test_queue_actually_zero_is_still_healthy(self) -> None:
+        """queue waiting/running=0은 available+0이며 degraded 근거가 아니다."""
+        status = aggregate_status(
+            api=_api(),
+            queue=_queue(waiting=0, running=0),
+            workers=_workers(),
+            artifact_store=_artifact(),
+        )
+        assert status == "healthy"
+
+    def test_workers_actually_zero_is_still_healthy(self) -> None:
+        """workers active=0은 available+0이며 degraded 근거가 아니다."""
+        status = aggregate_status(
+            api=_api(),
+            queue=_queue(),
+            workers=_workers(active=0),
+            artifact_store=_artifact(),
+        )
+        assert status == "healthy"
+
+    def test_artifact_unavailable_is_degraded(self) -> None:
+        status = aggregate_status(
+            api=_api(),
+            queue=_queue(),
+            workers=_workers(),
+            artifact_store=_artifact(availability="unavailable", last_write_at=None),
+        )
+        assert status == "degraded"
+
+    def test_required_subsystem_partial_is_degraded(self) -> None:
+        """api/queue/workers/artifact_store 중 하나라도 partial이면 degraded."""
+        status = aggregate_status(
+            api=_api(availability="partial"),
+            queue=_queue(),
+            workers=_workers(),
+            artifact_store=_artifact(),
+        )
+        assert status == "degraded"
+
+    def test_queue_unavailable_is_degraded(self) -> None:
+        status = aggregate_status(
+            api=_api(),
+            queue=_queue(availability="unavailable", waiting=None, running=None),
+            workers=_workers(),
+            artifact_store=_artifact(),
+        )
+        assert status == "degraded"
+
+    def test_workers_unavailable_is_degraded(self) -> None:
+        status = aggregate_status(
+            api=_api(),
+            queue=_queue(),
+            workers=_workers(availability="unavailable", active=None, capacity=None),
+            artifact_store=_artifact(),
+        )
+        assert status == "degraded"
+
+    def test_no_samples_with_rest_available_is_healthy(self) -> None:
+        """sample_count=0/p95=null은 startup/무표본 상태일 수 있으므로 degraded 근거가 아니다."""
+        status = aggregate_status(
+            api=_api(sample_count=0, p95=None),
+            queue=_queue(),
+            workers=_workers(),
+            artifact_store=_artifact(),
+        )
+        assert status == "healthy"
+
+    def test_provider_has_no_parameter_and_no_influence(self) -> None:
+        """Provider status는 #516에서 optional이므로 판정 함수는 이를 아예 받지 않는다."""
+        import inspect
+
+        params = inspect.signature(aggregate_status).parameters
+        assert "provider" not in params
+
+
+# =============================================================================
+# window/bucket validation
+# =============================================================================
+
+
+class TestValidation:
+    def test_validate_window_accepts_24h(self) -> None:
+        assert validate_window("24h") == "24h"
+
+    def test_validate_window_rejects_others(self) -> None:
+        assert validate_window("7d") is None
+        assert validate_window("") is None
+
+    def test_validate_bucket_accepts_hour(self) -> None:
+        assert validate_bucket("hour") == "hour"
+
+    def test_validate_bucket_rejects_others(self) -> None:
+        assert validate_bucket("day") is None
+        assert validate_bucket("") is None
+
+
+# =============================================================================
+# Build statistics 집계
+# =============================================================================
+
+
+_NOW = datetime(2026, 8, 15, 10, 30, 0, tzinfo=timezone.utc)
+
+
+class TestBuildStatistics:
+    def test_empty_index_is_available_with_zero_buckets(self, tmp_path: Path) -> None:
+        index = BuildIndex(tmp_path)
+        stats = build_statistics(
+            index, window="24h", bucket="hour", principal=None, enforce_ownership=False, now=_NOW
+        )
+        assert stats.availability == "available"
+        assert stats.excluded_count == 0
+        assert len(stats.buckets) == 24
+        assert all(b.total == 0 for b in stats.buckets)
+        assert stats.recent_runs == ()
+
+    def test_counts_ok_failed_cancelled_in_correct_bucket(self, tmp_path: Path) -> None:
+        index = BuildIndex(tmp_path)
+        index.insert_or_replace(
+            run_id="ok-1", status="ok", started_at=None, finished_at="2026-08-15T09:15:00Z"
+        )
+        index.insert_or_replace(
+            run_id="failed-1",
+            status="failed",
+            started_at=None,
+            finished_at="2026-08-15T09:45:00Z",
+        )
+        index.insert_or_replace(
+            run_id="cancelled-1",
+            status="cancelled",
+            started_at=None,
+            finished_at="2026-08-15T09:59:59Z",
+        )
+        stats = build_statistics(
+            index, window="24h", bucket="hour", principal=None, enforce_ownership=False, now=_NOW
+        )
+        bucket_09 = next(b for b in stats.buckets if b.bucket_start == "2026-08-15T09:00:00Z")
+        assert bucket_09.total == 3
+        assert bucket_09.ok == 1
+        assert bucket_09.failed == 1
+        assert bucket_09.cancelled == 1
+        assert bucket_09.bucket_end == "2026-08-15T10:00:00Z"
+
+    def test_bucket_boundary_is_half_open(self, tmp_path: Path) -> None:
+        """정각 timestamp는 다음 bucket에 속한다([start, end) 반열린)."""
+        index = BuildIndex(tmp_path)
+        index.insert_or_replace(
+            run_id="on-boundary",
+            status="ok",
+            started_at=None,
+            finished_at="2026-08-15T09:00:00Z",
+        )
+        stats = build_statistics(
+            index, window="24h", bucket="hour", principal=None, enforce_ownership=False, now=_NOW
+        )
+        bucket_09 = next(b for b in stats.buckets if b.bucket_start == "2026-08-15T09:00:00Z")
+        bucket_08 = next(b for b in stats.buckets if b.bucket_start == "2026-08-15T08:00:00Z")
+        assert bucket_09.total == 1
+        assert bucket_08.total == 0
+
+    def test_entries_outside_window_are_excluded(self, tmp_path: Path) -> None:
+        index = BuildIndex(tmp_path)
+        # window는 [2026-08-14T11:00, 2026-08-15T11:00) — 하루 전은 window 밖.
+        index.insert_or_replace(
+            run_id="too-old",
+            status="ok",
+            started_at=None,
+            finished_at="2026-08-13T09:00:00Z",
+        )
+        stats = build_statistics(
+            index, window="24h", bucket="hour", principal=None, enforce_ownership=False, now=_NOW
+        )
+        assert all(b.total == 0 for b in stats.buckets)
+
+    def test_malformed_timestamp_excluded_and_marks_partial(self, tmp_path: Path) -> None:
+        """날짜 prefix는 정상이지만 시각 부분이 손상된 legacy 값(#516)."""
+        index = BuildIndex(tmp_path)
+        index.insert_or_replace(
+            run_id="good", status="ok", started_at=None, finished_at="2026-08-15T09:00:00Z"
+        )
+        index.insert_or_replace(
+            run_id="bad", status="ok", started_at=None, finished_at="2026-08-15T09:99:00Z"
+        )
+        stats = build_statistics(
+            index, window="24h", bucket="hour", principal=None, enforce_ownership=False, now=_NOW
+        )
+        assert stats.availability == "partial"
+        assert stats.excluded_count == 1
+        total = sum(b.total for b in stats.buckets)
+        assert total == 1  # malformed 행은 어떤 bucket에도 세지 않는다.
+
+    def test_null_finished_at_excluded_and_marks_partial(self, tmp_path: Path) -> None:
+        """finished_at NULL 행도 침묵하며 누락되지 않고 partial로 집계된다 (#516)."""
+        index = BuildIndex(tmp_path)
+        index.insert_or_replace(
+            run_id="good", status="ok", started_at=None, finished_at="2026-08-15T09:00:00Z"
+        )
+        index.insert_or_replace(
+            run_id="null-finished", status="ok", started_at=None, finished_at=None
+        )
+        stats = build_statistics(
+            index, window="24h", bucket="hour", principal=None, enforce_ownership=False, now=_NOW
+        )
+        assert stats.availability == "partial"
+        assert stats.excluded_count == 1
+
+    def test_index_query_failure_is_unavailable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        index = BuildIndex(tmp_path)
+
+        def _raise(*_args: object, **_kwargs: object) -> list:
+            raise RuntimeError("simulated sqlite failure")
+
+        monkeypatch.setattr(index, "list_between", _raise)
+        stats = build_statistics(
+            index, window="24h", bucket="hour", principal=None, enforce_ownership=False, now=_NOW
+        )
+        assert stats.availability == "unavailable"
+        assert stats.buckets == ()
+        assert stats.recent_runs == ()
+
+    def test_deterministic_bucket_ordering(self, tmp_path: Path) -> None:
+        index = BuildIndex(tmp_path)
+        stats = build_statistics(
+            index, window="24h", bucket="hour", principal=None, enforce_ownership=False, now=_NOW
+        )
+        starts = [b.bucket_start for b in stats.buckets]
+        assert starts == sorted(starts)
+        assert len(starts) == len(set(starts))
+
+    def test_recent_runs_bounded_to_ten(self, tmp_path: Path) -> None:
+        index = BuildIndex(tmp_path)
+        for i in range(15):
+            index.insert_or_replace(
+                run_id=f"run-{i:02d}",
+                status="ok",
+                started_at=None,
+                finished_at=f"2026-08-15T09:{i:02d}:00Z",
+            )
+        stats = build_statistics(
+            index, window="24h", bucket="hour", principal=None, enforce_ownership=False, now=_NOW
+        )
+        assert len(stats.recent_runs) == 10
+
+    def test_ownership_filters_other_principal_when_enforced(self, tmp_path: Path) -> None:
+        index = BuildIndex(tmp_path)
+        index.insert_or_replace(
+            run_id="mine",
+            status="ok",
+            started_at=None,
+            finished_at="2026-08-15T09:00:00Z",
+            created_by="oidc:userA",
+        )
+        index.insert_or_replace(
+            run_id="theirs",
+            status="ok",
+            started_at=None,
+            finished_at="2026-08-15T09:10:00Z",
+            created_by="oidc:userB",
+        )
+        principal = Principal(kind="oidc", identifier="userA")
+        stats = build_statistics(
+            index,
+            window="24h",
+            bucket="hour",
+            principal=principal,
+            enforce_ownership=True,
+            now=_NOW,
+        )
+        run_ids = {r.run_id for r in stats.recent_runs}
+        assert run_ids == {"mine"}
+        total = sum(b.total for b in stats.buckets)
+        assert total == 1
+
+    def test_ownership_not_filtered_when_enforcement_off(self, tmp_path: Path) -> None:
+        index = BuildIndex(tmp_path)
+        index.insert_or_replace(
+            run_id="mine",
+            status="ok",
+            started_at=None,
+            finished_at="2026-08-15T09:00:00Z",
+            created_by="oidc:userA",
+        )
+        index.insert_or_replace(
+            run_id="theirs",
+            status="ok",
+            started_at=None,
+            finished_at="2026-08-15T09:10:00Z",
+            created_by="oidc:userB",
+        )
+        principal = Principal(kind="oidc", identifier="userA")
+        stats = build_statistics(
+            index,
+            window="24h",
+            bucket="hour",
+            principal=principal,
+            enforce_ownership=False,
+            now=_NOW,
+        )
+        run_ids = {r.run_id for r in stats.recent_runs}
+        assert run_ids == {"mine", "theirs"}
+
+    def test_dev_principal_bypasses_ownership_filter(self, tmp_path: Path) -> None:
+        index = BuildIndex(tmp_path)
+        index.insert_or_replace(
+            run_id="theirs",
+            status="ok",
+            started_at=None,
+            finished_at="2026-08-15T09:10:00Z",
+            created_by="oidc:userB",
+        )
+        principal = Principal(kind="dev")
+        stats = build_statistics(
+            index,
+            window="24h",
+            bucket="hour",
+            principal=principal,
+            enforce_ownership=True,
+            now=_NOW,
+        )
+        run_ids = {r.run_id for r in stats.recent_runs}
+        assert run_ids == {"theirs"}
+
+
+# =============================================================================
+# dispatch 레벨: route wiring, ownership 격리, secret 미노출
+# =============================================================================
+
+
+class TestMonitoringDispatch:
+    def test_summary_route_returns_200(self, tmp_path: Path) -> None:
+        resp = dispatch(_service(tmp_path), "GET", "/monitoring/summary", None)
+        assert resp.status_code == 200
+        assert resp.body["status"] == "healthy"
+        assert resp.body["queue"]["availability"] == "available"  # type: ignore[index]
+        assert resp.body["queue"]["waiting"] == 0  # type: ignore[index]
+        assert resp.body["queue"]["running"] == 0  # type: ignore[index]
+        assert resp.body["queue"]["total"] == 0  # type: ignore[index]
+        assert resp.body["workers"]["availability"] == "available"  # type: ignore[index]
+        assert resp.body["workers"]["active"] == 0  # type: ignore[index]
+        assert resp.body["workers"]["capacity"] == 10  # type: ignore[index]
+        assert resp.body["workers"]["utilization"] == 0.0  # type: ignore[index]
+
+    def test_summary_status_is_degraded_when_artifact_store_unavailable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """artifact_store BuildIndex 쿼리가 실패해 unavailable이면 전체 status는 degraded."""
+        service = _service(tmp_path)
+        monkeypatch.setattr(
+            service._build_index,
+            "latest_successful_finished_at",
+            lambda: (_ for _ in ()).throw(RuntimeError("simulated sqlite failure")),
+        )
+        resp = dispatch(service, "GET", "/monitoring/summary", None)
+        assert resp.status_code == 200
+        assert resp.body["artifact_store"]["availability"] == "unavailable"  # type: ignore[index]
+        assert resp.body["status"] == "degraded"
+
+    def test_builds_route_returns_200_with_defaults(self, tmp_path: Path) -> None:
+        resp = dispatch(_service(tmp_path), "GET", "/monitoring/builds", None, query="")
+        assert resp.status_code == 200
+        assert resp.body["window"] == "24h"
+        assert resp.body["bucket"] == "hour"
+
+    def test_builds_route_rejects_unsupported_window(self, tmp_path: Path) -> None:
+        resp = dispatch(_service(tmp_path), "GET", "/monitoring/builds", None, query="window=7d")
+        assert resp.status_code == 400
+
+    def test_builds_route_rejects_unsupported_bucket(self, tmp_path: Path) -> None:
+        resp = dispatch(_service(tmp_path), "GET", "/monitoring/builds", None, query="bucket=day")
+        assert resp.status_code == 400
+
+    def test_cross_user_recent_runs_not_leaked_when_ownership_enforced(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(_OWNERSHIP_ENV, "true")
+        service = _service(tmp_path)
+        _build_as(service, "runA", "oidc:userA")
+        _build_as(service, "runB", "oidc:userB")
+
+        user_a = Principal(kind="oidc", identifier="userA")
+        resp = service.monitoring_builds(window="24h", bucket="hour", principal=user_a)
+        assert resp.status_code == 200
+        recent_run_ids = {
+            cast(dict[str, JsonValue], r)["run_id"]
+            for r in cast(list[JsonValue], resp.body["recent_runs"])
+        }
+        assert "runB" not in recent_run_ids
+
+    def test_no_secrets_or_internal_paths_in_summary_response(self, tmp_path: Path) -> None:
+        resp = dispatch(_service(tmp_path), "GET", "/monitoring/summary", None)
+        rendered = str(resp.body)
+        assert str(tmp_path) not in rendered
+        for forbidden in ("owner_id", "api_key", "bearer", "credential", "secret"):
+            assert forbidden not in rendered.lower()
+
+    def test_no_secrets_or_dataset_owner_in_builds_response(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        dispatch(service, "POST", "/build", {"spec": VALID_SPEC_YAML, "run_id": "run-1"})
+        resp = dispatch(service, "GET", "/monitoring/builds", None, query="")
+        rendered = str(resp.body)
+        assert str(tmp_path) not in rendered
+        for forbidden in ("owner_id", "dataset_id", "credential", "secret"):
+            assert forbidden not in rendered.lower()
+
+    def test_dispatch_records_latency_sample(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        dispatch(service, "GET", "/healthz", None)
+        sample_count, _ = service._latency_recorder.snapshot()
+        assert sample_count >= 1

--- a/tests/unit/test_service_contract.py
+++ b/tests/unit/test_service_contract.py
@@ -60,6 +60,8 @@ _DISPATCH_ROUTES: dict[tuple[str, str], str] = {
     ("/builds/{run_id}/stages", "GET"): "listBuildStages",
     ("/builds/{run_id}/stages/{stage}", "GET"): "getBuildStageDetail",
     ("/builds/{run_id}/quality", "GET"): "getBuildQuality",
+    ("/monitoring/summary", "GET"): "getMonitoringSummary",
+    ("/monitoring/builds", "GET"): "getMonitoringBuilds",
 }
 
 # (path, method) 형태의 계약 필수 오퍼레이션. BuilderService.dispatch가 실제로
@@ -89,6 +91,8 @@ _REQUIRED_OPERATIONS = [
     ("/builds/{run_id}/stages", "get"),
     ("/builds/{run_id}/stages/{stage}", "get"),
     ("/builds/{run_id}/quality", "get"),
+    ("/monitoring/summary", "get"),
+    ("/monitoring/builds", "get"),
 ]
 
 
@@ -355,6 +359,8 @@ _IMPLEMENTED_OPERATIONS = {
     "listBuildStages",
     "getBuildStageDetail",
     "getBuildQuality",
+    "getMonitoringSummary",
+    "getMonitoringBuilds",
 }
 
 
@@ -572,6 +578,8 @@ _OPERATION_STATUS_CODES: dict[str, set[int]] = {
     "listBuildStages": {200, 400, 403, 404},
     "getBuildStageDetail": {200, 400, 403, 404},
     "getBuildQuality": {200, 400, 403, 404},
+    "getMonitoringSummary": {200},
+    "getMonitoringBuilds": {200, 400},
 }
 
 
@@ -1115,3 +1123,43 @@ class TestResponseConformance:
         resp = dispatch(_conform_service(tmp_path), "GET", "/builds/nope/quality", None)
         assert resp.status_code == 404
         _assert_conforms(resp, "/builds/{run_id}/quality", "GET")
+
+    def test_monitoring_summary_200(self, tmp_path: Path) -> None:
+        resp = dispatch(_conform_service(tmp_path), "GET", "/monitoring/summary", None)
+        assert resp.status_code == 200
+        _assert_conforms(resp, "/monitoring/summary", "GET")
+
+    def test_monitoring_summary_200_after_build(self, tmp_path: Path) -> None:
+        # 요청 처리 후 latency 표본이 기록되어도 계약을 벗어나지 않는지 확인.
+        service = _conform_service(tmp_path)
+        dispatch(service, "POST", "/build", {"spec": _CONFORM_SPEC_YAML, "run_id": "conform-mon"})
+        resp = dispatch(service, "GET", "/monitoring/summary", None)
+        assert resp.status_code == 200
+        _assert_conforms(resp, "/monitoring/summary", "GET")
+        assert resp.body["api"]["sample_count"] >= 1  # type: ignore[index]
+
+    def test_monitoring_builds_200_empty(self, tmp_path: Path) -> None:
+        resp = dispatch(_conform_service(tmp_path), "GET", "/monitoring/builds", None, query="")
+        assert resp.status_code == 200
+        _assert_conforms(resp, "/monitoring/builds", "GET")
+
+    def test_monitoring_builds_200_after_build(self, tmp_path: Path) -> None:
+        service = _conform_service(tmp_path)
+        dispatch(service, "POST", "/build", {"spec": _CONFORM_SPEC_YAML, "run_id": "conform-mon-b"})
+        resp = dispatch(service, "GET", "/monitoring/builds", None, query="window=24h&bucket=hour")
+        assert resp.status_code == 200
+        _assert_conforms(resp, "/monitoring/builds", "GET")
+
+    def test_monitoring_builds_400_bad_window(self, tmp_path: Path) -> None:
+        resp = dispatch(
+            _conform_service(tmp_path), "GET", "/monitoring/builds", None, query="window=7d"
+        )
+        assert resp.status_code == 400
+        _assert_conforms(resp, "/monitoring/builds", "GET")
+
+    def test_monitoring_builds_400_bad_bucket(self, tmp_path: Path) -> None:
+        resp = dispatch(
+            _conform_service(tmp_path), "GET", "/monitoring/builds", None, query="bucket=day"
+        )
+        assert resp.status_code == 400
+        _assert_conforms(resp, "/monitoring/builds", "GET")

--- a/uv.lock
+++ b/uv.lock
@@ -739,7 +739,7 @@ dependencies = [
 requires-dist = [
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.2,<2" },
     { name = "httpx", specifier = ">=0.27,<1" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1,<3" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1,<2" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5,<10" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10,<3" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.2,<3" },


### PR DESCRIPTION
## 요약
#516 최종 점검 — "Builder API Healthy/Degraded"가 명시돼 있었지만 구현에는
sample_count/p95만 있고 aggregate 판정이 빠져 있던 1건을 보완합니다.

## 변경 사항
- `monitoring.aggregate_status()` 추가: required subsystem
  (api/queue/workers/artifact_store) availability가 모두 `available`이면
  `healthy`, 하나라도 `partial`/`unavailable`이면 `degraded`.
- `MonitoringSummaryResponse.status: healthy | degraded` 추가 (OpenAPI 1.10.0
  유지, 신규 minor bump 없음).
- API_CONTRACT.md에 판정 규칙 문서화.

## 의도적으로 하지 않은 것
- latency SLA threshold(p95 100ms/500ms/1s 등) 미발명 — 근거(ADR/config) 없음.
- Provider status는 optional이라 판정에서 제외.
- `sample_count=0`/`p95_latency_ms=null`, `queue`/`workers`의 실제 0건 자체를
  degraded 근거로 사용하지 않음(availability만 본다).
- #516의 기존 구현(build_statistics, ownership 필터링 등)은 변경 없음.

## 테스트
- `TestAggregateStatus` 신설: all available→healthy, queue/workers 실제
  0→healthy, artifact unavailable→degraded, required subsystem
  partial/unavailable→degraded, provider 미포함 확인, sample_count=0/p95=null
  +나머지 available→healthy.
- dispatch 레벨 2건 추가 (healthy 기본 경로, artifact_store 쿼리 실패 시
  degraded).
- 기존 OpenAPI conformance 테스트가 신규 `status` 필드 포함 응답에도 통과.

## 검증
- `uv run ruff check .` ✅
- `uv run ruff format --check .` ✅
- `uv run mypy src` ✅
- `uv run pytest` — 1166 passed / 7 failed (전부 이번 변경과 무관한 기존
  Windows 환경 이슈: symlink 권한 `WinError 1314`, tzdata 미설치로 인한
  `ZoneInfoNotFoundError`). `test_monitoring.py`+`test_service_contract.py`만
  따로 실행 시 131/131 통과.
- `git diff --check` ✅