### PR TITLE
perf: /query 기동·엔진 시간 분리와 워커 예산 문서화 (#523, #524)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ ADR 0006). 설정은 환경변수로 주입합니다 — `docker-entrypoint.sh`�
 | `KPUBDATA_BUILDER_HOST` | 바인딩 호스트 | `0.0.0.0` | 선택 |
 | `KPUBDATA_BUILDER_DEV_MODE` | `true`/`1`이면 API 키 없이 기동 (로컬 개발 전용) | 미설정 | 선택 |
 | `KPUBDATA_BUILDER_MAX_WORKERS` | 동시 요청 스레드 상한 | `10` | 선택 |
+| `KPUBDATA_QUERY_MAX_CONCURRENCY` | 동시 query child process 상한 | `2` | 선택 |
 | `KPUBDATA_BUILDER_ALLOWED_ORIGINS` | CORS 허용 오리진 (콤마 구분, default-deny) | 미설정 | 선택 |
 | `KPUBDATA_BUILDER_CREDENTIAL_MASTER_KEY` | 사용자별 Provider credential AES-GCM master key (URL-safe base64 32 bytes) | 미설정 | credential CRUD 사용 시 필수 |
 | `KPUBDATA_BUILDER_PROVIDER_TEST_TIMEOUT` | Provider connection test 전송 timeout(초) | `10` | 선택 |
@@ -220,6 +221,9 @@ ADR 0006). 설정은 환경변수로 주입합니다 — `docker-entrypoint.sh`�
 > 거부합니다. `service/app.py`의 "키 미설정 = 인증 생략" 동작은 로컬 개발 편의 전용이며
 > 컨테이너로 누출되지 않습니다. 로컬에서 인증 없이 띄우려면 `KPUBDATA_BUILDER_DEV_MODE=1`을
 > 명시하세요.
