### PR TITLE
feat: add Multi-source Join/Composition BuildSpec and Gold assembly (#506)

### DIFF
--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -53,6 +53,7 @@ v0.4 Builder service는 동기식 실행 모델을 유지합니다.
 | stage summary/preview | `GET /builds/{run_id}/stages`, `GET /builds/{run_id}/stages/{stage}`로 source별 Bronze/Silver/Gold 상태와 안전한 요약을 반환 |
 | structured quality/drift | `GET /builds/{run_id}/quality`로 run의 source별 `quality_results`/`schema_drift`를, `GET /datasets/{dataset_id}/quality/history`로 dataset의 run별 PASS/WARN/FAIL 집계 이력을 반환 |
 | read-only query | `POST /query`가 server-resolved Silver/Gold table을 logical `dataset`으로 등록하고 별도 capacity/timeout 안에서 실행 |
+| composition(join) | `BuildSpec.composition`이 있으면 `POST /build` 응답에 source별 `outcomes`와 별도로 `composition` 키(결합 결과)가 노출됨 |
 | 인증 실패 | `401`은 재인증 대상, `403`은 권한 요청 대상, `503`은 JWKS 일시 장애 대상 |
 
 정책과 구현이 다르면 구현 각주를 늘리지 말고 다음 순서로 정리합니다.
@@ -172,6 +173,31 @@ v0.4 Builder service는 동기식 실행 모델을 유지합니다.
   filesystem/network 접근, DML/DDL은 거부합니다.
 - query는 HTTP worker pool과 별도인 bounded capacity를 사용합니다. Query timeout은 child
   process를 실제 종료하며 429/504 오류는 안정적인 `code`로 구분됩니다.
+
+### Composition/Join (#506)
+
+- `BuildSpec.composition`은 두 source의 검증된 Silver를 join해 별도 결합 Gold
+  dataset(`gold/{composition.name}/`)을 부가로 만듭니다. source별 독립 Gold는
+  그대로 유지되며, `composition`이 없는 기존 multi-source BuildSpec은 영향받지
+  않습니다.
+- `composition.join.left`/`right`가 참조하는 source는 `alias`를 반드시 선언해야
+  하고, `composition`을 쓰는 BuildSpec 안에서는 선언된 `alias` 값이 서로
+  달라야 합니다 — 이 규칙은 `composition`이 없는 BuildSpec에는 적용되지 않습니다.
+- alias 참조·`join.type`/`join.on_duplicate_key` 어휘 같은 구조 문제는
+  `validate_spec`이 스펙 파싱 직후 거부합니다. join key 컬럼의 존재 여부와 dtype
+  일치(완전 동일만 허용, 자동 캐스팅 없음)는 두 source가 각각 Silver를 통과해야
+  알 수 있으므로 빌드 파이프라인의 런타임 게이트가 담당합니다.
+- 양쪽 join key가 모두 중복 값을 가지면(many-to-many) 결과 행이 곱셈으로
+  폭증할 수 있습니다 — 기본 `on_duplicate_key: warn`은 결과를 만들고 경고를
+  남기며, `fail`은 composition을 실패 처리합니다.
+- `POST /build` 응답의 `composition` 키는 `{name, status, error}`이며
+  `status`는 `ok`/`failed`(join 실행 자체 실패)/`skipped`(참조한 source가
+  실패해 join을 시도조차 못함) 중 하나입니다. `composition`만 실패하고 모든
+  source가 성공해도 최상위 `error` 요약은 composition의 error에서 파생됩니다.
+- `manifest.json`의 `composition`(`CompositionProvenance`, additive)에는 join
+  조건과 좌우 원본 행 수·distinct key 수·결과 행 수가 그대로 기록되어 원천과
+  join 조건을 추적할 수 있습니다. legacy manifest는 이 필드가 없거나 null이며
+  "composition 미사용 run"으로 해석해야 합니다.
 
 ### Stable Owner Identity (#505)
 

--- a/BUILD_SPEC.md
+++ b/BUILD_SPEC.md
@@ -50,6 +50,7 @@ exports:
 | `pii` | object | PII 검출 정책 |
 | `license` | string | 데이터셋 라이선스 또는 이용허락 범위 |
 | `quality` | object | Silver 통계 기반 품질 임계 정책 |
+| `composition` | object | 두 source를 join해 하나의 결합 Gold dataset을 추가로 만드는 계약 (#506) |
 
 ## 4. 필드 상세
 
@@ -334,6 +335,76 @@ WARN/FAIL 결과를 남기며, WARN은 Build를 계속하고 FAIL은 Gold 진입
 컬럼이 없어 dtype을 검사할 수 없는 경우 dtype PASS를 만들지 않습니다 — "required
 FAIL + dtype PASS" 같은 모순을 피합니다. Schema 위반은 severity 설정과 무관하게
 항상 hard failure입니다(#189의 기존 게이트 그대로).
+
+### 4.12 `composition` (optional)
+
+두 source의 검증된 Silver 테이블을 join해 하나의 결합 Gold dataset을
+추가로 만드는 계약입니다(#506). `composition` 없는 기존 multi-source
+BuildSpec은 그대로 동작합니다 — source별 독립 Gold가 회귀 없이 유지되고,
+composition은 부가 산출물로 `gold/{composition.name}/`에 추가됩니다.
+
+초기 범위는 **두 source, 단일 equi-join**으로 제한합니다. 자유형 SQL
+transformation과 3개 이상의 join graph는 지원하지 않습니다.
+
+```yaml
+sources:
+  - provider: datago
+    dataset: apt_trade
+    alias: sales
+  - provider: datago
+    dataset: region_meta
+    alias: region
+
+composition:
+  name: sales_with_region
+  join:
+    left: sales
+    right: region
+    left_key: region_id
+    right_key: id
+    type: inner
+    on_duplicate_key: warn
+```
+
+| 필드 | 타입 | 필수 | 설명 |
+| :--- | :--- | :--- | :--- |
+| `name` | string | 예 | 결합 결과 Gold dataset 이름. 다른 source의 output key(alias 또는 `provider.dataset`)와 겹칠 수 없습니다. |
+| `join` | object | 예 | 아래 join 계약 |
+| `join.left` | string | 예 | 왼쪽 source의 alias (`sources[].alias` 참조) |
+| `join.right` | string | 예 | 오른쪽 source의 alias |
+| `join.left_key` | string | 예 | 왼쪽 테이블의 join key 컬럼명 |
+| `join.right_key` | string | 예 | 오른쪽 테이블의 join key 컬럼명 |
+| `join.type` | string | 아니오 | `inner`(기본) \| `left` |
+| `join.on_duplicate_key` | string | 아니오 | `warn`(기본) \| `fail` |
+
+**alias 필수/중복 규칙**: `composition.join.left`/`right`가 참조하는 두
+source는 반드시 비어 있지 않은 `alias`를 선언해야 하며, `composition`을
+쓰는 BuildSpec에서는 선언된 모든 `sources[].alias` 값이 서로 달라야
+합니다(빈 alias는 이 유일성 검사 대상이 아닙니다). 이 규칙은 `composition`이
+없는 BuildSpec에는 적용되지 않습니다.
+
+**join key 검증 시점**: alias 참조·`type`/`on_duplicate_key` 어휘 같은
+구조적 문제는 `validate_spec`(구조 검증)이 스펙 파싱 직후 잡습니다. 하지만
+join key 컬럼의 **존재 여부와 dtype 호환성**은 두 source가 각각 Silver
+단계를 통과해야만 알 수 있으므로, 여기서는 검증할 수 없고 빌드 파이프라인의
+런타임 게이트(orchestrator, Silver 완료 직후)에서 확인해 실패시킵니다. dtype은
+완전히 동일해야 join이 허용됩니다 — 자동 캐스팅은 하지 않으며, 타입을
+맞추려면 `sources[].schema.casts`(§4.4, #437)로 Silver 단계에서 명시적으로
+정규화하세요.
+
+**duplicate-key row explosion guard**: 두 source가 동일 값으로 join key가
+모두 중복이면(many-to-many) 결과 행이 곱셈으로 폭증할 수 있습니다. 기본값
+`on_duplicate_key: warn`은 결과를 만들고 manifest에 경고와 함께 정확한 행 수/
+distinct key 수를 남기며, `fail`은 Gold 진입 전에 composition을 실패 처리합니다.
+
+**참조된 source가 실패한 경우**: `composition.join`이 참조하는 source 중
+하나라도 Bronze/Silver를 통과하지 못하면 join을 시도하지 않고
+`skipped`로 기록합니다(다른 source의 독립 Gold는 영향받지 않습니다).
+
+**provenance**: manifest의 `composition` 필드(`CompositionProvenance`)에
+join 조건(source/key/type)과 좌우 원본 행 수·distinct key 수·결과 행 수가
+그대로 기록되어 추적 가능합니다. `POST /build` 응답에도 `outcomes`(소스별)와
+별도로 `composition`(결합 결과) 키가 노출됩니다.
 
 ## 5. 검증 규칙
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@
 - ValidationError에 structured_problems 추가
 - README 인증 서술 fail-closed 정책에 맞게 수정 (#423)
 
+### 수정됨
+- `stages/_path_safety.ensure_within`이 Windows에서 여러 source를 병렬(ThreadPoolExecutor)로 빌드할 때 간헐적으로 traversal 오탐하던 버그 수정 — `root`/`target` 중 한쪽만 `Path.resolve()`의 `\\?\` 확장 프리픽스를 얻는 비대칭이 원인 (#506 조사 중 발견, composition과 무관한 기존 버그)
+
 ### 제거됨
 - .omc/state/sessions 추적 해제 (#380)
 - PLAN.md를 .github/로 이동 (#425)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.4 (Unreleased)
 
 ### 추가됨
+- **Multi-source Join/Composition (#506)**: `BuildSpec.composition`(`CompositionSpec`/`JoinSpec`)으로 두 source의 검증된 Silver를 equi-join해 결합 Gold dataset(`gold/{composition.name}/`) 생성. alias 필수/중복 검증, join key 존재/dtype 일치 런타임 게이트, duplicate-key many-to-many 폭증 warn/fail 게이트, manifest `composition`(`CompositionProvenance`, additive)과 `POST /build` 응답 `composition` 키로 결합 결과를 source별 결과와 구분해 노출. API 계약 1.11.0 → 1.12.0
 - **Built Dataset Catalog·Detail·Stage Summary API (#488)**: `GET /datasets`, `GET /datasets/{dataset_id}`, `GET /datasets/{dataset_id}/runs`로 `BuildSpec.dataset_id` 단위 grouping/latest run/run history 조회. `GET /builds/{run_id}/stages`, `GET /builds/{run_id}/stages/{stage}`로 source별 Bronze/Silver/Gold 상태와 안전한 summary/preview 조회
 - **인증 시스템 (B2-B5)**: Principal 추상화(#384), Google OIDC Bearer 검증(#385), 허용 목록 게이트(#386), API 계약 bearerAuth(#387)
 - **인가 (C1/C2)**: manifest·BuildIndex에 principal 기록(#388), ENFORCE_OWNERSHIP 플래그(#389)

--- a/contract/builder-api.yaml
+++ b/contract/builder-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: KPubData Builder Service API
-  version: "1.11.0"
+  version: "1.12.0"
   description: >-
     Builder 중심 서비스 계약. BuildSpec 검증, preview, build 실행, artifact 조회,
     계약 버전 조회를 제공한다. CLI와 HTTP service mode(#36)가 동일한 도메인 계약을
@@ -1660,6 +1660,13 @@ components:
           oneOf:
             - $ref: "#/components/schemas/QualityPolicy"
             - type: "null"
+        composition:
+          description: >-
+            두 source를 join해 하나의 결합 Gold dataset을 추가로 만드는 계약
+            (#506). None이면 기존과 동일하게 source별 독립 Gold만 생성한다.
+          oneOf:
+            - $ref: "#/components/schemas/CompositionSpec"
+            - type: "null"
 
     SourceRef:
       type: object
@@ -1829,6 +1836,53 @@ components:
           items:
             $ref: "#/components/schemas/QualityCompareColumnsRule"
           default: []
+
+    JoinSpec:
+      type: object
+      description: >-
+        두 source를 결합하는 equi-join 계약(#506). 초기 범위는 두 source
+        단일 join으로 제한한다 — 3개 이상 join graph, 자유형 SQL join
+        조건은 지원하지 않는다. left/right는 sources[].alias를 참조해야
+        하며, 참조되는 source는 alias를 반드시 선언해야 한다.
+      required: [left, right, left_key, right_key]
+      properties:
+        left:
+          type: string
+          description: 왼쪽 source의 alias (sources[].alias 참조)
+        right:
+          type: string
+          description: 오른쪽 source의 alias
+        left_key:
+          type: string
+          description: 왼쪽 테이블의 join key 컬럼명
+        right_key:
+          type: string
+          description: 오른쪽 테이블의 join key 컬럼명
+        type:
+          type: string
+          enum: [inner, left]
+          default: inner
+        on_duplicate_key:
+          type: string
+          enum: [warn, fail]
+          default: warn
+          description: >-
+            양쪽 join key가 모두 중복 값을 가져(many-to-many) 결과 행이
+            곱셈으로 폭증할 수 있을 때의 처리. warn은 경고만 남기고 결과를
+            만들고, fail은 빌드를 실패시킨다.
+
+    CompositionSpec:
+      type: object
+      description: 여러 source를 하나의 결합 Gold dataset으로 조립하는 계약(#506).
+      required: [name, join]
+      properties:
+        name:
+          type: string
+          description: >-
+            결합 결과 Gold dataset 이름. 다른 source의 output key(alias 또는
+            provider.dataset)와 겹치면 안 된다.
+        join:
+          $ref: "#/components/schemas/JoinSpec"
 
     SpecRequest:
       type: object
@@ -2406,6 +2460,11 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/BuildOutcome"
+        composition:
+          description: BuildSpec.composition이 없으면 null (#506).
+          oneOf:
+            - $ref: "#/components/schemas/CompositionOutcome"
+            - type: "null"
         manifest:
           type: string
           description: 기록된 manifest.json의 경로
@@ -2425,6 +2484,11 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/BuildOutcome"
+        composition:
+          description: BuildSpec.composition이 없으면 null (#506).
+          oneOf:
+            - $ref: "#/components/schemas/CompositionOutcome"
+            - type: "null"
         manifest:
           type: string
           description: partial 정책으로 남은 manifest.json의 경로
@@ -2432,7 +2496,10 @@ components:
           type: string
         error:
           type: string
-          description: 첫 번째 실패 outcome의 error에서 파생된 human-readable 요약 (#226)
+          description: >-
+            첫 번째 실패 outcome의 error에서 파생된 human-readable 요약
+            (#226). 모든 source가 성공하고 composition만 실패한 경우
+            composition.error에서 파생된다 (#506).
 
     ArtifactsResponse:
       type: object
@@ -2504,6 +2571,84 @@ components:
             type: array
             items:
               $ref: "#/components/schemas/SchemaDriftFinding"
+        composition:
+          description: >-
+            BuildSpec.composition으로 두 source를 join한 결과의 출처 추적
+            정보(#506, additive). composition이 없거나 실행되지 않았으면
+            null이다 — legacy manifest reader는 부재와 null을 모두
+            "composition 미사용 run"으로 해석해야 한다.
+          oneOf:
+            - $ref: "#/components/schemas/CompositionProvenance"
+            - type: "null"
+
+    CompositionProvenance:
+      type: object
+      description: composition(join) 실행 결과의 상세 출처 정보 (#506).
+      required:
+        - name
+        - left
+        - right
+        - join_type
+        - left_key
+        - right_key
+        - left_row_count
+        - left_distinct_key_count
+        - right_row_count
+        - right_distinct_key_count
+        - output_row_count
+        - duplicate_key_warning
+      properties:
+        name:
+          type: string
+        left:
+          type: string
+        right:
+          type: string
+        join_type:
+          type: string
+          enum: [inner, left]
+        left_key:
+          type: string
+        right_key:
+          type: string
+        left_row_count:
+          type: integer
+        left_distinct_key_count:
+          type: integer
+          description: 왼쪽 join key의 distinct 값 수 (null 제외)
+        right_row_count:
+          type: integer
+        right_distinct_key_count:
+          type: integer
+          description: 오른쪽 join key의 distinct 값 수 (null 제외)
+        output_row_count:
+          type: integer
+        duplicate_key_warning:
+          type: boolean
+          description: >-
+            양쪽 join key가 모두 중복 값을 가져(many-to-many) 행 폭증 위험이
+            감지됐는지 여부. 실제 처리(경고만/빌드 실패)는 JoinSpec의
+            on_duplicate_key가 결정한다 — 이 필드는 감지 여부만 기록한다.
+
+    CompositionOutcome:
+      type: object
+      description: >-
+        composition(join) 실행 결과 (#506). source별 BuildOutcome과 별도로
+        노출된다 — bronze/silver/gold stage 개념이 적용되지 않고, "combined
+        result"로 명확히 구분되어야 하기 때문이다.
+      required: [name, status, error]
+      properties:
+        name:
+          type: string
+        status:
+          type: string
+          enum: [ok, failed, skipped]
+          description: >-
+            ok(성공) / failed(join 자체 실행 실패: 키 부재·타입 불일치·명시적
+            fail 게이트) / skipped(참조한 source가 실패해 join을 시도조차
+            못함)
+        error:
+          type: [string, "null"]
 
     BuildSpecSnapshotResponse:
       type: object

--- a/docs/guides/openapi-examples.md
+++ b/docs/guides/openapi-examples.md
@@ -1,7 +1,7 @@
 # OpenAPI 예제 추출
 
 `contract/builder-api.yaml`의 각 JSON media type에는 Studio와 사람이 함께 사용할 수 있는
-named request/response example이 있다. 예제는 API 계약 `1.11.0`의 wire schema를 따르며,
+named request/response example이 있다. 예제는 API 계약 `1.12.0`의 wire schema를 따르며,
 credential 원문, 실제 secret, 내부 절대 경로를 포함하지 않는다.
 
 Studio 같은 소비자는 저장소 루트에서 다음 명령으로 예제를 단일 JSON 문서로 추출할 수 있다.

--- a/src/kpubdata_builder/manifest/__init__.py
+++ b/src/kpubdata_builder/manifest/__init__.py
@@ -11,6 +11,7 @@
 
 from __future__ import annotations
 
+from .composition import CompositionProvenance
 from .environment import BuildEnvironment, capture_build_environment
 from .models import MANIFEST_SCHEMA_VERSION, BuildManifest
 from .provenance import (
@@ -26,6 +27,7 @@ __all__ = [
     "MANIFEST_SCHEMA_VERSION",
     "BuildEnvironment",
     "BuildManifest",
+    "CompositionProvenance",
     "FieldSummary",
     "SchemaSummary",
     "SourceProvenance",

--- a/src/kpubdata_builder/manifest/composition.py
+++ b/src/kpubdata_builder/manifest/composition.py
@@ -1,0 +1,53 @@
+"""빌드 매니페스트용 composition(join) provenance 모델 (#506).
+
+CompositionSpec/JoinSpec으로 두 source를 결합한 결과의 출처 추적 정보를 담는다.
+duplicate key로 인한 explosion 위험은 사전 계산된 비율이 아니라 원본 행 수/distinct
+키 수를 그대로 남긴다 — auditor가 스스로 재계산/검증할 수 있게 하기 위함이다
+(임의 요약값으로 근거를 감추지 않는다는 이 저장소의 기존 provenance 원칙과 동일).
+
+주요 구성:
+    - CompositionProvenance: composition 결과의 출처 스냅샷
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CompositionProvenance:
+    """composition(join) 실행 결과의 상세 출처 정보.
+
+    속성:
+        name: 결합 Gold dataset 이름 (CompositionSpec.name).
+        left: 왼쪽 source의 output key(alias).
+        right: 오른쪽 source의 output key(alias).
+        join_type: "inner" | "left".
+        left_key: 왼쪽 join key 컬럼명.
+        right_key: 오른쪽 join key 컬럼명.
+        left_row_count: 왼쪽 Silver 테이블 행 수.
+        left_distinct_key_count: 왼쪽 join key 컬럼의 distinct 값 수 (null 제외).
+        right_row_count: 오른쪽 Silver 테이블 행 수.
+        right_distinct_key_count: 오른쪽 join key 컬럼의 distinct 값 수 (null 제외).
+        output_row_count: join 결과 행 수.
+        duplicate_key_warning: 양쪽 join key 모두 중복 값을 가져(many-to-many) 행
+            폭증 위험이 감지됐는지 여부. 감지 시 실제 처리(경고만 남길지, 빌드를
+            실패시킬지)는 JoinSpec.on_duplicate_key가 결정한다 — 이 필드는 감지
+            여부만 기록한다.
+    """
+
+    name: str
+    left: str
+    right: str
+    join_type: str
+    left_key: str
+    right_key: str
+    left_row_count: int
+    left_distinct_key_count: int
+    right_row_count: int
+    right_distinct_key_count: int
+    output_row_count: int
+    duplicate_key_warning: bool
+
+
+__all__ = ["CompositionProvenance"]

--- a/src/kpubdata_builder/manifest/models.py
+++ b/src/kpubdata_builder/manifest/models.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 
 from ..quality.models import QualityCheckResult, SchemaDriftFinding
+from .composition import CompositionProvenance
 from .environment import BuildEnvironment
 from .provenance import SourceProvenance
 from .schema_summary import SchemaSummary
@@ -56,6 +57,10 @@ class BuildManifest:
         schema_drift: source_key별 구조화된 SchemaDriftFinding 목록 (#486, additive).
             drift 자체는 deterministic 감지 결과이며 PASS/WARN/FAIL 게이트에는
             관여하지 않는다.
+        composition: BuildSpec.composition으로 두 source를 join한 결과의 출처
+            추적 정보 (#506, additive). composition이 없거나 실행되지 않았으면
+            None이다 — legacy manifest reader는 이 필드가 없거나 null이면
+            "composition 미사용 run"으로 해석해야 한다.
     """
 
     build_id: str
@@ -75,6 +80,7 @@ class BuildManifest:
     owner_id: str | None = None
     quality_results: dict[str, tuple[QualityCheckResult, ...]] = field(default_factory=dict)
     schema_drift: dict[str, tuple[SchemaDriftFinding, ...]] = field(default_factory=dict)
+    composition: CompositionProvenance | None = None
 
 
 __all__ = ["MANIFEST_SCHEMA_VERSION", "BuildManifest"]

--- a/src/kpubdata_builder/manifest/writer.py
+++ b/src/kpubdata_builder/manifest/writer.py
@@ -61,6 +61,9 @@ def manifest_writer(manifest: BuildManifest, output_path: Path) -> None:
         "schema_drift": {
             key: [asdict(f) for f in findings] for key, findings in manifest.schema_drift.items()
         },
+        # additive (#506): composition(join) 실행 결과의 출처. composition 미사용
+        # run은 null이다 — legacy 소비자가 이 키를 몰라도 무해하다.
+        "composition": asdict(manifest.composition) if manifest.composition is not None else None,
     }
     serialized = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
     try:

--- a/src/kpubdata_builder/pipeline/__init__.py
+++ b/src/kpubdata_builder/pipeline/__init__.py
@@ -16,7 +16,7 @@ Bronze → Silver → Gold → (Export) → Manifest 흐름을 묶는 orchestrat
 from __future__ import annotations
 
 from .context import BuildContext
-from .orchestrator import BuildResult, SourceBuildOutcome, run_build
+from .orchestrator import BuildResult, CompositionOutcome, SourceBuildOutcome, run_build
 from .preview import (
     DEFAULT_PREVIEW_SEED,
     MAX_PREVIEW_DIFF_ITEMS,
@@ -33,6 +33,7 @@ __all__ = [
     "MAX_PREVIEW_DIFF_ITEMS",
     "BuildContext",
     "BuildResult",
+    "CompositionOutcome",
     "PreviewDiffItem",
     "PreviewResult",
     "PreviewTransformSummary",

--- a/src/kpubdata_builder/pipeline/export.py
+++ b/src/kpubdata_builder/pipeline/export.py
@@ -16,7 +16,7 @@ def export_gold_package(package: GoldPackage, *, output_dir: Path) -> tuple[Path
         records=tuple(_json_record(row) for row in package.table.to_dicts()),
         schema={name: str(dtype) for name, dtype in package.table.schema.items()},
         metadata=package.metadata,
-        provenance=(package.source_silver,),
+        provenance=package.source_refs if package.source_refs else (package.source_silver,),
         statistics={"row_count": package.table.height},
     )
     return tuple(

--- a/src/kpubdata_builder/pipeline/orchestrator.py
+++ b/src/kpubdata_builder/pipeline/orchestrator.py
@@ -6,8 +6,14 @@ BuildSpec의 각 소스를 Bronze → Silver → Gold 순서로 실행하고, �
 부분 성공 정책(BUILD_STATE.md): 소스 중 하나라도 실패하면 전체 상태는 failed로
 기록하되, 성공한 소스의 산출물과 실패 정보를 매니페스트에 함께 남긴다.
 
+BuildSpec.composition이 있으면(#506) 모든 source가 Bronze/Silver/Gold를 마친 뒤,
+composition이 참조하는 두 source의 검증된 Silver를 join해 별도 결합 Gold
+dataset(gold/{composition.name}/)을 추가로 만든다. 기존 source별 독립 Gold는
+그대로 유지된다 — composition은 부가 산출물이지 대체가 아니다.
+
 주요 구성:
     - SourceBuildOutcome: 소스별 실행 결과
+    - CompositionOutcome: composition(join) 실행 결과 (#506)
     - BuildResult: 전체 실행 결과
     - run_build: 파이프라인 진입점
 """
@@ -15,7 +21,7 @@ BuildSpec의 각 소스를 Bronze → Silver → Gold 순서로 실행하고, �
 from __future__ import annotations
 
 import logging
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
@@ -25,6 +31,7 @@ from ..errors import DatasetValidationError, ValidationError
 from ..exporters import get_exporter
 from ..manifest import (
     BuildManifest,
+    CompositionProvenance,
     SchemaSummary,
     SourceProvenance,
     build_schema_summary,
@@ -34,18 +41,22 @@ from ..manifest import (
     manifest_writer,
 )
 from ..quality import QualityCheckResult, SchemaDriftFinding, evaluate_quality
-from ..spec import BuildSpec, ExportTarget, SourceRef, write_buildspec_snapshot
+from ..spec import BuildSpec, CompositionSpec, ExportTarget, SourceRef, write_buildspec_snapshot
 from ..spec.validator import validate_spec
 from ..stages.bronze.build import SourceClient, build_bronze_artifact
 from ..stages.bronze.models import BronzeArtifact, utc_now
 from ..stages.bronze.persist import persist_bronze_artifact
 from ..stages.gold.build import build_gold_package
 from ..stages.gold.card import build_dataset_card, render_dataset_card
+from ..stages.gold.compose import CompositionError, build_composed_gold_package
 from ..stages.gold.persist import persist_gold_package
 from ..stages.silver.build import build_silver_dataset
 from ..stages.silver.drift import DriftFinding, detect_drift, find_previous_silver
+from ..stages.silver.models import SilverDataset
 from ..stages.silver.persist import persist_silver_dataset
 from ..stages.silver.pii import scan_pii
+from ..stages.silver.summarize import build_schema
+from ..tabular import DEFAULT_PREVIEW_LIMIT
 from .context import BuildContext
 from .export import export_gold_package
 
@@ -95,6 +106,26 @@ class SourceBuildOutcome:
 
 
 @dataclass(frozen=True)
+class CompositionOutcome:
+    """composition(join) 실행 결과 (#506).
+
+    SourceBuildOutcome과 별도 타입으로 둔다 — composition에는 bronze/silver/gold
+    stage 개념이 적용되지 않고(두 source의 Silver를 결합할 뿐), manifest에서도
+    "combined result"로 명확히 구분되어야 하기 때문이다.
+
+    속성:
+        name: 결합 Gold dataset 이름 (CompositionSpec.name).
+        status: "ok" | "failed"(join 자체 실행 실패) | "skipped"(참조한 source가
+            실패해 join을 시도조차 못함).
+        error: 실패/스킵 사유.
+    """
+
+    name: str
+    status: str
+    error: str | None = None
+
+
+@dataclass(frozen=True)
 class BuildResult:
     """전체 빌드 실행 결과.
 
@@ -103,6 +134,8 @@ class BuildResult:
         status: 전체 상태 ("ok" 또는 "failed").
         outcomes: 소스별 실행 결과.
         manifest_path: 기록된 빌드 매니페스트 경로.
+        composition_outcome: composition 실행 결과. BuildSpec.composition이
+            없으면 None(#506).
     """
 
     context: BuildContext
@@ -110,6 +143,7 @@ class BuildResult:
     outcomes: tuple[SourceBuildOutcome, ...]
     manifest_path: Path
     spec_digest: str
+    composition_outcome: CompositionOutcome | None = None
 
 
 def _fetch_source_key(source: SourceRef) -> str:
@@ -206,6 +240,7 @@ class _SourcePipelineResult:
     quality_results: tuple[QualityCheckResult, ...] = ()
     quality_evaluated: bool = False
     schema_drift: tuple[SchemaDriftFinding, ...] = ()
+    silver: SilverDataset | None = None
 
 
 def _run_source_pipeline(
@@ -213,11 +248,17 @@ def _run_source_pipeline(
     *,
     client: SourceClient,
     context: BuildContext,
+    capture_silver: bool = False,
 ) -> _SourcePipelineResult:
     """한 소스를 Bronze → Silver → Gold로 실행하고 산출물을 저장한다.
 
     공유 가변 컨테이너를 인자로 받는 대신 결과를 로컬로 모아 반환하므로,
     여러 소스에 대해 동시에(스레드 풀에서) 안전하게 호출할 수 있다 (#247).
+
+    매개변수:
+        capture_silver: True면 검증을 통과한 SilverDataset을 결과에 함께 담는다.
+            composition(#506)이 이 소스를 참조할 때만 켜서, composition을 쓰지
+            않는 일반 빌드는 Silver 테이블을 불필요하게 오래 들고 있지 않는다.
     """
     fetch_key = _fetch_source_key(source)
     output_key = _output_source_key(source)
@@ -225,6 +266,7 @@ def _run_source_pipeline(
     outputs: list[str] = []
     provenance_entry: SourceProvenance | None = None
     evaluated_row_count: int | None = None
+    captured_silver: SilverDataset | None = None
     # 예외가 발생해도(schema 검증 실패, quality FAIL 등) 이미 계산된 구조화된
     # 결과는 살아남아 실패 outcome에도 실린다 (#486) — quality_results가 예외
     # 때문에 사라지지 않는다.
@@ -332,6 +374,10 @@ def _run_source_pipeline(
             silver, output_root=context.output_root, run_id=context.run_id
         )
         completed.append("silver")
+        # Silver 게이트(schema/PII/quality)를 모두 통과한 시점에만 담는다 — composition(#506)이
+        # 이 값을 join에 그대로 쓰므로, 검증 실패한 데이터가 흘러들면 안 된다.
+        if capture_silver:
+            captured_silver = silver
         _record_output_paths(
             outputs,
             silver_paths.table_path,
@@ -404,6 +450,7 @@ def _run_source_pipeline(
             quality_results=quality_results,
             quality_evaluated=quality_evaluated,
             schema_drift=schema_drift,
+            silver=captured_silver,
         )
     except Exception as exc:  # stage 실패를 결과로 변환하여 매니페스트에 기록
         # 검증 오류(ValidationError, DatasetValidationError)는 파일시스템 경로를
@@ -434,7 +481,145 @@ def _run_source_pipeline(
             quality_results=quality_results,
             quality_evaluated=quality_evaluated,
             schema_drift=schema_drift,
+            silver=captured_silver,
         )
+
+
+@dataclass(frozen=True)
+class _CompositionPipelineResult:
+    """composition 실행의 로컬 결과 (#506). _SourcePipelineResult와 동일한 이유로
+    분리한다 — 모든 source 스레드가 끝난 뒤 단일 스레드에서만 실행되지만, 반환값을
+    바로 매니페스트 병합 루프에 꽂을 수 있게 같은 모양을 유지한다."""
+
+    outcome: CompositionOutcome
+    output_paths: tuple[str, ...] = ()
+    row_count: int | None = None
+    schema_summary: SchemaSummary | None = None
+    provenance: CompositionProvenance | None = None
+
+
+def _run_composition(
+    composition: CompositionSpec,
+    *,
+    silver_by_key: Mapping[str, SilverDataset],
+    context: BuildContext,
+) -> _CompositionPipelineResult:
+    """composition(join)을 실행하고 결합 Gold 산출물을 저장한다 (#506).
+
+    join key 존재/dtype 호환성 검증과 duplicate-key explosion 감지는 여기서
+    호출하는 ``build_composed_gold_package``(빌드 파이프라인의 런타임 검증
+    게이트)가 담당한다 — spec.validator는 alias 참조 같은 구조만 검증한다.
+
+    참조된 source 중 하나라도 Silver를 통과하지 못했으면(``silver_by_key``에
+    없으면) join을 시도하지 않고 "skipped"로 반환한다.
+    """
+    join = composition.join
+    missing = [alias for alias in (join.left, join.right) if alias not in silver_by_key]
+    if missing:
+        return _CompositionPipelineResult(
+            outcome=CompositionOutcome(
+                name=composition.name,
+                status="skipped",
+                error=(
+                    f"source(s) {missing} did not complete Silver successfully; "
+                    "composition was not attempted"
+                ),
+            )
+        )
+
+    try:
+        package, stats = build_composed_gold_package(
+            left_silver=silver_by_key[join.left],
+            right_silver=silver_by_key[join.right],
+            join=join,
+            dataset_name=composition.name,
+            exports=context.spec.exports,
+            metadata={"title": context.spec.title, "description": context.spec.description},
+        )
+    except CompositionError as exc:
+        return _CompositionPipelineResult(
+            outcome=CompositionOutcome(name=composition.name, status="failed", error=str(exc))
+        )
+
+    if stats.duplicate_key_warning:
+        # on_duplicate_key="fail"이었다면 build_composed_gold_package가 이미 CompositionError를
+        # 던졌으므로 여기 도달했다는 건 severity="warn"(기본)이라는 뜻이다 — 로그만 남기고 진행.
+        logger.warning(
+            "composition %r: duplicate join keys on both sides may have multiplied rows "
+            "(left=%s distinct_keys=%d/%d rows, right=%s distinct_keys=%d/%d rows, "
+            "output_rows=%d) (#506)",
+            composition.name,
+            join.left,
+            stats.left_distinct_key_count,
+            stats.left_row_count,
+            join.right,
+            stats.right_distinct_key_count,
+            stats.right_row_count,
+            stats.output_row_count,
+        )
+
+    outputs: list[str] = []
+    gold_paths = persist_gold_package(
+        package, output_root=context.output_root, run_id=context.run_id
+    )
+    _record_output_paths(
+        outputs,
+        gold_paths.table_path,
+        gold_paths.package_path,
+        *gold_paths.splits_paths.values(),
+    )
+    export_paths = export_gold_package(package, output_dir=gold_paths.gold_dir)
+    _record_output_paths(outputs, *export_paths)
+
+    combined_schema = build_schema(package.table)
+    card = build_dataset_card(
+        title=context.spec.title,
+        description=context.spec.description,
+        sources=(join.left, join.right),
+        fields=((col.name, col.dtype, col.nullable) for col in combined_schema.columns),
+        sample_rows=package.table.head(DEFAULT_PREVIEW_LIMIT).to_dicts(),
+        license=_dataset_card_license(context.spec),
+        version=_dataset_card_version(context.spec),
+    )
+    card_path = gold_paths.gold_dir / "README.md"
+    _ = card_path.write_text(render_dataset_card(card), encoding="utf-8")
+    _record_output_paths(outputs, card_path)
+
+    export_artifact = ArtifactDataset(
+        records=tuple(package.table.iter_rows(named=True)),
+        metadata={"title": context.spec.title, "description": context.spec.description},
+        statistics={"row_count": package.table.height},
+        provenance=(join.left, join.right),
+    )
+    buildspec_export_paths = _execute_exports(
+        gold_paths.gold_dir, export_artifact, context.spec.exports
+    )
+    _record_output_paths(outputs, *buildspec_export_paths)
+
+    schema_summary = build_schema_summary(
+        (col.name, col.dtype, col.nullable) for col in combined_schema.columns
+    )
+    provenance = CompositionProvenance(
+        name=composition.name,
+        left=join.left,
+        right=join.right,
+        join_type=join.type,
+        left_key=join.left_key,
+        right_key=join.right_key,
+        left_row_count=stats.left_row_count,
+        left_distinct_key_count=stats.left_distinct_key_count,
+        right_row_count=stats.right_row_count,
+        right_distinct_key_count=stats.right_distinct_key_count,
+        output_row_count=stats.output_row_count,
+        duplicate_key_warning=stats.duplicate_key_warning,
+    )
+    return _CompositionPipelineResult(
+        outcome=CompositionOutcome(name=composition.name, status="ok"),
+        output_paths=tuple(outputs),
+        row_count=stats.output_row_count,
+        schema_summary=schema_summary,
+        provenance=provenance,
+    )
 
 
 def run_build(
@@ -474,8 +659,21 @@ def run_build(
         spec, output_root=context.output_root, run_id=context.run_id
     )
 
+    # composition(#506)이 참조하는 alias의 Silver만 스레드 결과에 담아 살려둔다 —
+    # composition을 쓰지 않는 빌드는 기존과 동일하게 아무 것도 추가로 보존하지 않는다.
+    composition_aliases: frozenset[str] = (
+        frozenset({spec.composition.join.left, spec.composition.join.right})
+        if spec.composition is not None
+        else frozenset()
+    )
+
     def _worker(source: SourceRef) -> _SourcePipelineResult:
-        return _run_source_pipeline(source, client=client, context=context)
+        return _run_source_pipeline(
+            source,
+            client=client,
+            context=context,
+            capture_silver=_output_source_key(source) in composition_aliases,
+        )
 
     # 소스별 fetch/stage는 대부분 네트워크 I/O 대기이므로 스레드 풀로 동시에 실행해
     # 총 소요 시간을 줄인다 (#247). executor.map은 완료 순서가 아니라 spec.sources
@@ -494,6 +692,7 @@ def run_build(
     provenance: list[SourceProvenance] = []
     quality_results: dict[str, tuple[QualityCheckResult, ...]] = {}
     schema_drift: dict[str, tuple[SchemaDriftFinding, ...]] = {}
+    silver_by_key: dict[str, SilverDataset] = {}
     for result in results:
         outputs.extend(result.output_paths)
         if result.row_count is not None:
@@ -510,12 +709,32 @@ def run_build(
             quality_results[result.outcome.source_key] = result.quality_results
         if result.schema_drift:
             schema_drift[result.outcome.source_key] = result.schema_drift
+        if result.silver is not None:
+            silver_by_key[result.outcome.source_key] = result.silver
+
+    # composition(#506)은 모든 source가 끝난 뒤, 참조된 두 source의 검증된 Silver를
+    # 가지고 단일 스레드에서 실행한다 — join 자체는 병렬화 대상이 아니다.
+    composition_outcome: CompositionOutcome | None = None
+    composition_provenance: CompositionProvenance | None = None
+    if spec.composition is not None:
+        composition_result = _run_composition(
+            spec.composition, silver_by_key=silver_by_key, context=context
+        )
+        composition_outcome = composition_result.outcome
+        composition_provenance = composition_result.provenance
+        outputs.extend(composition_result.output_paths)
+        if composition_result.row_count is not None:
+            row_counts[composition_result.outcome.name] = composition_result.row_count
+        if composition_result.schema_summary is not None:
+            schema_summaries[composition_result.outcome.name] = composition_result.schema_summary
 
     errors = tuple(
         f"{outcome.source_key}: {outcome.error}"
         for outcome in outcomes
         if outcome.status == "failed" and outcome.error is not None
     )
+    if composition_outcome is not None and composition_outcome.status != "ok":
+        errors = (*errors, f"{composition_outcome.name}: {composition_outcome.error}")
     status = "ok" if not errors else "failed"
 
     manifest = BuildManifest(
@@ -534,6 +753,7 @@ def run_build(
         owner_id=owner_id,
         quality_results=quality_results,
         schema_drift=schema_drift,
+        composition=composition_provenance,
     )
     manifest_path = context.output_root / context.run_id / "manifest.json"
     manifest_writer(manifest, manifest_path)
@@ -544,4 +764,5 @@ def run_build(
         outcomes=outcomes,
         manifest_path=manifest_path,
         spec_digest=spec_digest,
+        composition_outcome=composition_outcome,
     )

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -211,7 +211,10 @@ def _strip_internal_fields(entries: list[_BuildListEntry]) -> list[_BuildListEnt
 # MonitoringSummaryResponse.status(healthy/degraded)는 required subsystem
 # availability로부터 계산되는 deterministic aggregate다(latency threshold
 # 미사용).
-API_CONTRACT_VERSION = "1.11.0"
+# 1.11.0 -> 1.12.0: BuildSpec.composition(JoinSpec)과 POST /build 응답의
+# composition 키, manifest.composition(CompositionProvenance) 추가 (#506,
+# additive — 기존 필드/엔드포인트는 변경되지 않는다).
+API_CONTRACT_VERSION = "1.12.0"
 
 
 def _quality_result_to_json(r: QualityCheckResult) -> dict[str, JsonValue]:
@@ -746,13 +749,27 @@ class BuilderService:
             "manifest": str(result.manifest_path),
             "api_version": API_CONTRACT_VERSION,
         }
+        # composition(#506) 결과는 outcomes(소스별)와 별도로 노출한다 — bronze/silver/gold
+        # stage 개념이 없고 "combined result"로 명확히 구분되어야 하기 때문이다.
+        # BuildSpec.composition이 없으면 null이다.
+        if result.composition_outcome is not None:
+            body["composition"] = {
+                "name": result.composition_outcome.name,
+                "status": result.composition_outcome.status,
+                "error": _redact_secret_text(result.composition_outcome.error, secret_values),
+            }
+        else:
+            body["composition"] = None
         # 실패한 빌드는 첫 번째 실패 outcome의 error를 최상위 `error` 요약으로 노출해,
         # Studio 같은 소비자가 outcomes 배열을 파싱하지 않고도 사람이 읽을 수 있는
-        # 사유를 즉시 표면화할 수 있게 한다 (#226).
+        # 사유를 즉시 표면화할 수 있게 한다 (#226). composition만 실패하고 모든 source가
+        # 성공한 경우도 놓치지 않도록 composition_outcome도 함께 살핀다 (#506).
         if result.status != "ok":
             first_error = next(
                 (o.error for o in result.outcomes if o.status != "ok" and o.error), None
             )
+            if first_error is None and result.composition_outcome is not None:
+                first_error = result.composition_outcome.error
             body["error"] = _redact_secret_text(first_error, secret_values) or "build failed"
 
         # ADR 0003: 빌드 완료 후 인덱스 갱신 (best-effort, 실패해도 빌드 성공 유지)

--- a/src/kpubdata_builder/spec/__init__.py
+++ b/src/kpubdata_builder/spec/__init__.py
@@ -12,7 +12,16 @@ models와 loader의 공개 심볼을 re-export 한다. validate_spec은 exporter
 from __future__ import annotations
 
 from .loader import load_spec, parse_spec
-from .models import BuildSpec, ExportTarget, JsonPrimitive, JsonValue, SourceRef, SplitSpec
+from .models import (
+    BuildSpec,
+    CompositionSpec,
+    ExportTarget,
+    JoinSpec,
+    JsonPrimitive,
+    JsonValue,
+    SourceRef,
+    SplitSpec,
+)
 from .serializer import (
     BUILDSPEC_SNAPSHOT_FILENAME,
     canonical_spec_mapping,
@@ -26,7 +35,9 @@ from .template import load_template, render_template
 __all__ = [
     "BuildSpec",
     "BUILDSPEC_SNAPSHOT_FILENAME",
+    "CompositionSpec",
     "ExportTarget",
+    "JoinSpec",
     "JsonPrimitive",
     "JsonValue",
     "SourceRef",

--- a/src/kpubdata_builder/spec/loader.py
+++ b/src/kpubdata_builder/spec/loader.py
@@ -20,7 +20,9 @@ from ..errors import SpecLoadError
 from .models import (
     BuildSpec,
     CompareColumnsRule,
+    CompositionSpec,
     ExportTarget,
+    JoinSpec,
     JsonValue,
     PiiPolicy,
     QualityPolicy,
@@ -29,6 +31,12 @@ from .models import (
     SourceRef,
     SplitSpec,
 )
+
+# JoinSpec.type 허용 어휘 (#506). 초기 범위는 equi-join inner/left로 제한한다.
+_JOIN_TYPES = ("inner", "left")
+
+# JoinSpec.on_duplicate_key 허용 어휘 (#506). quality의 severity 관례를 재사용한다.
+_JOIN_DUPLICATE_KEY_SEVERITIES = ("warn", "fail")
 
 # quality.*_severity 값의 허용 어휘 (#486). 기존 threshold 위반은 "warn"이 기본이며,
 # 명시적으로 "fail"을 선언해야 Gold 진입 전 소스가 실패한다.
@@ -71,6 +79,7 @@ def parse_spec(data: dict[str, object]) -> BuildSpec:
         if license_obj is not None and not isinstance(license_obj, str):
             raise TypeError("license must be a string")
         quality = _parse_quality(data.get("quality"))
+        composition = _parse_composition(data.get("composition"))
     except (KeyError, TypeError, ValueError) as exc:
         raise SpecLoadError(f"Failed to parse build spec: {exc}") from exc
 
@@ -86,6 +95,7 @@ def parse_spec(data: dict[str, object]) -> BuildSpec:
         pii=pii,
         license=license_obj,
         quality=quality,
+        composition=composition,
     )
 
 
@@ -481,6 +491,54 @@ def _parse_quality(value: object) -> QualityPolicy | None:
         range=range_rules,
         compare_columns=compare_columns_rules,
     )
+
+
+def _parse_join(value: object) -> JoinSpec:
+    """composition.join 매핑을 JoinSpec으로 변환한다 (#506).
+
+    left/right/left_key/right_key는 필수 문자열이다. type/on_duplicate_key는
+    고정 어휘 필드라 pii.mode와 동일하게 여기서 즉시 검증한다 — left/right가
+    실제 sources[].alias와 대응하는지, join key가 실제로 존재/호환되는지는
+    구조가 아니라 값 검증이라 validator/orchestrator가 각각 담당한다.
+    """
+    mapping = _ensure_mapping(value, field_name="composition.join")
+    left = _require_string(mapping, "left", prefix="composition.join")
+    right = _require_string(mapping, "right", prefix="composition.join")
+    left_key = _require_string(mapping, "left_key", prefix="composition.join")
+    right_key = _require_string(mapping, "right_key", prefix="composition.join")
+
+    join_type = mapping.get("type", "inner")
+    if not isinstance(join_type, str) or join_type not in _JOIN_TYPES:
+        raise ValueError(f"composition.join.type must be one of {_JOIN_TYPES}, got {join_type!r}")
+
+    on_duplicate_key = mapping.get("on_duplicate_key", "warn")
+    if (
+        not isinstance(on_duplicate_key, str)
+        or on_duplicate_key not in _JOIN_DUPLICATE_KEY_SEVERITIES
+    ):
+        raise ValueError(
+            "composition.join.on_duplicate_key must be one of "
+            f"{_JOIN_DUPLICATE_KEY_SEVERITIES}, got {on_duplicate_key!r}"
+        )
+
+    return JoinSpec(
+        left=left,
+        right=right,
+        left_key=left_key,
+        right_key=right_key,
+        type=join_type,
+        on_duplicate_key=on_duplicate_key,
+    )
+
+
+def _parse_composition(value: object) -> CompositionSpec | None:
+    """composition 매핑을 CompositionSpec으로 변환한다 (없으면 None, #506)."""
+    if value is None:
+        return None
+    mapping = _ensure_mapping(value, field_name="composition")
+    name = _require_string(mapping, "name", prefix="composition")
+    join = _parse_join(_require_present(mapping, "join"))
+    return CompositionSpec(name=name, join=join)
 
 
 __all__ = [

--- a/src/kpubdata_builder/spec/models.py
+++ b/src/kpubdata_builder/spec/models.py
@@ -185,6 +185,53 @@ class QualityPolicy:
 
 
 @dataclass(frozen=True)
+class JoinSpec:
+    """두 source를 결합하는 equi-join 계약 (#506).
+
+    구조(참조 alias 존재, type/severity 어휘)는 spec.validator가 파싱 직후 검증한다.
+    join key의 실제 존재 여부와 dtype 호환성은 파싱 시점엔 알 수 없다(Silver 스키마가
+    나와야 확인 가능) — 그 부분은 spec.validator가 아니라 orchestrator의 빌드 파이프라인
+    검증 게이트(런타임)에서 확인한다. 완료조건 문서의 "validate 단계에서 확인"은 이
+    구조 검증과 파이프라인 게이트를 합쳐 부르는 표현으로 읽어야 한다.
+
+    속성:
+        left: 왼쪽 source의 alias (BuildSpec.sources[].alias 참조).
+        right: 오른쪽 source의 alias.
+        left_key: 왼쪽 테이블의 join key 컬럼명.
+        right_key: 오른쪽 테이블의 join key 컬럼명.
+        type: join 종류. "inner" | "left" (초기 범위, #506).
+        on_duplicate_key: 양쪽 key 모두 중복 값을 가져 many-to-many로 행이
+            폭증할 수 있을 때의 처리. "warn"(기본, manifest에 경고만 기록) |
+            "fail"(빌드 실패). QualityPolicy의 severity 관례를 따른다.
+    """
+
+    left: str
+    right: str
+    left_key: str
+    right_key: str
+    type: str = "inner"
+    on_duplicate_key: str = "warn"
+
+
+@dataclass(frozen=True)
+class CompositionSpec:
+    """여러 source를 하나의 Gold dataset으로 조립하는 계약 (#506).
+
+    초기 범위는 두 source 단일 equi-join으로 제한한다(3개 이상 join graph는
+    제외 범위) — 그래서 리스트가 아니라 단일 JoinSpec만 받는다.
+
+    속성:
+        name: 결합 결과 Gold dataset 이름. gold/{name}/ 출력 디렉터리 세그먼트로도
+            쓰이므로 다른 source의 output key(alias 또는 provider.dataset)와
+            겹치면 안 된다.
+        join: 결합에 사용할 단일 JoinSpec.
+    """
+
+    name: str
+    join: JoinSpec
+
+
+@dataclass(frozen=True)
 class BuildSpec:
     """데이터셋 산출물을 위한 선언적 빌드 명세.
 
@@ -202,6 +249,8 @@ class BuildSpec:
             ``publish=True`` 시 반드시 선언해야 한다 (#443). kpubdata 가 라이선스
             메타데이터를 제공하지 않으므로 사용자 명시 선언만이 출처이다.
         quality: 데이터 품질 임계 정책. None이면 검사를 생략한다 (하위 호환, #446).
+        composition: 두 source를 join해 하나의 Gold dataset으로 조립하는 계약.
+            None이면 기존과 동일하게 source별 독립 Gold만 생성한다 (하위 호환, #506).
 
     예시:
         >>> BuildSpec.from_yaml("specs/sample.yaml")
@@ -218,6 +267,7 @@ class BuildSpec:
     pii: PiiPolicy | None = None
     license: str | None = None
     quality: QualityPolicy | None = None
+    composition: CompositionSpec | None = None
 
     @classmethod
     def from_yaml(cls, path: str | Path) -> BuildSpec:
@@ -247,7 +297,9 @@ class BuildSpec:
 
 __all__ = [
     "BuildSpec",
+    "CompositionSpec",
     "ExportTarget",
+    "JoinSpec",
     "JsonPrimitive",
     "JsonValue",
     "SourceRef",

--- a/src/kpubdata_builder/spec/serializer.py
+++ b/src/kpubdata_builder/spec/serializer.py
@@ -132,6 +132,21 @@ def canonical_spec_mapping(spec: BuildSpec) -> dict[str, JsonValue]:
             ],
         }
 
+    composition: JsonValue = None
+    if spec.composition is not None:
+        join = spec.composition.join
+        composition = {
+            "name": spec.composition.name,
+            "join": {
+                "left": join.left,
+                "right": join.right,
+                "left_key": join.left_key,
+                "right_key": join.right_key,
+                "type": join.type,
+                "on_duplicate_key": join.on_duplicate_key,
+            },
+        }
+
     return {
         "dataset_id": spec.dataset_id,
         "title": spec.title,
@@ -144,6 +159,7 @@ def canonical_spec_mapping(spec: BuildSpec) -> dict[str, JsonValue]:
         "pii": pii,
         "license": spec.license,
         "quality": quality,
+        "composition": composition,
     }
 
 

--- a/src/kpubdata_builder/spec/validator.py
+++ b/src/kpubdata_builder/spec/validator.py
@@ -118,6 +118,7 @@ def validate_spec(spec: BuildSpec) -> None:
     problems.extend(_pii_problems(spec))
     problems.extend(_license_problems(spec))
     problems.extend(_quality_problems(spec))
+    problems.extend(_composition_problems(spec))
     if problems:
         raise ValidationError([str(p) for p in problems], structured=problems)
 
@@ -326,6 +327,102 @@ def _license_problems(spec: BuildSpec) -> list[ValidationProblem]:
                 "license is required when publish=true (재배포 가능성 명시, #443)",
             )
         )
+    return problems
+
+
+def _composition_problems(spec: BuildSpec) -> list[ValidationProblem]:
+    """composition의 alias 참조/구조적 일관성을 검증한다 (#506).
+
+    composition이 None이면 아무 것도 검사하지 않는다 — composition 없는 기존
+    multi-source BuildSpec은 이 검증의 영향을 받지 않는다. join key 존재 여부와
+    dtype 호환성은 Silver 스키마가 나와야 알 수 있으므로(파싱/구조 검증 시점엔
+    미지) 여기서 다루지 않는다 — orchestrator의 빌드 파이프라인 검증 게이트가
+    런타임에 담당한다.
+    """
+    problems: list[ValidationProblem] = []
+    composition = spec.composition
+    if composition is None:
+        return problems
+
+    if not composition.name.strip():
+        problems.append(
+            _p("empty_field", "composition.name", "composition.name must be a non-empty string")
+        )
+    else:
+        existing_output_keys = {
+            source.alias if source.alias else f"{source.provider}.{source.dataset}"
+            for source in spec.sources
+        }
+        if composition.name in existing_output_keys:
+            problems.append(
+                _p(
+                    "composition_name_collision",
+                    "composition.name",
+                    f"composition.name {composition.name!r} collides with an existing source "
+                    "output key (alias or provider.dataset)",
+                )
+            )
+
+    join = composition.join
+    aliases = [source.alias for source in spec.sources if source.alias]
+    duplicate_aliases = sorted({a for a in aliases if aliases.count(a) > 1})
+    if duplicate_aliases:
+        problems.append(
+            _p(
+                "duplicate_source_alias",
+                "sources",
+                "sources[].alias must be unique when composition is used; "
+                f"duplicates: {duplicate_aliases}",
+            )
+        )
+
+    if join.left and join.left == join.right:
+        problems.append(
+            _p(
+                "self_join",
+                "composition.join",
+                "composition.join.left and right must reference different sources, "
+                f"both are {join.left!r}",
+            )
+        )
+
+    for side_name, alias in (("left", join.left), ("right", join.right)):
+        if not alias.strip():
+            problems.append(
+                _p(
+                    "empty_field",
+                    f"composition.join.{side_name}",
+                    f"composition.join.{side_name} must be a non-empty string",
+                )
+            )
+            continue
+        if not any(source.alias == alias for source in spec.sources):
+            problems.append(
+                _p(
+                    "unknown_composition_source",
+                    f"composition.join.{side_name}",
+                    f"composition.join.{side_name} {alias!r} does not match any sources[].alias "
+                    "(a source referenced by composition must declare a non-empty alias)",
+                )
+            )
+
+    if not join.left_key.strip():
+        problems.append(
+            _p(
+                "empty_field",
+                "composition.join.left_key",
+                "composition.join.left_key must be a non-empty string",
+            )
+        )
+    if not join.right_key.strip():
+        problems.append(
+            _p(
+                "empty_field",
+                "composition.join.right_key",
+                "composition.join.right_key must be a non-empty string",
+            )
+        )
+
     return problems
 
 

--- a/src/kpubdata_builder/stages/_path_safety.py
+++ b/src/kpubdata_builder/stages/_path_safety.py
@@ -40,6 +40,26 @@ def validate_path_segment(value: str, *, field_name: str) -> None:
         )
 
 
+def _strip_windows_extended_prefix(path: Path) -> Path:
+    """Windows ``\\\\?\\`` 확장 경로 프리픽스를 제거해 일관되게 비교할 수 있게 한다.
+
+    Windows에서 ``Path.resolve()``는 대상에 대한 파일 핸들을 열 수 있으면
+    ``\\\\?\\`` 프리픽스가 붙은 확장 경로를 돌려주고, 동시 디스크 I/O로 핸들
+    열기가 일시적으로 실패하면 프리픽스 없는 수동 정규화 경로로 폴백한다.
+    같은 실제 경로인데도 어느 쪽이 폴백을 탔는지에 따라 문자열이 달라져,
+    여러 source를 스레드 풀에서 동시에 쓰는 상황(#247)에서
+    ``is_relative_to`` 비교가 간헐적으로 잘못된 traversal 오탐을 냈다(#506
+    composition 작업 중 재현·확인). POSIX에서는 경로가 이 프리픽스로
+    시작할 수 없으므로 no-op이다.
+    """
+    text = str(path)
+    if text.startswith("\\\\?\\UNC\\"):
+        return Path("\\\\" + text[len("\\\\?\\UNC\\") :])
+    if text.startswith("\\\\?\\"):
+        return Path(text[len("\\\\?\\") :])
+    return path
+
+
 def ensure_within(root: Path, target: Path, *, label: str) -> None:
     """target(해석 후)이 root(해석 후) 아래에 포함되는지 검증한다.
 
@@ -54,8 +74,8 @@ def ensure_within(root: Path, target: Path, *, label: str) -> None:
     예외:
         ValueError: target이 root 밖으로 벗어나는 경우.
     """
-    resolved_root = root.resolve()
-    resolved_target = target.resolve()
+    resolved_root = _strip_windows_extended_prefix(root.resolve())
+    resolved_target = _strip_windows_extended_prefix(target.resolve())
     if not resolved_target.is_relative_to(resolved_root):
         raise ValueError(f"Resolved {label} {resolved_target} escapes output_root {resolved_root}")
 
@@ -79,8 +99,8 @@ def safe_output_path(base_dir: Path, relative_path: str | os.PathLike[str]) -> P
         PathTraversalError: 결합·해석된 경로가 base_dir를 벗어나는 경우.
     """
     candidate = base_dir / relative_path
-    resolved_base = base_dir.resolve()
-    resolved_target = candidate.resolve()
+    resolved_base = _strip_windows_extended_prefix(base_dir.resolve())
+    resolved_target = _strip_windows_extended_prefix(candidate.resolve())
     if not resolved_target.is_relative_to(resolved_base):
         raise PathTraversalError(
             f"output path {os.fspath(relative_path)!r} escapes base directory "

--- a/src/kpubdata_builder/stages/gold/__init__.py
+++ b/src/kpubdata_builder/stages/gold/__init__.py
@@ -14,18 +14,22 @@ from __future__ import annotations
 
 from .build import build_gold_package
 from .card import CardField, DatasetCard, build_dataset_card, render_dataset_card
+from .compose import CompositionError, CompositionStats, build_composed_gold_package
 from .models import ExportPlan, GoldPackage
 from .persist import GoldPersistResult, persist_gold_package
 from .split import apply_splits, apply_splits_to_frame
 
 __all__ = [
     "CardField",
+    "CompositionError",
+    "CompositionStats",
     "DatasetCard",
     "ExportPlan",
     "GoldPackage",
     "GoldPersistResult",
     "apply_splits",
     "apply_splits_to_frame",
+    "build_composed_gold_package",
     "build_dataset_card",
     "build_gold_package",
     "persist_gold_package",

--- a/src/kpubdata_builder/stages/gold/compose.py
+++ b/src/kpubdata_builder/stages/gold/compose.py
@@ -1,0 +1,162 @@
+"""두 source의 Silver 테이블을 결합해 하나의 Gold dataset으로 조립한다 (#506).
+
+BuildSpec.composition(JoinSpec)이 선언한 두 source를 equi-join한다. 자유형 SQL이
+아니라 typed join key/type만 허용한다(#506 이슈 제외범위: 자유형 SQL transformation).
+
+join key 존재/dtype 호환성 검증은 spec.validator(구조 검증)가 아니라 여기 — 즉
+orchestrator가 호출하는 빌드 파이프라인의 런타임 게이트에서 수행한다. spec 파싱
+시점에는 아직 Silver 스키마가 없어 alias/type 어휘 이상의 검증이 불가능하기
+때문이다.
+
+주요 구성:
+    - CompositionError: join 실행 실패(키 부재/타입 불일치/명시적 fail 게이트)
+    - CompositionStats: provenance 기록용 join 실행 통계
+    - build_composed_gold_package: 두 SilverDataset → (GoldPackage, CompositionStats)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+import polars as pl
+
+from ...spec import ExportTarget, JoinSpec
+from ..silver.models import SilverDataset
+from .models import ExportPlan, GoldPackage
+
+_JOIN_HOW: dict[str, Literal["inner", "left"]] = {"inner": "inner", "left": "left"}
+
+
+class CompositionError(RuntimeError):
+    """composition(join) 실행 실패. orchestrator가 소스 실패와 동일하게 처리한다."""
+
+
+@dataclass(frozen=True)
+class CompositionStats:
+    """join 실행 통계 — CompositionProvenance로 그대로 옮겨진다."""
+
+    left_row_count: int
+    left_distinct_key_count: int
+    right_row_count: int
+    right_distinct_key_count: int
+    output_row_count: int
+    duplicate_key_warning: bool
+
+
+def _dtypes_compatible(left: pl.DataType, right: pl.DataType) -> bool:
+    """join key dtype 호환성을 판단한다.
+
+    완전히 동일한 dtype만 호환으로 본다. Polars ``DataFrame.join``은 Int64/Float64처럼
+    "숫자형끼리도" 암묵적으로 캐스팅해 주지 않고 SchemaError로 거부한다 — 여기서 느슨하게
+    허용해도 실제 join 시점에 다른 오류로 실패할 뿐이므로 미리 정확히 같은 실패를
+    명확한 메시지로 낸다. 타입을 맞추려면 자유형 캐스팅 대신 기존
+    ``sources[].schema.casts`` 계약(#437)으로 Silver 단계에서 명시적으로 정규화한다.
+    """
+    return left == right
+
+
+def _validate_join_keys(
+    left_table: pl.DataFrame, right_table: pl.DataFrame, join: JoinSpec
+) -> None:
+    """join key 존재와 dtype 호환성을 확인한다. 빌드 파이프라인의 런타임 검증 게이트다."""
+    if join.left_key not in left_table.columns:
+        raise CompositionError(
+            f"composition.join.left_key {join.left_key!r} not found in {join.left!r} columns: "
+            f"{sorted(left_table.columns)}"
+        )
+    if join.right_key not in right_table.columns:
+        raise CompositionError(
+            f"composition.join.right_key {join.right_key!r} not found in {join.right!r} columns: "
+            f"{sorted(right_table.columns)}"
+        )
+    left_dtype = left_table.schema[join.left_key]
+    right_dtype = right_table.schema[join.right_key]
+    if not _dtypes_compatible(left_dtype, right_dtype):
+        raise CompositionError(
+            f"composition join key dtype mismatch: {join.left}.{join.left_key} ({left_dtype}) "
+            f"vs {join.right}.{join.right_key} ({right_dtype})"
+        )
+
+
+def _distinct_key_count(table: pl.DataFrame, key: str) -> int:
+    """null을 제외한 join key의 distinct 값 수. null은 어느 표준에서도 서로 일치하지 않는다."""
+    return int(table[key].drop_nulls().n_unique())
+
+
+def build_composed_gold_package(
+    *,
+    left_silver: SilverDataset,
+    right_silver: SilverDataset,
+    join: JoinSpec,
+    dataset_name: str,
+    exports: Sequence[ExportTarget] = (),
+    metadata: Mapping[str, str] | None = None,
+) -> tuple[GoldPackage, CompositionStats]:
+    """두 SilverDataset을 join해 결합 GoldPackage와 실행 통계를 만든다.
+
+    매개변수:
+        left_silver: join.left에 대응하는 Silver 데이터셋.
+        right_silver: join.right에 대응하는 Silver 데이터셋.
+        join: 결합 계약.
+        dataset_name: 결합 결과 Gold dataset 이름 (CompositionSpec.name).
+        exports: 내보내기 대상 목록 (BuildSpec.exports 재사용).
+        metadata: 패키지에 실을 메타데이터.
+
+    반환값:
+        (GoldPackage, CompositionStats): 결합 패키지와 provenance 기록용 통계.
+
+    예외:
+        CompositionError: join key가 없거나 dtype이 호환되지 않는 경우, 또는
+            ``join.on_duplicate_key == "fail"``인데 many-to-many 중복 키가
+            감지된 경우.
+    """
+    left_table = left_silver.table
+    right_table = right_silver.table
+    _validate_join_keys(left_table, right_table, join)
+
+    left_row_count = left_table.height
+    right_row_count = right_table.height
+    left_distinct = _distinct_key_count(left_table, join.left_key)
+    right_distinct = _distinct_key_count(right_table, join.right_key)
+    # 양쪽 join key가 모두 중복 값을 가지면 many-to-many가 되어 행이 곱셈으로
+    # 폭증할 수 있다 — 정확한 배수보다 이 구조적 신호(양쪽 다 non-unique)를 감지한다.
+    duplicate_key_warning = left_distinct < left_row_count and right_distinct < right_row_count
+
+    if duplicate_key_warning and join.on_duplicate_key == "fail":
+        raise CompositionError(
+            f"composition {dataset_name!r}: duplicate join keys on both sides "
+            f"({join.left}.{join.left_key}: {left_row_count - left_distinct} duplicate rows, "
+            f"{join.right}.{join.right_key}: {right_row_count - right_distinct} duplicate rows) "
+            "would multiply output rows (on_duplicate_key='fail')"
+        )
+
+    combined = left_table.join(
+        right_table,
+        left_on=join.left_key,
+        right_on=join.right_key,
+        how=_JOIN_HOW[join.type],
+        suffix=f"_{join.right}",
+    )
+
+    stats = CompositionStats(
+        left_row_count=left_row_count,
+        left_distinct_key_count=left_distinct,
+        right_row_count=right_row_count,
+        right_distinct_key_count=right_distinct,
+        output_row_count=combined.height,
+        duplicate_key_warning=duplicate_key_warning,
+    )
+    package = GoldPackage(
+        dataset_name=dataset_name,
+        table=combined,
+        export_plan=ExportPlan(targets=tuple(exports)),
+        source_silver=f"{join.left}+{join.right}",
+        metadata=dict(metadata or {}),
+        source_refs=(join.left, join.right),
+    )
+    return package, stats
+
+
+__all__ = ["CompositionError", "CompositionStats", "build_composed_gold_package"]

--- a/src/kpubdata_builder/stages/gold/models.py
+++ b/src/kpubdata_builder/stages/gold/models.py
@@ -37,8 +37,14 @@ class GoldPackage:
         dataset_name: 데이터셋 이름 (출력 디렉터리 세그먼트로도 사용).
         table: export용 최종 Polars 테이블.
         export_plan: 내보내기 계획.
-        source_silver: 원천 SilverDataset의 source 참조.
+        source_silver: 원천 SilverDataset의 source 참조 (사람이 읽는 단일 라벨).
         metadata: 패키지에 실을 임의 메타데이터.
+        source_refs: 조립에 사용된 실제 source 식별자 목록 (#506). 단일 소스
+            패키지는 None(생략)이며, 이때 export/카드 렌더링은 source_silver 하나를
+            provenance 항목으로 쓴다. composition으로 만든 패키지는 여기에
+            (left_alias, right_alias)를 담아 각 항목이 개별 provenance로 노출되게
+            한다 — source_silver를 "join:a+b" 같은 합성 문자열로 오버로딩하지
+            않기 위한 필드다.
     """
 
     dataset_name: str
@@ -47,3 +53,4 @@ class GoldPackage:
     source_silver: str
     metadata: dict[str, str] = field(default_factory=dict)
     splits: dict[str, pl.DataFrame] | None = None
+    source_refs: tuple[str, ...] | None = None

--- a/src/kpubdata_builder/stages/gold/persist.py
+++ b/src/kpubdata_builder/stages/gold/persist.py
@@ -41,6 +41,11 @@ def _package_metadata(package: GoldPackage) -> dict[str, JsonValue]:
     return {
         "dataset_name": package.dataset_name,
         "source_silver": package.source_silver,
+        "source_refs": (
+            cast(list[JsonValue], list(package.source_refs))
+            if package.source_refs is not None
+            else None
+        ),
         "row_count": package.table.height,
         "columns": cast(list[JsonValue], list(package.table.columns)),
         "metadata": dict(package.metadata),

--- a/tests/unit/test_composition.py
+++ b/tests/unit/test_composition.py
@@ -1,0 +1,483 @@
+"""Multi-source Join/Composition BuildSpec 및 Gold assembly 검증 (#506)."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from pathlib import Path
+from typing import cast
+
+import polars as pl
+import pytest
+
+from kpubdata_builder import ValidationError
+from kpubdata_builder.pipeline import run_build
+from kpubdata_builder.pipeline.context import BuildContext
+from kpubdata_builder.pipeline.orchestrator import _run_composition
+from kpubdata_builder.spec import (
+    BuildSpec,
+    CompositionSpec,
+    ExportTarget,
+    JoinSpec,
+    JsonValue,
+    SourceRef,
+    canonical_spec_mapping,
+    parse_spec,
+)
+from kpubdata_builder.spec.validator import validate_spec
+from kpubdata_builder.stages.gold.compose import CompositionError, build_composed_gold_package
+from kpubdata_builder.stages.silver.models import SilverDataset, ValidationResult
+from kpubdata_builder.stages.silver.preview import build_preview
+from kpubdata_builder.stages.silver.summarize import build_schema, build_statistics
+
+_SALES = SourceRef(provider="datago", dataset="sales", alias="sales")
+_REGION = SourceRef(provider="datago", dataset="region", alias="region")
+_EXPORTS = (ExportTarget(kind="jsonl", output_path="data.jsonl"),)
+
+
+def _make_silver(rows: list[dict[str, JsonValue]]) -> SilverDataset:
+    table = pl.DataFrame(rows)
+    return SilverDataset(
+        table=table,
+        schema=build_schema(table),
+        statistics=build_statistics(table),
+        preview=build_preview(table, limit=5),
+        validation=ValidationResult(ok=True),
+        source_bronze="x",
+    )
+
+
+def _spec(composition: CompositionSpec | None, **kwargs: object) -> BuildSpec:
+    return BuildSpec(
+        dataset_id="combined_dataset",
+        title="Combined",
+        description="combined dataset",
+        sources=(_SALES, _REGION),
+        exports=_EXPORTS,
+        composition=composition,
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+class _FakeResult:
+    def __init__(self, items: list[dict[str, JsonValue]]) -> None:
+        self._items = items
+
+    @property
+    def items(self) -> Iterable[dict[str, JsonValue]]:
+        return self._items
+
+
+class _FakeDataset:
+    def __init__(self, items: list[dict[str, JsonValue]]) -> None:
+        self._items = items
+
+    def list(self, **_params: JsonValue) -> _FakeResult:
+        return _FakeResult(self._items)
+
+
+class _FakeClient:
+    def __init__(self, data: dict[str, list[dict[str, JsonValue]]]) -> None:
+        self._data = data
+
+    def dataset(self, source_key: str) -> _FakeDataset:
+        return _FakeDataset(self._data[source_key])
+
+
+# --------------------------------------------------------------------------
+# spec.validator: composition 구조 검증
+# --------------------------------------------------------------------------
+
+
+def test_validate_spec_accepts_valid_composition() -> None:
+    spec = _spec(
+        CompositionSpec(
+            name="combined",
+            join=JoinSpec(left="sales", right="region", left_key="region_id", right_key="id"),
+        )
+    )
+    validate_spec(spec)  # 예외 없음
+
+
+def test_validate_spec_rejects_unknown_composition_alias() -> None:
+    spec = _spec(
+        CompositionSpec(
+            name="combined",
+            join=JoinSpec(left="sales", right="nope", left_key="region_id", right_key="id"),
+        )
+    )
+    with pytest.raises(ValidationError) as exc_info:
+        validate_spec(spec)
+    codes = [p.code for p in (exc_info.value.structured_problems or [])]
+    assert "unknown_composition_source" in codes
+
+
+def test_validate_spec_rejects_self_join() -> None:
+    spec = _spec(
+        CompositionSpec(
+            name="combined",
+            join=JoinSpec(left="sales", right="sales", left_key="id", right_key="id"),
+        )
+    )
+    with pytest.raises(ValidationError) as exc_info:
+        validate_spec(spec)
+    codes = [p.code for p in (exc_info.value.structured_problems or [])]
+    assert "self_join" in codes
+
+
+def test_validate_spec_rejects_duplicate_alias_when_composition_used() -> None:
+    spec = BuildSpec(
+        dataset_id="d",
+        title="t",
+        description="desc",
+        sources=(
+            SourceRef(provider="datago", dataset="sales", alias="dup"),
+            SourceRef(provider="datago", dataset="region", alias="dup"),
+        ),
+        exports=_EXPORTS,
+        composition=CompositionSpec(
+            name="combined",
+            join=JoinSpec(left="dup", right="dup", left_key="id", right_key="id"),
+        ),
+    )
+    with pytest.raises(ValidationError) as exc_info:
+        validate_spec(spec)
+    codes = [p.code for p in (exc_info.value.structured_problems or [])]
+    assert "duplicate_source_alias" in codes
+
+
+def test_validate_spec_rejects_composition_name_collision_with_source_output_key() -> None:
+    spec = _spec(
+        CompositionSpec(
+            name="sales",  # sales의 alias와 충돌
+            join=JoinSpec(left="sales", right="region", left_key="region_id", right_key="id"),
+        )
+    )
+    with pytest.raises(ValidationError) as exc_info:
+        validate_spec(spec)
+    codes = [p.code for p in (exc_info.value.structured_problems or [])]
+    assert "composition_name_collision" in codes
+
+
+def test_validate_spec_rejects_blank_join_keys() -> None:
+    spec = _spec(
+        CompositionSpec(
+            name="combined",
+            join=JoinSpec(left="sales", right="region", left_key="", right_key="id"),
+        )
+    )
+    with pytest.raises(ValidationError) as exc_info:
+        validate_spec(spec)
+    problems = [str(p) for p in (exc_info.value.structured_problems or [])]
+    assert any("composition.join.left_key" in p for p in problems)
+
+
+def test_validate_spec_without_composition_is_unaffected() -> None:
+    # composition 없는 기존 multi-source BuildSpec은 회귀가 없어야 한다 (완료 조건).
+    spec = _spec(None)
+    validate_spec(spec)  # 예외 없음
+
+
+# --------------------------------------------------------------------------
+# spec.loader / spec.serializer: 파싱과 canonical 직렬화
+# --------------------------------------------------------------------------
+
+
+def test_parse_spec_reads_composition_block() -> None:
+    data: dict[str, object] = {
+        "dataset_id": "d",
+        "title": "t",
+        "description": "desc",
+        "sources": [
+            {"provider": "datago", "dataset": "sales", "alias": "sales"},
+            {"provider": "datago", "dataset": "region", "alias": "region"},
+        ],
+        "exports": [{"kind": "jsonl", "output_path": "data.jsonl"}],
+        "composition": {
+            "name": "combined",
+            "join": {
+                "left": "sales",
+                "right": "region",
+                "left_key": "region_id",
+                "right_key": "id",
+                "type": "left",
+                "on_duplicate_key": "fail",
+            },
+        },
+    }
+    spec = parse_spec(data)
+    assert spec.composition is not None
+    assert spec.composition.name == "combined"
+    assert spec.composition.join.type == "left"
+    assert spec.composition.join.on_duplicate_key == "fail"
+
+
+def test_parse_spec_composition_defaults() -> None:
+    data: dict[str, object] = {
+        "dataset_id": "d",
+        "title": "t",
+        "description": "desc",
+        "sources": [{"provider": "datago", "dataset": "sales", "alias": "sales"}],
+        "exports": [{"kind": "jsonl", "output_path": "data.jsonl"}],
+        "composition": {
+            "name": "combined",
+            "join": {"left": "a", "right": "b", "left_key": "k1", "right_key": "k2"},
+        },
+    }
+    spec = parse_spec(data)
+    assert spec.composition is not None
+    assert spec.composition.join.type == "inner"
+    assert spec.composition.join.on_duplicate_key == "warn"
+
+
+@pytest.mark.parametrize("field", ["type", "on_duplicate_key"])
+def test_parse_spec_rejects_unknown_join_vocabulary(field: str) -> None:
+    join: dict[str, object] = {"left": "a", "right": "b", "left_key": "k1", "right_key": "k2"}
+    join[field] = "bogus"
+    data: dict[str, object] = {
+        "dataset_id": "d",
+        "title": "t",
+        "description": "desc",
+        "sources": [{"provider": "datago", "dataset": "sales", "alias": "sales"}],
+        "exports": [{"kind": "jsonl", "output_path": "data.jsonl"}],
+        "composition": {"name": "combined", "join": join},
+    }
+    with pytest.raises(Exception, match="composition.join"):
+        parse_spec(data)
+
+
+def test_canonical_spec_mapping_includes_composition() -> None:
+    spec = _spec(
+        CompositionSpec(
+            name="combined",
+            join=JoinSpec(left="sales", right="region", left_key="region_id", right_key="id"),
+        )
+    )
+    mapping = canonical_spec_mapping(spec)
+    assert mapping["composition"] == {
+        "name": "combined",
+        "join": {
+            "left": "sales",
+            "right": "region",
+            "left_key": "region_id",
+            "right_key": "id",
+            "type": "inner",
+            "on_duplicate_key": "warn",
+        },
+    }
+
+
+def test_canonical_spec_mapping_composition_none_by_default() -> None:
+    spec = _spec(None)
+    mapping = canonical_spec_mapping(spec)
+    assert mapping["composition"] is None
+
+
+# --------------------------------------------------------------------------
+# stages.gold.compose: join 실행 게이트 (키 존재/dtype/duplicate-key)
+# --------------------------------------------------------------------------
+
+
+def test_build_composed_gold_package_inner_join_happy_path() -> None:
+    sales = _make_silver([{"id": "1", "region_id": "A"}, {"id": "2", "region_id": "B"}])
+    region = _make_silver([{"id": "A", "name": "Seoul"}, {"id": "B", "name": "Busan"}])
+    join = JoinSpec(left="sales", right="region", left_key="region_id", right_key="id")
+
+    package, stats = build_composed_gold_package(
+        left_silver=sales, right_silver=region, join=join, dataset_name="combined"
+    )
+
+    assert package.dataset_name == "combined"
+    assert package.source_refs == ("sales", "region")
+    assert package.source_silver == "sales+region"
+    assert stats.output_row_count == 2
+    assert stats.duplicate_key_warning is False
+
+
+def test_build_composed_gold_package_left_join_keeps_unmatched_rows() -> None:
+    sales = _make_silver([{"id": "1", "region_id": "A"}, {"id": "2", "region_id": "Z"}])
+    region = _make_silver([{"id": "A", "name": "Seoul"}])
+    join = JoinSpec(left="sales", right="region", left_key="region_id", right_key="id", type="left")
+
+    package, stats = build_composed_gold_package(
+        left_silver=sales, right_silver=region, join=join, dataset_name="combined"
+    )
+
+    assert stats.output_row_count == 2  # unmatched "Z" row survives as null-filled row
+    assert package.table.height == 2
+
+
+def test_build_composed_gold_package_rejects_missing_left_key() -> None:
+    sales = _make_silver([{"id": "1"}])
+    region = _make_silver([{"id": "A"}])
+    join = JoinSpec(left="sales", right="region", left_key="nope", right_key="id")
+
+    with pytest.raises(CompositionError, match="left_key"):
+        build_composed_gold_package(
+            left_silver=sales, right_silver=region, join=join, dataset_name="combined"
+        )
+
+
+def test_build_composed_gold_package_rejects_dtype_mismatch() -> None:
+    sales = _make_silver([{"id": "1", "region_id": 1}])
+    region = _make_silver([{"id": "A", "region_id": "1"}])
+    join = JoinSpec(left="sales", right="region", left_key="region_id", right_key="region_id")
+
+    with pytest.raises(CompositionError, match="dtype mismatch"):
+        build_composed_gold_package(
+            left_silver=sales, right_silver=region, join=join, dataset_name="combined"
+        )
+
+
+def test_build_composed_gold_package_warns_on_many_to_many_duplicate_keys() -> None:
+    # 양쪽 다 key "A"가 중복이면 2x2=4행으로 폭증한다.
+    sales = _make_silver([{"id": "1", "region_id": "A"}, {"id": "2", "region_id": "A"}])
+    region = _make_silver([{"id": "A", "name": "S1"}, {"id": "A", "name": "S2"}])
+    join = JoinSpec(left="sales", right="region", left_key="region_id", right_key="id")
+
+    package, stats = build_composed_gold_package(
+        left_silver=sales, right_silver=region, join=join, dataset_name="combined"
+    )
+
+    assert stats.duplicate_key_warning is True
+    assert stats.left_row_count == 2
+    assert stats.left_distinct_key_count == 1
+    assert stats.right_row_count == 2
+    assert stats.right_distinct_key_count == 1
+    assert stats.output_row_count == 4
+    assert package.table.height == 4  # 경고만 하고 결과는 만든다(기본 warn)
+
+
+def test_build_composed_gold_package_fails_closed_on_duplicate_key_when_severity_fail() -> None:
+    sales = _make_silver([{"id": "1", "region_id": "A"}, {"id": "2", "region_id": "A"}])
+    region = _make_silver([{"id": "A", "name": "S1"}, {"id": "A", "name": "S2"}])
+    join = JoinSpec(
+        left="sales",
+        right="region",
+        left_key="region_id",
+        right_key="id",
+        on_duplicate_key="fail",
+    )
+
+    with pytest.raises(CompositionError, match="on_duplicate_key='fail'"):
+        build_composed_gold_package(
+            left_silver=sales, right_silver=region, join=join, dataset_name="combined"
+        )
+
+
+# --------------------------------------------------------------------------
+# pipeline.orchestrator._run_composition: skip/failed 분기
+# --------------------------------------------------------------------------
+
+
+def test_run_composition_skips_when_referenced_source_missing(tmp_path: Path) -> None:
+    composition = CompositionSpec(
+        name="combined",
+        join=JoinSpec(left="sales", right="region", left_key="region_id", right_key="id"),
+    )
+    spec = _spec(composition)
+    context = BuildContext.create(spec, output_root=tmp_path, run_id="run1")
+    sales = _make_silver([{"id": "1", "region_id": "A"}])
+
+    # region의 Silver가 없다 — 실패했거나 스레드 결과에서 capture되지 않은 상태를 흉내.
+    result = _run_composition(composition, silver_by_key={"sales": sales}, context=context)
+
+    assert result.outcome.status == "skipped"
+    assert result.provenance is None
+    assert "region" in (result.outcome.error or "")
+
+
+# --------------------------------------------------------------------------
+# pipeline.orchestrator.run_build: end-to-end
+# --------------------------------------------------------------------------
+
+
+def _combined_data() -> _FakeClient:
+    return _FakeClient(
+        {
+            "datago.sales": [
+                {"id": "1", "region_id": "A"},
+                {"id": "2", "region_id": "B"},
+                {"id": "3", "region_id": "Z"},
+            ],
+            "datago.region": [{"id": "A", "name": "Seoul"}, {"id": "B", "name": "Busan"}],
+        }
+    )
+
+
+def test_run_build_produces_combined_gold_dataset(tmp_path: Path) -> None:
+    composition = CompositionSpec(
+        name="combined",
+        join=JoinSpec(left="sales", right="region", left_key="region_id", right_key="id"),
+    )
+    spec = _spec(composition)
+
+    result = run_build(spec, client=_combined_data(), output_root=tmp_path, run_id="run1")
+
+    assert result.status == "ok"
+    assert result.composition_outcome is not None
+    assert result.composition_outcome.status == "ok"
+
+    # source별 독립 Gold는 그대로 유지된다 (회귀 없음 요건).
+    gold_dir = tmp_path / "run1" / "gold"
+    assert {p.name for p in gold_dir.iterdir()} == {"sales", "region", "combined"}
+
+    combined_table = pl.read_parquet(gold_dir / "combined" / "table.parquet")
+    assert combined_table.height == 2  # region_id "Z"는 inner join에서 제외
+
+    manifest = cast(
+        dict[str, JsonValue], json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    )
+    row_counts = cast(dict[str, int], manifest["row_counts"])
+    assert row_counts["combined"] == 2
+    assert row_counts["sales"] == 3  # source별 row_count는 조립과 무관하게 그대로
+
+    composition_manifest = cast(dict[str, JsonValue], manifest["composition"])
+    assert composition_manifest["output_row_count"] == 2
+    assert composition_manifest["left"] == "sales"
+    assert composition_manifest["right"] == "region"
+
+    # source_refs로 provenance가 개별 노출된다 (② 조사 결과 반영) — 카드에 두 줄로 나온다.
+    package_json = json.loads((gold_dir / "combined" / "package.json").read_text(encoding="utf-8"))
+    assert package_json["source_refs"] == ["sales", "region"]
+    readme = (gold_dir / "combined" / "README.md").read_text(encoding="utf-8")
+    assert "- sales" in readme
+    assert "- region" in readme
+
+
+def test_run_build_composition_failure_marks_build_failed_but_keeps_source_outputs(
+    tmp_path: Path,
+) -> None:
+    composition = CompositionSpec(
+        name="combined",
+        join=JoinSpec(left="sales", right="region", left_key="nope", right_key="id"),
+    )
+    spec = _spec(composition)
+
+    result = run_build(spec, client=_combined_data(), output_root=tmp_path, run_id="run1")
+
+    assert result.status == "failed"
+    assert result.composition_outcome is not None
+    assert result.composition_outcome.status == "failed"
+    # source별 outcome은 join 실패와 무관하게 성공으로 남는다.
+    assert all(o.status == "ok" for o in result.outcomes)
+    gold_dir = tmp_path / "run1" / "gold"
+    assert (gold_dir / "sales").is_dir()
+    assert (gold_dir / "region").is_dir()
+    assert not (gold_dir / "combined").exists()
+
+
+def test_run_build_without_composition_is_unaffected(tmp_path: Path) -> None:
+    # composition 없는 기존 multi-source BuildSpec 회귀 없음 (완료 조건).
+    spec = _spec(None)
+
+    result = run_build(spec, client=_combined_data(), output_root=tmp_path, run_id="run1")
+
+    assert result.status == "ok"
+    assert result.composition_outcome is None
+    gold_dir = tmp_path / "run1" / "gold"
+    assert {p.name for p in gold_dir.iterdir()} == {"sales", "region"}
+    manifest = cast(
+        dict[str, JsonValue], json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    )
+    assert manifest["composition"] is None

--- a/tests/unit/test_openapi_examples.py
+++ b/tests/unit/test_openapi_examples.py
@@ -175,7 +175,7 @@ def test_extraction_script_emits_documented_json_shape() -> None:
         text=True,
     )
     payload = json.loads(completed.stdout)
-    assert payload["contract_version"] == "1.11.0"
+    assert payload["contract_version"] == "1.12.0"
     assert len(payload["examples"]) >= 50
     assert set(payload["examples"][0]) == {
         "path",

--- a/tests/unit/test_path_safety.py
+++ b/tests/unit/test_path_safety.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 import pytest
 
@@ -31,8 +31,10 @@ class TestStripWindowsExtendedPrefix:
     def test_strips_unc_extended_prefix(self) -> None:
         result = _strip_windows_extended_prefix(Path("\\\\?\\UNC\\server\\share"))
         # bare UNC share root은 pathlib이 anchor로 취급해 trailing backslash를
-        # 붙여 문자열화한다(drive root "C:\\"와 동일한 관례) — 버그가 아니다.
-        assert str(result) == "\\\\server\\share\\"
+        # 붙여 문자열화한다(drive root "C:\\"와 동일한 관례) — 이 anchor
+        # 정규화는 Windows pathlib에서만 일어나므로, POSIX CI에서도 동일하게
+        # 검증하도록 PureWindowsPath로 비교한다.
+        assert str(PureWindowsPath(str(result))) == "\\\\server\\share\\"
 
     def test_noop_without_prefix(self) -> None:
         plain = Path("C:\\a\\b")

--- a/tests/unit/test_path_safety.py
+++ b/tests/unit/test_path_safety.py
@@ -8,10 +8,39 @@ import pytest
 
 from kpubdata_builder.errors import PathTraversalError
 from kpubdata_builder.stages._path_safety import (
+    _strip_windows_extended_prefix,
     ensure_within,
     safe_output_path,
     validate_path_segment,
 )
+
+
+class TestStripWindowsExtendedPrefix:
+    """Windows ``\\\\?\\`` 확장 경로 프리픽스 제거 (#506).
+
+    멀티소스 병렬 빌드(#247)에서 ``Path.resolve()``가 root/target 중 한쪽에만
+    이 프리픽스를 붙이는 경우가 있어(핸들 열기 성공 여부에 따라 갈림)
+    ``ensure_within``이 간헐적으로 잘못된 traversal 오탐을 냈다. 순수 문자열
+    함수라 플랫폼과 무관하게 테스트한다.
+    """
+
+    def test_strips_extended_prefix(self) -> None:
+        result = _strip_windows_extended_prefix(Path("\\\\?\\C:\\a\\b"))
+        assert str(result) == "C:\\a\\b"
+
+    def test_strips_unc_extended_prefix(self) -> None:
+        result = _strip_windows_extended_prefix(Path("\\\\?\\UNC\\server\\share"))
+        # bare UNC share root은 pathlib이 anchor로 취급해 trailing backslash를
+        # 붙여 문자열화한다(drive root "C:\\"와 동일한 관례) — 버그가 아니다.
+        assert str(result) == "\\\\server\\share\\"
+
+    def test_noop_without_prefix(self) -> None:
+        plain = Path("C:\\a\\b")
+        assert _strip_windows_extended_prefix(plain) == plain
+
+    def test_noop_for_posix_path(self) -> None:
+        plain = Path("/a/b")
+        assert _strip_windows_extended_prefix(plain) == plain
 
 
 class TestValidatePathSegment:
@@ -46,6 +75,31 @@ class TestEnsureWithin:
 
         with pytest.raises(ValueError, match="escapes output_root"):
             ensure_within(root, root / ".." / "outside", label="dir")
+
+    def test_tolerates_inconsistent_extended_prefix_between_root_and_target(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """root/target 중 한쪽에만 확장 프리픽스가 붙어도 동일 경로로 인식해야 한다 (#506).
+
+        실제 Windows 환경에서는 ``root.resolve()``와 ``target.resolve()``가 서로 다른
+        시점에 호출되며, 동시 I/O로 한쪽만 핸들 기반 확장 경로(``\\\\?\\``)를 얻고
+        다른 쪽은 폴백하는 비대칭이 발생할 수 있다 — 이를 monkeypatch로 재현한다.
+        """
+        root = tmp_path / "root"
+        root.mkdir()
+        target = root / "run1" / "silver" / "sales"
+        target.mkdir(parents=True)
+        real_resolve = Path.resolve
+
+        def fake_resolve(self: Path, strict: bool = False) -> Path:
+            resolved = real_resolve(self, strict=strict)
+            if self == target:
+                return Path("\\\\?\\" + str(resolved))
+            return resolved
+
+        monkeypatch.setattr(Path, "resolve", fake_resolve)
+
+        ensure_within(root, target, label="silver directory")  # 예외 없음
 
     def test_rejects_escape_via_existing_symlink(self, tmp_path: Path) -> None:
         root = tmp_path / "root"


### PR DESCRIPTION
## Summary
- `BuildSpec.composition` (`CompositionSpec`/`JoinSpec`)으로 두 source의 검증된 Silver를 equi-join해 결합 Gold dataset(`gold/{composition.name}/`)을 부가로 생성합니다. 기존 source별 독립 Gold는 그대로 유지됩니다 — `composition` 없는 기존 multi-source BuildSpec은 회귀 없음.
- 초기 범위는 이슈 본문 그대로 두 source·단일 inner/left equi-join으로 제한합니다(자유형 SQL transformation, 3개 이상 join graph, 자동 join 추천 실행은 제외).
- join key 존재/dtype 완전 일치 검증과 duplicate-key many-to-many 폭증 감지(warn 기본/fail opt-in)는 Silver 스키마가 나와야 알 수 있어 `spec.validator`가 아니라 빌드 파이프라인의 런타임 게이트(orchestrator)에서 수행합니다. alias 필수/중복, self-join, name 충돌 같은 구조 문제는 `validate_spec`이 파싱 직후 거부합니다.
- manifest에 `composition`(`CompositionProvenance`, additive)으로 join 조건과 좌/우 원본 행 수·distinct key 수·결과 행 수를 남겨 duplicate-key 경고가 사후에도 감사 가능하게 했습니다(bool 하나로 뭉개지 않음).
- `GoldPackage.source_refs`를 추가해, 결합 데이터셋의 provenance가 게시되는 dataset card/HF 메타데이터에 `source_silver`를 `"left+right"` 같은 합성 문자열로 오버로딩하지 않고 개별 항목으로 노출되게 했습니다.
- `POST /build` 응답에 `outcomes`(소스별)와 분리된 `composition` 키를 추가했고, source는 전부 성공했는데 composition만 실패한 경우도 top-level `error` 요약에서 누락되지 않도록 고쳤습니다.
- `contract/builder-api.yaml`에 `CompositionSpec`/`JoinSpec`/`CompositionProvenance`/`CompositionOutcome` 스키마를 추가하고 API 계약을 1.11.0 → 1.12.0(additive)으로 올렸습니다.
- Preview/schema/statistics 확장(이슈 범위 체크리스트의 "composition schema/statistics/preview")은 이번 PR에서 의도적으로 제외했습니다 — 별도 후속 이슈로 분리 예정입니다.

## 별도로 발견해 함께 고친 버그
composition을 멀티소스 병렬 빌드로 테스트하던 중, `stages/_path_safety.ensure_within`이 **composition과 무관하게** Windows에서 여러 source를 `ThreadPoolExecutor`로 동시 빌드할 때 간헐적으로 traversal 오탐하는 기존 버그를 발견했습니다. `root.resolve()`/`target.resolve()`가 동시 I/O 상황에서 한쪽만 `\?\` 확장 경로 프리픽스를 얻는 비대칭이 원인입니다. 순수 2-source 빌드로 재현(수정 전 15회 중 8회 실패 → 수정 후 40회 전부 성공)해 별도 커밋으로 분리했습니다.

## Test plan
- [x] `pytest tests/` — 1228 passed, 기존부터 있던 무관한 Windows 환경 실패 5건(`test_fetch.py` os.rename 비-덮어쓰기, symlink 권한 필요 2건, POSIX 절대경로 가정 1건)은 이 브랜치 이전 `main`에서도 동일하게 재현되는 것을 확인함
- [x] `ruff check` / `ruff format --check` / `mypy src/` 전부 clean
- [x] 신규 `tests/unit/test_composition.py` 23건: validator 구조 검증, loader/serializer round-trip, `build_composed_gold_package` (inner/left join, 키 부재, dtype 불일치, duplicate-key warn/fail), orchestrator end-to-end(성공/실패/composition 없는 회귀)
- [x] `tests/unit/test_path_safety.py`에 회귀 테스트 4건 추가(순수 prefix-strip 유닛 테스트 + monkeypatch 기반 비대칭 재현)

🤖 Generated with [Claude Code](https://claude.com/claude-code)