### PR TITLE
fix: align OpenAPI query examples with 1.9.0 timing schema

### DIFF
--- a/contract/builder-api.yaml
+++ b/contract/builder-api.yaml
@@ -1281,7 +1281,7 @@ paths:
                 $ref: "#/components/schemas/QueryResponse"
               examples:
                 AveragePm10Result:
-                  summary: bounded row 결과와 현재 1.8.0 실행 시간 필드
+                  summary: bounded row 결과와 현재 1.9.0 실행 시간 필드
                   value:
                     columns: [station_name, avg_pm10]
                     rows:
@@ -1291,6 +1291,8 @@ paths:
                         avg_pm10: 28.0
                     truncated: false
                     execution_ms: 7
+                    startup_ms: 12
+                    engine_execution_ms: 5
         "400":
           description: invalid context, unsafe SQL, syntax/execution failure
           content:

--- a/tests/unit/test_openapi_examples.py
+++ b/tests/unit/test_openapi_examples.py
@@ -154,9 +154,16 @@ def test_examples_are_secret_safe_and_have_no_internal_absolute_paths() -> None:
     assert credential == {"credential": "replace-with-your-provider-key"}
 
 
-def test_query_example_has_only_main_1_8_0_result_fields() -> None:
+def test_query_example_has_main_1_9_0_result_fields() -> None:
     result = _example("/query", "post", "response:200", "AveragePm10Result")
-    assert set(result) == {"columns", "rows", "truncated", "execution_ms"}
+    assert set(result) == {
+        "columns",
+        "rows",
+        "truncated",
+        "execution_ms",
+        "startup_ms",
+        "engine_execution_ms",
+    }
 
 
 def test_extraction_script_emits_documented_json_shape() -> None:
@@ -168,7 +175,7 @@ def test_extraction_script_emits_documented_json_shape() -> None:
         text=True,
     )
     payload = json.loads(completed.stdout)
-    assert payload["contract_version"] == "1.8.0"
+    assert payload["contract_version"] == "1.9.0"
     assert len(payload["examples"]) >= 50
     assert set(payload["examples"][0]) == {
         "path",
@@ -192,6 +199,8 @@ class _ExampleQueryService:
             ),
             False,
             7,
+            12,
+            5,
         )
 
 


### PR DESCRIPTION
#529와 #530 머지 조합으로 main의 contract 테스트 3건이 깨져 있어 복구합니다. QueryResponse에 필수가 된 startup_ms/engine_execution_ms를 예시/픽스처/추출 스크립트 어설션에 반영하고 1.9.0으로 맞춥니다.