+
+HTTP, 비동기 build, query의 서로 다른 동시성 상한과 리소스 산정 방법은
+[배포 가이드의 동시성·백프레셔 절](./docs/deploy.md#8-동시성풀백프레셔)을 참고하세요.
 
 ```bash
 # 이미지 빌드

--- a/contract/builder-api.yaml
+++ b/contract/builder-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: KPubData Builder Service API
-  version: "1.8.0"
+  version: "1.9.0"
   description: >-
     Builder 중심 서비스 계약. BuildSpec 검증, preview, build 실행, artifact 조회,
     계약 버전 조회를 제공한다. CLI와 HTTP service mode(#36)가 동일한 도메인 계약을
@@ -17,7 +17,8 @@ info:
     `evaluated_checks`를 함께 반환해 "0건 평가"와 "애초에 계산된 적 없음"을
     구분한다(#514, additive). v1.7.0은 Silver/Gold read-only `/query`를
     추가한다(#504, additive). v1.8.0은 stable principal별 encrypted Provider
-    credential CRUD와 Provider status/test API를 추가한다(#492, additive).
+    credential CRUD와 Provider status/test API를 추가한다(#492, additive). v1.9.0은
+    `/query` 응답에 child startup과 Polars engine 실행 시간을 추가한다(#523, additive).
 servers:
   - url: http://localhost:8000
     description: 로컬 builder 개발 서버
@@ -836,7 +837,7 @@ components:
     QueryResponse:
       type: object
       additionalProperties: false
-      required: [columns, rows, truncated, execution_ms]
+      required: [columns, rows, truncated, execution_ms, startup_ms, engine_execution_ms]
       properties:
         columns:
           type: array
@@ -848,7 +849,24 @@ components:
             additionalProperties:
               $ref: "#/components/schemas/JsonValue"
         truncated: {type: boolean}
-        execution_ms: {type: integer, minimum: 0}
+        execution_ms:
+          type: integer
+          minimum: 0
+          description: >-
+            QueryEngine.execute 진입부터 child payload 수신·검증과 child join까지의
+            parent end-to-end monotonic wall time(ms). 기존 필드 의미를 유지한다.
+        startup_ms:
+          type: integer
+          minimum: 0
+          description: >-
+            Parent의 QueryEngine.execute 진입부터 spawned child가 Polars import와 bounded
+            SQL setup을 끝내고 scan_parquet를 시작하기 직전까지의 monotonic time(ms).
+        engine_execution_ms:
+          type: integer
+          minimum: 0
+          description: >-
+            Child에서 scan_parquet 직전부터 SQLContext 생성, execute, collect 완료
+            직후까지의 Polars engine monotonic time(ms).
 
     ValidationError:
       type: object

--- a/docs/adrs/0008-async-build-job-model.md
+++ b/docs/adrs/0008-async-build-job-model.md
@@ -6,6 +6,11 @@
 
 > 본 ADR은 ADR 0002에서 "시맨틱을 완비한 뒤 별도 후속에서 구현"으로 연기한 **비동기 job 실행 모델**의 설계를 다룬다. v0.4 범위 밖이며, 승인 후 구현 이슈로 분해된다.
 
+> **현재 구현 주의**: 제안 이후 process-local `AsyncBuildExecutor`(worker 10, queued job
+> 10)와 active registry가 일부 구현되었다. 이는 본 ADR을 승인됨으로 전환하지 않는다.
+> 취소, queue 영속성, crash recovery, partial manifest 규약은 여전히 미해결이며 운영 시
+> [배포 가이드](../deploy.md#8-동시성풀백프레셔)의 제한을 따른다.
+
 ## 결정 필요 사항 (이슈 #334)
 
 1. 상태 머신 확정(`queued → running → succeeded | failed`, `+ cancelled`).
@@ -20,6 +25,10 @@ ADR 0002는 v0.4에서 **동기 `POST /build`만** 유지하기로 결정했다.
 
 현재 실행 인프라:
 - `service/http.py`의 `BoundedThreadingHTTPServer`(#253)가 동시성 상한을 갖는다.
+- HTTP pool과 별도로 `service/jobs.py`의 in-process async build pool이 실행되며, bounded
+  queued-job 수를 넘는 제출은 `429`로 거절한다.
+- `/query`는 별도 semaphore로 동시 spawned child process 수를 제한한다. 이 permit은 build
+  worker나 HTTP worker를 예약하지 않는다.
 - `store/build_index.py`(ADR 0003)는 **완료된 빌드의 파생 인덱스**다. 빌드 진행 중에는 `manifest.json`이 없으므로 이 인덱스로 `queued`/`running`을 표현하지 않는다(ADR 0003 §2).
 - `run_id`는 현재 클라이언트 지정 가능(`validate_path_segment`로 경로 안전성 검증).
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -65,9 +65,86 @@ Builder HTTP 서비스를 로컬 개발 이상으로 운영하기 위한 배포�
 - `Dockerfile` `HEALTHCHECK` — urllib로 `/healthz` 폴링 (#372).
 - `SIGTERM` — 우아운 종료(진행 중 요청 drain, #374). ACA/K8s 롤링 업데이트 대응.
 
+## 8. 동시성·풀·백프레셔
+
+단일 Builder process 안에는 역할이 다른 실행 제한이 세 개 있다. 숫자가 같더라도 하나의
+공유 pool이 아니며 서로 대신하지 않는다.
+
+| 계층 | 구현 | 기본값 | 포화 시 동작 |
+| :--- | :--- | :--- | :--- |
+| HTTP 요청 | 별도 `ThreadPoolExecutor` (`kpubdata-http`) | service 기본 10, ACA template 4 | executor의 무제한 내부 queue에서 대기. 명시적 `429`가 아니므로 앞단 ingress timeout/connection limit가 필요 |
+| 비동기 build | 별도 in-process `ThreadPoolExecutor` (`kpubdata-build`) | CLI가 HTTP와 같은 worker 설정 사용(service 기본 10, ACA 4), queued job 10 | queued 상태가 10건이면 제출을 `429`로 거절. 실행 중 job은 queue 수에 포함하지 않음 |
+| query | `BoundedSemaphore` + 요청마다 `spawn` child process | service 기본 2, ACA template 1 | permit을 기다리지 않고 즉시 `429 query_busy`; 성공·실패 후 permit 반환 |
+
+`POST /build`는 동기식이므로 전체 pipeline이 끝날 때까지 HTTP worker 하나를 점유한다.
+`POST /query`도 child process의 결과 또는 timeout을 기다리는 동안 HTTP worker 하나를
+점유한다. 반면 비동기 `POST /builds`의 HTTP worker 점유는 queue 제출까지로 짧고, 실제
+build는 별도 build pool에서 실행된다. 따라서 query semaphore가 남아 있어도 모든 HTTP
+worker가 동기 build/query에 묶이면 새 요청은 HTTP executor queue에서 기다린다.
+
+HTTP executor queue에는 길이 제한이 없다. 외부 ingress에서 요청 수, body 크기, idle/request
+timeout을 제한하고, 장시간 동기 호출의 클라이언트 timeout을 서버 query timeout보다 길게
+잡는다. 비동기 build queue의 검사는 process-local이므로 단일 replica 전제와 결합되며,
+재시작하면 대기/실행 상태를 복구하지 못한다.
+
+ADR 0008은 여전히 **제안됨(Proposed)** 상태다. 현재 비동기 build pool과 active registry는
+그 ADR의 일부 방향만 선행 구현한 것이며, 취소, persistent queue, crash recovery, partial
+manifest 정책까지 승인·완료됐다는 뜻이 아니다.
+
+## 9. 리소스 예산과 튜닝
+
+최소 메모리 예산은 다음 항목을 실측해 합산한다.
+
+```text
+memory >= base process
+        + HTTP_workers * per_HTTP_thread
+        + active_build_workers * per_build_working_set
+        + query_concurrency * (per_Polars_child + 최대 8 MiB IPC payload)
+        + filesystem/cache headroom
+```
+
+CPU 수요는 대략 `active_build_workers * build_CPU` +
+`query_concurrency * Polars_child_CPU` + HTTP overhead다. Polars child 하나도 내부적으로 여러
+thread를 사용할 수 있으므로 `query_concurrency`를 vCPU 수처럼 간주하면 안 된다. 작은 ACA
+인스턴스는 `infra/main.bicep` 기본값인 1 vCPU/2 GiB, HTTP worker 4, async build worker 4,
+query concurrency 1에서 시작한다. HTTP와 build는 같은 설정값을 받지만 서로 다른 pool이라
+동시에 각각 4개까지 실행될 수 있다. 따라서 CPU/memory 중심 build를 많이 제출하는 환경에서는
+이 기본 ACA 크기만으로 안전하다고 가정하지 말고 working set과 throttling을 관찰해야 한다.
+
+query timing은 다음 경계를 사용한다.
+
+- `execution_ms`: parent의 `QueryEngine.execute` 진입부터 payload 수신·검증과 child join까지.
+- `startup_ms`: 같은 parent 시작점부터 spawned child의 Polars import와 bounded SQL setup 완료,
+  `scan_parquet` 직전까지.
+- `engine_execution_ms`: child의 `scan_parquet` 직전부터 SQL context/execute/collect 완료까지.
+- 구조화 로그의 `ipc_serialization_ms`: 위 두 child 구간을 end-to-end에서 뺀 nonnegative
+  remainder. row 변환, JSON 크기 확인, Pipe 직렬화/전송, scheduling, join과 ms 반올림을
+  포함하므로 세 필드가 정확히 합산된다고 가정하지 않는다.
+
+고정 성능 threshold를 CI에 두지 않는다. 실제 배포와 같은 CPU/memory에서 동일 parquet와
+canonical SQL을 준비하고, cold query(새 child)와 warm filesystem-cache query를 각각 30회
+실행한다. 첫 실행을 별도로 보존하고 세 timing의 p50/p95, RSS, CPU throttling, `429` 비율을
+함께 기록한 뒤 concurrency를 한 단계씩 올린다. 데이터, image digest, ACA SKU, 반복 횟수를
+결과와 함께 남겨야 비교 가능하다.
+
+## 10. Process 격리 선택
+
+query는 의도적으로 `spawn`을 사용한다. thread가 이미 실행 중인 service process를 `fork`하면
+다른 thread가 잡은 lock, logging/runtime 상태, Polars native thread-pool 상태를 child가
+불완전하게 상속할 수 있다. startup이 짧아 보인다는 이유로 `fork`로 바꾸는 것은 안전한
+대체가 아니다.
+
+장기적으로 pre-spawn query worker pool을 두면 import startup과 process 생성 비용을 줄일 수
+있지만, worker별 메모리가 상시 필요하고 손상된 native state/사용자 query 간 상태 격리,
+timeout 시 worker 교체, queue 공정성, 배포 drain을 새로 설계해야 한다. 현재 per-query child는
+startup 비용 대신 강한 취소·수명 격리를 선택한다. 비동기 build pool을 별도 process/service로
+분리하면 HTTP process 장애와 GIL/메모리 경쟁을 줄이지만 외부 queue, 상태 영속성, credential
+전달 신뢰경계와 운영 복잡도가 증가한다. 이 tradeoff는 ADR 0008 승인 과정에서 결정한다.
+
 ## 관련
 
 - [ADR 0006](./adrs/0006-service-auth-and-deployment.md) — 인증·배포(fail-closed, Docker)
 - ADR 0009(PR #398) — 사용자 인증(Google OIDC, 제안됨)
 - ADR 0010(PR #399) — 상태 백엔드 분리(제안됨)
+- [ADR 0008](./adrs/0008-async-build-job-model.md) — 비동기 build job 모델(제안됨)
 - [API_CONTRACT.md](./API_CONTRACT.md) — `/healthz`, 401/403/503 응답

--- a/infra/README.md
+++ b/infra/README.md
@@ -21,8 +21,18 @@ az deployment group create \
   --parameters \
     imageName=ghcr.io/yeongseon/kpubdata-builder:latest \
     apiKey=$(az keyvault secret show --vault-name <kv> --name builder-api-key --query value -o tsv) \
-    allowedOrigins=https://studio.example.com
+    allowedOrigins=https://studio.example.com \
+    containerCpu=1.0 \
+    containerMemory=2Gi \
+    builderMaxWorkers=4 \
+    queryMaxConcurrency=1
 ```
+
+`main.bicep`의 보수적 기본값은 단일 replica에 `1.0` vCPU/`2Gi`, HTTP worker 4개,
+query child 1개다. 애플리케이션 자체 기본값(HTTP 10, query 2)보다 작게 명시하여 작은
+ACA 인스턴스의 process/thread 과다 경쟁을 피한다. 비동기 build pool은 현재 코드 기본값
+10개로 고정되어 있으며 이 Bicep parameter의 영향을 받지 않는다. 산정과 튜닝 절차는
+[`docs/deploy.md`](../docs/deploy.md#9-리소스-예산과-튜닝)를 따른다.
 
 ## 리소스
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -34,6 +34,32 @@ param storageAccountName string = 'kpubdatabuilder'
 @description('Allowed CORS origins (comma-separated).')
 param allowedOrigins string = ''
 
+@description('ACA CPU cores assigned to the single Builder replica.')
+@allowed([
+  '0.5'
+  '1.0'
+  '1.5'
+  '2.0'
+])
+param containerCpu string = '1.0'
+
+@description('ACA memory assigned to the single Builder replica.')
+@allowed([
+  '1Gi'
+  '2Gi'
+  '3Gi'
+  '4Gi'
+])
+param containerMemory string = '2Gi'
+
+@description('KPUBDATA_BUILDER_MAX_WORKERS: maximum concurrent HTTP request threads.')
+@minValue(1)
+param builderMaxWorkers int = 4
+
+@description('KPUBDATA_QUERY_MAX_CONCURRENCY: maximum spawned query child processes.')
+@minValue(1)
+param queryMaxConcurrency int = 1
+
 @description('Location for all resources.')
 param location string = resourceGroup().location
 
@@ -50,8 +76,13 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
   }
 }
 
