### PR TITLE
feat: Public API·File·URL source ingestion 통합 (#498)

### DIFF
--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -265,6 +265,46 @@ v0.4 Builder service는 동기식 실행 모델을 유지합니다.
   그렇지 않으면 다른 principal의 최신 run들이 LIMIT을 다 채워 요청자 본인의
   recent run이 빠질 수 있습니다.
 
+### File·URL Source Ingestion (#498)
+
+Public API/File/URL source가 동일한 canonical source contract와
+Bronze→Silver→Gold pipeline을 공유합니다. `BuildSpec.sources[].kind`가
+`public_api`(기본)/`file`/`url`을 구분하며, `kind`를 생략한 source는 항상
+`public_api`로 해석되어 기존 동작이 그대로 유지됩니다.
+
+- **File 업로드**: `POST /uploads`는 JSON이 아니라 raw binary body를 받습니다
+  (multipart 대신 동등한 binary upload). `format`/`encoding`/`filename`은
+  query parameter로 전달하며, 서버가 즉시 파싱 가능성을 검증해(손상·빈 파일은
+  400) fail-fast합니다. 저장된 content는 요청 principal의 `owner_id`로
+  격리되며, 다시 원문을 내려주는 API는 없습니다 — `GET /uploads/{upload_id}`는
+  메타데이터만 반환합니다. `BuildSpec.sources[].upload_id`가 참조하는 업로드는
+  build/preview를 요청한 principal과 소유자가 같아야 하며, 다르면 존재 여부를
+  구분하지 않고 동일하게 not found로 처리합니다(fail-closed, #505의 ownership
+  패턴과 동일). `sources[].format`/`encoding`은 업로드 시점에 검증된 값과
+  정확히 일치해야 합니다. 업로드 content는 로컬 파일시스템 경로가 아니라
+  SQLite에 저장되므로 path traversal 표면이 없고, `upload_id`는 서버가
+  발급하는 불투명한 식별자(`upl_<hex32>`)입니다 — 사용자가 filename/path를
+  직접 참조할 수 없습니다.
+- **URL fetch(P0)**: `kind="url"` source는 GET, Auth=None인 안전한 HTTP(S)
+  fetch만 지원합니다(Bearer credential 연동은 #492 이후 P1). SSRF 방어로
+  `https` 외 scheme과 userinfo가 포함된 URL을 거부하고, hostname을 DNS로 직접
+  resolve해 loopback/private/link-local/reserved 등 비공인(non-global) 주소로의
+  접속을 차단합니다(하나라도 비공인이면 전체 거부). 실제 TCP 연결은 검증한
+  IP에 직접 여는 방식으로 검증 시점과 연결 시점 사이의 DNS rebinding을
+  방지하며, redirect마다 동일 검증을 반복합니다(최대 5회). 응답 크기와
+  connect/read timeout에 상한을 둡니다. BuildSpec 계약에 header/POST/PUT/PATCH
+  필드가 아예 없어 임의 header나 다른 HTTP method를 표현할 수 없습니다.
+- **Provenance/manifest 비노출**: file source의 provenance는 로컬 파일시스템
+  경로 대신 `upload_id`만 담습니다. url source의 provenance/manifest는 query
+  string이 제거된 endpoint만 담아 우연히 섞인 secret이 남지 않게 합니다. 두
+  kind 모두 기존 `SourceProvenance`(provider/dataset 필드) 모양을 그대로
+  재사용합니다 — file은 `provider="file", dataset=upload_id`, url은
+  `provider="url", dataset=<host+path 기반 경로-안전 slug>`로 채웁니다(사람이
+  읽는 원본 endpoint는 `fetch_params.endpoint`에 별도로 남습니다).
+- **Preview/Build 동일 경로**: `POST /preview`와 `POST /build` 모두 같은
+  source resolver를 공유하므로, file/url source도 Public API source와 동일한
+  스키마/샘플/quality 판정 흐름을 거칩니다.
+
 ## 4. 인증과 CORS
 
 브라우저 클라이언트(Studio 등)와의 연동을 위해 CORS는 default-deny입니다.

--- a/BUILD_SPEC.md
+++ b/BUILD_SPEC.md
@@ -73,7 +73,19 @@ exports:
 
 ### 4.4 `sources` (배열)
 
-각 소스는 다음 필드를 가집니다.
+`kind` 필드로 세 종류의 source를 표현합니다(#498). `kind`를 생략하면 항상
+`public_api`로 해석되므로 기존 BuildSpec은 수정 없이 그대로 동작합니다.
+
+| kind | 의미 |
+| :--- | :--- |
+| `public_api` (기본) | 기존 kpubdata provider/dataset 참조 |
+| `file` | `POST /uploads`로 사전 업로드한 파일(CSV/JSON/JSONL/Parquet) 참조 |
+| `url` | 안전한 GET(Auth=None) HTTP(S) 소스 |
+
+`alias`/`schema`는 세 kind 공통 필드입니다. 그 외 필드는 kind별로 서로
+배타적이며, 다른 kind의 필드가 섞이면 BuildSpec 로드 시 즉시 거부됩니다.
+
+#### `kind: public_api` (기본값)
 
 ```yaml
 sources:
@@ -96,11 +108,71 @@ sources:
 
 | 필드 | 타입 | 필수 | 설명 |
 | :--- | :--- | :--- | :--- |
+| `kind` | string | 아니오 | 생략 시 `public_api` |
 | `provider` | string | 예 | `kpubdata` provider 이름 |
 | `dataset` | string | 예 | provider 내부 dataset 이름 |
 | `params` | object | 아니오 | source 호출 파라미터 (JSON 호환 값) |
 | `alias` | string | 아니오 | 조립 단계에서 사용할 사용자 정의 소스 이름 |
 | `schema` | object | 아니오 | Silver 정규화 및 required-column/dtype 검증 계약 |
+
+#### `kind: file` (#498)
+
+`POST /uploads`가 발급한 `upload_id`를 참조합니다. 파일시스템 경로를 직접
+쓸 수 없습니다 — `upload_id`는 서버가 발급한 불투명한 식별자(`upl_<hex32>`)이며,
+업로드 자체는 principal의 owner_id로 격리됩니다(다른 사용자의 upload_id를
+참조할 수 없음). `format`/`encoding`은 업로드 시점에 검증된 값과 정확히
+일치해야 합니다.
+
+```yaml
+sources:
+  - kind: file
+    upload_id: upl_0123456789abcdef0123456789abcdef
+    format: csv
+    encoding: utf-8
+    alias: uploaded_trades
+```
+
+| 필드 | 타입 | 필수 | 설명 |
+| :--- | :--- | :--- | :--- |
+| `kind` | string | 예 | `file` |
+| `upload_id` | string | 예 | `POST /uploads` 응답의 `upload_id` |
+| `format` | string | 예 | `csv` \| `json` \| `jsonl` \| `parquet` (업로드 시 검증된 값과 일치해야 함) |
+| `encoding` | string | 아니오 | 텍스트 포맷(csv/json/jsonl) 디코딩 인코딩. 기본값 `utf-8`. parquet은 무시됨 |
+| `alias` | string | 아니오 | 조립 단계에서 사용할 사용자 정의 소스 이름 |
+| `schema` | object | 아니오 | Silver 정규화 및 required-column/dtype 검증 계약 |
+
+지원 포맷은 CSV/JSON(top-level array of objects)/JSONL/Parquet입니다.
+Excel/ZIP은 범위 밖입니다.
+
+#### `kind: url` (#498 P0)
+
+GET, Auth=None인 안전한 HTTP(S) 소스만 P0 범위입니다. Bearer credential
+연동은 #492 이후 P1 확장입니다.
+
+```yaml
+sources:
+  - kind: url
+    endpoint: https://example.org/data.json
+    method: GET
+    alias: external_feed
+```
+
+| 필드 | 타입 | 필수 | 설명 |
+| :--- | :--- | :--- | :--- |
+| `kind` | string | 예 | `url` |
+| `endpoint` | string | 예 | fetch할 절대 URL. `https`만 허용하며 userinfo(`user:pass@host`)는 금지 |
+| `method` | string | 아니오 | 기본값 `GET`. P0는 `GET`만 허용 |
+| `format` | string | 아니오 | `json` \| `jsonl` \| `csv`. 생략 시 응답 `Content-Type`으로 추론(기본 `json`) |
+| `alias` | string | 아니오 | 조립 단계에서 사용할 사용자 정의 소스 이름 |
+| `schema` | object | 아니오 | Silver 정규화 및 required-column/dtype 검증 계약 |
+
+**SSRF 방어(#498)**: `https` 외 scheme(`http`/`file`/`ftp` 등) 거부, userinfo
+포함 URL 거부, hostname을 DNS로 직접 resolve해 loopback/private/link-local/
+reserved 등 비공인(non-global) 주소로의 fetch 거부(하나라도 비공인이면 전체
+거부), 실제 TCP 연결은 검증된 IP에 직접 연결(DNS rebinding 방지), redirect마다
+동일 검증 반복(최대 5회), connect/read timeout과 응답 크기 상한 적용. 임의
+header나 POST/PUT/PATCH는 계약에 필드 자체가 없어 표현할 수 없습니다.
+provenance/manifest에는 query string이 제거된 endpoint만 남습니다.
 
 `schema`는 다음 선택 필드를 지원합니다.
 

--- a/contract/builder-api.yaml
+++ b/contract/builder-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: KPubData Builder Service API
-  version: "1.11.0"
+  version: "1.12.0"
   description: >-
     Builder 중심 서비스 계약. BuildSpec 검증, preview, build 실행, artifact 조회,
     계약 버전 조회를 제공한다. CLI와 HTTP service mode(#36)가 동일한 도메인 계약을
@@ -39,6 +39,17 @@ info:
     계산되는 deterministic aggregate이며 latency threshold는 사용하지 않는다.
     Provider 상태는 요청마다 네트워크 프로브를 유발하므로(#492) 이번
     버전에서는 응답에도, aggregate status 판정에도 포함하지 않는다.
+    v1.12.0은 Public API·File·URL source를 동일한 canonical contract와
+    Bronze→Silver→Gold pipeline으로 처리한다(#498, additive). BuildSpec
+    `sources[]`에 `kind`(`public_api`/`file`/`url`)를 추가하며, `kind`를 생략한
+    기존 source는 항상 `public_api`로 해석되어 기존 동작이 그대로 유지된다.
+    `kind="file"` source를 위해 `POST /uploads`, `GET /uploads/{upload_id}`,
+    `DELETE /uploads/{upload_id}`를 추가한다 — 업로드는 principal의 owner_id로
+    격리되고 서버가 즉시 파싱 가능성을 검증한다. `kind="url"` source는 P0
+    범위(GET, Auth=None, https만 허용)로 SSRF를 방어하는 safe fetch(DNS
+    재검증, redirect마다 재검증, 응답 크기 상한)를 거친다. 두 kind 모두 기존
+    Bronze artifact/provenance 계약을 그대로 재사용하며, provenance/manifest에
+    로컬 파일 경로나 쿼리스트링 secret을 남기지 않는다.
 servers:
   - url: http://localhost:8000
     description: 로컬 builder 개발 서버
@@ -325,6 +336,140 @@ paths:
           description: 런타임 Provider 카탈로그 조회 실패
         "503":
           description: encrypted credential store가 구성되지 않음
+
+  /uploads:
+    post:
+      operationId: createUpload
+      summary: kind="file" source(#498)용 파일 업로드
+      description: >-
+        요청 body는 JSON이 아니라 업로드할 파일의 raw bytes다(multipart 대신 동등한
+        binary upload, #498). `format`/`encoding`/`filename`은 query parameter로
+        전달한다. 서버가 즉시 파싱 가능성을 검증해(손상·빈 파일은 400) fail-fast하고,
+        성공하면 서버가 발급한 불투명한 `upload_id`를 반환한다 — 이 값을 BuildSpec의
+        `sources[].upload_id`로 참조한다(형식은 `sources[].format`/`encoding`과
+        정확히 일치해야 한다). content는 요청 principal의 owner_id로 격리되며,
+        원문 content를 다시 내려주는 API는 없다(메타데이터만 조회 가능).
+      parameters:
+        - name: format
+          in: query
+          required: true
+          description: 업로드 content의 파싱 포맷
+          schema:
+            type: string
+            enum: [csv, json, jsonl, parquet]
+        - name: encoding
+          in: query
+          required: false
+          description: 텍스트 포맷(csv/json/jsonl) 디코딩 인코딩. parquet은 무시된다.
+          schema:
+            type: string
+            default: utf-8
+        - name: filename
+          in: query
+          required: false
+          description: >-
+            표시 전용 원본 파일명. 파일시스템 경로로 쓰이지 않으며 응답의
+            original_filename에 basename만 반영된다.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        "200":
+          description: 업로드 저장 완료
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UploadMetadata"
+              examples:
+                Uploaded:
+                  summary: csv 업로드 성공
+                  value:
+                    upload_id: upl_0123456789abcdef0123456789abcdef
+                    format: csv
+                    encoding: utf-8
+                    size_bytes: 1024
+                    original_filename: trades.csv
+                    created_at: "2026-08-16T09:00:00+00:00"
+        "400":
+          description: 빈 body, 손상된 content, 지원하지 않는 format, 또는 크기 초과
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: stable principal을 확인할 수 없음
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "413":
+          description: 업로드 크기가 서버 상한을 초과함
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /uploads/{upload_id}:
+    get:
+      operationId: getUpload
+      summary: 업로드 메타데이터 조회 (#498, content는 응답에 포함하지 않음)
+      parameters:
+        - $ref: "#/components/parameters/UploadId"
+      responses:
+        "200":
+          description: 안전한(secret-free) 업로드 메타데이터
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UploadMetadata"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: stable principal을 확인할 수 없음
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: 존재하지 않거나 principal 소유가 아닌 upload_id (구분해 노출하지 않음)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      operationId: deleteUpload
+      summary: 현재 principal 소유 업로드 삭제 (#498)
+      parameters:
+        - $ref: "#/components/parameters/UploadId"
+      responses:
+        "200":
+          description: 삭제 완료
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UploadDeleteResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: stable principal을 확인할 수 없음
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: 존재하지 않거나 principal 소유가 아닌 upload_id (구분해 노출하지 않음)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
   /validate:
     post:
@@ -1522,6 +1667,16 @@ components:
         type: string
         pattern: "^[a-z0-9][a-z0-9_-]{0,63}$"
 
+    UploadId:
+      name: upload_id
+      in: path
+      required: true
+      description: >-
+        POST /uploads가 발급한 불투명한 식별자(#498). 사용자가 지정한 값이 아니다.
+      schema:
+        type: string
+        pattern: "^upl_[a-f0-9]{32}$"
+
   schemas:
     Error:
       type: object
@@ -1664,17 +1819,29 @@ components:
     SourceRef:
       type: object
       description: >-
-        kpubdata provider/dataset 참조. 제거된 normalization_mode 필드는 허용하지
-        않으며 정규화와 검증은 schema 계약으로 선언한다.
+        Canonical source 참조(#498). `kind`로 public_api(기본, 하위 호환)/file/url을
+        구분한다. `kind`를 생략한 source는 항상 `public_api`로 해석되며
+        provider/dataset이 필수다. `file`은 upload_id+format(+encoding)이,
+        `url`은 endpoint(+method+format)가 필수다 — kind별 조건부 필수/금지
+        조합은 OpenAPI object schema로 표현하지 않고(이 계약의 기존 패턴과 동일하게
+        `additionalProperties`로 열어두고) `spec/loader.py`·`validator.py`가
+        엄격히 강제한다. url source는 P0 범위(GET, Auth=None)의 SSRF-safe fetch만
+        허용하며 https가 아닌 scheme·userinfo가 포함된 endpoint는 거부된다.
+        제거된 normalization_mode 필드는 허용하지 않는다.
       additionalProperties: true
       not:
         required: [normalization_mode]
-      required: [provider, dataset]
       properties:
+        kind:
+          type: string
+          enum: [public_api, file, url]
+          default: public_api
         provider:
           type: string
+          description: kind="public_api"에서 필수.
         dataset:
           type: string
+          description: kind="public_api"에서 필수.
         params:
           type: object
           additionalProperties:
@@ -1686,6 +1853,30 @@ components:
           oneOf:
             - $ref: "#/components/schemas/SchemaContract"
             - type: "null"
+        upload_id:
+          type: string
+          pattern: "^upl_[a-f0-9]{32}$"
+          description: kind="file"에서 필수. POST /uploads가 발급한 식별자.
+        format:
+          type: string
+          enum: [csv, json, jsonl, parquet]
+          description: >-
+            kind="file"에서 필수(업로드 시 검증된 format과 정확히 일치해야 함).
+            kind="url"에서는 선택(json/jsonl/csv만 허용, 생략 시 응답
+            Content-Type로 추론).
+        encoding:
+          type: string
+          default: utf-8
+          description: kind="file"에서 텍스트(csv/json/jsonl) 디코딩에 쓰는 인코딩.
+        endpoint:
+          type: string
+          format: uri
+          description: kind="url"에서 필수. https만 허용한다(SSRF 정책, #498).
+        method:
+          type: string
+          enum: [GET]
+          default: GET
+          description: kind="url"에서만 쓰이며 P0는 GET만 허용한다.
 
     SchemaContract:
       type: object
@@ -1706,6 +1897,40 @@ components:
           additionalProperties:
             type: string
           default: {}
+
+    UploadMetadata:
+      type: object
+      description: >-
+        안전한(secret-free) 업로드 메타데이터(#498). content는 절대 포함하지
+        않으며, 이 API로는 원문 content를 다시 조회할 수 없다.
+      required: [upload_id, format, encoding, size_bytes, original_filename, created_at]
+      properties:
+        upload_id:
+          type: string
+          pattern: "^upl_[a-f0-9]{32}$"
+        format:
+          type: string
+          enum: [csv, json, jsonl, parquet]
+        encoding:
+          type: string
+        size_bytes:
+          type: integer
+          minimum: 0
+        original_filename:
+          type: [string, "null"]
+          description: 표시 전용 원본 파일명(파일시스템 경로 아님).
+        created_at:
+          type: string
+          format: date-time
+
+    UploadDeleteResponse:
+      type: object
+      required: [upload_id, deleted]
+      properties:
+        upload_id:
+          type: string
+        deleted:
+          type: boolean
 
     ExportTarget:
       type: object

--- a/docs/adrs/0014-source-ingestion-file-url-boundary.md
+++ b/docs/adrs/0014-source-ingestion-file-url-boundary.md
@@ -1,0 +1,87 @@
+# ADR 0014: Public API·File·URL Source 통합 경계
+
+- 상태: 승인됨
+- 관련 이슈: #498, #484(parent)
+
+## 배경
+
+Builder는 지금까지 `sources[].provider`/`dataset`을 통해 kpubdata 호환 client로만
+데이터를 가져왔다. Studio prototype(`kpubdata_ui_prototype_v1.html`)의 Add Data
+흐름은 Public API 외에도 사용자가 올린 파일(File Upload)과 사용자가 지정한 외부
+HTTP(S) endpoint(URL/REST)를 같은 Preview→Build 흐름으로 다뤄야 한다. 두 신규
+경로는 서로 다른 보안 위협을 새로 끌어들인다.
+
+- File Upload: 서버가 사용자 content를 저장·재사용해야 한다 — 저장 위치, 소유권
+  격리, filename을 filesystem path로 오용하는 경로 주입이 문제가 된다.
+- URL/REST: 서버가 사용자가 지정한 임의 endpoint로 직접 요청을 보내야 한다 —
+  서버를 프록시 삼아 내부망(loopback/private/link-local/클라우드 metadata IP
+  등)을 스캔·접근하는 SSRF가 문제가 된다.
+
+## 결정
+
+세 source kind(`public_api`/`file`/`url`)를 `SourceRef.kind`로 구분하되, 셋
+모두 기존 Bronze→Silver→Gold pipeline과 `BronzeArtifact`/`SourceProvenance`
+계약을 그대로 재사용한다(새 pipeline을 만들지 않는다). `kind`를 생략한 기존
+source는 항상 `public_api`로 해석되어 기존 BuildSpec은 수정 없이 동작한다.
+
+`stages.bronze.resolve.build_bronze_artifact_for_source()`가 kind별 resolver를
+호출해 동일한 `BronzeArtifact`로 수렴시키는 단일 진입점이다. Silver 이후 단계는
+소스가 어떤 kind였는지 전혀 알 필요가 없다. `source_identity()`가 모든 kind에
+대해 기존 `(provider, dataset)` 자리를 채우는 canonical identity를 계산해,
+provenance/manifest/output 디렉터리 세그먼트가 새 필드 없이 기존 계약 그대로
+동작하게 한다 — file은 `("file", upload_id)`, url은 `("url", <경로-안전
+slug>)`다. url의 사람이 읽는(query 제거된) endpoint는 별도로
+`fetch_params.endpoint`에만 담기고 경로/식별자에는 쓰이지 않는다.
+
+### File Upload
+
+- `POST /uploads`는 JSON이 아니라 raw binary body를 받는다(multipart 대신
+  동등한 binary upload). `format`/`encoding`/`filename`은 query parameter다.
+- content는 파일시스템이 아니라 SQLite BLOB(`uploads.sqlite3`)에 저장한다 —
+  path traversal 표면 자체를 없앤다. `upload_id`는 서버가
+  `secrets.token_hex`로 발급하는 불투명한 식별자(`upl_<hex32>`)이며 사용자가
+  filename/path를 직접 지정할 수 없다.
+- 모든 조회/삭제는 `(owner_id, upload_id)`로 scoping된다. 다른 owner의
+  upload_id는 존재 여부를 구분하지 않고 동일하게 not found로 처리한다
+  (fail-closed, #505 ownership 패턴과 동일).
+- 업로드 시점에 즉시 파싱을 시도해(`ingestion.tabular_ingest`) 손상·빈 파일을
+  fail-fast로 거부한다. `sources[].format`/`encoding`은 업로드 시점에 검증된
+  값과 정확히 일치해야 한다 — BuildSpec이 업로드와 다른 해석을 강제할 수 없다.
+- `BuilderService`는 업로드 저장소를 지연 생성한다: file source가 없는
+  preview/build는 `.service/uploads.sqlite3`를 만들지 않는다(기존 "preview는
+  파일을 쓰지 않는다" 계약 유지).
+
+### URL/REST Safe Fetch (P0)
+
+P0는 GET, Auth=None만 지원한다. Bearer credential 연동은 #492 이후 P1이다.
+`ingestion.url_fetch.safe_fetch_get()`이 다음을 강제한다.
+
+- scheme은 `https`만 허용한다(file/ftp/http 등은 구조적으로 거부).
+- URL에 userinfo(`user:pass@host`)가 있으면 거부한다.
+- hostname을 `socket.getaddrinfo`로 직접 resolve하고, 모든 결과가
+  `ipaddress.*.is_global`(공인 주소)일 때만 진행한다 — 하나라도 비공인이면
+  전체를 거부한다(fail-closed). IP 리터럴 hostname도 이 경로를 통과한다.
+- 실제 TCP 연결은 검증한 IP에 직접 연다(`_PinnedHTTPSConnection`) — Host
+  header/TLS SNI는 원본 hostname을 유지한다. hostname으로 다시 resolve해
+  연결하면 검증 시점과 연결 시점 사이 DNS 응답이 바뀌는 DNS rebinding으로
+  검증을 우회당할 수 있어, 검증한 IP를 그대로 재사용한다.
+- redirect는 자동으로 따라가지 않고 매 hop마다 위 검증을 처음부터 반복한다
+  (최대 5회, 초과 시 거부).
+- 응답 크기 상한(기본 20 MiB, 환경변수로 조정)과 connect/read timeout을
+  강제한다.
+- 사용자 정의 header를 보내지 않는다 — BuildSpec `url` source 계약에 header
+  필드 자체가 없어 임의 header/POST/PUT/PATCH를 표현할 수 없다.
+
+## 결과
+
+- 세 source kind가 동일한 Bronze artifact 계약과 pipeline을 공유해 Silver/Gold
+  구현이 kind 분기를 추가로 갖지 않는다.
+- File Upload와 URL Fetch 모두 provenance/manifest/output 경로에 로컬
+  파일시스템 경로나 secret이 될 수 있는 query string을 남기지 않는다.
+- 파일 업로드는 SQLite BLOB 저장으로 path traversal 표면이 없고, URL fetch는
+  DNS rebinding까지 방어하는 IP-pinned 연결로 SSRF를 구조적으로 차단한다.
+- URL Bearer credential, 대용량 업로드 자동 정리(TTL sweep), 비동기 build
+  job(`POST /builds`)으로의 owner_id 전파는 이 결정의 범위가 아니다 — 특히
+  비동기 경로는 현재 `owner_id`를 만들지 않으므로, file source를 참조하는
+  build는 동기 `POST /build`로만 안정적으로 동작한다(비동기 경로는 owner_id
+  부재로 해당 소스가 명확한 오류로 실패한다).

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -18,6 +18,7 @@ KPubData Builder의 주요 설계 결정을 기록합니다. 각 ADR은 배경·
 | [0012](./0012-provider-credential-boundary.md) | Provider credential 저장·주입 경계 | 승인됨 | #492 |
 | [0013](./0013-api-contract-release-policy.md) | API 계약 버전과 릴리스 경계 정책 | 승인됨 | #521 |
 | [0012](./0012-provider-credential-boundary.md) | 사용자별 Provider Credential 저장과 Client 격리 | 승인됨 | #492, #505 |
+| [0014](./0014-source-ingestion-file-url-boundary.md) | Public API·File·URL Source 통합 경계 | 승인됨 | #498 |
 
 ## 작성 규칙
 

--- a/docs/guides/openapi-examples.md
+++ b/docs/guides/openapi-examples.md
@@ -1,7 +1,7 @@
 # OpenAPI 예제 추출
 
 `contract/builder-api.yaml`의 각 JSON media type에는 Studio와 사람이 함께 사용할 수 있는
-named request/response example이 있다. 예제는 API 계약 `1.11.0`의 wire schema를 따르며,
+named request/response example이 있다. 예제는 API 계약 `1.12.0`의 wire schema를 따르며,
 credential 원문, 실제 secret, 내부 절대 경로를 포함하지 않는다.
 
 Studio 같은 소비자는 저장소 루트에서 다음 명령으로 예제를 단일 JSON 문서로 추출할 수 있다.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
       - BuildSpec 어시스턴트 그라운딩(제안): adrs/0011-buildspec-assistant-grounding.md
       - Provider Credential 경계: adrs/0012-provider-credential-boundary.md
       - API 계약 릴리스 정책: adrs/0013-api-contract-release-policy.md
+      - Public API·File·URL Source 경계: adrs/0014-source-ingestion-file-url-boundary.md
 
 markdown_extensions:
   - admonition

--- a/src/kpubdata_builder/ingestion/__init__.py
+++ b/src/kpubdata_builder/ingestion/__init__.py
@@ -1,0 +1,26 @@
+"""File/URL source ingestion (#498).
+
+Public API source는 기존 kpubdata client 경로(``stages.bronze.build``)를 그대로
+쓴다. 이 패키지는 ``kind="file"``/``kind="url"`` source에만 필요한 두 가지를
+제공한다.
+
+    - ``url_fetch``: SSRF를 방어하는 안전한 GET(Auth=None) fetch.
+    - ``tabular_ingest``: CSV/JSON/JSONL/Parquet 원시 bytes를 레코드로 파싱.
+
+두 경로 모두 최종적으로 기존 Bronze→Silver→Gold pipeline이 소비하는
+``dict[str, JsonValue]`` 레코드를 만든다 — 새 pipeline이 아니라 기존 pipeline
+앞단에 붙는 resolver다.
+"""
+
+from __future__ import annotations
+
+from .errors import IngestionError
+from .tabular_ingest import parse_tabular_bytes
+from .url_fetch import FetchResult, safe_fetch_get
+
+__all__ = [
+    "FetchResult",
+    "IngestionError",
+    "parse_tabular_bytes",
+    "safe_fetch_get",
+]

--- a/src/kpubdata_builder/ingestion/errors.py
+++ b/src/kpubdata_builder/ingestion/errors.py
@@ -1,0 +1,17 @@
+"""File/URL ingestion 오류 계층 (#498)."""
+
+from __future__ import annotations
+
+from ..errors import BuildError
+
+
+class IngestionError(BuildError):
+    """file/url source의 fetch 또는 파싱이 실패했음을 나타낸다 (#498).
+
+    SSRF 차단, 응답 크기 초과, 빈/손상된 content, 지원하지 않는 형식 등
+    사용자에게 그대로 보여줘도 안전한 메시지만 담는다 — raw 응답 본문이나
+    내부 스택은 포함하지 않는다.
+    """
+
+
+__all__ = ["IngestionError"]

--- a/src/kpubdata_builder/ingestion/tabular_ingest.py
+++ b/src/kpubdata_builder/ingestion/tabular_ingest.py
@@ -24,7 +24,10 @@ _TEXT_FORMATS = frozenset({"csv", "json", "jsonl"})
 
 
 def parse_tabular_bytes(
-    raw: bytes, *, format: str, encoding: str = "utf-8"  # noqa: A002 - 계약 필드명과 맞춘다
+    raw: bytes,
+    *,
+    format: str,
+    encoding: str = "utf-8",  # noqa: A002 - 계약 필드명과 맞춘다
 ) -> tuple[dict[str, JsonValue], ...]:
     """원시 bytes를 ``format`` 규칙으로 파싱해 레코드 튜플로 반환한다.
 
@@ -89,8 +92,7 @@ def _parse_json(text: str) -> tuple[dict[str, JsonValue], ...]:
         # 허용한다 — 이 코드베이스가 quality.compare_columns 등에서 이미 지키는
         # "자유형 eval/추측 금지" 원칙과 동일하다.
         raise IngestionError(
-            "json content must be a top-level array of objects "
-            '(e.g. [{"col": "value"}, ...])'
+            'json content must be a top-level array of objects (e.g. [{"col": "value"}, ...])'
         )
     return tuple(cast(list[dict[str, JsonValue]], data))
 

--- a/src/kpubdata_builder/ingestion/tabular_ingest.py
+++ b/src/kpubdata_builder/ingestion/tabular_ingest.py
@@ -1,0 +1,116 @@
+"""File/URL 원시 bytes를 Bronze 레코드로 파싱한다 (#498).
+
+File upload와 URL fetch는 서로 다른 경로로 bytes를 얻지만, 그 bytes를 레코드로
+바꾸는 규칙은 동일해야 한다(같은 CSV 파싱 결과는 어디서 왔든 같은 레코드가
+되어야 한다) — 그래서 두 kind가 이 모듈 하나를 공유한다.
+
+지원 포맷은 CSV/JSON/JSONL/Parquet(#498 P0 범위)이다. Excel/ZIP은 범위 밖이며
+loader/validator가 이미 그 값을 거부한다.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from typing import cast
+
+import polars as pl
+
+from ..spec import JsonValue
+from ..tabular.convert import dataframe_to_records
+from .errors import IngestionError
+
+_TEXT_FORMATS = frozenset({"csv", "json", "jsonl"})
+
+
+def parse_tabular_bytes(
+    raw: bytes, *, format: str, encoding: str = "utf-8"  # noqa: A002 - 계약 필드명과 맞춘다
+) -> tuple[dict[str, JsonValue], ...]:
+    """원시 bytes를 ``format`` 규칙으로 파싱해 레코드 튜플로 반환한다.
+
+    매개변수:
+        raw: 파일 또는 HTTP 응답의 원시 bytes.
+        format: ``"csv"`` | ``"json"`` | ``"jsonl"`` | ``"parquet"``.
+        encoding: 텍스트 포맷(csv/json/jsonl) 디코딩에 쓸 인코딩. parquet은
+            바이너리 포맷이라 무시된다.
+
+    반환값:
+        레코드 튜플. Bronze pipeline이 소비하는 것과 동일한
+        ``dict[str, JsonValue]`` 형태다.
+
+    예외:
+        IngestionError: 빈 content, 지원하지 않는 format, 디코딩/파싱 실패.
+    """
+    if not raw:
+        raise IngestionError("source content is empty")
+
+    if format == "parquet":
+        return _parse_parquet(raw)
+    if format in _TEXT_FORMATS:
+        text = _decode(raw, encoding)
+        if format == "csv":
+            return _parse_csv(text)
+        if format == "json":
+            return _parse_json(text)
+        return _parse_jsonl(text)
+    raise IngestionError(f"unsupported format: {format!r}")
+
+
+def _decode(raw: bytes, encoding: str) -> str:
+    try:
+        return raw.decode(encoding)
+    except (LookupError, UnicodeDecodeError) as exc:
+        raise IngestionError(f"failed to decode content as {encoding!r}: {exc}") from exc
+
+
+def _parse_parquet(raw: bytes) -> tuple[dict[str, JsonValue], ...]:
+    try:
+        frame = pl.read_parquet(io.BytesIO(raw))
+    except Exception as exc:  # polars가 던지는 예외 타입이 다양해 광범위하게 잡는다
+        raise IngestionError(f"failed to parse parquet content: {exc}") from exc
+    return tuple(dataframe_to_records(frame))
+
+
+def _parse_csv(text: str) -> tuple[dict[str, JsonValue], ...]:
+    try:
+        frame = pl.read_csv(io.StringIO(text), infer_schema_length=None)
+    except Exception as exc:
+        raise IngestionError(f"failed to parse csv content: {exc}") from exc
+    return tuple(dataframe_to_records(frame))
+
+
+def _parse_json(text: str) -> tuple[dict[str, JsonValue], ...]:
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise IngestionError(f"failed to parse json content: {exc}") from exc
+    if not isinstance(data, list) or not all(isinstance(item, dict) for item in data):
+        # 자유형 key 추측(예: {"data": [...]}) 대신 명시적으로 array-of-object만
+        # 허용한다 — 이 코드베이스가 quality.compare_columns 등에서 이미 지키는
+        # "자유형 eval/추측 금지" 원칙과 동일하다.
+        raise IngestionError(
+            "json content must be a top-level array of objects "
+            '(e.g. [{"col": "value"}, ...])'
+        )
+    return tuple(cast(list[dict[str, JsonValue]], data))
+
+
+def _parse_jsonl(text: str) -> tuple[dict[str, JsonValue], ...]:
+    records: list[dict[str, JsonValue]] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            raise IngestionError(f"failed to parse jsonl line {line_number}: {exc}") from exc
+        if not isinstance(parsed, dict):
+            raise IngestionError(f"jsonl line {line_number} must be a JSON object")
+        records.append(parsed)
+    if not records:
+        raise IngestionError("jsonl content has no non-empty lines")
+    return tuple(records)
+
+
+__all__ = ["parse_tabular_bytes"]

--- a/src/kpubdata_builder/ingestion/url_fetch.py
+++ b/src/kpubdata_builder/ingestion/url_fetch.py
@@ -85,16 +85,32 @@ class _PinnedHTTPSConnection(http.client.HTTPSConnection):
     시점 사이에 DNS 응답이 바뀌면(DNS rebinding) private IP로 연결될 수 있다.
     이 클래스는 미리 검증한 ``pinned_ip`` 로만 소켓을 열고, TLS SNI/인증서
     검증에는 원본 ``host`` 를 그대로 쓴다(가상 호스팅·인증서 검증 정합성 유지).
+
+    ``connect_timeout``과 ``read_timeout``을 분리해 적용한다: TCP+TLS
+    connect에는 ``connect_timeout``을, 연결이 성립한 뒤 socket read에는
+    ``read_timeout``을 쓴다(#538 review) — ``connect()``가 실제 connect 전에
+    ``self.timeout``이 이미 read_timeout으로 덮어써지면 connect_timeout이
+    사실상 쓰이지 않게 되므로, connect가 끝난 뒤에만 timeout을 전환한다.
     """
 
-    def __init__(self, host: str, pinned_ip: str, port: int, *, timeout: float) -> None:
-        super().__init__(host, port, timeout=timeout)
+    def __init__(
+        self,
+        host: str,
+        pinned_ip: str,
+        port: int,
+        *,
+        connect_timeout: float,
+        read_timeout: float,
+    ) -> None:
+        super().__init__(host, port, timeout=connect_timeout)
         self._pinned_ip = pinned_ip
+        self._read_timeout = read_timeout
 
     def connect(self) -> None:  # noqa: D102 - http.client 시그니처 오버라이드
         sock = socket.create_connection((self._pinned_ip, self.port), timeout=self.timeout)
         context = ssl.create_default_context()
         self.sock = context.wrap_socket(sock, server_hostname=self.host)
+        self.sock.settimeout(self._read_timeout)
 
 
 def _validate_url_shape(url: str) -> tuple[str, str, int, str]:
@@ -193,9 +209,10 @@ def safe_fetch_get(
     for _ in range(max_redirects + 1):
         _scheme, host, port, path = _validate_url_shape(current_url)
         pinned_ip = _resolve_and_validate(host, port)
-        connection = _PinnedHTTPSConnection(host, pinned_ip, port, timeout=connect_timeout)
+        connection = _PinnedHTTPSConnection(
+            host, pinned_ip, port, connect_timeout=connect_timeout, read_timeout=read_timeout
+        )
         try:
-            connection.timeout = read_timeout
             # 사용자 정의 header는 절대 전달하지 않는다 — arbitrary header 금지(#498).
             connection.request(
                 "GET",
@@ -208,7 +225,11 @@ def safe_fetch_get(
             response = connection.getresponse()
             if response.status in _REDIRECT_STATUSES:
                 location = response.getheader("Location")
-                _ = response.read()  # 연결 재사용을 위해 body를 비운다.
+                # redirect body는 읽지 않는다 — 매 hop마다 connection을
+                # finally에서 close()하므로 "연결 재사용을 위해 비운다"는 이유가
+                # 성립하지 않고, 여기서 amt 없이 read()하면 최종 200 응답만
+                # bound하는 _read_bounded()의 max_bytes cap을 우회하는 unbounded
+                # read가 된다(BLOCKER, #538 review).
                 if not location:
                     raise IngestionError("redirect response is missing a Location header")
                 current_url = urljoin(current_url, location)

--- a/src/kpubdata_builder/ingestion/url_fetch.py
+++ b/src/kpubdata_builder/ingestion/url_fetch.py
@@ -1,0 +1,228 @@
+"""URL source를 위한 SSRF-safe GET fetch (#498 P0).
+
+Public API/File과 달리 URL source는 사용자가 임의의 endpoint를 지정할 수 있다.
+서버가 그 endpoint로 직접 요청을 보내므로, 검증 없이 접속하면 서버를 프록시
+삼아 내부망(loopback/private/link-local/클라우드 metadata IP 등)을 스캔·접근하는
+SSRF 공격이 가능하다. 이 모듈은 다음을 강제한다(#498 체크리스트):
+
+    - GET만 허용, Authorization 등 임의 header를 보내지 않는다(Auth=None, P0).
+    - scheme은 https만 허용한다("HTTPS 기본 허용" — file/ftp 등은 이미 스킴
+      자체가 거부된다).
+    - URL에 userinfo(``user:pass@host``)가 있으면 거부한다.
+    - hostname을 DNS로 직접 resolve하고, 모든 resolve 결과가 공인
+      (global-routable) 주소일 때만 진행한다 — 하나라도 private/loopback/
+      link-local/reserved면 전체를 거부한다(fail-closed).
+    - 실제 TCP 연결은 검증한 IP에 직접 연결한다(Host header는 원본 hostname
+      유지) — hostname으로 다시 connect하면 확인 시점과 연결 시점 사이에 DNS가
+      바뀌는 DNS rebinding으로 검증을 우회당할 수 있다.
+    - redirect를 자동으로 따라가지 않고 매 hop마다 같은 검증을 반복한다.
+    - connect/read timeout과 응답 크기 상한을 강제한다.
+
+이 모듈은 순수 네트워크 계층이다 — 응답 bytes를 레코드로 파싱하는 책임은
+``tabular_ingest``에 있다.
+"""
+
+from __future__ import annotations
+
+import http.client
+import ipaddress
+import os
+import socket
+import ssl
+from dataclasses import dataclass
+from urllib.parse import urljoin, urlsplit, urlunsplit
+
+from .errors import IngestionError
+
+# 허용하는 scheme. http/file/ftp 등은 여기 없으므로 구조적으로 거부된다.
+_ALLOWED_SCHEMES = frozenset({"https"})
+
+_DEFAULT_CONNECT_TIMEOUT_SECONDS = 5.0
+_DEFAULT_READ_TIMEOUT_SECONDS = 15.0
+_DEFAULT_MAX_REDIRECTS = 5
+_READ_CHUNK_BYTES = 65536
+
+# 응답 크기 상한 (#498). 환경변수로 override 가능하되 기본값은 보수적으로 둔다.
+_MAX_FETCH_BYTES_ENV = "KPUBDATA_BUILDER_URL_FETCH_MAX_BYTES"
+_DEFAULT_MAX_FETCH_BYTES = 20 * 1024 * 1024  # 20 MiB
+
+_REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
+
+
+def default_max_fetch_bytes() -> int:
+    """응답 크기 상한을 환경변수에서 읽는다 (없으면 기본값)."""
+    raw = os.environ.get(_MAX_FETCH_BYTES_ENV, "").strip()
+    if not raw:
+        return _DEFAULT_MAX_FETCH_BYTES
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DEFAULT_MAX_FETCH_BYTES
+    return value if value > 0 else _DEFAULT_MAX_FETCH_BYTES
+
+
+@dataclass(frozen=True)
+class FetchResult:
+    """fetch 성공 결과.
+
+    속성:
+        content: 응답 본문 원시 bytes.
+        content_type: 응답 ``Content-Type`` 헤더값 (없으면 빈 문자열).
+        final_url: redirect를 모두 따라간 뒤 실제로 요청한 URL. provenance에는
+            이 값이 아니라 sanitize된 identity만 남긴다 — 호출자 책임.
+    """
+
+    content: bytes
+    content_type: str
+    final_url: str
+
+
+class _PinnedHTTPSConnection(http.client.HTTPSConnection):
+    """DNS로 검증한 IP에만 직접 연결하는 HTTPSConnection.
+
+    ``http.client.HTTPSConnection`` 은 기본적으로 ``self.host`` 를 다시
+    resolve해 연결한다 — 검증(``_resolve_and_validate``) 시점과 실제 connect
+    시점 사이에 DNS 응답이 바뀌면(DNS rebinding) private IP로 연결될 수 있다.
+    이 클래스는 미리 검증한 ``pinned_ip`` 로만 소켓을 열고, TLS SNI/인증서
+    검증에는 원본 ``host`` 를 그대로 쓴다(가상 호스팅·인증서 검증 정합성 유지).
+    """
+
+    def __init__(self, host: str, pinned_ip: str, port: int, *, timeout: float) -> None:
+        super().__init__(host, port, timeout=timeout)
+        self._pinned_ip = pinned_ip
+
+    def connect(self) -> None:  # noqa: D102 - http.client 시그니처 오버라이드
+        sock = socket.create_connection((self._pinned_ip, self.port), timeout=self.timeout)
+        context = ssl.create_default_context()
+        self.sock = context.wrap_socket(sock, server_hostname=self.host)
+
+
+def _validate_url_shape(url: str) -> tuple[str, str, int, str]:
+    """scheme/userinfo/host 구조를 검증하고 (scheme, host, port, path+query)를 반환한다."""
+    parts = urlsplit(url)
+    if parts.scheme not in _ALLOWED_SCHEMES:
+        raise IngestionError(
+            f"refusing to fetch url with scheme {parts.scheme or 'none'!r} "
+            "(only https is allowed, SSRF policy #498)"
+        )
+    if parts.username or parts.password:
+        raise IngestionError("refusing to fetch url containing userinfo (SSRF policy #498)")
+    host = parts.hostname
+    if not host:
+        raise IngestionError("url must include a host")
+    port = parts.port or 443
+    path = urlunsplit(("", "", parts.path or "/", parts.query, ""))
+    return parts.scheme, host, port, path
+
+
+def _resolve_and_validate(host: str, port: int) -> str:
+    """host를 DNS resolve하고, 모든 결과가 공인 IP일 때만 첫 IP를 반환한다.
+
+    하나라도 private/loopback/link-local/reserved/multicast/unspecified면
+    전체를 거부한다(fail-closed) — 일부 응답만 사설이어도 어떤 스택이 그 주소를
+    고를지 보장할 수 없기 때문이다.
+    """
+    try:
+        infos = socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as exc:
+        raise IngestionError(f"failed to resolve host: {host}") from exc
+    if not infos:
+        raise IngestionError(f"no addresses resolved for host: {host}")
+
+    resolved_ips: list[str] = []
+    for _family, _socktype, _proto, _canonname, sockaddr in infos:
+        # sockaddr는 IPv4(host, port)/IPv6(host, port, flowinfo, scope_id) 두 형태를
+        # 아우르는 튜플이라 index 0의 정적 타입이 str|int로 넓어진다 — 실제 값은
+        # 항상 주소 문자열이므로 str()로 명시한다.
+        ip_text = str(sockaddr[0])
+        try:
+            ip = ipaddress.ip_address(ip_text)
+        except ValueError as exc:
+            raise IngestionError(f"resolved a non-IP address for host: {host}") from exc
+        if not ip.is_global:
+            raise IngestionError(
+                f"refusing to fetch from non-public address for host {host!r} (SSRF policy #498)"
+            )
+        resolved_ips.append(ip_text)
+    return resolved_ips[0]
+
+
+def _read_bounded(response: http.client.HTTPResponse, max_bytes: int) -> bytes:
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = response.read(_READ_CHUNK_BYTES)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > max_bytes:
+            raise IngestionError(
+                f"response exceeds max size ({max_bytes} bytes, SSRF/DoS policy #498)"
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def safe_fetch_get(
+    url: str,
+    *,
+    connect_timeout: float = _DEFAULT_CONNECT_TIMEOUT_SECONDS,
+    read_timeout: float = _DEFAULT_READ_TIMEOUT_SECONDS,
+    max_bytes: int | None = None,
+    max_redirects: int = _DEFAULT_MAX_REDIRECTS,
+) -> FetchResult:
+    """검증된 GET(Auth=None) 요청 하나를 안전하게 수행한다 (#498).
+
+    매개변수:
+        url: fetch할 절대 https URL.
+        connect_timeout: TCP+TLS 연결 timeout(초).
+        read_timeout: 소켓 읽기 timeout(초).
+        max_bytes: 응답 본문 크기 상한. 생략 시 환경변수/기본값을 사용.
+        max_redirects: 따라갈 최대 redirect 횟수. 매 hop마다 scheme/userinfo/DNS
+            검증을 처음부터 다시 수행한다.
+
+    반환값:
+        FetchResult: 본문 bytes, Content-Type, 최종 URL.
+
+    예외:
+        IngestionError: SSRF 정책 위반, DNS 실패, timeout, 크기 초과, 비정상
+            status, 과도한 redirect.
+    """
+    resolved_max_bytes = max_bytes if max_bytes is not None else default_max_fetch_bytes()
+    current_url = url
+    for _ in range(max_redirects + 1):
+        _scheme, host, port, path = _validate_url_shape(current_url)
+        pinned_ip = _resolve_and_validate(host, port)
+        connection = _PinnedHTTPSConnection(host, pinned_ip, port, timeout=connect_timeout)
+        try:
+            connection.timeout = read_timeout
+            # 사용자 정의 header는 절대 전달하지 않는다 — arbitrary header 금지(#498).
+            connection.request(
+                "GET",
+                path,
+                headers={
+                    "Accept": "application/json, application/x-ndjson, text/csv;q=0.9, */*;q=0.1",
+                    "User-Agent": "kpubdata-builder-url-source/1.0",
+                },
+            )
+            response = connection.getresponse()
+            if response.status in _REDIRECT_STATUSES:
+                location = response.getheader("Location")
+                _ = response.read()  # 연결 재사용을 위해 body를 비운다.
+                if not location:
+                    raise IngestionError("redirect response is missing a Location header")
+                current_url = urljoin(current_url, location)
+                continue
+            if response.status != 200:
+                raise IngestionError(f"unexpected HTTP status from url source: {response.status}")
+            content_type = response.getheader("Content-Type", "") or ""
+            content = _read_bounded(response, resolved_max_bytes)
+            return FetchResult(content=content, content_type=content_type, final_url=current_url)
+        except (TimeoutError, OSError, ssl.SSLError) as exc:
+            raise IngestionError(f"failed to fetch url source: {exc}") from exc
+        finally:
+            connection.close()
+    raise IngestionError(f"too many redirects (max {max_redirects}, SSRF policy #498)")
+
+
+__all__ = ["FetchResult", "default_max_fetch_bytes", "safe_fetch_get"]

--- a/src/kpubdata_builder/pipeline/orchestrator.py
+++ b/src/kpubdata_builder/pipeline/orchestrator.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from ..artifact import ArtifactDataset
 from ..errors import DatasetValidationError, ValidationError
 from ..exporters import get_exporter
+from ..ingestion import IngestionError
 from ..manifest import (
     BuildManifest,
     SchemaSummary,
@@ -36,9 +37,10 @@ from ..manifest import (
 from ..quality import QualityCheckResult, SchemaDriftFinding, evaluate_quality
 from ..spec import BuildSpec, ExportTarget, SourceRef, write_buildspec_snapshot
 from ..spec.validator import validate_spec
-from ..stages.bronze.build import SourceClient, build_bronze_artifact
+from ..stages.bronze.build import SourceClient
 from ..stages.bronze.models import BronzeArtifact, utc_now
 from ..stages.bronze.persist import persist_bronze_artifact
+from ..stages.bronze.resolve import build_bronze_artifact_for_source, source_identity
 from ..stages.gold.build import build_gold_package
 from ..stages.gold.card import build_dataset_card, render_dataset_card
 from ..stages.gold.persist import persist_gold_package
@@ -46,6 +48,7 @@ from ..stages.silver.build import build_silver_dataset
 from ..stages.silver.drift import DriftFinding, detect_drift, find_previous_silver
 from ..stages.silver.persist import persist_silver_dataset
 from ..stages.silver.pii import scan_pii
+from ..uploads import UploadRepository
 from .context import BuildContext
 from .export import export_gold_package
 
@@ -113,8 +116,9 @@ class BuildResult:
 
 
 def _fetch_source_key(source: SourceRef) -> str:
-    """Bronze fetch에 사용할 실제 provider.dataset 키를 반환한다."""
-    return f"{source.provider}.{source.dataset}"
+    """Bronze fetch identity 키를 반환한다 (kind별 canonical identity, #498)."""
+    provider, dataset = source_identity(source)
+    return f"{provider}.{dataset}"
 
 
 def _output_source_key(source: SourceRef) -> str:
@@ -213,13 +217,17 @@ def _run_source_pipeline(
     *,
     client: SourceClient,
     context: BuildContext,
+    upload_repository: UploadRepository | None = None,
+    owner_id: str | None = None,
 ) -> _SourcePipelineResult:
     """한 소스를 Bronze → Silver → Gold로 실행하고 산출물을 저장한다.
 
     공유 가변 컨테이너를 인자로 받는 대신 결과를 로컬로 모아 반환하므로,
     여러 소스에 대해 동시에(스레드 풀에서) 안전하게 호출할 수 있다 (#247).
+
+    ``upload_repository``/``owner_id`` 는 ``kind="file"`` source에서만 쓰인다
+    (#498) — 업로드 소유권 확인에 필요한 stable principal id다.
     """
-    fetch_key = _fetch_source_key(source)
     output_key = _output_source_key(source)
     completed: list[str] = []
     outputs: list[str] = []
@@ -232,8 +240,13 @@ def _run_source_pipeline(
     quality_evaluated = False
     schema_drift: tuple[SchemaDriftFinding, ...] = ()
     try:
-        bronze = build_bronze_artifact(
-            client, source_key=fetch_key, fetch_params=dict(source.params)
+        # kind(public_api/file/url)에 맞는 resolver로 원시 레코드를 가져온다
+        # (#498) — 이후 Silver/Gold는 kind를 전혀 알 필요가 없다.
+        bronze = build_bronze_artifact_for_source(
+            source,
+            client=client,
+            upload_repository=upload_repository,
+            owner_id=owner_id,
         )
         bronze = _retag_bronze_artifact(bronze, output_key=output_key)
         bronze_paths = persist_bronze_artifact(
@@ -243,12 +256,17 @@ def _run_source_pipeline(
         _record_output_paths(outputs, bronze_paths.records_path, bronze_paths.metadata_path)
         # bronze 성공 직후 확정한다: 이후 단계가 실패해도(부분 실패) provenance는 남는다
         # (병렬화 이전 shared list에 즉시 append하던 것과 동일한 동작을 유지) (#247).
+        provenance_provider, provenance_dataset = source_identity(source)
         provenance_entry = build_source_provenance(
-            provider=source.provider,
-            dataset=source.dataset,
+            provider=provenance_provider,
+            dataset=provenance_dataset,
             fetched_at=bronze.fetched_at,
             records=bronze.raw_records,
-            params=source.params,
+            # bronze.fetch_params는 kind별 resolver가 이미 secret/path 없이
+            # 채운 값이다(#498) — file은 upload_id/format/encoding, url은 query
+            # string이 제거된 endpoint/method, public_api는 기존 source.params
+            # 그대로다.
+            params=bronze.fetch_params,
         )
 
         required_columns = source.schema.required if source.schema else ()
@@ -407,11 +425,14 @@ def _run_source_pipeline(
         )
     except Exception as exc:  # stage 실패를 결과로 변환하여 매니페스트에 기록
         # 검증 오류(ValidationError, DatasetValidationError)는 파일시스템 경로를
-        # 포함하지 않으므로 메시지를 그대로 전달한다.
+        # 포함하지 않으므로 메시지를 그대로 전달한다. IngestionError(#498)도
+        # 마찬가지로 안전한 메시지만 담도록 설계되어 있다(raw 응답 본문/내부
+        # 스택 없음) — SSRF 차단·오버사이즈·손상 파일 사유를 사용자가 바로
+        # 확인할 수 있어야 한다.
         # ExportError/ManifestError 등 다른 BuildError 하위 예외는 목적지 경로
         # 같은 내부 정보를 메시지에 포함할 수 있으므로, 상세 내용은 서버 경고로
         # 기록하고 클라이언트에는 일반 메시지만 반환한다 (#225).
-        if isinstance(exc, (ValidationError, DatasetValidationError)):
+        if isinstance(exc, (ValidationError, DatasetValidationError, IngestionError)):
             error_msg = str(exc)
         else:
             logger.error(
@@ -445,6 +466,7 @@ def run_build(
     run_id: str | None = None,
     created_by: str | None = None,
     owner_id: str | None = None,
+    upload_repository: UploadRepository | None = None,
 ) -> BuildResult:
     """BuildSpec을 Medallion 파이프라인으로 실행한다.
 
@@ -455,7 +477,12 @@ def run_build(
         run_id: 실행 식별자. 생략 시 타임스탬프 기반으로 생성.
         created_by: 빌드를 요청한 principal의 display/legacy 라벨(#388).
         owner_id: canonical stable persistent owner identity (#505). manifest에
-            created_by와 함께 additive로 기록된다.
+            created_by와 함께 additive로 기록된다. ``kind="file"`` source가
+            있으면 업로드 소유권 확인에도 이 값을 그대로 재사용한다(#498) —
+            "이 run을 요청한 principal"과 "이 run이 참조하는 업로드의 소유자"는
+            항상 같은 사람이어야 한다.
+        upload_repository: ``kind="file"`` source의 업로드 content를 조회할
+            저장소 (#498). None이면 file source가 있는 build는 실패한다.
 
     반환값:
         BuildResult: 전체 상태, 소스별 결과, 매니페스트 경로.
@@ -475,7 +502,13 @@ def run_build(
     )
 
     def _worker(source: SourceRef) -> _SourcePipelineResult:
-        return _run_source_pipeline(source, client=client, context=context)
+        return _run_source_pipeline(
+            source,
+            client=client,
+            context=context,
+            upload_repository=upload_repository,
+            owner_id=owner_id,
+        )
 
     # 소스별 fetch/stage는 대부분 네트워크 I/O 대기이므로 스레드 풀로 동시에 실행해
     # 총 소요 시간을 줄인다 (#247). executor.map은 완료 순서가 아니라 spec.sources

--- a/src/kpubdata_builder/pipeline/preview.py
+++ b/src/kpubdata_builder/pipeline/preview.py
@@ -41,10 +41,12 @@ from ..quality import QualityCheckResult, evaluate_quality
 from ..spec import BuildSpec, JsonValue, SourceRef
 from ..spec.models import QualityPolicy
 from ..spec.validator import validate_spec
-from ..stages.bronze.build import SourceClient, build_bronze_artifact
+from ..stages.bronze.build import SourceClient
+from ..stages.bronze.resolve import build_bronze_artifact_for_source, source_identity
 from ..stages.silver.build import build_silver_dataset
 from ..stages.silver.preview import select_preview_rows
 from ..tabular import DEFAULT_PREVIEW_LIMIT, PreviewSlice, SchemaInfo, TableStatistics
+from ..uploads import UploadRepository
 
 SampleMode = Literal["first", "random"]
 _SAMPLE_MODES: tuple[SampleMode, ...] = ("first", "random")
@@ -156,8 +158,9 @@ class PreviewResult:
 
 
 def _fetch_key(source: SourceRef) -> str:
-    """kpubdata Client.dataset()에 전달할 정규 fetch 키 (provider.dataset)."""
-    return f"{source.provider}.{source.dataset}"
+    """Bronze fetch identity 키를 반환한다 (kind별 canonical identity, #498)."""
+    provider, dataset = source_identity(source)
+    return f"{provider}.{dataset}"
 
 
 def _output_key(source: SourceRef) -> str:
@@ -251,17 +254,26 @@ def _preview_source(
     quality_policy: QualityPolicy | None,
     sample_mode: SampleMode,
     seed: int,
+    upload_repository: UploadRepository | None = None,
+    owner_id: str | None = None,
 ) -> SourcePreview:
-    """한 소스를 fetch → Silver(메모리)로 만들어 스키마/샘플/diff/quality 결과를 추출한다."""
-    # fetch_key는 항상 provider.dataset (kpubdata.Client 계약). 표면 키는 alias 우선.
-    fetch_key = _fetch_key(source)
+    """한 소스를 fetch → Silver(메모리)로 만들어 스키마/샘플/diff/quality 결과를 추출한다.
+
+    ``upload_repository``/``owner_id`` 는 ``kind="file"`` source에서만 쓰인다(#498).
+    """
     out_key = _output_key(source)
     try:
         required_columns = source.schema.required if source.schema else ()
         column_dtypes = source.schema.dtypes if source.schema else None
         casts = source.schema.casts if source.schema else None
-        bronze = build_bronze_artifact(
-            client, source_key=fetch_key, fetch_params=dict(source.params)
+        # kind(public_api/file/url)에 맞는 resolver로 원시 레코드를 가져온다
+        # (#498) — Build와 동일한 resolver를 공유해 preview와 build가 같은
+        # source에 대해 항상 같은 데이터를 본다.
+        bronze = build_bronze_artifact_for_source(
+            source,
+            client=client,
+            upload_repository=upload_repository,
+            owner_id=owner_id,
         )
         silver = build_silver_dataset(
             bronze,
@@ -358,6 +370,8 @@ def preview_build(
     limit: int = DEFAULT_PREVIEW_LIMIT,
     sample_mode: SampleMode = "first",
     seed: int = DEFAULT_PREVIEW_SEED,
+    upload_repository: UploadRepository | None = None,
+    owner_id: str | None = None,
 ) -> PreviewResult:
     """각 소스의 스키마와 샘플 행, Source↔Silver diff를 산출한다 (파일 미기록).
 
@@ -368,6 +382,9 @@ def preview_build(
         sample_mode: "first"(상위 N행, 기본값) 또는 "random"(결정적 무작위 N행).
         seed: sample_mode="random"일 때 쓰는 시드. 동일 입력+동일 seed는 항상
             동일 sample을 반환한다. sample_mode="first"에서는 쓰이지 않는다.
+        upload_repository: ``kind="file"`` source의 업로드 content를 조회할
+            저장소 (#498). None이면 file source가 있는 preview는 실패한다.
+        owner_id: 업로드 소유권 확인에 쓰이는 stable principal id (#498).
 
     반환값:
         PreviewResult: 소스별 스키마/샘플/diff.
@@ -394,6 +411,8 @@ def preview_build(
             quality_policy=spec.quality,
             sample_mode=sample_mode,
             seed=seed,
+            upload_repository=upload_repository,
+            owner_id=owner_id,
         )
         for source in spec.sources
     )

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -18,6 +18,7 @@ import inspect
 import json
 import logging
 import os
+import threading
 import time
 from collections.abc import Callable, Iterable, Mapping
 from datetime import datetime, timezone
@@ -35,6 +36,7 @@ from ..credentials import (
     SQLiteCredentialRepository,
 )
 from ..errors import SpecLoadError, ValidationError
+from ..ingestion import IngestionError, parse_tabular_bytes
 from ..pipeline import DEFAULT_PREVIEW_SEED, SampleMode, preview_build, run_build
 from ..quality import QualityCheckResult
 from ..query.engine import QueryExecutionError, QueryTimeoutError
@@ -47,12 +49,19 @@ from ..query.resolver import (
 from ..query.security import UnsafeQueryError, validate_read_only_sql
 from ..query.service import QueryBusyError, QueryService
 from ..spec import BuildSpec, JsonValue, parse_spec
+from ..spec.models import SOURCE_FILE_FORMATS
 from ..spec.serializer import BUILDSPEC_SNAPSHOT_FILENAME, compute_spec_digest
 from ..spec.validator import validate_spec
 from ..stages._path_safety import ensure_within, validate_path_segment
 from ..stages.bronze.build import SourceClient
 from ..store import BuildIndex
 from ..tabular import DEFAULT_PREVIEW_LIMIT
+from ..uploads import (
+    SQLiteUploadRepository,
+    UploadMetadata,
+    UploadRepository,
+    resolve_max_upload_bytes,
+)
 from . import datasets as datasets_service
 from . import monitoring as monitoring_service
 from . import ownership as ownership_module
@@ -72,6 +81,7 @@ from .providers import (
 )
 from .responses import FileResponse, ServiceResponse
 from .routes import ROUTE_ADAPTERS
+from .routes import uploads as uploads_route
 from .routes.core import MAX_PREVIEW_LIMIT
 
 logger = logging.getLogger(__name__)
@@ -90,6 +100,11 @@ class _CloseableClient(Protocol):
 def _close_request_client(client: SourceClient) -> None:
     if isinstance(client, _CloseableClient):
         client.close()
+
+
+def _raise_provider_test_error(client: SourceClient, provider: str) -> None:
+    """provider_status의 client 생성 실패 fallback에서 쓰는 항상-raise operation."""
+    raise RuntimeError()
 
 
 def _credential_repository_from_env(output_root: Path) -> CredentialRepository | None:
@@ -211,7 +226,12 @@ def _strip_internal_fields(entries: list[_BuildListEntry]) -> list[_BuildListEnt
 # MonitoringSummaryResponse.status(healthy/degraded)는 required subsystem
 # availability로부터 계산되는 deterministic aggregate다(latency threshold
 # 미사용).
-API_CONTRACT_VERSION = "1.11.0"
+# 1.11.0 -> 1.12.0: BuildSpec sources[]에 kind="file"/"url"을 추가하고 (기존
+# provider/dataset source는 kind="public_api"로 additive 해석), POST /uploads,
+# GET /uploads/{upload_id}, DELETE /uploads/{upload_id}를 추가한다(#498,
+# additive — 기존 엔드포인트/kind 없는 source는 변경되지 않는다). url source는
+# P0 범위(GET, Auth=None, https만 허용)로 SSRF를 방어하는 safe fetch를 거친다.
+API_CONTRACT_VERSION = "1.12.0"
 
 
 def _quality_result_to_json(r: QualityCheckResult) -> dict[str, JsonValue]:
@@ -227,6 +247,18 @@ def _quality_result_to_json(r: QualityCheckResult) -> dict[str, JsonValue]:
         "affected_rows": r.affected_rows,
         "evaluated_rows": r.evaluated_rows,
         "detail": r.detail,
+    }
+
+
+def _upload_metadata_body(metadata: UploadMetadata) -> dict[str, JsonValue]:
+    """UploadMetadata를 wire JSON으로 변환한다 (#498). content는 절대 포함하지 않는다."""
+    return {
+        "upload_id": metadata.upload_id,
+        "format": metadata.format,
+        "encoding": metadata.encoding,
+        "size_bytes": metadata.size_bytes,
+        "original_filename": metadata.original_filename,
+        "created_at": metadata.created_at,
     }
 
 
@@ -248,6 +280,7 @@ class BuilderService:
         client_factory: Callable[..., SourceClient],
         query_service: QueryService | None = None,
         credential_repository: CredentialRepository | None = None,
+        upload_repository: UploadRepository | None = None,
         provider_test_operation: ProviderTestOperation = default_provider_test,
         provider_test_timeout: float | None = None,
         async_max_workers: int = 10,
@@ -256,6 +289,14 @@ class BuilderService:
         self._output_root = output_root
         self._client_factory = client_factory
         self._build_index = BuildIndex(output_root)  # #309, ADR 0003
+        # kind="file" source(#498)의 업로드 저장소. 명시적으로 주입되지 않으면
+        # 실제로 처음 쓰일 때까지 SQLite 파일을 만들지 않는다(지연 생성,
+        # `_upload_repository` property) — credential repository(마스터 키
+        # 미설정 시 None)처럼, 업로드 기능을 쓰지 않는 워크스페이스에는 흔적을
+        # 남기지 않는다(예: preview는 파일을 하나도 쓰지 않는다는 기존 계약).
+        self._upload_repository_override: UploadRepository | None = upload_repository
+        self._upload_repository_lazy: UploadRepository | None = None
+        self._upload_repository_lock = threading.Lock()
         # Monitoring API용 bounded latency recorder (#516). dispatch()가 매 요청
         # 처리 시간을 기록한다 — 인스턴스별로 분리해 테스트 간 상태가 섞이지 않는다.
         self._latency_recorder = monitoring_service.LatencyRecorder()
@@ -275,6 +316,36 @@ class BuilderService:
             max_workers=async_max_workers,
             max_queue_size=async_max_queue_size,
         )
+
+    @property
+    def _upload_repository(self) -> UploadRepository:
+        """kind="file" source(#498)의 업로드 저장소를 지연 생성해 반환한다.
+
+        명시적으로 주입됐으면 그대로 쓴다. 아니면 처음 호출될 때만
+        SQLite 파일을 만든다 — preview/build가 업로드를 전혀 참조하지 않는
+        워크스페이스에는 ``.service/uploads.sqlite3`` 흔적을 남기지 않는다.
+        """
+        if self._upload_repository_override is not None:
+            return self._upload_repository_override
+        with self._upload_repository_lock:
+            if self._upload_repository_lazy is None:
+                self._upload_repository_lazy = SQLiteUploadRepository(
+                    self._output_root / ".service" / "uploads.sqlite3",
+                    max_bytes=resolve_max_upload_bytes(),
+                )
+            return self._upload_repository_lazy
+
+    def _upload_repository_for(self, spec: BuildSpec) -> UploadRepository | None:
+        """spec에 ``kind="file"`` source가 있을 때만 업로드 저장소를 만든다 (#498).
+
+        file source가 없는 preview/build는 이 property를 아예 건드리지 않아
+        지연 생성이 실제로 지연되게 한다 — property 자체를 호출하면(설령
+        결과를 안 쓰더라도) 매 요청마다 SQLite를 초기화하게 되므로 여기서
+        먼저 필요 여부를 가른다.
+        """
+        if any(source.kind == "file" for source in spec.sources):
+            return self._upload_repository
+        return None
 
     def _create_client(
         self,
@@ -372,7 +443,7 @@ class BuilderService:
                 provider=provider,
                 configured=True,
                 client=cast(SourceClient, object()),
-                operation=lambda _client, _provider: (_ for _ in ()).throw(RuntimeError()),
+                operation=_raise_provider_test_error,
             )
             return ServiceResponse(200, cast(dict[str, JsonValue], test_result_body(result)))
         finally:
@@ -446,6 +517,63 @@ class BuilderService:
             200,
             {"provider": provider, "configured": False, "masked": None, "updated_at": None},
         )
+
+    def create_upload(
+        self,
+        raw: bytes,
+        *,
+        format: str,  # noqa: A002 - 계약 필드명과 맞춘다
+        encoding: str,
+        original_filename: str | None,
+        principal: Principal,
+    ) -> ServiceResponse:
+        """업로드 content를 저장하고 즉시 파싱 가능한지 검증한다 (#498).
+
+        저장은 owner_id로 격리된다 — 나중에 BuildSpec의 ``kind="file"`` source가
+        이 upload_id를 참조하려면 같은 principal이어야 한다(``build``/``preview``의
+        resolver가 다시 확인한다). 파싱 가능성은 여기서 fail-fast로 확인한다 —
+        나중에 build 시점에야 손상된 파일임을 알게 되는 것을 피한다.
+        """
+        if principal.owner_id is None:
+            return ServiceResponse(403, {"error": "stable principal is required"})
+        if format not in SOURCE_FILE_FORMATS:
+            return ServiceResponse(
+                400,
+                {"error": f"format must be one of {SOURCE_FILE_FORMATS}, got {format!r}"},
+            )
+        try:
+            _ = parse_tabular_bytes(raw, format=format, encoding=encoding)
+        except IngestionError as exc:
+            return ServiceResponse(400, {"error": str(exc)})
+        try:
+            metadata = self._upload_repository.put(
+                principal.owner_id,
+                content=raw,
+                format=format,
+                encoding=encoding,
+                original_filename=original_filename,
+            )
+        except ValueError as exc:
+            return ServiceResponse(400, {"error": str(exc)})
+        return ServiceResponse(200, _upload_metadata_body(metadata))
+
+    def get_upload(self, upload_id: str, *, principal: Principal) -> ServiceResponse:
+        """현재 principal 소유 업로드의 안전한 메타데이터만 반환한다 (content 제외)."""
+        if principal.owner_id is None:
+            return ServiceResponse(403, {"error": "stable principal is required"})
+        metadata = self._upload_repository.get_metadata(principal.owner_id, upload_id)
+        if metadata is None:
+            return ServiceResponse(404, {"error": f"upload not found: {upload_id}"})
+        return ServiceResponse(200, _upload_metadata_body(metadata))
+
+    def delete_upload(self, upload_id: str, *, principal: Principal) -> ServiceResponse:
+        """현재 principal 소유 업로드만 삭제한다."""
+        if principal.owner_id is None:
+            return ServiceResponse(403, {"error": "stable principal is required"})
+        deleted = self._upload_repository.delete(principal.owner_id, upload_id)
+        if not deleted:
+            return ServiceResponse(404, {"error": f"upload not found: {upload_id}"})
+        return ServiceResponse(200, {"upload_id": upload_id, "deleted": True})
 
     def query(
         self, body: Mapping[str, JsonValue] | None, *, principal: Principal
@@ -585,7 +713,12 @@ class BuilderService:
         if isinstance(spec_or_error, ServiceResponse):
             return spec_or_error
 
-        provider_names = tuple(source.provider for source in spec_or_error.sources)
+        # provider credential은 kind="public_api" source에만 의미가 있다(#498) —
+        # file/url source의 provider는 항상 빈 문자열이므로 섞으면 credential
+        # resolver에 의미 없는 provider 이름이 전달된다.
+        provider_names = tuple(
+            source.provider for source in spec_or_error.sources if source.kind == "public_api"
+        )
         try:
             provider_keys = (
                 self._credential_resolver.provider_keys(principal.owner_id, provider_names)
@@ -608,6 +741,8 @@ class BuilderService:
                 limit=limit,
                 sample_mode=cast(SampleMode, sample_mode),
                 seed=seed,
+                upload_repository=self._upload_repository_for(spec_or_error),
+                owner_id=principal.owner_id if principal is not None else None,
             )
         finally:
             _close_request_client(client)
@@ -690,7 +825,11 @@ class BuilderService:
         if isinstance(spec_or_error, ServiceResponse):
             return spec_or_error
 
-        provider_names = tuple(source.provider for source in spec_or_error.sources)
+        # provider credential은 kind="public_api" source에만 의미가 있다(#498) —
+        # file/url source의 provider는 항상 빈 문자열이다.
+        provider_names = tuple(
+            source.provider for source in spec_or_error.sources if source.kind == "public_api"
+        )
         try:
             provider_keys = (
                 self._credential_resolver.provider_keys(principal.owner_id, provider_names)
@@ -714,6 +853,7 @@ class BuilderService:
                 run_id=run_id,
                 created_by=created_by,
                 owner_id=owner_id,
+                upload_repository=self._upload_repository_for(spec_or_error),
             )
         finally:
             _close_request_client(client)
@@ -1409,6 +1549,7 @@ def dispatch(
     *,
     api_key: str | None = None,
     bearer_token: str | None = None,
+    raw_body: bytes | None = None,
 ) -> ServiceResponse | FileResponse:
     """``_dispatch_impl``을 호출하고 처리 시간을 Monitoring latency 표본으로
     기록한다 (#516).
@@ -1416,11 +1557,21 @@ def dispatch(
     타이밍은 라우팅+인증+비즈니스 로직 전체를 감싼다(HTTP 소켓 I/O는 제외 —
     그건 http.py 계층). metric 기록 실패가 요청 실패로 전파되지 않도록
     ``LatencyRecorder.record``가 이미 내부적으로 예외를 흡수한다.
+
+    ``raw_body``는 ``POST /uploads``(#498)에서만 쓰이는 binary body다 — 다른
+    모든 endpoint는 JSON ``body``만 사용하며 ``raw_body``는 None이다.
     """
     started = time.perf_counter()
     try:
         return _dispatch_impl(
-            service, method, path, body, query, api_key=api_key, bearer_token=bearer_token
+            service,
+            method,
+            path,
+            body,
+            query,
+            api_key=api_key,
+            bearer_token=bearer_token,
+            raw_body=raw_body,
         )
     finally:
         elapsed_ms = (time.perf_counter() - started) * 1000
@@ -1436,6 +1587,7 @@ def _dispatch_impl(
     *,
     api_key: str | None = None,
     bearer_token: str | None = None,
+    raw_body: bytes | None = None,
 ) -> ServiceResponse | FileResponse:
     """(method, path)를 BuilderService 연산으로 라우팅한다.
 
@@ -1454,6 +1606,16 @@ def _dispatch_impl(
     principal = authenticate(api_key=api_key, bearer_token=bearer_token)
     if isinstance(principal, AuthError):
         return ServiceResponse(principal.status_code, {"error": principal.reason})
+
+    # /uploads(#498)는 binary body(raw_body)가 필요한 유일한 endpoint라 표준
+    # RouteAdapter(JSON body만 받음) 목록에 넣지 않고 여기서 직접 호출한다 —
+    # 과거의 거대한 dispatch monolith를 복원하는 것이 아니라, 이 한 endpoint의
+    # 전송 형태가 route adapter 계약과 다르기 때문이다.
+    uploads_response = uploads_route.handle(
+        service, method, path, principal, query=query, raw_body=raw_body
+    )
+    if uploads_response is not None:
+        return uploads_response
 
     for adapter in ROUTE_ADAPTERS:
         response = adapter(service, method, path, body, query, principal)

--- a/src/kpubdata_builder/service/datasets.py
+++ b/src/kpubdata_builder/service/datasets.py
@@ -28,6 +28,7 @@ import yaml
 from ..spec import BuildSpec, JsonValue, parse_spec
 from ..spec.serializer import BUILDSPEC_SNAPSHOT_FILENAME
 from ..stages._path_safety import ensure_within
+from ..stages.bronze.resolve import source_identity
 from ..store import BuildEntry, BuildIndex
 from .auth import Principal
 from .ownership import ownership_allows
@@ -360,10 +361,14 @@ def build_dataset_summary(output_root: Path, record: RunRecord) -> dict[str, Jso
         return None
     manifest = read_manifest(output_root, record.run_id) or {}
 
-    sources: list[JsonValue] = [
-        {"provider": source.provider, "dataset": source.dataset, "alias": source.alias}
-        for source in spec.sources
-    ]
+    # file/url kind(#498)는 provider/dataset이 항상 빈 문자열이므로
+    # source_identity()로 kind별 canonical identity("file"/upload_id,
+    # "url"/query 없는 endpoint)를 채운다 — public_api는 기존과 동일하게
+    # source.provider/source.dataset 그대로다.
+    sources: list[JsonValue] = []
+    for source in spec.sources:
+        provider, dataset = source_identity(source)
+        sources.append({"provider": provider, "dataset": dataset, "alias": source.alias})
 
     row_counts: dict[str, JsonValue] = {}
     total_row_count = 0

--- a/src/kpubdata_builder/service/http.py
+++ b/src/kpubdata_builder/service/http.py
@@ -25,12 +25,18 @@ from typing import Any, cast
 from urllib.parse import urlsplit
 
 from ..spec import JsonValue
+from ..uploads import resolve_max_upload_bytes
 from .app import BuilderService, FileResponse, dispatch
 from .auth import validate_oidc_config
 
 # 단일 요청이 메모리를 고갈시키거나 단일 스레드 서버를 멈추게 하지 않도록 body 크기를
 # 제한한다. spec YAML 요청에 충분하면서도 남용을 막는 보수적 상한 (#186).
 _MAX_BODY_BYTES = 10 * 1024 * 1024  # 10 MiB
+
+# POST /uploads(#498)는 JSON이 아니라 파일 binary를 담으므로 일반 JSON 상한보다
+# 크게 잡는다 — 실제 상한은 uploads.resolve_max_upload_bytes()(환경변수로 조정)를
+# 그대로 재사용해 두 곳에 서로 다른 숫자를 두지 않는다.
+_UPLOADS_PATH = "/uploads"
 
 # 소켓 읽기 타임아웃(초). 느린 클라이언트/slowloris 공격이 스레드를 무한 점거하지 않도록
 # 한다 (#219). ThreadingHTTPServer를 사용하더라도 각 연결 스레드가 여기서 해제된다.
@@ -138,6 +144,20 @@ def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
 
         def _dispatch(self, method: str) -> None:
             self._request_id = uuid.uuid4().hex[:12]
+            # 쿼리 스트링이 경로/run_id로 새지 않도록 path 컴포넌트만으로 라우팅하고,
+            # 쿼리는 별도로 dispatch에 전달한다 (#252). body 크기 상한을 고르려면
+            # method+path를 먼저 알아야 하므로 body를 읽기 전에 파싱한다.
+            # getattr 기본값은 실제 서빙 경로에서는 절대 쓰이지 않는다 —
+            # BaseHTTPRequestHandler.parse_request()가 do_*() 호출 전에 항상
+            # self.path를 채운다. 오직 body-read 실패만 다루는 단위 테스트가
+            # object.__new__()로 handler를 만들어 self.path를 생략하는 경우에만
+            # 쓰인다 (#498 이전부터의 기존 테스트 fixture, TestHttpRobustness).
+            split = urlsplit(getattr(self, "path", ""))
+            path = split.path
+            # POST /uploads(#498)만 JSON이 아니라 파일 binary body를 받는다 — 다른
+            # 모든 endpoint는 지금까지와 동일하게 JSON body만 받는다.
+            is_binary_upload = method == "POST" and path == _UPLOADS_PATH
+            max_body_bytes = resolve_max_upload_bytes() if is_binary_upload else _MAX_BODY_BYTES
             try:
                 length = int(self.headers.get("Content-Length", 0) or 0)
             except ValueError:
@@ -147,7 +167,7 @@ def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
                 self._write(400, {"error": "invalid Content-Length header"})
                 return
             # 선언된 길이가 상한을 넘으면 body를 읽지 않고 413으로 거부한다 (#186).
-            if length > _MAX_BODY_BYTES:
+            if length > max_body_bytes:
                 self._write(413, {"error": "request body too large"})
                 return
             # body 읽기: 타임아웃이나 불완전한 읽기는 dropped connection 대신
@@ -164,7 +184,10 @@ def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
             else:
                 raw = b""
             body: dict[str, JsonValue] | None = None
-            if raw:
+            raw_body: bytes | None = None
+            if is_binary_upload:
+                raw_body = raw
+            elif raw:
                 try:
                     parsed = cast(object, json.loads(raw))
                 except json.JSONDecodeError:
@@ -176,10 +199,6 @@ def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
                     self._write(400, {"error": "JSON body must be an object"})
                     return
                 body = cast(dict[str, JsonValue], parsed)
-            # 쿼리 스트링이 경로/run_id로 새지 않도록 path 컴포넌트만으로 라우팅하고,
-            # 쿼리는 별도로 dispatch에 전달한다 (#252).
-            split = urlsplit(self.path)
-            path = split.path
             # dispatch()에서 예상치 못한 예외가 발생하면 연결을 끊는 대신 JSON 500을
             # 반환한다. 상세 정보는 서버 로그에만 기록하고 클라이언트에는 누설하지 않는다 (#218).
             try:
@@ -191,6 +210,7 @@ def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
                     query=split.query,
                     api_key=self.headers.get("X-API-Key"),
                     bearer_token=self.headers.get("Authorization"),
+                    raw_body=raw_body,
                 )
             except Exception:
                 _logger.error(

--- a/src/kpubdata_builder/service/routes/uploads.py
+++ b/src/kpubdata_builder/service/routes/uploads.py
@@ -1,0 +1,74 @@
+"""File source 업로드 CRUD route (#498).
+
+다른 route adapter와 달리 ``POST /uploads`` 는 JSON이 아니라 raw binary body를
+받는다 — 그래서 ``ROUTE_ADAPTERS``(표준 ``RouteAdapter`` 시그니처, JSON body만
+받음)에 넣지 않고 ``app._dispatch_impl`` 이 인증 직후 직접 호출한다(``raw_body``
+가 필요한 유일한 endpoint). GET/DELETE는 binary body가 필요 없다.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from urllib.parse import parse_qs
+
+from ...stages._path_safety import validate_path_segment
+from ..auth import Principal
+from ..responses import ServiceResponse
+from ._types import RouteResponse
+
+if TYPE_CHECKING:
+    from ..app import BuilderService
+
+_PREFIX = "/uploads/"
+
+
+def handle(
+    service: BuilderService,
+    method: str,
+    path: str,
+    principal: Principal,
+    *,
+    query: str,
+    raw_body: bytes | None,
+) -> RouteResponse | None:
+    if method == "POST" and path == "/uploads":
+        return _handle_create(service, principal, query=query, raw_body=raw_body)
+
+    if path.startswith(_PREFIX) and "/" not in path[len(_PREFIX) :]:
+        upload_id = path[len(_PREFIX) :]
+        try:
+            validate_path_segment(upload_id, field_name="upload_id")
+        except ValueError as exc:
+            return ServiceResponse(400, {"error": str(exc)})
+        if method == "GET":
+            return service.get_upload(upload_id, principal=principal)
+        if method == "DELETE":
+            return service.delete_upload(upload_id, principal=principal)
+    return None
+
+
+def _handle_create(
+    service: BuilderService, principal: Principal, *, query: str, raw_body: bytes | None
+) -> RouteResponse:
+    if not raw_body:
+        return ServiceResponse(400, {"error": "request body must not be empty"})
+    params = parse_qs(query)
+    format_values = params.get("format")
+    if not format_values or not format_values[-1].strip():
+        return ServiceResponse(
+            400, {"error": "'format' query parameter is required (csv/json/jsonl/parquet)"}
+        )
+    encoding_values = params.get("encoding")
+    encoding = encoding_values[-1] if encoding_values else "utf-8"
+    filename_values = params.get("filename")
+    original_filename = filename_values[-1] if filename_values else None
+    return service.create_upload(
+        raw_body,
+        format=format_values[-1],
+        encoding=encoding,
+        original_filename=original_filename,
+        principal=principal,
+    )
+
+
+__all__ = ["handle"]

--- a/src/kpubdata_builder/service/stages.py
+++ b/src/kpubdata_builder/service/stages.py
@@ -26,6 +26,7 @@ from ..stages._stage_reader import (
     read_gold_summary,
     read_silver_summary,
 )
+from ..stages.bronze.resolve import source_identity
 
 Stage = Literal["bronze", "silver", "gold"]
 STAGE_NAMES: tuple[Stage, ...] = ("bronze", "silver", "gold")
@@ -98,9 +99,14 @@ def _output_source_key(source: SourceRef) -> str:
     """pipeline.orchestrator._output_source_key와 동일한 규칙을 미러링한다.
 
     stage 조회는 파이프라인이 실제로 파일을 쓸 때 쓴 것과 같은 output-facing
-    key(alias 우선, 아니면 provider.dataset)로 소스를 찾아야 한다.
+    key(alias 우선, 아니면 kind별 canonical identity)로 소스를 찾아야 한다.
+    file/url kind(#498)는 provider/dataset이 비어 있으므로 orchestrator와
+    동일한 source_identity()로 identity를 채운다.
     """
-    return source.alias if source.alias else f"{source.provider}.{source.dataset}"
+    if source.alias:
+        return source.alias
+    provider, dataset = source_identity(source)
+    return f"{provider}.{dataset}"
 
 
 def match_source_ref(spec: BuildSpec, source_key: str) -> SourceRef | None:

--- a/src/kpubdata_builder/spec/loader.py
+++ b/src/kpubdata_builder/spec/loader.py
@@ -18,6 +18,7 @@ import yaml
 
 from ..errors import SpecLoadError
 from .models import (
+    SOURCE_KINDS,
     BuildSpec,
     CompareColumnsRule,
     ExportTarget,
@@ -220,8 +221,29 @@ def _parse_json_mapping(value: object, *, field_name: str) -> dict[str, JsonValu
     return parsed
 
 
+# kind별로만 유효한 field들 (#498). 서로 다른 kind의 field가 섞인 source는 명백한
+# 계약 오류이므로 loader가 즉시 거부한다 — "kind=file인데 provider도 있음" 같은
+# 모호한 spec을 조용히 부분 해석하지 않는다.
+_PUBLIC_API_ONLY_FIELDS: tuple[str, ...] = ("upload_id", "format", "encoding", "endpoint", "method")
+_FILE_ONLY_FIELDS: tuple[str, ...] = ("provider", "dataset", "params", "endpoint", "method")
+_URL_ONLY_FIELDS: tuple[str, ...] = ("provider", "dataset", "params", "upload_id", "encoding")
+
+
+def _reject_foreign_fields(
+    mapping: dict[str, object], forbidden: tuple[str, ...], *, prefix: str, kind: str
+) -> None:
+    present = sorted(name for name in forbidden if name in mapping)
+    if present:
+        raise TypeError(f"{prefix}: fields {present} are not valid for kind={kind!r} (#498)")
+
+
 def _parse_sources(value: object) -> tuple[SourceRef, ...]:
-    """sources 배열을 SourceRef 튜플로 변환한다."""
+    """sources 배열을 SourceRef 튜플로 변환한다 (#498).
+
+    ``kind`` 로 public_api(기본, 하위 호환)/file/url을 구분해 서로 다른 field
+    조합을 파싱한다. ``kind`` 를 생략한 기존 source는 항상 ``public_api`` 로
+    해석된다 — 기존 Public API BuildSpec은 재작성 없이 그대로 동작한다.
+    """
     if not isinstance(value, list):
         raise TypeError("sources must be a list")
     if not value:
@@ -232,11 +254,6 @@ def _parse_sources(value: object) -> tuple[SourceRef, ...]:
     for index, item in enumerate(items):
         prefix = f"sources[{index}]"
         mapping = _ensure_mapping(item, field_name=prefix)
-        provider = _require_string(mapping, "provider", prefix=prefix)
-        dataset = _require_string(mapping, "dataset", prefix=prefix)
-        params = _parse_json_mapping(
-            mapping.get("params", {}), field_name=f"sources[{index}].params"
-        )
         # normalization_mode 필드는 제거됨 (#438). sources[].schema 가 대체.
         # 조용히 무시하지 않고 명시적 에러로 알린다.
         if "normalization_mode" in mapping:
@@ -244,21 +261,96 @@ def _parse_sources(value: object) -> tuple[SourceRef, ...]:
                 f"sources[{index}].normalization_mode is removed; "
                 "use sources[].schema instead (#438)"
             )
+        kind_obj = mapping.get("kind", "public_api")
+        if not isinstance(kind_obj, str):
+            raise TypeError(f"{prefix}.kind must be a string")
+        if kind_obj not in SOURCE_KINDS:
+            raise ValueError(
+                f"{prefix}.kind {kind_obj!r} is not supported; use one of {SOURCE_KINDS} (#498)"
+            )
         alias_obj = mapping.get("alias", "")
         if not isinstance(alias_obj, str):
             raise TypeError(f"sources[{index}].alias must be a string")
         schema_obj = mapping.get("schema")
         schema = _parse_schema(schema_obj, prefix=prefix) if schema_obj is not None else None
-        parsed_sources.append(
-            SourceRef(
-                provider=provider,
-                dataset=dataset,
-                params=params,
-                alias=alias_obj,
-                schema=schema,
+
+        if kind_obj == "file":
+            parsed_sources.append(
+                _parse_file_source(mapping, index=index, alias=alias_obj, schema=schema)
             )
-        )
+        elif kind_obj == "url":
+            parsed_sources.append(
+                _parse_url_source(mapping, index=index, alias=alias_obj, schema=schema)
+            )
+        else:
+            parsed_sources.append(
+                _parse_public_api_source(mapping, index=index, alias=alias_obj, schema=schema)
+            )
     return tuple(parsed_sources)
+
+
+def _parse_public_api_source(
+    mapping: dict[str, object], *, index: int, alias: str, schema: SchemaContract | None
+) -> SourceRef:
+    prefix = f"sources[{index}]"
+    _reject_foreign_fields(mapping, _PUBLIC_API_ONLY_FIELDS, prefix=prefix, kind="public_api")
+    provider = _require_string(mapping, "provider", prefix=prefix)
+    dataset = _require_string(mapping, "dataset", prefix=prefix)
+    params = _parse_json_mapping(mapping.get("params", {}), field_name=f"{prefix}.params")
+    return SourceRef(
+        provider=provider,
+        dataset=dataset,
+        params=params,
+        alias=alias,
+        schema=schema,
+        kind="public_api",
+    )
+
+
+def _parse_file_source(
+    mapping: dict[str, object], *, index: int, alias: str, schema: SchemaContract | None
+) -> SourceRef:
+    """kind='file' source를 파싱한다 (#498). 값 vocabulary(허용 format/encoding
+    존재 여부, upload_id 형태)의 의미 검증은 validator.py가 담당한다."""
+    prefix = f"sources[{index}]"
+    _reject_foreign_fields(mapping, _FILE_ONLY_FIELDS, prefix=prefix, kind="file")
+    upload_id = _require_string(mapping, "upload_id", prefix=prefix)
+    format_value = _require_string(mapping, "format", prefix=prefix)
+    encoding_obj = mapping.get("encoding", "utf-8")
+    if not isinstance(encoding_obj, str) or not encoding_obj.strip():
+        raise TypeError(f"{prefix}.encoding must be a non-empty string")
+    return SourceRef(
+        alias=alias,
+        schema=schema,
+        kind="file",
+        upload_id=upload_id,
+        format=format_value,
+        encoding=encoding_obj,
+    )
+
+
+def _parse_url_source(
+    mapping: dict[str, object], *, index: int, alias: str, schema: SchemaContract | None
+) -> SourceRef:
+    """kind='url' source를 파싱한다 (#498). scheme/userinfo/method vocabulary 같은
+    SSRF 관련 의미 검증은 validator.py가 담당한다 — 여기서는 구조만 본다."""
+    prefix = f"sources[{index}]"
+    _reject_foreign_fields(mapping, _URL_ONLY_FIELDS, prefix=prefix, kind="url")
+    endpoint = _require_string(mapping, "endpoint", prefix=prefix)
+    method_obj = mapping.get("method", "GET")
+    if not isinstance(method_obj, str) or not method_obj.strip():
+        raise TypeError(f"{prefix}.method must be a non-empty string")
+    format_obj = mapping.get("format", "")
+    if not isinstance(format_obj, str):
+        raise TypeError(f"{prefix}.format must be a string")
+    return SourceRef(
+        alias=alias,
+        schema=schema,
+        kind="url",
+        endpoint=endpoint,
+        method=method_obj,
+        format=format_obj,
+    )
 
 
 def _parse_schema(value: object, *, prefix: str) -> SchemaContract:

--- a/src/kpubdata_builder/spec/models.py
+++ b/src/kpubdata_builder/spec/models.py
@@ -11,6 +11,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TypeAlias
@@ -41,23 +42,69 @@ class SchemaContract:
     casts: dict[str, str] = field(default_factory=dict)
 
 
+#: 지원하는 SourceRef.kind 값 (#498). 알 수 없는 kind는 loader가 즉시 거부한다.
+SOURCE_KINDS: tuple[str, ...] = ("public_api", "file", "url")
+
+#: url kind에서 허용하는 HTTP method (#498 P0 — GET, Auth=None만 지원).
+SOURCE_URL_METHODS: tuple[str, ...] = ("GET",)
+
+#: file kind에서 허용하는 업로드 포맷 (#498 P0). Excel/ZIP은 범위 밖이다.
+SOURCE_FILE_FORMATS: tuple[str, ...] = ("csv", "json", "jsonl", "parquet")
+
+#: url kind에서 허용하는 응답 포맷 (#498 P0). 지정하지 않으면 Content-Type로 추론한다.
+SOURCE_URL_FORMATS: tuple[str, ...] = ("json", "jsonl", "csv")
+
+#: 서버가 발급하는 upload_id 형태 (#498). ``POST /uploads`` 만 이 형태의 id를
+#: 만든다 — 사용자가 임의 문자열을 upload_id로 넣어 filesystem/조회를 조작할 수
+#: 없도록 loader/validator가 이 패턴으로 형태를 고정한다.
+UPLOAD_ID_PATTERN: re.Pattern[str] = re.compile(r"^upl_[a-f0-9]{32}$")
+
+
 @dataclass(frozen=True)
 class SourceRef:
-    """kpubdata의 정규화된 소스 쿼리를 가리키는 참조.
+    """Canonical 소스 참조 — Public API / File / URL 세 kind를 표현한다 (#498).
+
+    ``kind`` 로 세 가지 소스를 구분한다. 세 kind는 서로 다른 field 조합을 쓰지만
+    ``alias``/``schema`` 는 공통이다(공통 alias/schema 정책, #498).
+
+    - ``"public_api"``(기본값, 하위 호환): 기존 kpubdata provider/dataset 참조.
+      ``provider``/``dataset``/``params`` 를 쓴다. kind를 생략한 기존 BuildSpec은
+      항상 이 kind로 해석된다 — 기존 Public API BuildSpec 동작은 그대로 유지된다.
+    - ``"file"``: 사전에 ``POST /uploads`` 로 업로드된 파일을 가리킨다. 로컬
+      파일시스템 경로 대신 서버가 발급한 불투명한 ``upload_id`` 만 참조한다 —
+      filename/path를 직접 참조하지 않는다(경로 주입 방지).
+    - ``"url"``: 안전한 GET(Auth=None) HTTP(S) 소스를 가리킨다. arbitrary header나
+      POST/PUT/PATCH는 계약에 없다 — 필드 자체가 없어 표현할 수 없다.
 
     속성:
-        provider: provider 식별자.
-        dataset: dataset 식별자.
-        params: list 호출에 전달할 원시 파라미터.
-        alias: 조립 단계에서 사용할 사용자 정의 소스 이름.
-        schema: 소스 스키마 계약. None 이면 Silver 검증을 생략한다 (하위 호환, #437).
+        provider: provider 식별자. ``kind="public_api"`` 에서만 사용.
+        dataset: dataset 식별자. ``kind="public_api"`` 에서만 사용.
+        params: list 호출에 전달할 원시 파라미터. ``kind="public_api"`` 에서만 사용.
+        alias: 조립 단계에서 사용할 사용자 정의 소스 이름 (모든 kind 공통).
+        schema: 소스 스키마 계약. None 이면 Silver 검증을 생략한다 (모든 kind 공통,
+            하위 호환, #437).
+        kind: ``"public_api"``(기본) | ``"file"`` | ``"url"``.
+        upload_id: 업로드된 파일의 서버 발급 식별자. ``kind="file"`` 에서만 사용.
+        format: 파일/응답 파싱 포맷. ``kind="file"`` 은 필수(csv/json/jsonl/parquet),
+            ``kind="url"`` 은 선택(json/jsonl/csv, 생략 시 Content-Type로 추론).
+        encoding: 텍스트 디코딩에 쓸 인코딩. ``kind="file"`` 에서만 의미가 있다
+            (parquet 제외 — 바이너리 포맷이라 인코딩이 없다). 기본값 ``"utf-8"``.
+        endpoint: 안전하게 fetch할 절대 URL. ``kind="url"`` 에서만 사용.
+        method: HTTP method. ``kind="url"`` 에서만 사용하며 P0는 ``"GET"`` 만
+            허용한다.
     """
 
-    provider: str
-    dataset: str
+    provider: str = ""
+    dataset: str = ""
     params: dict[str, JsonValue] = field(default_factory=dict)
     alias: str = ""
     schema: SchemaContract | None = None
+    kind: str = "public_api"
+    upload_id: str = ""
+    format: str = ""
+    encoding: str = "utf-8"
+    endpoint: str = ""
+    method: str = "GET"
 
 
 @dataclass(frozen=True)
@@ -250,6 +297,11 @@ __all__ = [
     "ExportTarget",
     "JsonPrimitive",
     "JsonValue",
+    "SOURCE_FILE_FORMATS",
+    "SOURCE_KINDS",
+    "SOURCE_URL_FORMATS",
+    "SOURCE_URL_METHODS",
     "SourceRef",
     "SplitSpec",
+    "UPLOAD_ID_PATTERN",
 ]

--- a/src/kpubdata_builder/spec/serializer.py
+++ b/src/kpubdata_builder/spec/serializer.py
@@ -79,15 +79,26 @@ def canonical_spec_mapping(spec: BuildSpec) -> dict[str, JsonValue]:
                 "dtypes": _canonical_json(cast(JsonValue, source.schema.dtypes)),
                 "casts": _canonical_json(cast(JsonValue, source.schema.casts)),
             }
-        sources.append(
-            {
-                "provider": source.provider,
-                "dataset": source.dataset,
-                "params": _canonical_json(source.params),
-                "alias": source.alias,
-                "schema": schema,
-            }
-        )
+        # kind별로 유효한 field만 싣는다 (#498). loader의 _reject_foreign_fields가
+        # kind-foreign field의 "존재"만으로 거부하므로, 여기서 모든 kind의 field를
+        # 항상 함께 실으면 canonical snapshot 자체가 round-trip 불가능한 spec이
+        # 된다 — schema(#437)가 이미 쓰는 "관련 없으면 아예 emit하지 않는다" 패턴을
+        # 그대로 따른다. 기존 public_api-only spec에는 "kind": "public_api" 한
+        # 필드만 additive로 늘어난다.
+        entry: dict[str, JsonValue] = {"kind": source.kind, "alias": source.alias, "schema": schema}
+        if source.kind == "file":
+            entry["upload_id"] = source.upload_id
+            entry["format"] = source.format
+            entry["encoding"] = source.encoding
+        elif source.kind == "url":
+            entry["endpoint"] = source.endpoint
+            entry["method"] = source.method
+            entry["format"] = source.format
+        else:
+            entry["provider"] = source.provider
+            entry["dataset"] = source.dataset
+            entry["params"] = _canonical_json(source.params)
+        sources.append(entry)
 
     exports: list[JsonValue] = [
         {

--- a/src/kpubdata_builder/spec/validator.py
+++ b/src/kpubdata_builder/spec/validator.py
@@ -23,6 +23,7 @@ from ..exporters import EXPORTER_REGISTRY
 from ..tabular.polars_helpers import _NAMED_DTYPES
 from .models import (
     SOURCE_FILE_FORMATS,
+    SOURCE_KINDS,
     SOURCE_URL_FORMATS,
     SOURCE_URL_METHODS,
     UPLOAD_ID_PATTERN,
@@ -260,19 +261,34 @@ def _schema_problems(spec: BuildSpec) -> list[ValidationProblem]:
 
 
 def _source_kind_problems(spec: BuildSpec) -> list[ValidationProblem]:
-    """kind='file'/'url' source의 값 vocabulary와 SSRF 관련 형태를 검증한다 (#498).
+    """kind vocabulary와 kind='file'/'url' source의 값·SSRF 관련 형태를 검증한다 (#498).
 
-    field 구조(서로 다른 kind의 field 혼입 금지)는 loader가 이미 거부한다. 여기서는
-    loader가 검사하지 않는 의미 규칙(허용 format/encoding/method vocabulary, URL
-    scheme/userinfo, upload_id 형태)만 다룬다. 실제 네트워크 SSRF 방어(DNS
-    resolve·redirect 재검증)는 fetch 시점(ingestion.url_fetch)의 책임이다 — 여기서는
-    명백히 안전하지 않은 선언(scheme=http, userinfo 포함 등)을 build 실행 전에
-    빠르게 거부한다.
+    ``kind`` 자체가 ``SOURCE_KINDS``(public_api/file/url) 밖이면 여기서
+    거부한다 — loader(YAML 경로)는 이미 거부하지만, ``SourceRef(kind="ftp",
+    ...)``처럼 loader를 거치지 않고 BuildSpec을 직접 구성하면 이 검사가 유일한
+    방어선이다(fail-closed, #538 review). canonical source kind 계약은
+    public_api | file | url 세 가지뿐이며, 알 수 없는 kind를 암묵적으로
+    public_api처럼 처리하지 않는다.
+
+    나머지는 loader가 검사하지 않는 의미 규칙(허용 format/encoding/method
+    vocabulary, URL scheme/userinfo, upload_id 형태)만 다룬다. 실제 네트워크
+    SSRF 방어(DNS resolve·redirect 재검증)는 fetch 시점(ingestion.url_fetch)의
+    책임이다 — 여기서는 명백히 안전하지 않은 선언(scheme=http, userinfo 포함
+    등)을 build 실행 전에 빠르게 거부한다.
     """
     problems: list[ValidationProblem] = []
     for i, source in enumerate(spec.sources):
         prefix = f"sources[{i}]"
-        if source.kind == "file":
+        if source.kind not in SOURCE_KINDS:
+            problems.append(
+                _p(
+                    "unsupported_source_kind",
+                    f"{prefix}.kind",
+                    f"{prefix}.kind {source.kind!r} is not supported; "
+                    f"use one of {SOURCE_KINDS} (#498)",
+                )
+            )
+        elif source.kind == "file":
             problems.extend(_file_source_problems(source, prefix))
         elif source.kind == "url":
             problems.extend(_url_source_problems(source, prefix))
@@ -327,8 +343,7 @@ def _url_source_problems(source: SourceRef, prefix: str) -> list[ValidationProbl
             _p(
                 "unsupported_source_method",
                 f"{prefix}.method",
-                f"{prefix}.method {source.method!r} is not supported "
-                "(P0 supports GET only, #498)",
+                f"{prefix}.method {source.method!r} is not supported (P0 supports GET only, #498)",
                 hint=f"Use one of: {', '.join(SOURCE_URL_METHODS)}",
             )
         )

--- a/src/kpubdata_builder/spec/validator.py
+++ b/src/kpubdata_builder/spec/validator.py
@@ -13,13 +13,22 @@ BL3 (#417): problems를 {code, path, message, hint} 객체 배열로 구조화.
 
 from __future__ import annotations
 
+import codecs
 import math
 from dataclasses import dataclass
+from urllib.parse import urlsplit
 
 from ..errors import ValidationError
 from ..exporters import EXPORTER_REGISTRY
 from ..tabular.polars_helpers import _NAMED_DTYPES
-from .models import BuildSpec
+from .models import (
+    SOURCE_FILE_FORMATS,
+    SOURCE_URL_FORMATS,
+    SOURCE_URL_METHODS,
+    UPLOAD_ID_PATTERN,
+    BuildSpec,
+    SourceRef,
+)
 
 
 @dataclass(frozen=True)
@@ -61,22 +70,25 @@ def validate_spec(spec: BuildSpec) -> None:
     if not spec.sources:
         problems.append(_p("missing_sources", "sources", "at least one source is required"))
     for i, source in enumerate(spec.sources):
-        if not source.provider.strip():
-            problems.append(
-                _p(
-                    "empty_field",
-                    f"sources[{i}].provider",
-                    f"sources[{i}].provider must be a non-empty string",
+        # provider/dataset은 kind="public_api"(기본값)에서만 의미가 있다 — 다른
+        # kind의 필수/금지 field는 _source_kind_problems가 검증한다 (#498).
+        if source.kind == "public_api":
+            if not source.provider.strip():
+                problems.append(
+                    _p(
+                        "empty_field",
+                        f"sources[{i}].provider",
+                        f"sources[{i}].provider must be a non-empty string",
+                    )
                 )
-            )
-        if not source.dataset.strip():
-            problems.append(
-                _p(
-                    "empty_field",
-                    f"sources[{i}].dataset",
-                    f"sources[{i}].dataset must be a non-empty string",
+            if not source.dataset.strip():
+                problems.append(
+                    _p(
+                        "empty_field",
+                        f"sources[{i}].dataset",
+                        f"sources[{i}].dataset must be a non-empty string",
+                    )
                 )
-            )
         if source.alias and not source.alias.strip():
             problems.append(
                 _p(
@@ -115,6 +127,7 @@ def validate_spec(spec: BuildSpec) -> None:
             break
     problems.extend(_split_problems(spec))
     problems.extend(_schema_problems(spec))
+    problems.extend(_source_kind_problems(spec))
     problems.extend(_pii_problems(spec))
     problems.extend(_license_problems(spec))
     problems.extend(_quality_problems(spec))
@@ -243,6 +256,118 @@ def _schema_problems(spec: BuildSpec) -> list[ValidationProblem]:
                         hint=f"Use one of: {', '.join(supported)}",
                     )
                 )
+    return problems
+
+
+def _source_kind_problems(spec: BuildSpec) -> list[ValidationProblem]:
+    """kind='file'/'url' source의 값 vocabulary와 SSRF 관련 형태를 검증한다 (#498).
+
+    field 구조(서로 다른 kind의 field 혼입 금지)는 loader가 이미 거부한다. 여기서는
+    loader가 검사하지 않는 의미 규칙(허용 format/encoding/method vocabulary, URL
+    scheme/userinfo, upload_id 형태)만 다룬다. 실제 네트워크 SSRF 방어(DNS
+    resolve·redirect 재검증)는 fetch 시점(ingestion.url_fetch)의 책임이다 — 여기서는
+    명백히 안전하지 않은 선언(scheme=http, userinfo 포함 등)을 build 실행 전에
+    빠르게 거부한다.
+    """
+    problems: list[ValidationProblem] = []
+    for i, source in enumerate(spec.sources):
+        prefix = f"sources[{i}]"
+        if source.kind == "file":
+            problems.extend(_file_source_problems(source, prefix))
+        elif source.kind == "url":
+            problems.extend(_url_source_problems(source, prefix))
+    return problems
+
+
+def _file_source_problems(source: SourceRef, prefix: str) -> list[ValidationProblem]:
+    problems: list[ValidationProblem] = []
+    if not source.upload_id.strip():
+        problems.append(
+            _p(
+                "empty_field",
+                f"{prefix}.upload_id",
+                f"{prefix}.upload_id must be a non-empty string",
+            )
+        )
+    elif not UPLOAD_ID_PATTERN.match(source.upload_id):
+        problems.append(
+            _p(
+                "invalid_upload_id",
+                f"{prefix}.upload_id",
+                f"{prefix}.upload_id {source.upload_id!r} is not a valid upload identifier",
+                hint="upload_id must come from POST /uploads",
+            )
+        )
+    if source.format not in SOURCE_FILE_FORMATS:
+        problems.append(
+            _p(
+                "unsupported_source_format",
+                f"{prefix}.format",
+                f"{prefix}.format {source.format!r} is not supported for kind='file'",
+                hint=f"Use one of: {', '.join(SOURCE_FILE_FORMATS)}",
+            )
+        )
+    try:
+        codecs.lookup(source.encoding)
+    except LookupError:
+        problems.append(
+            _p(
+                "unknown_encoding",
+                f"{prefix}.encoding",
+                f"{prefix}.encoding {source.encoding!r} is not a known encoding",
+            )
+        )
+    return problems
+
+
+def _url_source_problems(source: SourceRef, prefix: str) -> list[ValidationProblem]:
+    problems: list[ValidationProblem] = []
+    if source.method not in SOURCE_URL_METHODS:
+        problems.append(
+            _p(
+                "unsupported_source_method",
+                f"{prefix}.method",
+                f"{prefix}.method {source.method!r} is not supported "
+                "(P0 supports GET only, #498)",
+                hint=f"Use one of: {', '.join(SOURCE_URL_METHODS)}",
+            )
+        )
+    if source.format and source.format not in SOURCE_URL_FORMATS:
+        problems.append(
+            _p(
+                "unsupported_source_format",
+                f"{prefix}.format",
+                f"{prefix}.format {source.format!r} is not supported for kind='url'",
+                hint=f"Use one of: {', '.join(SOURCE_URL_FORMATS)}",
+            )
+        )
+    problems.extend(_endpoint_problems(source.endpoint, f"{prefix}.endpoint"))
+    return problems
+
+
+def _endpoint_problems(endpoint: str, path: str) -> list[ValidationProblem]:
+    if not endpoint.strip():
+        return [_p("empty_field", path, f"{path} must be a non-empty string")]
+    parsed = urlsplit(endpoint)
+    problems: list[ValidationProblem] = []
+    if parsed.scheme != "https":
+        problems.append(
+            _p(
+                "unsafe_url_scheme",
+                path,
+                f"{path} must use https (got {parsed.scheme or 'none'!r}) — SSRF policy, #498",
+            )
+        )
+    if parsed.username or parsed.password:
+        problems.append(
+            _p(
+                "url_userinfo_forbidden",
+                path,
+                f"{path} must not contain userinfo (SSRF policy, #498)",
+            )
+        )
+    if not parsed.hostname:
+        problems.append(_p("missing_url_host", path, f"{path} must include a host"))
     return problems
 
 

--- a/src/kpubdata_builder/stages/bronze/__init__.py
+++ b/src/kpubdata_builder/stages/bronze/__init__.py
@@ -9,11 +9,14 @@ from __future__ import annotations
 from .build import build_bronze_artifact
 from .models import BronzeArtifact, ProvenanceEvent
 from .persist import BronzePersistResult, persist_bronze_artifact
+from .resolve import build_bronze_artifact_for_source, source_identity
 
 __all__ = [
     "BronzeArtifact",
     "BronzePersistResult",
     "ProvenanceEvent",
     "build_bronze_artifact",
+    "build_bronze_artifact_for_source",
     "persist_bronze_artifact",
+    "source_identity",
 ]

--- a/src/kpubdata_builder/stages/bronze/resolve.py
+++ b/src/kpubdata_builder/stages/bronze/resolve.py
@@ -30,6 +30,7 @@ from urllib.parse import urlsplit, urlunsplit
 from ...ingestion import IngestionError, parse_tabular_bytes, safe_fetch_get
 from ...ingestion.url_fetch import default_max_fetch_bytes
 from ...spec import JsonValue, SourceRef
+from ...spec.models import SOURCE_KINDS
 from ...uploads import UploadRepository
 from .build import SourceClient, build_bronze_artifact
 from .models import BronzeArtifact, ProvenanceEvent, require_timezone_aware, utc_now
@@ -103,7 +104,8 @@ def build_bronze_artifact_for_source(
         BronzeArtifact: kind와 무관하게 동일한 모양의 산출물.
 
     예외:
-        IngestionError: file/url fetch·파싱 실패, 소유권 없음, 저장소 미설정.
+        IngestionError: file/url fetch·파싱 실패, 소유권 없음, 저장소 미설정,
+            알 수 없는 source.kind(fail-closed, #538 review).
     """
     if source.kind == "file":
         return _build_from_upload(
@@ -111,12 +113,20 @@ def build_bronze_artifact_for_source(
         )
     if source.kind == "url":
         return _build_from_url(source, fetched_at=fetched_at)
-    provider, dataset = source_identity(source)
-    return build_bronze_artifact(
-        client,
-        source_key=f"{provider}.{dataset}",
-        fetch_params=dict(source.params),
-        fetched_at=fetched_at,
+    if source.kind == "public_api":
+        provider, dataset = source_identity(source)
+        return build_bronze_artifact(
+            client,
+            source_key=f"{provider}.{dataset}",
+            fetch_params=dict(source.params),
+            fetched_at=fetched_at,
+        )
+    # validate_spec이 loader를 거치지 않은 BuildSpec(직접 SourceRef 구성)도
+    # 이미 거부하지만, resolver 스스로도 "그 외는 public_api"라는 implicit
+    # fallback을 두지 않는다 — canonical kind 계약(public_api|file|url) 밖의
+    # 값은 여기서도 fail-closed로 막는다(BLOCKER, #538 review).
+    raise IngestionError(
+        f"unsupported source kind: {source.kind!r} (canonical kinds: {SOURCE_KINDS})"
     )
 
 

--- a/src/kpubdata_builder/stages/bronze/resolve.py
+++ b/src/kpubdata_builder/stages/bronze/resolve.py
@@ -1,0 +1,219 @@
+"""Source kind resolver — public_api/file/url을 동일한 BronzeArtifact로 만든다 (#498).
+
+새 pipeline이 아니라 기존 Bronze→Silver→Gold pipeline 앞에 붙는 resolver
+layer다. ``kind`` 에 따라 서로 다른 방식으로 원시 레코드를 얻지만, 세 경로 모두
+``build.build_bronze_artifact`` 와 동일한 ``BronzeArtifact`` 모양(raw_records/
+fetch_params/fetched_at/provenance)으로 수렴한다 — Silver 이후 단계는 소스가
+어떤 kind였는지 전혀 알 필요가 없다.
+
+기존 ``provider.dataset`` provenance 모양을 그대로 재사용한다(#498, "모든
+source가 동일 Bronze artifact contract 사용"): file은 ``("file", upload_id)``,
+url은 ``("url", <host+path 기반 안전한 slug>)`` 를 provider/dataset 자리에
+채운다. manifest/provenance 모델에 새 필드를 추가하지 않고 기존 계약을 그대로
+쓴다.
+
+이 ``(provider, dataset)`` 쌍은 provenance 식별자일 뿐 아니라 alias가 없을 때
+``pipeline.orchestrator``/``service.stages`` 가 그대로 output/persist 디렉터리
+세그먼트(``stages._path_safety.validate_path_segment``)로도 쓴다 — 그래서 url
+kind의 dataset은 사람이 읽기보다 "항상 안전한 경로 세그먼트"를 우선한다. 원본
+endpoint(query 제거)는 ``sanitize_endpoint_identity()`` 로 별도 계산해
+fetch_params/provenance.params에만 담는다(경로에는 쓰이지 않음).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from datetime import datetime
+from urllib.parse import urlsplit, urlunsplit
+
+from ...ingestion import IngestionError, parse_tabular_bytes, safe_fetch_get
+from ...ingestion.url_fetch import default_max_fetch_bytes
+from ...spec import JsonValue, SourceRef
+from ...uploads import UploadRepository
+from .build import SourceClient, build_bronze_artifact
+from .models import BronzeArtifact, ProvenanceEvent, require_timezone_aware, utc_now
+
+_NON_SLUG_CHARS = re.compile(r"[^a-zA-Z0-9]+")
+
+
+def source_identity(source: SourceRef) -> tuple[str, str]:
+    """모든 kind에 대해 (provider, dataset) 자리를 채우는 canonical identity.
+
+    기존 provenance/manifest/output-path 코드가 이미 ``"{provider}.{dataset}"``
+    형태를 source identity(및 alias 없을 때의 output 디렉터리 세그먼트)로
+    쓰므로, file/url kind도 그 모양에 맞춰 항상 경로로 안전한 값을 만든다.
+    """
+    if source.kind == "file":
+        return "file", source.upload_id
+    if source.kind == "url":
+        return "url", _url_path_safe_identity(source.endpoint)
+    return source.provider, source.dataset
+
+
+def _url_path_safe_identity(endpoint: str) -> str:
+    """endpoint를 ``validate_path_segment`` 를 항상 통과하는 slug로 줄인다.
+
+    URL은 ``:``/``/`` 등 경로 세그먼트로 쓸 수 없는 문자를 포함하므로, host를
+    영숫자-하이픈 slug로 정규화하고 (query 제거된) endpoint 전체의 SHA-256
+    앞 12자리를 붙여 서로 다른 경로가 우연히 같은 slug로 뭉치지 않게 한다.
+    사람이 읽는 endpoint는 이 값이 아니라 ``sanitize_endpoint_identity()`` 가
+    fetch_params/provenance.params에 별도로 담는다.
+    """
+    sanitized = sanitize_endpoint_identity(endpoint)
+    host = urlsplit(sanitized).hostname or "host"
+    slug = _NON_SLUG_CHARS.sub("-", host).strip("-") or "host"
+    digest = hashlib.sha256(sanitized.encode("utf-8")).hexdigest()[:12]
+    return f"{slug}-{digest}"
+
+
+def sanitize_endpoint_identity(endpoint: str) -> str:
+    """endpoint에서 query string/userinfo/fragment를 제거한 사람이 읽는 identity를 만든다.
+
+    url source의 P0는 Auth=None이라 endpoint 자체에 secret이 실릴 일이 적지만,
+    query string에 우연히 token 등이 섞였을 때도 provenance/manifest에 남지
+    않도록 방어적으로 제거한다("provenance endpoint secret 제거", #498). 경로
+    세그먼트로 쓰기에는 안전하지 않다 — 그 용도는 ``_url_path_safe_identity``.
+    """
+    parts = urlsplit(endpoint)
+    netloc = parts.hostname or ""
+    if parts.port:
+        netloc = f"{netloc}:{parts.port}"
+    return urlunsplit((parts.scheme, netloc, parts.path or "/", "", ""))
+
+
+def build_bronze_artifact_for_source(
+    source: SourceRef,
+    *,
+    client: SourceClient,
+    upload_repository: UploadRepository | None = None,
+    owner_id: str | None = None,
+    fetched_at: datetime | None = None,
+) -> BronzeArtifact:
+    """source.kind에 맞는 방식으로 fetch해 BronzeArtifact를 만든다 (#498).
+
+    매개변수:
+        source: canonical source 참조 (public_api/file/url).
+        client: public_api kind에서만 쓰이는 kpubdata 호환 client.
+        upload_repository: file kind에서 업로드 content를 조회할 저장소.
+        owner_id: file kind에서 업로드 소유권을 확인할 principal의 stable id.
+        fetched_at: fetch 완료 시각. 생략 시 현재 UTC.
+
+    반환값:
+        BronzeArtifact: kind와 무관하게 동일한 모양의 산출물.
+
+    예외:
+        IngestionError: file/url fetch·파싱 실패, 소유권 없음, 저장소 미설정.
+    """
+    if source.kind == "file":
+        return _build_from_upload(
+            source, upload_repository=upload_repository, owner_id=owner_id, fetched_at=fetched_at
+        )
+    if source.kind == "url":
+        return _build_from_url(source, fetched_at=fetched_at)
+    provider, dataset = source_identity(source)
+    return build_bronze_artifact(
+        client,
+        source_key=f"{provider}.{dataset}",
+        fetch_params=dict(source.params),
+        fetched_at=fetched_at,
+    )
+
+
+def _finalize(
+    *,
+    provider: str,
+    dataset: str,
+    records: tuple[dict[str, JsonValue], ...],
+    fetch_params: dict[str, JsonValue],
+    fetched_at: datetime | None,
+) -> BronzeArtifact:
+    resolved_fetched_at = fetched_at or utc_now()
+    require_timezone_aware(resolved_fetched_at, field_name="fetched_at")
+    source_key = f"{provider}.{dataset}"
+    provenance = ProvenanceEvent(
+        source_key=source_key, fetch_params=fetch_params, fetched_at=resolved_fetched_at
+    )
+    return BronzeArtifact(
+        source_key=source_key,
+        raw_records=records,
+        fetch_params=fetch_params,
+        fetched_at=resolved_fetched_at,
+        provenance=provenance,
+    )
+
+
+def _build_from_upload(
+    source: SourceRef,
+    *,
+    upload_repository: UploadRepository | None,
+    owner_id: str | None,
+    fetched_at: datetime | None,
+) -> BronzeArtifact:
+    if upload_repository is None:
+        raise IngestionError("file source requires an upload store to be configured")
+    if not owner_id:
+        raise IngestionError("file source requires an authenticated, stable principal owner")
+    metadata = upload_repository.get_metadata(owner_id, source.upload_id)
+    if metadata is None:
+        # 존재하지 않는 upload_id와 "principal 소유가 아닌" upload_id를
+        # 구분하지 않는다 — 다른 사용자의 upload 존재 여부를 흘리지 않는다
+        # (fail-closed, #505의 ownership 패턴과 동일).
+        raise IngestionError(f"upload not found: {source.upload_id}")
+    if metadata.format != source.format or metadata.encoding != source.encoding:
+        raise IngestionError(
+            "sources[].format/encoding does not match the stored upload "
+            f"(upload format={metadata.format!r} encoding={metadata.encoding!r})"
+        )
+    content = upload_repository.get_content(owner_id, source.upload_id)
+    if content is None:
+        raise IngestionError(f"upload not found: {source.upload_id}")
+    records = parse_tabular_bytes(content, format=source.format, encoding=source.encoding)
+    provider, dataset = source_identity(source)
+    fetch_params: dict[str, JsonValue] = {
+        "upload_id": source.upload_id,
+        "format": source.format,
+        "encoding": source.encoding,
+    }
+    return _finalize(
+        provider=provider,
+        dataset=dataset,
+        records=records,
+        fetch_params=fetch_params,
+        fetched_at=fetched_at,
+    )
+
+
+def _build_from_url(source: SourceRef, *, fetched_at: datetime | None) -> BronzeArtifact:
+    result = safe_fetch_get(source.endpoint, max_bytes=default_max_fetch_bytes())
+    resolved_format = source.format or _infer_format(result.content_type) or "json"
+    records = parse_tabular_bytes(result.content, format=resolved_format, encoding="utf-8")
+    provider, dataset = source_identity(source)
+    # fetch_params.endpoint는 사람이 읽는 (query 제거된) 원본 endpoint다 — path
+    # 세그먼트로 쓰이는 `dataset`(slug+hash, source_identity 참고)과는 다른 값이다.
+    fetch_params: dict[str, JsonValue] = {
+        "endpoint": sanitize_endpoint_identity(source.endpoint),
+        "method": source.method,
+    }
+    return _finalize(
+        provider=provider,
+        dataset=dataset,
+        records=records,
+        fetch_params=fetch_params,
+        fetched_at=fetched_at,
+    )
+
+
+def _infer_format(content_type: str) -> str | None:
+    """명시적 ``source.format`` 이 없을 때만 Content-Type로 포맷을 추정한다."""
+    normalized = content_type.split(";", 1)[0].strip().lower()
+    if normalized == "application/json":
+        return "json"
+    if normalized in ("application/x-ndjson", "application/jsonl"):
+        return "jsonl"
+    if normalized in ("text/csv", "application/csv"):
+        return "csv"
+    return None
+
+
+__all__ = ["build_bronze_artifact_for_source", "sanitize_endpoint_identity", "source_identity"]

--- a/src/kpubdata_builder/uploads/__init__.py
+++ b/src/kpubdata_builder/uploads/__init__.py
@@ -1,0 +1,25 @@
+"""File source 업로드 저장소 (#498).
+
+``POST /uploads`` 로 올라온 파일 bytes를 owner_id로 격리해 저장하고, BuildSpec의
+``kind="file"`` source가 참조하는 ``upload_id`` 로 조회한다.
+"""
+
+from __future__ import annotations
+
+from .models import UploadMetadata
+from .store import (
+    MAX_UPLOAD_BYTES_ENV,
+    SQLiteUploadRepository,
+    UploadRepository,
+    generate_upload_id,
+    resolve_max_upload_bytes,
+)
+
+__all__ = [
+    "MAX_UPLOAD_BYTES_ENV",
+    "SQLiteUploadRepository",
+    "UploadMetadata",
+    "UploadRepository",
+    "generate_upload_id",
+    "resolve_max_upload_bytes",
+]

--- a/src/kpubdata_builder/uploads/models.py
+++ b/src/kpubdata_builder/uploads/models.py
@@ -1,0 +1,31 @@
+"""업로드 메타데이터 모델 (#498)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class UploadMetadata:
+    """저장된 업로드의 안전한(secret-free) 메타데이터.
+
+    원시 content는 별도로 ``get_content()`` 를 통해서만 얻는다 — 목록/조회
+    응답에는 절대 포함하지 않는다.
+
+    속성:
+        upload_id: 서버가 발급한 불투명한 식별자(``upl_<hex32>``). 사용자가
+            지정한 filename/path가 아니다.
+        format: 업로드 시점에 검증된 포맷(csv/json/jsonl/parquet).
+        encoding: 업로드 시점에 검증된 인코딩(parquet은 의미 없음).
+        size_bytes: content 크기.
+        original_filename: 사용자가 보낸 원본 파일명(표시 전용, sanitize됨).
+            파일시스템 경로로 절대 쓰이지 않는다.
+        created_at: ISO-8601 UTC 생성 시각.
+    """
+
+    upload_id: str
+    format: str
+    encoding: str
+    size_bytes: int
+    original_filename: str | None
+    created_at: str

--- a/src/kpubdata_builder/uploads/store.py
+++ b/src/kpubdata_builder/uploads/store.py
@@ -148,9 +148,7 @@ class SQLiteUploadRepository:
     ) -> UploadMetadata:
         self._validate_owner_id(owner_id)
         if format not in SOURCE_FILE_FORMATS:
-            raise ValueError(
-                f"format must be one of {SOURCE_FILE_FORMATS}, got {format!r}"
-            )
+            raise ValueError(f"format must be one of {SOURCE_FILE_FORMATS}, got {format!r}")
         if not content:
             raise ValueError("upload content must not be empty")
         limit = max_bytes if max_bytes is not None else self._max_bytes

--- a/src/kpubdata_builder/uploads/store.py
+++ b/src/kpubdata_builder/uploads/store.py
@@ -1,0 +1,261 @@
+"""SQLite 기반 업로드 저장소 (#498).
+
+``credentials/store.py``(#492)와 같은 모양을 따른다 — 단일 SQLite 파일에
+``(owner_id, upload_id)`` 로 격리된 row를 저장한다. credential과 달리 업로드
+content는 secret이 아니므로 암호화하지 않지만, 다음 두 가지로 안전한 staging을
+보장한다(#498):
+
+    - ``upload_id`` 는 서버가 ``secrets`` 로 생성한다 — 사용자가 filename이나
+      path를 직접 지정해 파일시스템을 조작할 수 없다(파일 자체를 filesystem에
+      쓰지 않고 SQLite BLOB으로 저장하므로 path traversal 표면이 아예 없다).
+    - 모든 조회/삭제는 ``owner_id`` 로 scoping된다 — 다른 사용자의 upload는
+      존재 여부조차 구분되지 않고 동일하게 "not found"로 취급된다(fail-closed,
+      #505의 ownership 패턴과 동일).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import secrets
+import sqlite3
+import threading
+from collections.abc import Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Protocol
+
+from ..spec.models import SOURCE_FILE_FORMATS
+from .models import UploadMetadata
+
+MAX_UPLOAD_BYTES_ENV = "KPUBDATA_BUILDER_MAX_UPLOAD_BYTES"
+_DEFAULT_MAX_UPLOAD_BYTES = 20 * 1024 * 1024  # 20 MiB
+
+# 표시 전용 원본 filename의 최대 보존 길이. 파일시스템 경로로는 절대 쓰이지
+# 않으므로 위험한 문자 자체를 막을 필요는 없지만, 응답 크기를 bound한다.
+_MAX_DISPLAY_FILENAME_LENGTH = 255
+
+
+def resolve_max_upload_bytes() -> int:
+    """업로드 크기 상한을 환경변수에서 읽는다 (없거나 잘못되면 기본값)."""
+    raw = os.environ.get(MAX_UPLOAD_BYTES_ENV, "").strip()
+    if not raw:
+        return _DEFAULT_MAX_UPLOAD_BYTES
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DEFAULT_MAX_UPLOAD_BYTES
+    return value if value > 0 else _DEFAULT_MAX_UPLOAD_BYTES
+
+
+def generate_upload_id() -> str:
+    """``spec.models.UPLOAD_ID_PATTERN`` 과 항상 일치하는 새 upload_id를 만든다.
+
+    ``token_hex(16)`` 은 항상 32자리 소문자 16진수 문자열을 반환하므로
+    ``UPLOAD_ID_PATTERN``(``^upl_[a-f0-9]{32}$``)과 구조적으로 항상 일치한다.
+    """
+    return f"upl_{secrets.token_hex(16)}"
+
+
+def _sanitize_display_filename(original_filename: str | None) -> str | None:
+    """원본 filename을 표시 전용 문자열로 안전화한다.
+
+    파일시스템 경로로 쓰지 않으므로 traversal 방지가 목적이 아니라, 경로
+    구분자를 남겨 응답을 읽는 클라이언트가 실수로 path처럼 다루지 않도록
+    basename만 남기고 길이를 제한한다.
+    """
+    if original_filename is None:
+        return None
+    stripped = original_filename.strip()
+    if not stripped:
+        return None
+    basename = re.split(r"[\\/]", stripped)[-1]
+    return basename[:_MAX_DISPLAY_FILENAME_LENGTH] or None
+
+
+class UploadRepository(Protocol):
+    """owner_id + upload_id를 key로 하는 업로드 저장소 abstraction."""
+
+    def put(
+        self,
+        owner_id: str,
+        *,
+        content: bytes,
+        format: str,  # noqa: A002 - 계약 필드명과 맞춘다
+        encoding: str,
+        original_filename: str | None,
+        max_bytes: int | None = None,
+    ) -> UploadMetadata: ...
+
+    def get_metadata(self, owner_id: str, upload_id: str) -> UploadMetadata | None: ...
+
+    def get_content(self, owner_id: str, upload_id: str) -> bytes | None: ...
+
+    def delete(self, owner_id: str, upload_id: str) -> bool: ...
+
+    def list_for_owner(self, owner_id: str) -> Sequence[UploadMetadata]: ...
+
+
+class SQLiteUploadRepository:
+    """content를 BLOB으로 저장하는 SQLite 업로드 저장소."""
+
+    def __init__(self, path: Path, *, max_bytes: int | None = None) -> None:
+        self._path = path
+        self._max_bytes = max_bytes if max_bytes is not None else resolve_max_upload_bytes()
+        self._lock = threading.RLock()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self._path, timeout=5.0)
+        connection.execute("PRAGMA foreign_keys = ON")
+        return connection
+
+    def _initialize(self) -> None:
+        with self._lock, self._connect() as connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS uploads (
+                    upload_id TEXT PRIMARY KEY,
+                    owner_id TEXT NOT NULL,
+                    format TEXT NOT NULL,
+                    encoding TEXT NOT NULL,
+                    size_bytes INTEGER NOT NULL,
+                    original_filename TEXT,
+                    content BLOB NOT NULL,
+                    created_at TEXT NOT NULL
+                )
+                """
+            )
+            connection.execute(
+                "CREATE INDEX IF NOT EXISTS idx_uploads_owner_id ON uploads(owner_id)"
+            )
+
+    @staticmethod
+    def _validate_owner_id(owner_id: str) -> None:
+        if not owner_id:
+            raise ValueError("stable owner_id is required")
+
+    def put(
+        self,
+        owner_id: str,
+        *,
+        content: bytes,
+        format: str,  # noqa: A002 - 계약 필드명과 맞춘다
+        encoding: str,
+        original_filename: str | None,
+        max_bytes: int | None = None,
+    ) -> UploadMetadata:
+        self._validate_owner_id(owner_id)
+        if format not in SOURCE_FILE_FORMATS:
+            raise ValueError(
+                f"format must be one of {SOURCE_FILE_FORMATS}, got {format!r}"
+            )
+        if not content:
+            raise ValueError("upload content must not be empty")
+        limit = max_bytes if max_bytes is not None else self._max_bytes
+        if len(content) > limit:
+            raise ValueError(f"upload exceeds max size ({limit} bytes)")
+
+        upload_id = generate_upload_id()
+        display_filename = _sanitize_display_filename(original_filename)
+        created_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        with self._lock, self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO uploads(
+                    upload_id, owner_id, format, encoding, size_bytes,
+                    original_filename, content, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    upload_id,
+                    owner_id,
+                    format,
+                    encoding,
+                    len(content),
+                    display_filename,
+                    content,
+                    created_at,
+                ),
+            )
+        return UploadMetadata(
+            upload_id=upload_id,
+            format=format,
+            encoding=encoding,
+            size_bytes=len(content),
+            original_filename=display_filename,
+            created_at=created_at,
+        )
+
+    def get_metadata(self, owner_id: str, upload_id: str) -> UploadMetadata | None:
+        self._validate_owner_id(owner_id)
+        with self._lock, self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT format, encoding, size_bytes, original_filename, created_at
+                FROM uploads WHERE owner_id = ? AND upload_id = ?
+                """,
+                (owner_id, upload_id),
+            ).fetchone()
+        if row is None:
+            return None
+        return UploadMetadata(
+            upload_id=upload_id,
+            format=str(row[0]),
+            encoding=str(row[1]),
+            size_bytes=int(row[2]),
+            original_filename=str(row[3]) if row[3] is not None else None,
+            created_at=str(row[4]),
+        )
+
+    def get_content(self, owner_id: str, upload_id: str) -> bytes | None:
+        self._validate_owner_id(owner_id)
+        with self._lock, self._connect() as connection:
+            row = connection.execute(
+                "SELECT content FROM uploads WHERE owner_id = ? AND upload_id = ?",
+                (owner_id, upload_id),
+            ).fetchone()
+        if row is None:
+            return None
+        return bytes(row[0])
+
+    def delete(self, owner_id: str, upload_id: str) -> bool:
+        self._validate_owner_id(owner_id)
+        with self._lock, self._connect() as connection:
+            cursor = connection.execute(
+                "DELETE FROM uploads WHERE owner_id = ? AND upload_id = ?",
+                (owner_id, upload_id),
+            )
+        return cursor.rowcount > 0
+
+    def list_for_owner(self, owner_id: str) -> Sequence[UploadMetadata]:
+        self._validate_owner_id(owner_id)
+        with self._lock, self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT upload_id, format, encoding, size_bytes, original_filename, created_at
+                FROM uploads WHERE owner_id = ? ORDER BY created_at DESC
+                """,
+                (owner_id,),
+            ).fetchall()
+        return tuple(
+            UploadMetadata(
+                upload_id=str(row[0]),
+                format=str(row[1]),
+                encoding=str(row[2]),
+                size_bytes=int(row[3]),
+                original_filename=str(row[4]) if row[4] is not None else None,
+                created_at=str(row[5]),
+            )
+            for row in rows
+        )
+
+
+__all__ = [
+    "MAX_UPLOAD_BYTES_ENV",
+    "SQLiteUploadRepository",
+    "UploadRepository",
+    "generate_upload_id",
+    "resolve_max_upload_bytes",
+]

--- a/tests/unit/test_bronze_resolve.py
+++ b/tests/unit/test_bronze_resolve.py
@@ -69,9 +69,7 @@ def test_source_identity_for_url_is_a_safe_path_segment() -> None:
     쓰이므로(orchestrator._fetch_source_key), colon/slash가 남으면
     validate_path_segment가 거부한다(#498).
     """
-    source = SourceRef(
-        kind="url", endpoint="https://example.org:8443/data?token=secret&x=1#frag"
-    )
+    source = SourceRef(kind="url", endpoint="https://example.org:8443/data?token=secret&x=1#frag")
 
     provider, dataset = source_identity(source)
 
@@ -114,6 +112,20 @@ def test_public_api_source_delegates_to_existing_client_path() -> None:
     assert artifact.source_key == "datago.air_quality"
     assert artifact.raw_records == ({"id": "1"},)
     assert artifact.fetch_params == {"page": 1}
+
+
+def test_unknown_source_kind_is_rejected_fail_closed() -> None:
+    """알 수 없는 kind를 public_api처럼 암묵적으로 처리하지 않는다 (#538 review).
+
+    validate_spec이 loader를 거치지 않은 BuildSpec도 이미 거부하지만, resolver
+    자신도 "그 외는 public_api" implicit fallback을 두지 않고 독립적으로
+    fail-closed해야 한다 — resolver를 직접 호출하는 다른 경로(테스트, 향후
+    호출자)가 validate_spec을 우회해도 안전하도록.
+    """
+    source = SourceRef(kind="ftp", provider="datago", dataset="air_quality")
+
+    with pytest.raises(IngestionError, match="unsupported source kind"):
+        build_bronze_artifact_for_source(source, client=_FakeClient({}))
 
 
 # --- build_bronze_artifact_for_source: file ---------------------------------------
@@ -227,9 +239,7 @@ def test_url_source_uses_safe_fetch_and_declared_format(monkeypatch: pytest.Monk
 
     def _fake_fetch(url: str, *, max_bytes: int) -> FetchResult:
         assert url == "https://example.org/data.json"
-        return FetchResult(
-            content=b'[{"id": 1}]', content_type="application/json", final_url=url
-        )
+        return FetchResult(content=b'[{"id": 1}]', content_type="application/json", final_url=url)
 
     monkeypatch.setattr(resolve_module, "safe_fetch_get", _fake_fetch)
     source = SourceRef(kind="url", endpoint="https://example.org/data.json", format="json")

--- a/tests/unit/test_bronze_resolve.py
+++ b/tests/unit/test_bronze_resolve.py
@@ -1,0 +1,291 @@
+"""stages.bronze.resolve: source kind resolver가 동일한 BronzeArtifact를 만드는지 검증 (#498)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+import pytest
+
+from kpubdata_builder.ingestion import IngestionError
+from kpubdata_builder.ingestion.url_fetch import FetchResult
+from kpubdata_builder.spec import JsonValue, SourceRef
+from kpubdata_builder.stages._path_safety import validate_path_segment
+from kpubdata_builder.stages.bronze.resolve import (
+    build_bronze_artifact_for_source,
+    sanitize_endpoint_identity,
+    source_identity,
+)
+from kpubdata_builder.uploads import SQLiteUploadRepository
+from kpubdata_builder.uploads.store import generate_upload_id
+
+
+class _FakeResult:
+    def __init__(self, items: list[dict[str, JsonValue]]) -> None:
+        self._items = items
+
+    @property
+    def items(self) -> Iterable[dict[str, JsonValue]]:
+        return self._items
+
+
+class _FakeDataset:
+    def __init__(self, items: list[dict[str, JsonValue]]) -> None:
+        self._items = items
+
+    def list(self, **params: JsonValue) -> _FakeResult:
+        return _FakeResult(self._items)
+
+
+class _FakeClient:
+    def __init__(self, data: dict[str, list[dict[str, JsonValue]]]) -> None:
+        self._data = data
+
+    def dataset(self, source_key: str) -> _FakeDataset:
+        if source_key not in self._data:
+            raise KeyError(f"unknown source: {source_key}")
+        return _FakeDataset(self._data[source_key])
+
+
+# --- source_identity / sanitize_endpoint_identity ---------------------------------
+
+
+def test_source_identity_for_public_api_is_unchanged() -> None:
+    source = SourceRef(provider="datago", dataset="air_quality")
+
+    assert source_identity(source) == ("datago", "air_quality")
+
+
+def test_source_identity_for_file_uses_upload_id_not_path() -> None:
+    source = SourceRef(kind="file", upload_id="upl_" + "a" * 32, format="csv")
+
+    assert source_identity(source) == ("file", "upl_" + "a" * 32)
+
+
+def test_source_identity_for_url_is_a_safe_path_segment() -> None:
+    """url identity는 :,/ 등을 포함할 수 없다 — 항상 path segment로 안전해야 한다.
+
+    alias가 없으면 이 값이 그대로 bronze/silver/gold 출력 디렉터리 세그먼트로
+    쓰이므로(orchestrator._fetch_source_key), colon/slash가 남으면
+    validate_path_segment가 거부한다(#498).
+    """
+    source = SourceRef(
+        kind="url", endpoint="https://example.org:8443/data?token=secret&x=1#frag"
+    )
+
+    provider, dataset = source_identity(source)
+
+    assert provider == "url"
+    assert dataset.startswith("example-org-")
+    assert ":" not in dataset
+    assert "/" not in dataset
+    assert "secret" not in dataset
+    validate_path_segment(dataset, field_name="dataset")  # raises on failure
+
+
+def test_source_identity_for_url_is_stable_and_distinguishes_different_paths() -> None:
+    same_again = source_identity(SourceRef(kind="url", endpoint="https://example.org/data"))
+    different_path = source_identity(SourceRef(kind="url", endpoint="https://example.org/other"))
+
+    assert source_identity(SourceRef(kind="url", endpoint="https://example.org/data")) == same_again
+    assert same_again != different_path
+
+
+def test_sanitize_endpoint_identity_drops_query_string() -> None:
+    assert (
+        sanitize_endpoint_identity("https://example.org/data?api_key=shh")
+        == "https://example.org/data"
+    )
+
+
+def test_sanitize_endpoint_identity_defaults_empty_path_to_slash() -> None:
+    assert sanitize_endpoint_identity("https://example.org") == "https://example.org/"
+
+
+# --- build_bronze_artifact_for_source: public_api (기존 경로 그대로) --------------
+
+
+def test_public_api_source_delegates_to_existing_client_path() -> None:
+    source = SourceRef(provider="datago", dataset="air_quality", params={"page": 1})
+    client = _FakeClient({"datago.air_quality": [{"id": "1"}]})
+
+    artifact = build_bronze_artifact_for_source(source, client=client)
+
+    assert artifact.source_key == "datago.air_quality"
+    assert artifact.raw_records == ({"id": "1"},)
+    assert artifact.fetch_params == {"page": 1}
+
+
+# --- build_bronze_artifact_for_source: file ---------------------------------------
+
+
+def _upload_repo(tmp_path: Path) -> SQLiteUploadRepository:
+    return SQLiteUploadRepository(tmp_path / "uploads.sqlite3")
+
+
+def test_file_source_reads_and_parses_upload(tmp_path: Path) -> None:
+    repo = _upload_repo(tmp_path)
+    metadata = repo.put(
+        "owner-1", content=b"id,v\n1,10\n", format="csv", encoding="utf-8", original_filename=None
+    )
+    source = SourceRef(kind="file", upload_id=metadata.upload_id, format="csv", encoding="utf-8")
+
+    artifact = build_bronze_artifact_for_source(
+        source, client=_FakeClient({}), upload_repository=repo, owner_id="owner-1"
+    )
+
+    assert artifact.source_key == f"file.{metadata.upload_id}"
+    assert artifact.raw_records == ({"id": 1, "v": 10},)
+    assert artifact.fetch_params == {
+        "upload_id": metadata.upload_id,
+        "format": "csv",
+        "encoding": "utf-8",
+    }
+    # provenance에 파일시스템 경로가 전혀 남지 않는다.
+    assert artifact.provenance is not None
+    assert "\\" not in str(artifact.provenance.fetch_params)
+    assert "/" not in str(artifact.provenance.fetch_params.get("upload_id", ""))
+
+
+def test_file_source_without_repository_raises_ingestion_error() -> None:
+    source = SourceRef(kind="file", upload_id=generate_upload_id(), format="csv")
+
+    with pytest.raises(IngestionError, match="upload store"):
+        build_bronze_artifact_for_source(
+            source, client=_FakeClient({}), upload_repository=None, owner_id="owner-1"
+        )
+
+
+def test_file_source_without_owner_id_raises_ingestion_error(tmp_path: Path) -> None:
+    repo = _upload_repo(tmp_path)
+    source = SourceRef(kind="file", upload_id=generate_upload_id(), format="csv")
+
+    with pytest.raises(IngestionError, match="authenticated"):
+        build_bronze_artifact_for_source(
+            source, client=_FakeClient({}), upload_repository=repo, owner_id=None
+        )
+
+
+def test_file_source_unknown_upload_id_raises_ingestion_error(tmp_path: Path) -> None:
+    repo = _upload_repo(tmp_path)
+    source = SourceRef(kind="file", upload_id=generate_upload_id(), format="csv")
+
+    with pytest.raises(IngestionError, match="not found"):
+        build_bronze_artifact_for_source(
+            source, client=_FakeClient({}), upload_repository=repo, owner_id="owner-1"
+        )
+
+
+def test_file_source_owned_by_another_principal_raises_not_found(tmp_path: Path) -> None:
+    """다른 owner의 upload_id를 참조하면 존재 여부를 구분하지 않고 not found다."""
+    repo = _upload_repo(tmp_path)
+    metadata = repo.put(
+        "owner-1", content=b"id\n1\n", format="csv", encoding="utf-8", original_filename=None
+    )
+    source = SourceRef(kind="file", upload_id=metadata.upload_id, format="csv")
+
+    with pytest.raises(IngestionError, match="not found"):
+        build_bronze_artifact_for_source(
+            source, client=_FakeClient({}), upload_repository=repo, owner_id="owner-2"
+        )
+
+
+def test_file_source_format_mismatch_with_stored_upload_raises(tmp_path: Path) -> None:
+    repo = _upload_repo(tmp_path)
+    metadata = repo.put(
+        "owner-1", content=b"id\n1\n", format="csv", encoding="utf-8", original_filename=None
+    )
+    # BuildSpec은 json이라고 선언했지만 업로드는 csv로 저장됨.
+    source = SourceRef(kind="file", upload_id=metadata.upload_id, format="json", encoding="utf-8")
+
+    with pytest.raises(IngestionError, match="does not match"):
+        build_bronze_artifact_for_source(
+            source, client=_FakeClient({}), upload_repository=repo, owner_id="owner-1"
+        )
+
+
+def test_file_source_encoding_mismatch_with_stored_upload_raises(tmp_path: Path) -> None:
+    """format은 같아도 encoding만 다르면 조용히 재해석하지 않고 reject한다 (#498)."""
+    repo = _upload_repo(tmp_path)
+    metadata = repo.put(
+        "owner-1", content=b"id\n1\n", format="csv", encoding="utf-8", original_filename=None
+    )
+    # BuildSpec은 format=csv로 업로드와 같지만 encoding만 euc-kr로 선언함.
+    source = SourceRef(kind="file", upload_id=metadata.upload_id, format="csv", encoding="euc-kr")
+
+    with pytest.raises(IngestionError, match="does not match"):
+        build_bronze_artifact_for_source(
+            source, client=_FakeClient({}), upload_repository=repo, owner_id="owner-1"
+        )
+
+
+# --- build_bronze_artifact_for_source: url ----------------------------------------
+
+
+def test_url_source_uses_safe_fetch_and_declared_format(monkeypatch: pytest.MonkeyPatch) -> None:
+    import kpubdata_builder.stages.bronze.resolve as resolve_module
+
+    def _fake_fetch(url: str, *, max_bytes: int) -> FetchResult:
+        assert url == "https://example.org/data.json"
+        return FetchResult(
+            content=b'[{"id": 1}]', content_type="application/json", final_url=url
+        )
+
+    monkeypatch.setattr(resolve_module, "safe_fetch_get", _fake_fetch)
+    source = SourceRef(kind="url", endpoint="https://example.org/data.json", format="json")
+
+    artifact = build_bronze_artifact_for_source(source, client=_FakeClient({}))
+
+    assert artifact.source_key.startswith("url.example-org-")
+    assert artifact.raw_records == ({"id": 1},)
+    assert artifact.fetch_params == {"endpoint": "https://example.org/data.json", "method": "GET"}
+
+
+def test_url_source_infers_format_from_content_type_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kpubdata_builder.stages.bronze.resolve as resolve_module
+
+    def _fake_fetch(url: str, *, max_bytes: int) -> FetchResult:
+        return FetchResult(content=b"a,b\n1,2\n", content_type="text/csv", final_url=url)
+
+    monkeypatch.setattr(resolve_module, "safe_fetch_get", _fake_fetch)
+    source = SourceRef(kind="url", endpoint="https://example.org/data")
+
+    artifact = build_bronze_artifact_for_source(source, client=_FakeClient({}))
+
+    assert artifact.raw_records == ({"a": 1, "b": 2},)
+
+
+def test_url_source_defaults_to_json_when_format_and_content_type_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kpubdata_builder.stages.bronze.resolve as resolve_module
+
+    def _fake_fetch(url: str, *, max_bytes: int) -> FetchResult:
+        return FetchResult(content=b'[{"id": 1}]', content_type="", final_url=url)
+
+    monkeypatch.setattr(resolve_module, "safe_fetch_get", _fake_fetch)
+    source = SourceRef(kind="url", endpoint="https://example.org/data")
+
+    artifact = build_bronze_artifact_for_source(source, client=_FakeClient({}))
+
+    assert artifact.raw_records == ({"id": 1},)
+
+
+def test_url_source_provenance_excludes_query_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    import kpubdata_builder.stages.bronze.resolve as resolve_module
+
+    def _fake_fetch(url: str, *, max_bytes: int) -> FetchResult:
+        return FetchResult(content=b'[{"id": 1}]', content_type="application/json", final_url=url)
+
+    monkeypatch.setattr(resolve_module, "safe_fetch_get", _fake_fetch)
+    source = SourceRef(
+        kind="url", endpoint="https://example.org/data?api_key=super-secret", format="json"
+    )
+
+    artifact = build_bronze_artifact_for_source(source, client=_FakeClient({}))
+
+    assert "super-secret" not in str(artifact.fetch_params)
+    assert artifact.provenance is not None
+    assert "super-secret" not in str(artifact.provenance.fetch_params)

--- a/tests/unit/test_openapi_examples.py
+++ b/tests/unit/test_openapi_examples.py
@@ -175,7 +175,7 @@ def test_extraction_script_emits_documented_json_shape() -> None:
         text=True,
     )
     payload = json.loads(completed.stdout)
-    assert payload["contract_version"] == "1.11.0"
+    assert payload["contract_version"] == "1.12.0"
     assert len(payload["examples"]) >= 50
     assert set(payload["examples"][0]) == {
         "path",

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -646,3 +646,110 @@ def test_run_build_keeps_snapshot_when_source_pipeline_fails(tmp_path: Path) -> 
     assert result.status == "failed"
     assert (tmp_path / "failed-run" / "buildspec.yaml").is_file()
     assert result.spec_digest.startswith("sha256:")
+
+
+# --- Canonical source contract(#498): file/url kind가 동일 pipeline을 타는지 검증 ---
+
+
+def test_run_build_with_file_source_runs_full_pipeline(tmp_path: Path) -> None:
+    """kind="file" source도 public_api와 동일한 Bronze→Silver→Gold 산출물을 만든다."""
+    from kpubdata_builder.uploads import SQLiteUploadRepository
+
+    upload_repository = SQLiteUploadRepository(tmp_path / "uploads.sqlite3")
+    metadata = upload_repository.put(
+        "owner-1",
+        content=b"id,amount\n1,1000\n2,2500\n",
+        format="csv",
+        encoding="utf-8",
+        original_filename="trades.csv",
+    )
+    spec = _spec(
+        SourceRef(
+            kind="file",
+            upload_id=metadata.upload_id,
+            format="csv",
+            encoding="utf-8",
+            alias="uploaded_trades",
+        )
+    )
+
+    result = run_build(
+        spec,
+        client=_FakeClient({}),
+        output_root=tmp_path,
+        run_id="file-run",
+        owner_id="owner-1",
+        upload_repository=upload_repository,
+    )
+
+    assert result.status == "ok"
+    assert result.outcomes[0].source_key == "uploaded_trades"
+    assert result.outcomes[0].stages_completed == ("bronze", "silver", "gold")
+
+    gold_parquet = tmp_path / "file-run" / "gold" / "uploaded_trades" / "table.parquet"
+    assert pl.read_parquet(gold_parquet).to_dicts() == [
+        {"id": 1, "amount": 1000},
+        {"id": 2, "amount": 2500},
+    ]
+
+    # provenance/manifest 어디에도 로컬 파일시스템 경로가 남지 않는다(#498).
+    manifest_text = result.manifest_path.read_text(encoding="utf-8")
+    assert str(tmp_path / "uploads.sqlite3") not in manifest_text
+    manifest = cast(
+        dict[str, JsonValue], json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    )
+    provenance = cast(list[dict[str, JsonValue]], manifest["provenance"])
+    assert provenance[0]["provider"] == "file"
+    assert provenance[0]["dataset"] == metadata.upload_id
+    assert cast(dict[str, JsonValue], provenance[0]["params"])["upload_id"] == metadata.upload_id
+
+
+def test_run_build_with_file_source_fails_closed_without_owner(tmp_path: Path) -> None:
+    """owner_id 없이 file source를 실행하면 해당 소스만 명확히 실패한다."""
+    from kpubdata_builder.uploads import SQLiteUploadRepository
+
+    upload_repository = SQLiteUploadRepository(tmp_path / "uploads.sqlite3")
+    metadata = upload_repository.put(
+        "owner-1", content=b"id\n1\n", format="csv", encoding="utf-8", original_filename=None
+    )
+    spec = _spec(SourceRef(kind="file", upload_id=metadata.upload_id, format="csv"))
+
+    result = run_build(
+        spec,
+        client=_FakeClient({}),
+        output_root=tmp_path,
+        run_id="no-owner-run",
+        upload_repository=upload_repository,
+    )
+
+    assert result.status == "failed"
+    assert result.outcomes[0].status == "failed"
+    assert "authenticated" in (result.outcomes[0].error or "")
+
+
+def test_run_build_with_url_source_runs_full_pipeline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """kind="url" source도 SSRF-safe fetch를 거쳐 동일 pipeline을 탄다."""
+    from kpubdata_builder.ingestion.url_fetch import FetchResult
+    from kpubdata_builder.stages.bronze import resolve as resolve_module
+
+    def _fake_fetch(url: str, *, max_bytes: int) -> FetchResult:
+        assert url == "https://example.org/data.json"
+        return FetchResult(
+            content=b'[{"id": 1, "amount": 1000}]',
+            content_type="application/json",
+            final_url=url,
+        )
+
+    monkeypatch.setattr(resolve_module, "safe_fetch_get", _fake_fetch)
+    spec = _spec(
+        SourceRef(kind="url", endpoint="https://example.org/data.json", alias="external_feed")
+    )
+
+    result = run_build(spec, client=_FakeClient({}), output_root=tmp_path, run_id="url-run")
+
+    assert result.status == "ok"
+    assert result.outcomes[0].source_key == "external_feed"
+    gold_parquet = tmp_path / "url-run" / "gold" / "external_feed" / "table.parquet"
+    assert pl.read_parquet(gold_parquet).to_dicts() == [{"id": 1, "amount": 1000}]

--- a/tests/unit/test_preview.py
+++ b/tests/unit/test_preview.py
@@ -652,9 +652,7 @@ class TestSourceKinds:
             )
 
         monkeypatch.setattr(resolve_module, "safe_fetch_get", _fake_fetch)
-        spec = _spec(
-            SourceRef(kind="url", endpoint="https://example.org/data.json", alias="feed")
-        )
+        spec = _spec(SourceRef(kind="url", endpoint="https://example.org/data.json", alias="feed"))
 
         result = preview_build(spec, client=_FakeClient({}))
 

--- a/tests/unit/test_preview.py
+++ b/tests/unit/test_preview.py
@@ -581,3 +581,84 @@ class TestRegression:
         assert preview.preview.total_rows == 10
         assert len(preview.preview.rows) == 3
         assert preview.statistics.row_count == 10
+
+
+# ---------------------------------------------------------------------------
+# Canonical source contract(#498) — file/url kind가 public_api와 동일하게 preview된다.
+# ---------------------------------------------------------------------------
+
+
+class TestSourceKinds:
+    def test_preview_file_source_returns_schema_and_sample(self, tmp_path: Path) -> None:
+        from kpubdata_builder.uploads import SQLiteUploadRepository
+
+        repo = SQLiteUploadRepository(tmp_path / "uploads.sqlite3")
+        metadata = repo.put(
+            "owner-1",
+            content=b"id,amount\n1,1000\n2,2500\n",
+            format="csv",
+            encoding="utf-8",
+            original_filename=None,
+        )
+        spec = _spec(
+            SourceRef(kind="file", upload_id=metadata.upload_id, format="csv", alias="uploaded")
+        )
+
+        result = preview_build(
+            spec, client=_FakeClient({}), upload_repository=repo, owner_id="owner-1"
+        )
+
+        preview = result.previews[0]
+        assert preview.source_key == "uploaded"
+        assert preview.status == "ok"
+        assert [c.name for c in preview.schema.columns] == ["id", "amount"]
+        assert preview.preview.total_rows == 2
+
+    def test_preview_file_source_without_owner_reports_failed_status(self, tmp_path: Path) -> None:
+        from kpubdata_builder.uploads import SQLiteUploadRepository
+
+        repo = SQLiteUploadRepository(tmp_path / "uploads.sqlite3")
+        spec = _spec(
+            SourceRef(kind="file", upload_id="upl_" + "a" * 32, format="csv", alias="uploaded")
+        )
+
+        # upload_repository는 있지만 owner_id가 없다 — 인증되지 않은 preview 요청.
+        result = preview_build(spec, client=_FakeClient({}), upload_repository=repo)
+
+        preview = result.previews[0]
+        assert preview.status == "failed"
+        assert "authenticated" in (preview.error or "")
+
+    def test_preview_file_source_without_repository_reports_failed_status(self) -> None:
+        spec = _spec(
+            SourceRef(kind="file", upload_id="upl_" + "a" * 32, format="csv", alias="uploaded")
+        )
+
+        result = preview_build(spec, client=_FakeClient({}))
+
+        preview = result.previews[0]
+        assert preview.status == "failed"
+        assert "upload store" in (preview.error or "")
+
+    def test_preview_url_source_returns_schema_and_sample(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kpubdata_builder.ingestion.url_fetch import FetchResult
+        from kpubdata_builder.stages.bronze import resolve as resolve_module
+
+        def _fake_fetch(url: str, *, max_bytes: int) -> FetchResult:
+            return FetchResult(
+                content=b'[{"id": 1}, {"id": 2}]', content_type="application/json", final_url=url
+            )
+
+        monkeypatch.setattr(resolve_module, "safe_fetch_get", _fake_fetch)
+        spec = _spec(
+            SourceRef(kind="url", endpoint="https://example.org/data.json", alias="feed")
+        )
+
+        result = preview_build(spec, client=_FakeClient({}))
+
+        preview = result.previews[0]
+        assert preview.source_key == "feed"
+        assert preview.status == "ok"
+        assert preview.preview.total_rows == 2

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -1302,9 +1302,7 @@ class TestHttpUploads:
         assert fetched["upload_id"] == upload_id
         assert "content" not in fetched
 
-        delete_req = urllib.request.Request(
-            f"{base_url}/uploads/{upload_id}", method="DELETE"
-        )
+        delete_req = urllib.request.Request(f"{base_url}/uploads/{upload_id}", method="DELETE")
         with urllib.request.urlopen(delete_req, timeout=2.0) as response:
             assert response.status == 200
             deleted = cast(dict[str, object], json.loads(response.read()))

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -343,6 +343,143 @@ class TestBuild:
         assert resp.status_code == 404
 
 
+def _file_source_spec_yaml(upload_id: str) -> str:
+    return (
+        f"""
+dataset_id: dataset.uploaded
+title: Uploaded Trades
+description: file source build (#498)
+sources:
+  - kind: file
+    upload_id: {upload_id}
+    format: csv
+    encoding: utf-8
+exports:
+  - kind: jsonl
+    output_path: out/data.jsonl
+""".strip()
+        + "\n"
+    )
+
+
+class TestUploads:
+    """kind="file" source(#498) — POST /uploads가 owner_id로 격리한 업로드를
+    BuildSpec이 참조해 build/preview까지 이어지는 end-to-end 흐름을 검증한다."""
+
+    def test_create_upload_then_build_end_to_end(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        principal = Principal(kind="oidc", identifier="u1", owner_id="oidc:owner-1")
+
+        created = service.create_upload(
+            b"id,amount\n1,1000\n2,2500\n",
+            format="csv",
+            encoding="utf-8",
+            original_filename="trades.csv",
+            principal=principal,
+        )
+        assert created.status_code == 200
+        upload_id = created.body["upload_id"]
+        assert isinstance(upload_id, str)
+
+        result = service.build(
+            _file_source_spec_yaml(upload_id),
+            run_id="upload-run",
+            owner_id=principal.owner_id,
+            principal=principal,
+        )
+
+        assert result.status_code == 200
+        assert result.body["status"] == "ok"
+
+    def test_build_rejects_upload_owned_by_another_principal(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        owner = Principal(kind="oidc", identifier="u1", owner_id="oidc:owner-1")
+        other = Principal(kind="oidc", identifier="u2", owner_id="oidc:owner-2")
+
+        created = service.create_upload(
+            b"id\n1\n", format="csv", encoding="utf-8", original_filename=None, principal=owner
+        )
+        upload_id = created.body["upload_id"]
+        assert isinstance(upload_id, str)
+
+        result = service.build(
+            _file_source_spec_yaml(upload_id),
+            run_id="run-other-owner",
+            owner_id=other.owner_id,
+            principal=other,
+        )
+
+        assert result.status_code == 502
+        outcomes = cast(list[dict[str, JsonValue]], result.body["outcomes"])
+        assert outcomes[0]["status"] == "failed"
+        assert "not found" in cast(str, outcomes[0]["error"])
+
+    def test_get_and_delete_upload_round_trip(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        principal = Principal(kind="oidc", identifier="u1", owner_id="oidc:owner-1")
+        created = service.create_upload(
+            b"id\n1\n", format="csv", encoding="utf-8", original_filename=None, principal=principal
+        )
+        upload_id = created.body["upload_id"]
+        assert isinstance(upload_id, str)
+
+        fetched = service.get_upload(upload_id, principal=principal)
+        assert fetched.status_code == 200
+        assert fetched.body["upload_id"] == upload_id
+        assert "content" not in fetched.body
+
+        deleted = service.delete_upload(upload_id, principal=principal)
+        assert deleted.status_code == 200
+        assert deleted.body == {"upload_id": upload_id, "deleted": True}
+
+        missing = service.get_upload(upload_id, principal=principal)
+        assert missing.status_code == 404
+
+    def test_get_upload_hides_existence_from_other_principal(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        owner = Principal(kind="oidc", identifier="u1", owner_id="oidc:owner-1")
+        other = Principal(kind="oidc", identifier="u2", owner_id="oidc:owner-2")
+        created = service.create_upload(
+            b"id\n1\n", format="csv", encoding="utf-8", original_filename=None, principal=owner
+        )
+        upload_id = created.body["upload_id"]
+        assert isinstance(upload_id, str)
+
+        resp = service.get_upload(upload_id, principal=other)
+
+        assert resp.status_code == 404
+
+    def test_create_upload_rejects_corrupt_content(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        principal = Principal(kind="oidc", identifier="u1", owner_id="oidc:owner-1")
+
+        resp = service.create_upload(
+            b"not json",
+            format="json",
+            encoding="utf-8",
+            original_filename=None,
+            principal=principal,
+        )
+
+        assert resp.status_code == 400
+
+    def test_create_upload_rejects_unsupported_format(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        principal = Principal(kind="oidc", identifier="u1", owner_id="oidc:owner-1")
+
+        resp = service.create_upload(
+            b"data", format="xlsx", encoding="utf-8", original_filename=None, principal=principal
+        )
+
+        assert resp.status_code == 400
+
+    def test_preview_without_file_source_never_touches_upload_store(self, tmp_path: Path) -> None:
+        """file source가 없는 preview는 uploads.sqlite3를 만들지 않는다(지연 생성)."""
+        _service(tmp_path).preview(VALID_SPEC_YAML)
+
+        assert not (tmp_path / ".service" / "uploads.sqlite3").exists()
+
+
 class TestArtifacts:
     def test_lists_artifacts_after_build(self, tmp_path: Path) -> None:
         service = _service(tmp_path)
@@ -1137,6 +1274,93 @@ class TestHttpAdapter:
         # 버전·서비스 메타 정보가 누출되지 않아야 한다.
         assert "api_version" not in body
         assert "service" not in body
+
+
+class TestHttpUploads:
+    """POST /uploads(#498)의 실제 소켓 왕복 — binary body 전송·query 파싱·상한."""
+
+    def test_create_get_delete_upload_round_trip_over_http(
+        self, http_server: tuple[str, HTTPServer, threading.Thread]
+    ) -> None:
+        base_url, _, _ = http_server
+        req = urllib.request.Request(
+            f"{base_url}/uploads?format=csv&filename=trades.csv",
+            data=b"id,amount\n1,1000\n",
+            headers={"Content-Type": "application/octet-stream"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=2.0) as response:
+            assert response.status == 200
+            created = cast(dict[str, object], json.loads(response.read()))
+        upload_id = created["upload_id"]
+        assert isinstance(upload_id, str) and upload_id.startswith("upl_")
+        assert created["original_filename"] == "trades.csv"
+
+        with urllib.request.urlopen(f"{base_url}/uploads/{upload_id}", timeout=2.0) as response:
+            assert response.status == 200
+            fetched = cast(dict[str, object], json.loads(response.read()))
+        assert fetched["upload_id"] == upload_id
+        assert "content" not in fetched
+
+        delete_req = urllib.request.Request(
+            f"{base_url}/uploads/{upload_id}", method="DELETE"
+        )
+        with urllib.request.urlopen(delete_req, timeout=2.0) as response:
+            assert response.status == 200
+            deleted = cast(dict[str, object], json.loads(response.read()))
+        assert deleted["upload_id"] == upload_id
+        assert deleted["deleted"] is True
+
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            urllib.request.urlopen(f"{base_url}/uploads/{upload_id}", timeout=2.0)
+        assert exc_info.value.code == 404
+
+    def test_create_upload_over_configured_limit_returns_413(
+        self,
+        http_server: tuple[str, HTTPServer, threading.Thread],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("KPUBDATA_BUILDER_MAX_UPLOAD_BYTES", "10")
+        base_url, _, _ = http_server
+        req = urllib.request.Request(
+            f"{base_url}/uploads?format=csv",
+            data=b"a,b\n" * 10,
+            headers={"Content-Type": "application/octet-stream"},
+            method="POST",
+        )
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            urllib.request.urlopen(req, timeout=2.0)
+        assert exc_info.value.code == 413
+
+    def test_create_upload_missing_format_returns_400(
+        self, http_server: tuple[str, HTTPServer, threading.Thread]
+    ) -> None:
+        base_url, _, _ = http_server
+        req = urllib.request.Request(
+            f"{base_url}/uploads",
+            data=b"id,amount\n1,1000\n",
+            headers={"Content-Type": "application/octet-stream"},
+            method="POST",
+        )
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            urllib.request.urlopen(req, timeout=2.0)
+        assert exc_info.value.code == 400
+
+    def test_create_upload_body_is_not_parsed_as_json(
+        self, http_server: tuple[str, HTTPServer, threading.Thread]
+    ) -> None:
+        # POST /uploads의 body는 CSV/바이너리도 그대로 허용된다 — 다른 endpoint와
+        # 달리 JSON 파싱을 시도하지 않는다(#498). 이 body는 유효한 JSON이 아니지만
+        # (raw text) 유효한 CSV이므로 format=csv로 성공해야 한다.
+        base_url, _, _ = http_server
+        req = urllib.request.Request(
+            f"{base_url}/uploads?format=csv",
+            data=b"a,b\n1,2\n",
+            headers={"Content-Type": "application/octet-stream"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=2.0) as response:
+            assert response.status == 200
 
 
 class TestHttpRobustness:

--- a/tests/unit/test_service_contract.py
+++ b/tests/unit/test_service_contract.py
@@ -1225,9 +1225,7 @@ class TestResponseConformance:
         _assert_conforms(resp, "/uploads/{upload_id}", "GET")
 
     def test_get_upload_404_missing(self, tmp_path: Path) -> None:
-        resp = dispatch(
-            _conform_service(tmp_path), "GET", f"/uploads/upl_{'0' * 32}", None
-        )
+        resp = dispatch(_conform_service(tmp_path), "GET", f"/uploads/upl_{'0' * 32}", None)
         assert resp.status_code == 404
         _assert_conforms(resp, "/uploads/{upload_id}", "GET")
 
@@ -1242,8 +1240,6 @@ class TestResponseConformance:
         _assert_conforms(resp, "/uploads/{upload_id}", "DELETE")
 
     def test_delete_upload_404_missing(self, tmp_path: Path) -> None:
-        resp = dispatch(
-            _conform_service(tmp_path), "DELETE", f"/uploads/upl_{'0' * 32}", None
-        )
+        resp = dispatch(_conform_service(tmp_path), "DELETE", f"/uploads/upl_{'0' * 32}", None)
         assert resp.status_code == 404
         _assert_conforms(resp, "/uploads/{upload_id}", "DELETE")

--- a/tests/unit/test_service_contract.py
+++ b/tests/unit/test_service_contract.py
@@ -62,6 +62,9 @@ _DISPATCH_ROUTES: dict[tuple[str, str], str] = {
     ("/builds/{run_id}/quality", "GET"): "getBuildQuality",
     ("/monitoring/summary", "GET"): "getMonitoringSummary",
     ("/monitoring/builds", "GET"): "getMonitoringBuilds",
+    ("/uploads", "POST"): "createUpload",
+    ("/uploads/{upload_id}", "GET"): "getUpload",
+    ("/uploads/{upload_id}", "DELETE"): "deleteUpload",
 }
 
 # (path, method) 형태의 계약 필수 오퍼레이션. BuilderService.dispatch가 실제로
@@ -93,6 +96,9 @@ _REQUIRED_OPERATIONS = [
     ("/builds/{run_id}/quality", "get"),
     ("/monitoring/summary", "get"),
     ("/monitoring/builds", "get"),
+    ("/uploads", "post"),
+    ("/uploads/{upload_id}", "get"),
+    ("/uploads/{upload_id}", "delete"),
 ]
 
 
@@ -380,6 +386,9 @@ _IMPLEMENTED_OPERATIONS = {
     "getBuildQuality",
     "getMonitoringSummary",
     "getMonitoringBuilds",
+    "createUpload",
+    "getUpload",
+    "deleteUpload",
 }
 
 
@@ -599,6 +608,9 @@ _OPERATION_STATUS_CODES: dict[str, set[int]] = {
     "getBuildQuality": {200, 400, 403, 404},
     "getMonitoringSummary": {200},
     "getMonitoringBuilds": {200, 400},
+    "createUpload": {200, 400, 403, 413},
+    "getUpload": {200, 403, 404},
+    "deleteUpload": {200, 403, 404},
 }
 
 
@@ -1182,3 +1194,56 @@ class TestResponseConformance:
         )
         assert resp.status_code == 400
         _assert_conforms(resp, "/monitoring/builds", "GET")
+
+    def test_create_upload_200(self, tmp_path: Path) -> None:
+        resp = dispatch(
+            _conform_service(tmp_path),
+            "POST",
+            "/uploads",
+            None,
+            query="format=csv&filename=trades.csv",
+            raw_body=b"a,b\n1,2\n",
+        )
+        assert resp.status_code == 200
+        _assert_conforms(resp, "/uploads", "POST")
+
+    def test_create_upload_400_missing_format(self, tmp_path: Path) -> None:
+        resp = dispatch(
+            _conform_service(tmp_path), "POST", "/uploads", None, raw_body=b"a,b\n1,2\n"
+        )
+        assert resp.status_code == 400
+        _assert_conforms(resp, "/uploads", "POST")
+
+    def test_get_upload_200(self, tmp_path: Path) -> None:
+        service = _conform_service(tmp_path)
+        created = dispatch(
+            service, "POST", "/uploads", None, query="format=csv", raw_body=b"a,b\n1,2\n"
+        )
+        upload_id = cast(str, created.body["upload_id"])
+        resp = dispatch(service, "GET", f"/uploads/{upload_id}", None)
+        assert resp.status_code == 200
+        _assert_conforms(resp, "/uploads/{upload_id}", "GET")
+
+    def test_get_upload_404_missing(self, tmp_path: Path) -> None:
+        resp = dispatch(
+            _conform_service(tmp_path), "GET", f"/uploads/upl_{'0' * 32}", None
+        )
+        assert resp.status_code == 404
+        _assert_conforms(resp, "/uploads/{upload_id}", "GET")
+
+    def test_delete_upload_200(self, tmp_path: Path) -> None:
+        service = _conform_service(tmp_path)
+        created = dispatch(
+            service, "POST", "/uploads", None, query="format=csv", raw_body=b"a,b\n1,2\n"
+        )
+        upload_id = cast(str, created.body["upload_id"])
+        resp = dispatch(service, "DELETE", f"/uploads/{upload_id}", None)
+        assert resp.status_code == 200
+        _assert_conforms(resp, "/uploads/{upload_id}", "DELETE")
+
+    def test_delete_upload_404_missing(self, tmp_path: Path) -> None:
+        resp = dispatch(
+            _conform_service(tmp_path), "DELETE", f"/uploads/upl_{'0' * 32}", None
+        )
+        assert resp.status_code == 404
+        _assert_conforms(resp, "/uploads/{upload_id}", "DELETE")

--- a/tests/unit/test_source_contract.py
+++ b/tests/unit/test_source_contract.py
@@ -1,0 +1,339 @@
+"""Canonical source contract(#498): public_api/file/url kind parsing·validation·round-trip."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+import yaml
+
+from kpubdata_builder.errors import SpecLoadError, ValidationError
+from kpubdata_builder.spec import BuildSpec, ExportTarget, SourceRef, parse_spec
+from kpubdata_builder.spec.serializer import canonical_spec_mapping, serialize_spec
+from kpubdata_builder.spec.validator import validate_spec
+
+
+def _payload(*sources: dict[str, object]) -> dict[str, object]:
+    return {
+        "dataset_id": "dataset.sample",
+        "title": "Sample Dataset",
+        "description": "Sample description",
+        "sources": list(sources),
+        "exports": [{"kind": "jsonl", "output_path": "out/data.jsonl"}],
+    }
+
+
+def _spec(*sources: SourceRef) -> BuildSpec:
+    return BuildSpec(
+        dataset_id="dataset.sample",
+        title="Sample Dataset",
+        description="Sample description",
+        sources=tuple(sources),
+        exports=(ExportTarget(kind="jsonl", output_path="out/data.jsonl"),),
+    )
+
+
+# --- loader: kind 기본값/구조 -----------------------------------------------------
+
+
+def test_source_without_kind_defaults_to_public_api() -> None:
+    """kind가 없는 기존 source는 항상 public_api로 해석된다(#498, 하위 호환)."""
+    spec = parse_spec(_payload({"provider": "datago", "dataset": "air_quality"}))
+
+    assert spec.sources[0].kind == "public_api"
+    assert spec.sources[0].provider == "datago"
+    assert spec.sources[0].dataset == "air_quality"
+
+
+def test_explicit_public_api_kind_parses_same_as_default() -> None:
+    spec = parse_spec(
+        _payload({"kind": "public_api", "provider": "datago", "dataset": "air_quality"})
+    )
+
+    assert spec.sources[0] == SourceRef(provider="datago", dataset="air_quality", kind="public_api")
+
+
+def test_file_source_parses_required_fields() -> None:
+    spec = parse_spec(
+        _payload(
+            {
+                "kind": "file",
+                "upload_id": "upl_" + "a" * 32,
+                "format": "csv",
+                "encoding": "utf-8",
+                "alias": "uploaded",
+            }
+        )
+    )
+    source = spec.sources[0]
+
+    assert source.kind == "file"
+    assert source.upload_id == "upl_" + "a" * 32
+    assert source.format == "csv"
+    assert source.encoding == "utf-8"
+    assert source.alias == "uploaded"
+    assert source.provider == ""
+    assert source.dataset == ""
+
+
+def test_file_source_encoding_defaults_to_utf8() -> None:
+    spec = parse_spec(
+        _payload({"kind": "file", "upload_id": "upl_" + "a" * 32, "format": "csv"})
+    )
+
+    assert spec.sources[0].encoding == "utf-8"
+
+
+def test_url_source_parses_required_fields() -> None:
+    spec = parse_spec(
+        _payload({"kind": "url", "endpoint": "https://example.org/data.json", "method": "GET"})
+    )
+    source = spec.sources[0]
+
+    assert source.kind == "url"
+    assert source.endpoint == "https://example.org/data.json"
+    assert source.method == "GET"
+    assert source.provider == ""
+    assert source.dataset == ""
+
+
+def test_url_source_method_defaults_to_get() -> None:
+    spec = parse_spec(_payload({"kind": "url", "endpoint": "https://example.org/data.json"}))
+
+    assert spec.sources[0].method == "GET"
+
+
+def test_unknown_kind_is_rejected() -> None:
+    with pytest.raises(SpecLoadError, match="kind"):
+        parse_spec(_payload({"kind": "ftp", "endpoint": "ftp://example.org/data"}))
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        {"kind": "public_api", "provider": "datago", "dataset": "d", "upload_id": "upl_x"},
+        {"kind": "public_api", "provider": "datago", "dataset": "d", "endpoint": "https://x"},
+        {"kind": "file", "upload_id": "upl_" + "a" * 32, "format": "csv", "provider": "datago"},
+        {"kind": "file", "upload_id": "upl_" + "a" * 32, "format": "csv", "endpoint": "https://x"},
+        {"kind": "url", "endpoint": "https://example.org/data", "provider": "datago"},
+        {"kind": "url", "endpoint": "https://example.org/data", "upload_id": "upl_x"},
+    ],
+)
+def test_foreign_kind_fields_are_rejected(source: dict[str, object]) -> None:
+    """다른 kind의 field가 섞이면 loader가 즉시 거부한다 (#498)."""
+    with pytest.raises(SpecLoadError, match="not valid for kind"):
+        parse_spec(_payload(source))
+
+
+def test_file_source_missing_upload_id_is_rejected() -> None:
+    with pytest.raises(SpecLoadError):
+        parse_spec(_payload({"kind": "file", "format": "csv"}))
+
+
+def test_file_source_missing_format_is_rejected() -> None:
+    with pytest.raises(SpecLoadError):
+        parse_spec(_payload({"kind": "file", "upload_id": "upl_" + "a" * 32}))
+
+
+def test_url_source_missing_endpoint_is_rejected() -> None:
+    with pytest.raises(SpecLoadError):
+        parse_spec(_payload({"kind": "url"}))
+
+
+def test_alias_and_schema_are_common_across_kinds() -> None:
+    """alias/schema는 세 kind 모두 공통 필드다 (#498)."""
+    spec = parse_spec(
+        _payload(
+            {
+                "kind": "file",
+                "upload_id": "upl_" + "a" * 32,
+                "format": "csv",
+                "alias": "my_alias",
+                "schema": {"required": ["id"]},
+            }
+        )
+    )
+    source = spec.sources[0]
+
+    assert source.alias == "my_alias"
+    assert source.schema is not None
+    assert source.schema.required == ("id",)
+
+
+# --- validator: kind별 semantic 규칙 ----------------------------------------------
+
+
+def test_validate_spec_accepts_valid_file_source() -> None:
+    spec = _spec(
+        SourceRef(kind="file", upload_id="upl_" + "a" * 32, format="csv", encoding="utf-8")
+    )
+    validate_spec(spec)  # raises on failure
+
+
+def test_validate_spec_accepts_valid_url_source() -> None:
+    spec = _spec(SourceRef(kind="url", endpoint="https://example.org/data.json", method="GET"))
+    validate_spec(spec)  # raises on failure
+
+
+def test_validate_spec_rejects_malformed_upload_id() -> None:
+    spec = _spec(SourceRef(kind="file", upload_id="../../etc/passwd", format="csv"))
+
+    with pytest.raises(ValidationError) as exc_info:
+        validate_spec(spec)
+    codes = {p.code for p in exc_info.value.structured_problems or []}
+    assert "invalid_upload_id" in codes
+
+
+def test_validate_spec_rejects_empty_upload_id() -> None:
+    spec = _spec(SourceRef(kind="file", upload_id="", format="csv"))
+
+    with pytest.raises(ValidationError) as exc_info:
+        validate_spec(spec)
+    codes = {p.code for p in exc_info.value.structured_problems or []}
+    assert "empty_field" in codes
+
+
+def test_validate_spec_rejects_unsupported_file_format() -> None:
+    spec = _spec(SourceRef(kind="file", upload_id="upl_" + "a" * 32, format="xlsx"))
+
+    with pytest.raises(ValidationError) as exc_info:
+        validate_spec(spec)
+    codes = {p.code for p in exc_info.value.structured_problems or []}
+    assert "unsupported_source_format" in codes
+
+
+def test_validate_spec_rejects_unknown_encoding() -> None:
+    spec = _spec(
+        SourceRef(
+            kind="file", upload_id="upl_" + "a" * 32, format="csv", encoding="not-a-real-encoding"
+        )
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        validate_spec(spec)
+    codes = {p.code for p in exc_info.value.structured_problems or []}
+    assert "unknown_encoding" in codes
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "http://example.org/data",
+        "ftp://example.org/data",
+        "file:///etc/passwd",
+    ],
+)
+def test_validate_spec_rejects_non_https_url_scheme(endpoint: str) -> None:
+    spec = _spec(SourceRef(kind="url", endpoint=endpoint))
+
+    with pytest.raises(ValidationError) as exc_info:
+        validate_spec(spec)
+    codes = {p.code for p in exc_info.value.structured_problems or []}
+    assert "unsafe_url_scheme" in codes
+
+
+def test_validate_spec_rejects_url_with_userinfo() -> None:
+    spec = _spec(SourceRef(kind="url", endpoint="https://user:pass@example.org/data"))
+
+    with pytest.raises(ValidationError) as exc_info:
+        validate_spec(spec)
+    codes = {p.code for p in exc_info.value.structured_problems or []}
+    assert "url_userinfo_forbidden" in codes
+
+
+def test_validate_spec_rejects_non_get_method() -> None:
+    spec = _spec(replace(SourceRef(kind="url", endpoint="https://example.org/data"), method="POST"))
+
+    with pytest.raises(ValidationError) as exc_info:
+        validate_spec(spec)
+    codes = {p.code for p in exc_info.value.structured_problems or []}
+    assert "unsupported_source_method" in codes
+
+
+def test_validate_spec_rejects_unsupported_url_format() -> None:
+    spec = _spec(
+        SourceRef(kind="url", endpoint="https://example.org/data", format="parquet")
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        validate_spec(spec)
+    codes = {p.code for p in exc_info.value.structured_problems or []}
+    assert "unsupported_source_format" in codes
+
+
+def test_validate_spec_does_not_require_provider_dataset_for_file_or_url() -> None:
+    """file/url kind는 provider/dataset이 없어도(빈 문자열) 통과해야 한다."""
+    spec = _spec(
+        SourceRef(kind="file", upload_id="upl_" + "a" * 32, format="csv"),
+        SourceRef(kind="url", endpoint="https://example.org/data"),
+    )
+    validate_spec(spec)  # raises on failure
+
+
+# --- serializer: canonical snapshot round-trip ------------------------------------
+
+
+def test_canonical_mapping_only_includes_fields_for_that_kind() -> None:
+    spec = _spec(SourceRef(kind="file", upload_id="upl_" + "a" * 32, format="csv"))
+
+    mapping = canonical_spec_mapping(spec)
+    source_entry = mapping["sources"][0]
+
+    assert set(source_entry) == {"kind", "alias", "schema", "upload_id", "format", "encoding"}
+
+
+def test_public_api_source_round_trips_through_canonical_yaml() -> None:
+    spec = _spec(SourceRef(provider="datago", dataset="air_quality", alias="air"))
+
+    text = serialize_spec(spec)
+    reparsed = parse_spec(yaml.safe_load(text))
+
+    assert reparsed == spec
+
+
+def test_file_source_round_trips_through_canonical_yaml() -> None:
+    spec = _spec(
+        SourceRef(
+            kind="file",
+            upload_id="upl_" + "a" * 32,
+            format="csv",
+            encoding="euc-kr",
+            alias="uploaded",
+        )
+    )
+
+    text = serialize_spec(spec)
+    reparsed = parse_spec(yaml.safe_load(text))
+
+    assert reparsed == spec
+
+
+def test_url_source_round_trips_through_canonical_yaml() -> None:
+    spec = _spec(
+        SourceRef(
+            kind="url",
+            endpoint="https://example.org/data.json",
+            method="GET",
+            format="json",
+            alias="feed",
+        )
+    )
+
+    text = serialize_spec(spec)
+    reparsed = parse_spec(yaml.safe_load(text))
+
+    assert reparsed == spec
+
+
+def test_mixed_kind_sources_round_trip_together() -> None:
+    spec = _spec(
+        SourceRef(provider="datago", dataset="air_quality", alias="air"),
+        SourceRef(kind="file", upload_id="upl_" + "a" * 32, format="csv", alias="uploaded"),
+        SourceRef(kind="url", endpoint="https://example.org/data.json", alias="feed"),
+    )
+
+    text = serialize_spec(spec)
+    reparsed = parse_spec(yaml.safe_load(text))
+
+    assert reparsed == spec
+    validate_spec(reparsed)  # raises on failure

--- a/tests/unit/test_source_contract.py
+++ b/tests/unit/test_source_contract.py
@@ -77,9 +77,7 @@ def test_file_source_parses_required_fields() -> None:
 
 
 def test_file_source_encoding_defaults_to_utf8() -> None:
-    spec = parse_spec(
-        _payload({"kind": "file", "upload_id": "upl_" + "a" * 32, "format": "csv"})
-    )
+    spec = parse_spec(_payload({"kind": "file", "upload_id": "upl_" + "a" * 32, "format": "csv"}))
 
     assert spec.sources[0].encoding == "utf-8"
 
@@ -175,6 +173,22 @@ def test_validate_spec_accepts_valid_url_source() -> None:
     validate_spec(spec)  # raises on failure
 
 
+def test_validate_spec_rejects_unknown_kind_from_directly_constructed_sourceref() -> None:
+    """loader를 거치지 않고 SourceRef를 직접 구성해도 unknown kind는 거부된다.
+
+    loader(YAML 경로)는 이미 unknown kind를 거부하지만(``test_unknown_kind_is_rejected``),
+    ``SourceRef(kind="ftp", ...)``처럼 programmatic하게 BuildSpec을 구성하면
+    loader를 거치지 않는다 — validate_spec이 canonical kind 계약
+    (public_api|file|url)의 fail-closed 원칙을 지키는 유일한 방어선이다(#538 review).
+    """
+    spec = _spec(SourceRef(kind="ftp", provider="datago", dataset="air_quality"))
+
+    with pytest.raises(ValidationError) as exc_info:
+        validate_spec(spec)
+    codes = {p.code for p in exc_info.value.structured_problems or []}
+    assert "unsupported_source_kind" in codes
+
+
 def test_validate_spec_rejects_malformed_upload_id() -> None:
     spec = _spec(SourceRef(kind="file", upload_id="../../etc/passwd", format="csv"))
 
@@ -251,9 +265,7 @@ def test_validate_spec_rejects_non_get_method() -> None:
 
 
 def test_validate_spec_rejects_unsupported_url_format() -> None:
-    spec = _spec(
-        SourceRef(kind="url", endpoint="https://example.org/data", format="parquet")
-    )
+    spec = _spec(SourceRef(kind="url", endpoint="https://example.org/data", format="parquet"))
 
     with pytest.raises(ValidationError) as exc_info:
         validate_spec(spec)

--- a/tests/unit/test_tabular_ingest.py
+++ b/tests/unit/test_tabular_ingest.py
@@ -1,0 +1,123 @@
+"""ingestion.tabular_ingest: file/url source 원시 bytes → 레코드 파싱 검증 (#498)."""
+
+from __future__ import annotations
+
+import io
+
+import polars as pl
+import pytest
+
+from kpubdata_builder.ingestion import IngestionError, parse_tabular_bytes
+
+
+def test_parse_csv_bytes_returns_typed_records() -> None:
+    raw = b"id,amount\n1,1000\n2,2500\n"
+
+    records = parse_tabular_bytes(raw, format="csv")
+
+    assert records == ({"id": 1, "amount": 1000}, {"id": 2, "amount": 2500})
+
+
+def test_parse_csv_bytes_respects_encoding() -> None:
+    raw = "id,name\n1,서울\n".encode("euc-kr")
+
+    records = parse_tabular_bytes(raw, format="csv", encoding="euc-kr")
+
+    assert records == ({"id": 1, "name": "서울"},)
+
+
+def test_parse_json_array_of_objects() -> None:
+    raw = b'[{"id": 1, "v": 1.5}, {"id": 2, "v": 2.5}]'
+
+    records = parse_tabular_bytes(raw, format="json")
+
+    assert records == ({"id": 1, "v": 1.5}, {"id": 2, "v": 2.5})
+
+
+def test_parse_json_rejects_non_array_top_level() -> None:
+    raw = b'{"data": [{"id": 1}]}'
+
+    with pytest.raises(IngestionError, match="array of objects"):
+        parse_tabular_bytes(raw, format="json")
+
+
+def test_parse_json_rejects_array_of_scalars() -> None:
+    raw = b"[1, 2, 3]"
+
+    with pytest.raises(IngestionError, match="array of objects"):
+        parse_tabular_bytes(raw, format="json")
+
+
+def test_parse_json_rejects_malformed_json() -> None:
+    with pytest.raises(IngestionError, match="failed to parse json"):
+        parse_tabular_bytes(b"not json", format="json")
+
+
+def test_parse_jsonl_skips_blank_lines() -> None:
+    raw = b'{"id": 1}\n\n{"id": 2}\n'
+
+    records = parse_tabular_bytes(raw, format="jsonl")
+
+    assert records == ({"id": 1}, {"id": 2})
+
+
+def test_parse_jsonl_rejects_non_object_line() -> None:
+    raw = b'{"id": 1}\n[1, 2]\n'
+
+    with pytest.raises(IngestionError, match="must be a JSON object"):
+        parse_tabular_bytes(raw, format="jsonl")
+
+
+def test_parse_jsonl_rejects_malformed_line() -> None:
+    with pytest.raises(IngestionError, match="jsonl line 1"):
+        parse_tabular_bytes(b"not json\n", format="jsonl")
+
+
+def test_parse_jsonl_rejects_all_blank_content() -> None:
+    with pytest.raises(IngestionError, match="no non-empty lines"):
+        parse_tabular_bytes(b"\n\n\n", format="jsonl")
+
+
+def test_parse_parquet_round_trip() -> None:
+    frame = pl.DataFrame({"id": [1, 2], "amount": [1000, 2500]})
+    buffer = io.BytesIO()
+    frame.write_parquet(buffer)
+
+    records = parse_tabular_bytes(buffer.getvalue(), format="parquet")
+
+    assert records == ({"id": 1, "amount": 1000}, {"id": 2, "amount": 2500})
+
+
+def test_parse_parquet_rejects_corrupt_bytes() -> None:
+    with pytest.raises(IngestionError, match="failed to parse parquet"):
+        parse_tabular_bytes(b"not a parquet file", format="parquet")
+
+
+def test_parse_rejects_empty_content() -> None:
+    with pytest.raises(IngestionError, match="empty"):
+        parse_tabular_bytes(b"", format="csv")
+
+
+def test_parse_rejects_unsupported_format() -> None:
+    with pytest.raises(IngestionError, match="unsupported format"):
+        parse_tabular_bytes(b"data", format="xlsx")
+
+
+def test_parse_rejects_undecodable_bytes() -> None:
+    raw = "안녕".encode("euc-kr")
+
+    with pytest.raises(IngestionError, match="failed to decode"):
+        parse_tabular_bytes(raw, format="csv", encoding="ascii")
+
+
+def test_parse_rejects_unknown_encoding_name() -> None:
+    with pytest.raises(IngestionError, match="failed to decode"):
+        parse_tabular_bytes(b"id\n1\n", format="csv", encoding="not-a-real-encoding")
+
+
+def test_parse_csv_rejects_malformed_csv() -> None:
+    # 헤더는 2개 컬럼인데 데이터 행이 3개 필드를 가짐 — polars가 파싱 오류로 거부한다.
+    raw = b"a,b\n1,2,3\n"
+
+    with pytest.raises(IngestionError, match="failed to parse csv"):
+        parse_tabular_bytes(raw, format="csv")

--- a/tests/unit/test_uploads_store.py
+++ b/tests/unit/test_uploads_store.py
@@ -1,0 +1,154 @@
+"""uploads.store: SQLite 업로드 저장소의 owner 격리·크기 상한 검증 (#498)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kpubdata_builder.spec.models import UPLOAD_ID_PATTERN
+from kpubdata_builder.uploads import SQLiteUploadRepository
+from kpubdata_builder.uploads.store import generate_upload_id
+
+
+def _repo(tmp_path: Path, *, max_bytes: int = 1024) -> SQLiteUploadRepository:
+    return SQLiteUploadRepository(tmp_path / "uploads.sqlite3", max_bytes=max_bytes)
+
+
+def test_generate_upload_id_matches_contract_pattern() -> None:
+    for _ in range(20):
+        upload_id = generate_upload_id()
+        assert UPLOAD_ID_PATTERN.match(upload_id)
+
+
+def test_generate_upload_id_is_unique() -> None:
+    ids = {generate_upload_id() for _ in range(50)}
+    assert len(ids) == 50
+
+
+def test_put_then_get_metadata_and_content_round_trips(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+
+    metadata = repo.put(
+        "owner-1", content=b"a,b\n1,2\n", format="csv", encoding="utf-8", original_filename="t.csv"
+    )
+
+    assert UPLOAD_ID_PATTERN.match(metadata.upload_id)
+    assert metadata.format == "csv"
+    assert metadata.encoding == "utf-8"
+    assert metadata.size_bytes == len(b"a,b\n1,2\n")
+    assert metadata.original_filename == "t.csv"
+    assert metadata.created_at
+
+    fetched_metadata = repo.get_metadata("owner-1", metadata.upload_id)
+    assert fetched_metadata == metadata
+
+    content = repo.get_content("owner-1", metadata.upload_id)
+    assert content == b"a,b\n1,2\n"
+
+
+def test_get_metadata_and_content_isolated_by_owner(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    metadata = repo.put(
+        "owner-1", content=b"data", format="csv", encoding="utf-8", original_filename=None
+    )
+
+    # 다른 owner는 존재 자체를 모른다 — None(=404)만 볼 수 있다(fail-closed).
+    assert repo.get_metadata("owner-2", metadata.upload_id) is None
+    assert repo.get_content("owner-2", metadata.upload_id) is None
+    assert repo.delete("owner-2", metadata.upload_id) is False
+
+    # 진짜 owner는 정상 접근 가능하다.
+    assert repo.get_metadata("owner-1", metadata.upload_id) is not None
+
+
+def test_get_metadata_returns_none_for_unknown_id(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    assert repo.get_metadata("owner-1", "upl_" + "0" * 32) is None
+
+
+def test_delete_removes_upload_and_is_idempotent(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    metadata = repo.put(
+        "owner-1", content=b"data", format="csv", encoding="utf-8", original_filename=None
+    )
+
+    assert repo.delete("owner-1", metadata.upload_id) is True
+    assert repo.get_metadata("owner-1", metadata.upload_id) is None
+    # 두 번째 삭제는 아무것도 지울 게 없어 False.
+    assert repo.delete("owner-1", metadata.upload_id) is False
+
+
+def test_list_for_owner_returns_only_that_owners_uploads(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    m1 = repo.put("owner-1", content=b"1", format="csv", encoding="utf-8", original_filename=None)
+    repo.put("owner-2", content=b"2", format="csv", encoding="utf-8", original_filename=None)
+    m3 = repo.put("owner-1", content=b"3", format="json", encoding="utf-8", original_filename=None)
+
+    owner_1_uploads = repo.list_for_owner("owner-1")
+
+    assert {m.upload_id for m in owner_1_uploads} == {m1.upload_id, m3.upload_id}
+
+
+def test_put_rejects_empty_content(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    with pytest.raises(ValueError, match="empty"):
+        repo.put("owner-1", content=b"", format="csv", encoding="utf-8", original_filename=None)
+
+
+def test_put_rejects_content_over_max_bytes(tmp_path: Path) -> None:
+    repo = _repo(tmp_path, max_bytes=10)
+    with pytest.raises(ValueError, match="exceeds max size"):
+        repo.put(
+            "owner-1", content=b"x" * 11, format="csv", encoding="utf-8", original_filename=None
+        )
+
+
+def test_put_rejects_unsupported_format(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    with pytest.raises(ValueError, match="format"):
+        repo.put(
+            "owner-1", content=b"data", format="xlsx", encoding="utf-8", original_filename=None
+        )
+
+
+def test_put_rejects_missing_owner_id(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    with pytest.raises(ValueError, match="owner_id"):
+        repo.put("", content=b"data", format="csv", encoding="utf-8", original_filename=None)
+
+
+def test_put_sanitizes_display_filename_to_basename(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+
+    metadata = repo.put(
+        "owner-1",
+        content=b"data",
+        format="csv",
+        encoding="utf-8",
+        original_filename="../../etc/passwd",
+    )
+
+    # basename만 남는다 — 이 값은 표시 전용이며 파일시스템 경로로 쓰이지 않는다.
+    assert metadata.original_filename == "passwd"
+
+
+def test_put_treats_blank_filename_as_none(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+
+    metadata = repo.put(
+        "owner-1", content=b"data", format="csv", encoding="utf-8", original_filename="   "
+    )
+
+    assert metadata.original_filename is None
+
+
+def test_repository_persists_across_reopen(tmp_path: Path) -> None:
+    db_path = tmp_path / "uploads.sqlite3"
+    first = SQLiteUploadRepository(db_path, max_bytes=1024)
+    metadata = first.put(
+        "owner-1", content=b"data", format="csv", encoding="utf-8", original_filename=None
+    )
+
+    second = SQLiteUploadRepository(db_path, max_bytes=1024)
+    assert second.get_content("owner-1", metadata.upload_id) == b"data"

--- a/tests/unit/test_url_fetch.py
+++ b/tests/unit/test_url_fetch.py
@@ -14,6 +14,9 @@
 
 from __future__ import annotations
 
+import http.client
+import socket
+import ssl
 import threading
 from collections.abc import Iterator
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -22,6 +25,7 @@ import pytest
 
 from kpubdata_builder.ingestion import IngestionError
 from kpubdata_builder.ingestion.url_fetch import (
+    _PinnedHTTPSConnection,
     _read_bounded,
     _resolve_and_validate,
     _validate_url_shape,
@@ -148,6 +152,24 @@ class _Handler(BaseHTTPRequestHandler):
             self.send_header("Location", "/ok")
             self.send_header("Content-Length", "0")
             self.end_headers()
+        elif self.path == "/redirect-with-body":
+            # redirect(3xx)에도 body가 실릴 수 있다 — 이 body를 amt 없이
+            # read()하면 max_bytes cap을 우회하는 unbounded read가 된다는
+            # BLOCKER(#538 review)를 재현하기 위한 non-empty body.
+            body = b"ignored redirect body " * 10
+            self.send_response(302)
+            self.send_header("Location", "/ok")
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        elif self.path == "/redirect-to-private":
+            # redirect target이 private 주소면 hop마다 처음부터 SSRF 검증을
+            # 다시 해야 한다(회귀 방지, #538 review).
+            self.send_response(302)
+            self.send_header("Location", "https://10.0.0.1/private")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
         elif self.path == "/redirect-loop":
             self.send_response(302)
             self.send_header("Location", "/redirect-loop")
@@ -190,11 +212,18 @@ class _LoopbackHTTPConnection:
     나머지 로직은 실제 코드 그대로 실행되게 한다.
     """
 
-    def __init__(self, host: str, pinned_ip: str, port: int, *, timeout: float) -> None:
-        import http.client
-
-        self._delegate = http.client.HTTPConnection(pinned_ip, port, timeout=timeout)
+    def __init__(
+        self,
+        host: str,
+        pinned_ip: str,
+        port: int,
+        *,
+        connect_timeout: float,
+        read_timeout: float,
+    ) -> None:
+        self._delegate = http.client.HTTPConnection(pinned_ip, port, timeout=connect_timeout)
         self.host = host
+        self._read_timeout = read_timeout
 
     def request(self, method: str, path: str, headers: dict[str, str]) -> None:
         self._delegate.request(method, path, headers=headers)
@@ -221,14 +250,12 @@ def local_server(
     import kpubdata_builder.ingestion.url_fetch as url_fetch_module
 
     port = _raw_local_server.server_address[1]
-    monkeypatch.setattr(
-        url_fetch_module, "_resolve_and_validate", lambda host, _port: "127.0.0.1"
-    )
+    monkeypatch.setattr(url_fetch_module, "_resolve_and_validate", lambda host, _port: "127.0.0.1")
     monkeypatch.setattr(
         url_fetch_module,
         "_PinnedHTTPSConnection",
-        lambda host, pinned_ip, _port, *, timeout: _LoopbackHTTPConnection(
-            host, pinned_ip, port, timeout=timeout
+        lambda host, pinned_ip, _port, *, connect_timeout, read_timeout: _LoopbackHTTPConnection(
+            host, pinned_ip, port, connect_timeout=connect_timeout, read_timeout=read_timeout
         ),
     )
     yield _raw_local_server
@@ -270,3 +297,171 @@ def test_safe_fetch_get_rejects_non_200_status(local_server: HTTPServer) -> None
 def test_safe_fetch_get_rejects_non_https_before_any_connection() -> None:
     with pytest.raises(IngestionError, match="https"):
         safe_fetch_get("http://example.org/ok")
+
+
+# --- redirect body read는 절대 unbounded여선 안 된다 (BLOCKER, #538 review) ------
+
+
+def test_safe_fetch_get_does_not_perform_unbounded_read_on_redirect_body(
+    local_server: HTTPServer, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """redirect(3xx) 응답 body를 amt 없이 read()해 전체를 무제한으로 읽지 않는다.
+
+    무제한 read는 최종 200 응답에만 적용되는 ``_read_bounded()``의 max_bytes
+    cap을 redirect hop에서 우회하는 경로가 된다.
+    """
+    del local_server
+    calls: list[int | None] = []
+    original_read = http.client.HTTPResponse.read
+
+    def tracking_read(self: http.client.HTTPResponse, amt: int | None = None) -> bytes:
+        calls.append(amt)
+        return original_read(self, amt)
+
+    monkeypatch.setattr(http.client.HTTPResponse, "read", tracking_read)
+
+    result = safe_fetch_get("https://example.org/redirect-with-body")
+
+    assert result.content == b'[{"id": 1}]'  # 기존 정상 redirect 동작 유지.
+    # redirect hop을 포함해 어떤 read() 호출도 amt=None(무제한)이 아니어야
+    # 한다 — 마지막 200 응답만 _read_bounded()가 명시적 chunk size로 읽는다.
+    assert all(amt is not None for amt in calls)
+
+
+def test_safe_fetch_get_rejects_redirect_to_private_address(
+    _raw_local_server: HTTPServer, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """redirect target이 private 주소면 hop마다 검증을 처음부터 다시 해 거부한다.
+
+    redirect body 처리 방식을 바꾸는 것과 무관하게 SSRF 방어(hop별 재검증)에
+    회귀가 없어야 한다 — ``local_server`` fixture는 모든 host를 강제로
+    127.0.0.1로 바꾸므로 여기서는 첫 hop(example.org)만 로컬 서버로 우회하고
+    redirect target(10.0.0.1)은 실제 ``_resolve_and_validate``를 그대로
+    거치게 한다.
+    """
+    import kpubdata_builder.ingestion.url_fetch as url_fetch_module
+
+    port = _raw_local_server.server_address[1]
+    real_resolve_and_validate = url_fetch_module._resolve_and_validate
+
+    def fake_resolve(host: str, resolve_port: int) -> str:
+        if host == "example.org":
+            return "127.0.0.1"
+        return real_resolve_and_validate(host, resolve_port)
+
+    monkeypatch.setattr(url_fetch_module, "_resolve_and_validate", fake_resolve)
+    monkeypatch.setattr(
+        url_fetch_module,
+        "_PinnedHTTPSConnection",
+        lambda host, pinned_ip, _port, *, connect_timeout, read_timeout: _LoopbackHTTPConnection(
+            host, pinned_ip, port, connect_timeout=connect_timeout, read_timeout=read_timeout
+        ),
+    )
+
+    with pytest.raises(IngestionError, match="SSRF policy"):
+        safe_fetch_get("https://example.org/redirect-to-private")
+
+
+# --- connect/read timeout 분리 (SHOULD FIX, #538 review) -------------------------
+
+
+class _FakeTLSSocket:
+    """``ssl.SSLSocket``을 대체해 ``settimeout`` 호출만 기록하는 test double."""
+
+    def __init__(self) -> None:
+        self.settimeout_calls: list[float] = []
+
+    def settimeout(self, value: float) -> None:
+        self.settimeout_calls.append(value)
+
+
+def test_pinned_https_connection_uses_connect_timeout_for_connect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TCP connect에는 connect_timeout이 쓰이고, DNS를 다시 resolve하지 않는다."""
+    captured_addresses: list[tuple[str, int]] = []
+    captured_timeouts: list[float] = []
+    fake_raw_socket = object()
+    fake_tls_socket = _FakeTLSSocket()
+
+    def fake_create_connection(address: tuple[str, int], timeout: float) -> object:
+        captured_addresses.append(address)
+        captured_timeouts.append(timeout)
+        return fake_raw_socket
+
+    def fake_wrap_socket(
+        self: ssl.SSLContext, sock: object, *, server_hostname: str
+    ) -> _FakeTLSSocket:
+        assert sock is fake_raw_socket
+        assert server_hostname == "example.org"
+        return fake_tls_socket
+
+    monkeypatch.setattr(socket, "create_connection", fake_create_connection)
+    monkeypatch.setattr(ssl.SSLContext, "wrap_socket", fake_wrap_socket)
+
+    connection = _PinnedHTTPSConnection(
+        "example.org", "8.8.8.8", 443, connect_timeout=1.5, read_timeout=9.0
+    )
+    connection.connect()
+
+    # 검증된 IP에만 직접 연결한다 — hostname을 다시 resolve하지 않는다(DNS
+    # rebinding 방어 유지).
+    assert captured_addresses == [("8.8.8.8", 443)]
+    assert captured_timeouts == [1.5]
+
+
+def test_pinned_https_connection_switches_to_read_timeout_after_connect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """connect가 끝난 뒤 socket read timeout은 read_timeout으로 전환된다."""
+    fake_tls_socket = _FakeTLSSocket()
+
+    monkeypatch.setattr(socket, "create_connection", lambda address, timeout: object())
+    monkeypatch.setattr(
+        ssl.SSLContext,
+        "wrap_socket",
+        lambda self, sock, *, server_hostname: fake_tls_socket,
+    )
+
+    connection = _PinnedHTTPSConnection(
+        "example.org", "8.8.8.8", 443, connect_timeout=1.5, read_timeout=9.0
+    )
+    connection.connect()
+
+    assert fake_tls_socket.settimeout_calls == [9.0]
+
+
+class _TimeoutHTTPConnection:
+    """connect 단계에서 항상 timeout을 일으키는 ``_PinnedHTTPSConnection`` test double."""
+
+    def __init__(
+        self,
+        host: str,
+        pinned_ip: str,
+        port: int,
+        *,
+        connect_timeout: float,
+        read_timeout: float,
+    ) -> None:
+        del host, pinned_ip, port, connect_timeout, read_timeout
+
+    def request(self, method: str, path: str, headers: dict[str, str]) -> None:
+        del method, path, headers
+        raise TimeoutError("simulated connect timeout")
+
+    def getresponse(self) -> object:
+        raise AssertionError("must not be reached after a connect timeout")
+
+    def close(self) -> None:
+        return
+
+
+def test_safe_fetch_get_maps_timeout_to_ingestion_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """connect/read timeout은 원문 예외가 아니라 IngestionError로 안전하게 mapping된다."""
+    import kpubdata_builder.ingestion.url_fetch as url_fetch_module
+
+    monkeypatch.setattr(url_fetch_module, "_resolve_and_validate", lambda host, _port: "8.8.8.8")
+    monkeypatch.setattr(url_fetch_module, "_PinnedHTTPSConnection", _TimeoutHTTPConnection)
+
+    with pytest.raises(IngestionError, match="failed to fetch"):
+        safe_fetch_get("https://example.org/ok")

--- a/tests/unit/test_url_fetch.py
+++ b/tests/unit/test_url_fetch.py
@@ -1,0 +1,272 @@
+"""ingestion.url_fetch: url source의 SSRF-safe fetch 검증 (#498).
+
+``safe_fetch_get``은 hostname을 실제 DNS로 resolve해 공인(global-routable) IP인지
+확인하고, 검증한 IP에 직접 TLS 연결한다. 이 테스트는 두 계층을 나눠 검증한다.
+
+    - 순수 검증 로직(``_validate_url_shape``/``_resolve_and_validate``)은 IP
+      리터럴을 hostname으로 써서 실제 네트워크 호출 없이 빠르게 검증한다(IP
+      리터럴은 DNS 조회를 하지 않는다).
+    - 실제 fetch 흐름(redirect 추적, 크기 상한, 상태 코드 처리)은 로컬
+      ``http.server``를 띄우고 ``_resolve_and_validate``/``_PinnedHTTPSConnection``
+      두 seam만 이 로컬 서버를 가리키도록 monkeypatch해 검증한다 — 실제 SSRF
+      방어 로직(redirect-loop, 크기 상한)은 그대로 실행된다.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from kpubdata_builder.ingestion import IngestionError
+from kpubdata_builder.ingestion.url_fetch import (
+    _read_bounded,
+    _resolve_and_validate,
+    _validate_url_shape,
+    safe_fetch_get,
+)
+
+# --- 순수 검증 로직 (네트워크 불필요) --------------------------------------------
+
+
+@pytest.mark.parametrize("scheme_url", ["http://example.org/data", "ftp://example.org/data"])
+def test_validate_url_shape_rejects_non_https_scheme(scheme_url: str) -> None:
+    with pytest.raises(IngestionError, match="https"):
+        _validate_url_shape(scheme_url)
+
+
+def test_validate_url_shape_rejects_file_scheme() -> None:
+    with pytest.raises(IngestionError, match="https"):
+        _validate_url_shape("file:///etc/passwd")
+
+
+def test_validate_url_shape_rejects_userinfo() -> None:
+    with pytest.raises(IngestionError, match="userinfo"):
+        _validate_url_shape("https://user:pass@example.org/data")
+
+
+def test_validate_url_shape_rejects_missing_host() -> None:
+    with pytest.raises(IngestionError, match="host"):
+        _validate_url_shape("https:///data")
+
+
+def test_validate_url_shape_accepts_valid_https_url() -> None:
+    scheme, host, port, path = _validate_url_shape("https://example.org:8443/data?x=1")
+
+    assert scheme == "https"
+    assert host == "example.org"
+    assert port == 8443
+    assert path == "/data?x=1"
+
+
+def test_validate_url_shape_defaults_to_port_443() -> None:
+    _scheme, _host, port, path = _validate_url_shape("https://example.org/data")
+
+    assert port == 443
+    assert path == "/data"
+
+
+@pytest.mark.parametrize(
+    "loopback_or_private_ip",
+    [
+        "127.0.0.1",  # loopback
+        "10.0.0.1",  # private
+        "172.16.0.1",  # private
+        "192.168.1.1",  # private
+        "169.254.169.254",  # link-local (cloud metadata endpoint)
+        "0.0.0.0",  # unspecified
+        "::1",  # IPv6 loopback
+    ],
+)
+def test_resolve_and_validate_rejects_non_public_ip_literal(loopback_or_private_ip: str) -> None:
+    # IP 리터럴은 실제 DNS 조회를 하지 않으므로(getaddrinfo가 그대로 파싱만 함)
+    # 네트워크 접근 없이 검증할 수 있다.
+    with pytest.raises(IngestionError, match="SSRF policy"):
+        _resolve_and_validate(loopback_or_private_ip, 443)
+
+
+def test_resolve_and_validate_accepts_public_ip_literal() -> None:
+    resolved = _resolve_and_validate("8.8.8.8", 443)
+
+    assert resolved == "8.8.8.8"
+
+
+def test_resolve_and_validate_raises_for_unresolvable_host() -> None:
+    with pytest.raises(IngestionError, match="failed to resolve host"):
+        _resolve_and_validate("this-host-does-not-resolve.invalid", 443)
+
+
+# --- 응답 크기 상한 --------------------------------------------------------------
+
+
+class _FakeHTTPResponse:
+    """``http.client.HTTPResponse``의 최소 read() 계약만 흉내내는 테스트 더블."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = list(chunks)
+
+    def read(self, _size: int) -> bytes:
+        if not self._chunks:
+            return b""
+        return self._chunks.pop(0)
+
+
+def test_read_bounded_returns_full_content_under_limit() -> None:
+    response = _FakeHTTPResponse([b"hello", b" ", b"world", b""])
+
+    result = _read_bounded(response, max_bytes=100)  # type: ignore[arg-type]
+
+    assert result == b"hello world"
+
+
+def test_read_bounded_rejects_content_over_limit() -> None:
+    response = _FakeHTTPResponse([b"x" * 10, b"y" * 10, b""])
+
+    with pytest.raises(IngestionError, match="exceeds max size"):
+        _read_bounded(response, max_bytes=15)  # type: ignore[arg-type]
+
+
+# --- 전체 fetch 흐름 (로컬 HTTP 서버 + 검증 seam만 우회) -------------------------
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002 - stdlib 시그니처
+        return
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib 규약
+        if self.path == "/ok":
+            body = b'[{"id": 1}]'
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        elif self.path == "/redirect-once":
+            self.send_response(302)
+            self.send_header("Location", "/ok")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+        elif self.path == "/redirect-loop":
+            self.send_response(302)
+            self.send_header("Location", "/redirect-loop")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+        elif self.path == "/big":
+            body = b"x" * 1000
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        elif self.path == "/not-found":
+            self.send_response(404)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+        else:
+            self.send_response(404)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+
+@pytest.fixture
+def _raw_local_server() -> Iterator[HTTPServer]:
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+class _LoopbackHTTPConnection:
+    """``_PinnedHTTPSConnection`` 을 대체해 평문 HTTP로 로컬 서버에 연결하는 test double.
+
+    실제 프로덕션 경로는 TLS를 강제하지만, 이 fixture 서버는 자체서명 인증서
+    설정 없이 순수 HTTP만 제공한다 — url_fetch가 내부적으로 참조하는 connection
+    클래스만 이 test double로 바꿔서 redirect/크기 상한/상태 코드 처리 같은
+    나머지 로직은 실제 코드 그대로 실행되게 한다.
+    """
+
+    def __init__(self, host: str, pinned_ip: str, port: int, *, timeout: float) -> None:
+        import http.client
+
+        self._delegate = http.client.HTTPConnection(pinned_ip, port, timeout=timeout)
+        self.host = host
+
+    def request(self, method: str, path: str, headers: dict[str, str]) -> None:
+        self._delegate.request(method, path, headers=headers)
+
+    def getresponse(self) -> object:
+        return self._delegate.getresponse()
+
+    def close(self) -> None:
+        self._delegate.close()
+
+
+@pytest.fixture
+def local_server(
+    monkeypatch: pytest.MonkeyPatch, _raw_local_server: HTTPServer
+) -> Iterator[HTTPServer]:
+    """로컬 HTTP 서버를 띄우고, 검증 seam 두 곳만 그 서버를 가리키도록 우회한다.
+
+    실제 SSRF 검증(scheme/userinfo/redirect-loop 방어/크기 상한)은 그대로
+    실행되고, "hostname → 실제 소켓 연결" 두 지점(``_resolve_and_validate``,
+    ``_PinnedHTTPSConnection``)만 로컬 loopback 서버를 가리키도록 바꾼다. 이
+    fixture를 요청하는 테스트에서만 우회가 적용된다 — 순수 검증 로직 테스트는
+    영향받지 않는다.
+    """
+    import kpubdata_builder.ingestion.url_fetch as url_fetch_module
+
+    port = _raw_local_server.server_address[1]
+    monkeypatch.setattr(
+        url_fetch_module, "_resolve_and_validate", lambda host, _port: "127.0.0.1"
+    )
+    monkeypatch.setattr(
+        url_fetch_module,
+        "_PinnedHTTPSConnection",
+        lambda host, pinned_ip, _port, *, timeout: _LoopbackHTTPConnection(
+            host, pinned_ip, port, timeout=timeout
+        ),
+    )
+    yield _raw_local_server
+
+
+def test_safe_fetch_get_returns_content_and_content_type(local_server: HTTPServer) -> None:
+    del local_server
+    result = safe_fetch_get("https://example.org/ok")
+
+    assert result.content == b'[{"id": 1}]'
+    assert result.content_type == "application/json"
+
+
+def test_safe_fetch_get_follows_redirect(local_server: HTTPServer) -> None:
+    del local_server
+    result = safe_fetch_get("https://example.org/redirect-once")
+
+    assert result.content == b'[{"id": 1}]'
+
+
+def test_safe_fetch_get_rejects_redirect_loop(local_server: HTTPServer) -> None:
+    del local_server
+    with pytest.raises(IngestionError, match="too many redirects"):
+        safe_fetch_get("https://example.org/redirect-loop", max_redirects=3)
+
+
+def test_safe_fetch_get_enforces_max_bytes(local_server: HTTPServer) -> None:
+    del local_server
+    with pytest.raises(IngestionError, match="exceeds max size"):
+        safe_fetch_get("https://example.org/big", max_bytes=100)
+
+
+def test_safe_fetch_get_rejects_non_200_status(local_server: HTTPServer) -> None:
+    del local_server
+    with pytest.raises(IngestionError, match="unexpected HTTP status"):
+        safe_fetch_get("https://example.org/not-found")
+
+
+def test_safe_fetch_get_rejects_non_https_before_any_connection() -> None:
+    with pytest.raises(IngestionError, match="https"):
+        safe_fetch_get("http://example.org/ok")


### PR DESCRIPTION
## 개요

Closes #498

Public API / File Upload / URL(GET, Auth=None) source를
하나의 canonical source contract와 기존 Bronze → Silver → Gold 파이프라인으로 통합합니다.

기존 Public API BuildSpec은 하위 호환을 유지하고,
File/URL source도 별도 파이프라인을 만들지 않고 공통 Source Resolver를 통해
동일한 Preview / Build / Quality 흐름을 사용하도록 구현했습니다.

## 주요 변경사항

### Source Contract

- `SourceRef.kind` 추가
  - `public_api`
  - `file`
  - `url`
- 기존 `provider/dataset` source는 `public_api`로 하위 호환
- source kind별 required / forbidden field 검증
- canonical BuildSpec snapshot round-trip 지원
- kind별 실제 필드만 직렬화

### File Upload / Ingestion

- Upload API 추가
  - `POST /uploads`
  - `GET /uploads/{upload_id}`
  - `DELETE /uploads/{upload_id}`
- CSV / JSON / JSONL / Parquet 지원
- upload size / empty / corrupt / encoding 검증
- SQLite BLOB 기반 upload 저장
- server-generated opaque `upload_id`
- `(owner_id, upload_id)` 기준 사용자 격리
- client filename을 filesystem path로 사용하지 않음
- cross-owner 접근은 fail-closed 404 처리
- upload metadata를 format/encoding authority로 사용
- BuildSpec과 upload metadata 불일치 시 deterministic reject

### URL Source

P0 범위로 HTTPS GET / Auth=None만 지원합니다.

- DNS resolve 결과 검증
- globally routable address만 허용
- validated IP로 직접 연결해 DNS rebinding TOCTOU 완화
- IPv4 / IPv6 private·loopback·link-local·reserved destination 차단
- userinfo / 비HTTPS scheme 차단
- redirect hop마다 destination 재검증
- redirect 횟수 제한
- connect/read timeout
- 실제 response byte cap
- user-controlled request header 미지원

### Pipeline Integration

Public API / File / URL 모두 공통 Source Resolver를 거쳐
기존 `BronzeArtifact` contract에 연결합니다.

따라서 기존:

- Bronze → Silver → Gold
- Preview
- Schema / Statistics
- Quality
- Source ↔ Silver Diff / Sampling

경로를 그대로 재사용하며 source별 별도 pipeline이나 Quality logic을 추가하지 않았습니다.

### Provenance / Security

- raw credential 비노출
- upload filesystem path 비노출
- URL userinfo / secret-like endpoint 정보 redaction
- stable owner identity 재사용
- absolute internal path 비노출
- Provider adapter 재구현 없음

### API Contract / Docs

- Upload API 및 신규 Source schema OpenAPI 반영
- additive wire contract에 맞춰 API contract version 갱신
- `BUILD_SPEC.md`
- `API_CONTRACT.md`
- ADR 0014 Source Ingestion / File / URL security boundary 추가

## 검증

- 전체 pytest: **1327 tests 통과**
- 신규/관련 Source·Upload·SSRF·Pipeline tests 통과
- `uv run --frozen mypy src`: 통과
- `uv run --frozen ruff check .`: 통과
- `git diff --check`: 통과

Windows 환경에서는 기존 symlink privilege / tzdata / long-path 관련 실패가 재현되며,
동일 환경의 변경 전 `main`에서도 동일하게 발생하는 것을 확인했습니다.

추가 회귀 검증:
- File format mismatch → reject
- File encoding mismatch → reject
- 기존 Public API source 하위 호환
- cross-owner upload 접근 차단
- redirect public → private 차단
- oversized URL response 차단

## 제외 범위

- URL Bearer credential
- POST / PUT / PATCH URL source
- arbitrary request headers
- OAuth
- Excel / ZIP / resumable upload
- Multi-source Join / Composition (#506)
- Studio Add Data UI (#250)

## Known limitation

현재 async `POST /builds` execution context는 기존 구조상 `owner_id`를 source resolver까지 전달하지 않으므로,
file-backed source는 동기 `POST /build` 경로에서 지원됩니다.

async build의 principal/owner propagation은 기존 async execution 영역의 후속 정합화 대상으로 남기며,
이번 #498에서 async state machine의 범위를 확장하지 않았습니다.