-resource fileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2023-05-01' = {
+resource fileService 'Microsoft.Storage/storageAccounts/fileServices@2023-05-01' = {
   parent: storageAccount
+  name: 'default'
+}
+
+resource fileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2023-05-01' = {
+  parent: fileService
   name: azureFilesShareName
   properties: {
     shareQuota: 50
@@ -129,7 +160,19 @@ resource containerApp 'Microsoft.App/containerApps@2023-05-01' = {
               name: 'KPUBDATA_BUILDER_ALLOWED_ORIGINS'
               value: allowedOrigins
             }
+            {
+              name: 'KPUBDATA_BUILDER_MAX_WORKERS'
+              value: string(builderMaxWorkers)
+            }
+            {
+              name: 'KPUBDATA_QUERY_MAX_CONCURRENCY'
+              value: string(queryMaxConcurrency)
+            }
           ]
+          resources: {
+            cpu: json(containerCpu)
+            memory: containerMemory
+          }
           volumeMounts: [
             {
               volumeName: 'data'

--- a/src/kpubdata_builder/query/engine.py
+++ b/src/kpubdata_builder/query/engine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import math
 import multiprocessing
 import time
@@ -18,6 +19,8 @@ from typing import cast
 
 from ..spec import JsonValue
 from .models import QueryResult
+
+logger = logging.getLogger(__name__)
 
 
 class QueryExecutionError(RuntimeError):
@@ -49,14 +52,36 @@ def _json_value(value: object) -> JsonValue:
     return str(value)
 
 
-def _query_worker(connection: Connection, table_path: str, canonical_sql: str, limit: int) -> None:
+def _elapsed_ms(started_ns: int, ended_ns: int | None = None) -> int:
+    end = time.monotonic_ns() if ended_ns is None else ended_ns
+    return max(0, (end - started_ns) // 1_000_000)
+
+
+def _timing_from_payload(payload: dict[object, object], field: str) -> int:
+    value = payload.get(field)
+    if type(value) is not int or value < 0:
+        raise QueryExecutionError("query returned invalid timing data")
+    return value
+
+
+def _query_worker(
+    connection: Connection,
+    table_path: str,
+    canonical_sql: str,
+    limit: int,
+    parent_started_ns: int,
+) -> None:
     try:
         import polars as pl
 
+        bounded_sql = f"SELECT * FROM ({canonical_sql}) AS _kpubdata_result LIMIT {limit + 1}"
+        # Startup ends after spawn, Polars import, and query setup, immediately before scanning.
+        startup_ms = _elapsed_ms(parent_started_ns)
+        engine_started_ns = time.monotonic_ns()
         frame = pl.scan_parquet(table_path)
         context = pl.SQLContext({"dataset": frame}, eager=False, register_globals=False)
-        bounded_sql = f"SELECT * FROM ({canonical_sql}) AS _kpubdata_result LIMIT {limit + 1}"
         result = context.execute(bounded_sql).collect()
+        engine_execution_ms = _elapsed_ms(engine_started_ns)
         rows = [
             {str(key): _json_value(value) for key, value in row.items()}
             for row in result.to_dicts()
@@ -66,6 +91,8 @@ def _query_worker(connection: Connection, table_path: str, canonical_sql: str, l
             "columns": list(result.columns),
             "rows": rows[:limit],
             "truncated": len(rows) > limit,
+            "startup_ms": startup_ms,
+            "engine_execution_ms": engine_execution_ms,
         }
         if len(json.dumps(payload, ensure_ascii=False).encode("utf-8")) > MAX_QUERY_RESPONSE_BYTES:
             connection.send({"ok": False})
@@ -85,18 +112,18 @@ class QueryEngine:
         self,
         *,
         timeout_seconds: float = 10.0,
-        worker: Callable[[Connection, str, str, int], None] = _query_worker,
+        worker: Callable[[Connection, str, str, int, int], None] = _query_worker,
     ) -> None:
         self._timeout_seconds = timeout_seconds
         self._worker = worker
 
     def execute(self, table_path: Path, canonical_sql: str, *, limit: int) -> QueryResult:
-        started = time.monotonic()
+        started_ns = time.monotonic_ns()
         context = multiprocessing.get_context("spawn")
         parent, child = context.Pipe(duplex=False)
         process = context.Process(
             target=self._worker,
-            args=(child, str(table_path), canonical_sql, limit),
+            args=(child, str(table_path), canonical_sql, limit, started_ns),
             daemon=True,
         )
         process_started = False
@@ -125,13 +152,31 @@ class QueryEngine:
                 or not isinstance(truncated, bool)
             ):
                 raise QueryExecutionError("query returned an invalid result")
-            elapsed_ms = max(0, int((time.monotonic() - started) * 1000))
-            return QueryResult(
+            startup_ms = _timing_from_payload(payload, "startup_ms")
+            engine_execution_ms = _timing_from_payload(payload, "engine_execution_ms")
+            execution_ms = _elapsed_ms(started_ns)
+            result = QueryResult(
                 columns=tuple(str(column) for column in columns),
                 rows=tuple(cast(dict[str, JsonValue], row) for row in rows),
                 truncated=truncated,
-                execution_ms=elapsed_ms,
+                execution_ms=execution_ms,
+                startup_ms=startup_ms,
+                engine_execution_ms=engine_execution_ms,
             )
+            logger.info(
+                "query timing",
+                extra={
+                    "event": "query_timing",
+                    "execution_ms": execution_ms,
+                    "startup_ms": startup_ms,
+                    "engine_execution_ms": engine_execution_ms,
+                    "ipc_serialization_ms": max(0, execution_ms - startup_ms - engine_execution_ms),
+                    "row_count": len(result.rows),
+                    "column_count": len(result.columns),
+                    "truncated": result.truncated,
+                },
+            )
+            return result
         finally:
             child.close()
             parent.close()

--- a/src/kpubdata_builder/query/models.py
+++ b/src/kpubdata_builder/query/models.py
@@ -26,6 +26,8 @@ class QueryResult:
     rows: tuple[dict[str, JsonValue], ...]
     truncated: bool
     execution_ms: int
+    startup_ms: int
+    engine_execution_ms: int
 
 
 __all__ = ["QueryRequest", "QueryResult", "QueryStage"]

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -237,7 +237,8 @@ def _strip_internal_fields(entries: list[_BuildListEntry]) -> list[_BuildListEnt
 # 1.4.0 -> 1.5.0: Dataset Catalog·Detail·Stage Summary API 추가 (#488, additive).
 # 1.5.0 -> 1.6.0: 구조화된 Quality/Schema Drift 결과, quality history/detail API 추가
 # (#486, additive — 기존 엔드포인트는 변경되지 않는다).
-API_CONTRACT_VERSION = "1.8.0"
+# 1.8.0 -> 1.9.0: query startup/engine timing fields 추가 (#523, additive).
+API_CONTRACT_VERSION = "1.9.0"
 
 
 @dataclass(frozen=True)
@@ -537,6 +538,8 @@ class BuilderService:
                 "rows": list(result.rows),
                 "truncated": result.truncated,
                 "execution_ms": result.execution_ms,
+                "startup_ms": result.startup_ms,
+                "engine_execution_ms": result.engine_execution_ms,
             },
         )
 

--- a/tests/unit/test_query_api.py
+++ b/tests/unit/test_query_api.py
@@ -36,13 +36,13 @@ class _BlockingEngine:
             if self.calls == 2:
                 self.started.set()
         self.release.wait(timeout=5)
-        return QueryResult((), (), False, 1)
+        return QueryResult((), (), False, 1, 0, 0)
 
 
 class _QueryStub:
     def execute(self, table_path: Path, canonical_sql: str, *, limit: int) -> QueryResult:
         del table_path, canonical_sql, limit
-        return QueryResult(("value",), ({"value": 1},), False, 3)
+        return QueryResult(("value",), ({"value": 1},), False, 3, 1, 1)
 
 
 def _context(tmp_path: Path) -> ResolvedQueryContext:
@@ -79,6 +79,8 @@ def test_query_response_contains_only_documented_result_fields(
         "rows",
         "truncated",
         "execution_ms",
+        "startup_ms",
+        "engine_execution_ms",
     }
 
 

--- a/tests/unit/test_query_engine.py
+++ b/tests/unit/test_query_engine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import time
 from multiprocessing.connection import Connection
@@ -14,9 +15,13 @@ from kpubdata_builder.query.engine import QueryEngine, QueryExecutionError, Quer
 
 
 def _sleeping_worker(
-    connection: Connection, table_path: str, canonical_sql: str, limit: int
+    connection: Connection,
+    table_path: str,
+    canonical_sql: str,
+    limit: int,
+    parent_started_ns: int,
 ) -> None:
-    del canonical_sql, limit
+    del canonical_sql, limit, parent_started_ns
     Path(table_path).write_text(str(os.getpid()), encoding="utf-8")
     try:
         time.sleep(60)
@@ -58,21 +63,42 @@ def test_timeout_leaves_child_not_alive(tmp_path: Path) -> None:
     assert not _pid_is_alive(pid)
 
 
-def test_real_engine_executes_canonical_sql_and_hard_limit(tmp_path: Path) -> None:
+def test_real_engine_executes_canonical_sql_and_hard_limit(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     import polars as pl
 
     table_path = tmp_path / "table.parquet"
     pl.DataFrame({"value": [3, 1, 2]}).write_parquet(table_path)
+    sql = "SELECT value FROM dataset ORDER BY value"
+    caplog.set_level(logging.INFO, logger=engine_module.__name__)
 
     result = QueryEngine(timeout_seconds=5).execute(
         table_path,
-        "SELECT value FROM dataset ORDER BY value",
+        sql,
         limit=2,
     )
 
     assert result.columns == ("value",)
     assert result.rows == ({"value": 1}, {"value": 2})
     assert result.truncated is True
+    assert result.execution_ms >= 0
+    assert result.startup_ms >= 0
+    assert result.engine_execution_ms >= 0
+    timing_record = next(record for record in caplog.records if record.event == "query_timing")
+    assert timing_record.ipc_serialization_ms >= 0
+    assert sql not in timing_record.getMessage()
+    assert str(table_path) not in timing_record.getMessage()
+
+
+@pytest.mark.parametrize("value", [None, True, False, -1, 1.5, "1"])
+def test_timing_payload_requires_nonnegative_integer(value: object) -> None:
+    with pytest.raises(QueryExecutionError, match="invalid timing data"):
+        engine_module._timing_from_payload({"startup_ms": value}, "startup_ms")
+
+
+def test_timing_payload_accepts_zero() -> None:
+    assert engine_module._timing_from_payload({"startup_ms": 0}, "startup_ms") == 0
 
 
 def test_real_engine_raises_execution_error_for_unresolvable_column(tmp_path: Path) -> None:
@@ -112,8 +138,12 @@ def test_worker_rejects_result_over_response_byte_cap(
     connection = _CaptureConnection()
     monkeypatch.setattr(engine_module, "MAX_QUERY_RESPONSE_BYTES", 100)
 
-    engine_module._query_worker(  # type: ignore[arg-type]
-        connection, str(table_path), "SELECT * FROM dataset", 1
+    engine_module._query_worker(
+        connection,  # type: ignore[arg-type]
+        str(table_path),
+        "SELECT * FROM dataset",
+        1,
+        time.monotonic_ns(),
     )
 
     assert connection.payload == {"ok": False}

--- a/tests/unit/test_query_service.py
+++ b/tests/unit/test_query_service.py
@@ -30,7 +30,7 @@ class _BlockingEngine:
             if self.calls >= 2:
                 self.started.set()
         self.release.wait(timeout=5)
-        return QueryResult((), (), False, 0)
+        return QueryResult((), (), False, 0, 0, 0)
 
 
 def test_capacity_plus_one_is_rejected_without_engine_call() -> None:

--- a/tests/unit/test_service_contract.py
+++ b/tests/unit/test_service_contract.py
@@ -145,6 +145,16 @@ def test_service_api_version_matches_contract() -> None:
     assert str(_load_contract()["info"]["version"]) == API_CONTRACT_VERSION
 
 
+def test_query_response_requires_documented_nonnegative_timings() -> None:
+    schema = _load_contract()["components"]["schemas"]["QueryResponse"]
+
+    assert {"execution_ms", "startup_ms", "engine_execution_ms"} <= set(schema["required"])
+    for field in ("execution_ms", "startup_ms", "engine_execution_ms"):
+        assert schema["properties"][field]["type"] == "integer"
+        assert schema["properties"][field]["minimum"] == 0
+        assert schema["properties"][field]["description"]
+
+
 def test_build_manifest_does_not_publish_internal_owner_id() -> None:
     """persisted owner_id는 HTTP BuildManifest의 공개 property가 아니다 (#505)."""
     manifest = _load_contract()["components"]["schemas"]["BuildManifest"]


### PR DESCRIPTION
## 개요

Closes #523
Closes #524

`/query`의 기존 `execution_ms` 호환 의미를 유지하면서 spawn/Polars import 기동 시간과 실제 Polars 실행 시간을 child process에서 분리 계측합니다. 동시에 HTTP/build/query가 서로 다른 pool·semaphore·process 예산이라는 운영 모델을 문서와 ACA IaC에 반영합니다.

## Query timing

- `execution_ms`: parent `QueryEngine.execute` 전체 wall time, 기존 의미 유지
- `startup_ms`: parent 시작부터 spawned child의 Polars import 완료 및 scan 직전
- `engine_execution_ms`: scan/SQLContext/execute/collect 구간
- structured log `ipc_serialization_ms`: row 변환, IPC, scheduling, join, 반올림을 포함한 nonnegative remainder
- SQL, parquet path, credential은 timing log에 기록하지 않음
- 잘못된 child timing payload는 fail-closed

## 운영·배포

- HTTP executor, async build executor, query semaphore/process의 별도 포화 동작 문서화
- 동기 `/build`와 `/query`의 HTTP worker 점유 명시
- memory/CPU 예산식과 p50/p95 측정 절차 추가
- `fork` 비권장 및 pre-spawn pool의 격리 trade-off 명시
- ACA 기본값: 1 vCPU/2 GiB, HTTP 4, async build 4(별도 pool), query 1
- `infra/main.bicep`에 CPU/memory/worker/query parameter와 env 반영
- 기존 Azure Files Bicep parent 선언 수정
- API contract `1.9.0`

## 검증

- `uv run --frozen pytest -q`: 1071 passed
- `uv run --frozen ruff check .`: 통과
- `uv run --frozen ruff format --check .`: 181 files formatted
- `uv run --frozen mypy src`: 96 source files 통과
- Azure Bicep 0.46.1 compile: 통과

## 진행 중 PR 충돌

#526도 계약 버전을 변경할 수 있으므로 먼저 병합된 PR 이후 버전을 재산정해야 합니다. #528이 먼저 병합되면 query response wiring은 `BuilderService.query()`에 그대로 적용되고 route 변경은 필요 없습니다.