### PR TITLE
feat: add structured Run Event Timeline API (#496)

### DIFF
--- a/contract/builder-api.yaml
+++ b/contract/builder-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: KPubData Builder Service API
-  version: "1.12.0"
+  version: "1.13.0"
   description: >-
     Builder 중심 서비스 계약. BuildSpec 검증, preview, build 실행, artifact 조회,
     계약 버전 조회를 제공한다. CLI와 HTTP service mode(#36)가 동일한 도메인 계약을
@@ -50,6 +50,18 @@ info:
     재검증, redirect마다 재검증, 응답 크기 상한)를 거친다. 두 kind 모두 기존
     Bronze artifact/provenance 계약을 그대로 재사용하며, provenance/manifest에
     로컬 파일 경로나 쿼리스트링 secret을 남기지 않는다.
+    v1.13.0은 `GET /builds/{run_id}/events`를 추가한다(#496, additive — 기존
+    엔드포인트는 변경되지 않는다). run 실행 과정(submitted/started/finished/
+    failed, source fetch started/completed/failed, medallion
+    stage(bronze/silver/gold/export) started/completed/failed, quality
+    checkpoint)을 raw logger parsing 없이 append-only structured event
+    timeline으로 조회한다. `limit`(기본 200, 상한 1000)과 `tail`로 bounded
+    query를 제공하며, 반환은 항상 chronological ascending이다. event의
+    ordering identifier(`seq`)는 store가 append 시점에 부여하는 monotonic
+    값이라 병렬 source 간 실제 append 순서를 손실 없이 보존한다. Monitoring
+    (#516, `GET /monitoring/summary`·`GET /monitoring/builds`)은 시스템/집계
+    observability를 다루고, 이 endpoint는 단일 run의 event만 다룬다 — 역할이
+    분리되어 있다.
 servers:
   - url: http://localhost:8000
     description: 로컬 builder 개발 서버
@@ -1103,6 +1115,130 @@ paths:
                   summary: run history를 조회할 수 없는 dataset
                   value:
                     error: "dataset not found: unknown-dataset"
+
+  /builds/{run_id}/events:
+    get:
+      operationId: getBuildEvents
+      summary: >-
+        run의 append-only structured event timeline 조회 (#496). raw logger를
+        파싱하지 않고, 실제 실행 boundary(run/source fetch/medallion
+        stage/quality checkpoint)에서 남긴 구조화된 event만 반환한다. 반환은
+        항상 chronological ascending이다 — `tail=true`도 최신 `limit`개를
+        고르되 결과 자체는 뒤집지 않는다. 실패했다고 이전 성공 event를
+        지우지 않으므로(append-only), partial run에서도 마지막 정상 event와
+        실패 event를 함께 확인할 수 있다.
+      parameters:
+        - $ref: "#/components/parameters/RunId"
+        - name: limit
+          in: query
+          required: false
+          description: "반환할 최대 event 수 (기본값: 200, 상한: 1000)"
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 200
+        - name: tail
+          in: query
+          required: false
+          description: >-
+            true면 run 시작부터가 아니라 가장 최근 `limit`개를 선택한다(반환
+            순서는 여전히 chronological ascending).
+          schema:
+            type: boolean
+            default: false
+      responses:
+        "200":
+          description: run_id와 chronological ascending으로 정렬된 event 목록
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BuildEventsResponse"
+              examples:
+                CompletedRun:
+                  summary: 단일 source가 Bronze→Silver→Gold→Export까지 모두 성공한 run
+                  value:
+                    run_id: air-quality-20260815
+                    events:
+                      - seq: 1
+                        timestamp: "2026-08-15T09:30:00+00:00"
+                        run_id: air-quality-20260815
+                        event: run_started
+                        status: ok
+                        source_key: null
+                        stage: null
+                        message: pipeline execution started
+                        metrics: null
+                      - seq: 2
+                        timestamp: "2026-08-15T09:30:01+00:00"
+                        run_id: air-quality-20260815
+                        event: stage_completed
+                        status: ok
+                        source_key: air
+                        stage: bronze
+                        message: Bronze written
+                        metrics: {records: 84321}
+                      - seq: 3
+                        timestamp: "2026-08-15T09:30:02+00:00"
+                        run_id: air-quality-20260815
+                        event: run_finished
+                        status: ok
+                        source_key: null
+                        stage: null
+                        message: build completed
+                        metrics: null
+                PartialFailure:
+                  summary: 한 source가 bronze fetch에서 실패한 run — 이전 event는 남아 있다
+                  value:
+                    run_id: air-quality-partial
+                    events:
+                      - seq: 1
+                        timestamp: "2026-08-15T09:30:00+00:00"
+                        run_id: air-quality-partial
+                        event: run_started
+                        status: ok
+                        source_key: null
+                        stage: null
+                        message: pipeline execution started
+                        metrics: null
+                      - seq: 2
+                        timestamp: "2026-08-15T09:30:01+00:00"
+                        run_id: air-quality-partial
+                        event: source_fetch_failed
+                        status: fail
+                        source_key: air
+                        stage: null
+                        message: "pipeline failed for source 'air'"
+                        metrics: null
+                      - seq: 3
+                        timestamp: "2026-08-15T09:30:01+00:00"
+                        run_id: air-quality-partial
+                        event: run_failed
+                        status: fail
+                        source_key: null
+                        stage: null
+                        message: 1 source(s) failed
+                        metrics: null
+        "400":
+          description: 경로 안전하지 않은 run_id, 잘못된 limit, 또는 잘못된 tail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: 해당 run의 소유자가 아님
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: 해당 run을 찾을 수 없음
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
   /builds/{run_id}/stages:
     get:
@@ -2789,6 +2925,93 @@ components:
           type: string
         alias:
           type: string
+
+    BuildEventName:
+      type: string
+      description: >-
+        structured run event의 bounded vocabulary (#496). run_submitted은
+        실제 async job submission이 있는 `POST /builds`(비동기)에서만 발생하며
+        동기 `POST /build`에는 없다. run_cancelled은 아직 이 API에 없다 —
+        cancellation state transition(#481)이 구현되기 전까지는 발생하지
+        않는다.
+      enum:
+        - run_submitted
+        - run_started
+        - run_finished
+        - run_failed
+        - source_fetch_started
+        - source_fetch_completed
+        - source_fetch_failed
+        - stage_started
+        - stage_completed
+        - stage_failed
+        - quality_evaluated
+
+    BuildEventStatus:
+      type: string
+      description: >-
+        event의 결과. ok(성공/정상 완료), warn(quality_evaluated에서 FAIL 없이
+        WARN이 하나 이상), fail(실패).
+      enum: [ok, warn, fail]
+
+    BuildEventStageName:
+      type: string
+      description: 관련 medallion stage. export는 BuildSpec.exports 실행 단계다.
+      enum: [bronze, silver, gold, export]
+
+    BuildEvent:
+      type: object
+      description: >-
+        단일 structured run event(#496). arbitrary object dump, exception
+        객체, stack trace, raw provider response, raw path, credential은
+        담기지 않는다 — message/metrics는 항상 bounded하고 안전하다.
+      required: [seq, timestamp, run_id, event, status, source_key, stage, message, metrics]
+      properties:
+        seq:
+          type: integer
+          description: >-
+            store가 append 시점에 부여하는 monotonic ordering identifier.
+            병렬 source worker의 실제 append 순서를 그대로 보존하며, 존재하지
+            않는 causal ordering을 지어내지 않는다.
+        timestamp:
+          type: string
+          format: date-time
+          description: timezone-aware UTC 시각.
+        run_id:
+          type: string
+        event:
+          $ref: "#/components/schemas/BuildEventName"
+        status:
+          $ref: "#/components/schemas/BuildEventStatus"
+        source_key:
+          type: [string, "null"]
+          description: 관련 소스 식별자. run 수준 event는 null.
+        stage:
+          oneOf:
+            - $ref: "#/components/schemas/BuildEventStageName"
+            - type: "null"
+          description: 관련 medallion stage. source fetch/run 수준 event는 null.
+        message:
+          type: [string, "null"]
+          description: 사람이 읽는 bounded, 안전한 요약. 없으면 null.
+        metrics:
+          type: [object, "null"]
+          description: >-
+            JSON 직렬화 가능한 안전한 수치 요약(예: records/row_count/
+            check_count). 원본 provider 응답이나 임의 object는 담지 않는다.
+          additionalProperties: true
+
+    BuildEventsResponse:
+      type: object
+      description: run identity와 chronological ascending으로 정렬된 event 목록.
+      required: [run_id, events]
+      properties:
+        run_id:
+          type: string
+        events:
+          type: array
+          items:
+            $ref: "#/components/schemas/BuildEvent"
 
     StageStatusValue:
       type: string

--- a/src/kpubdata_builder/events/__init__.py
+++ b/src/kpubdata_builder/events/__init__.py
@@ -1,0 +1,38 @@
+"""Run 단위 structured event timeline (#496).
+
+Build 실행 과정(run/source fetch/medallion stage/quality checkpoint)을 raw
+logger parsing 없이 조회할 수 있도록 append-only event timeline을 제공한다.
+
+주요 구성:
+    - BuildEvent: 단일 structured event 모델
+    - BuildEventStore: append-only SQLite 저장소 (event timeline의 정본)
+    - BuildEventRecorder: pipeline이 안전하게 event를 남기기 위한 wrapper
+"""
+
+from __future__ import annotations
+
+from .models import (
+    BuildEvent,
+    EventName,
+    EventStatus,
+    QualityEventName,
+    RunEventName,
+    SourceFetchEventName,
+    StageEventName,
+    StageName,
+)
+from .recorder import BuildEventRecorder
+from .store import BuildEventStore
+
+__all__ = [
+    "BuildEvent",
+    "BuildEventRecorder",
+    "BuildEventStore",
+    "EventName",
+    "EventStatus",
+    "QualityEventName",
+    "RunEventName",
+    "SourceFetchEventName",
+    "StageEventName",
+    "StageName",
+]

--- a/src/kpubdata_builder/events/models.py
+++ b/src/kpubdata_builder/events/models.py
@@ -1,0 +1,92 @@
+"""Run 단위 structured event timeline 모델 (#496).
+
+Build 실행 과정을 raw logger 파싱 없이 조회할 수 있도록, run 안에서 일어나는
+주요 전이(run/source fetch/stage/quality)를 명시적 구조화 모델로 표현한다.
+
+원칙:
+    - event/status/stage 어휘는 bounded(Literal)하고 deterministic하다. 임의
+      logger message 문자열을 API 계약으로 승격하지 않는다.
+    - arbitrary object dumping, exception 객체 직렬화, stack trace, raw
+      provider response, raw path, credential은 이 모델에 담지 않는다 — 호출부
+      (``events.recorder``/``pipeline.orchestrator``)가 이미 안전하다고 확인한
+      값만 여기로 들어온다.
+    - ``seq``는 store가 append 시점에 부여하는 monotonic ordering identifier다
+      (#496) — 병렬 source worker가 동시에 append해도 store가 부여한 전역 순서를
+      그대로 신뢰할 수 있다. append 전에는 placeholder(0)다.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+from ..spec.models import JsonValue
+
+# run 수준 전이. "cancelled"는 아직 이 저장소에 실제 cancellation 전이가 없어
+# (#481 미구현) 어휘에 포함하지 않는다 — 그 전이가 생기면 함께 추가한다.
+RunEventName = Literal["run_submitted", "run_started", "run_finished", "run_failed"]
+
+# source fetch 전이 (#498 resolver 경계: public_api/file/url 공통).
+SourceFetchEventName = Literal[
+    "source_fetch_started", "source_fetch_completed", "source_fetch_failed"
+]
+
+# medallion stage 전이. "export"는 BuildSpec.exports 실행 단계다.
+StageEventName = Literal["stage_started", "stage_completed", "stage_failed"]
+
+# quality/schema 평가 체크포인트 (#486 결과를 재판정하지 않고 그대로 반영).
+QualityEventName = Literal["quality_evaluated"]
+
+EventName = RunEventName | SourceFetchEventName | StageEventName | QualityEventName
+
+# event의 결과. "ok"는 성공/정상 완료, "warn"은 quality_evaluated에서 WARN이
+# 하나 이상 있었지만 FAIL은 없었던 경우, "fail"은 실패다. run/source/stage 전이는
+# ok 또는 fail만 쓴다(started는 ok, completed는 ok, failed는 fail).
+EventStatus = Literal["ok", "warn", "fail"]
+
+StageName = Literal["bronze", "silver", "gold", "export"]
+
+
+@dataclass(frozen=True, slots=True)
+class BuildEvent:
+    """단일 structured run event.
+
+    속성:
+        seq: store가 append 시점에 부여하는 monotonic ordering identifier.
+            append 전에는 0(placeholder) — ``BuildEventStore.append()``가 실제
+            값을 채운 새 인스턴스를 반환한다.
+        timestamp: timezone-aware UTC 시각.
+        run_id: 이 event가 속한 run.
+        event: 어떤 전이가 일어났는지 (bounded vocabulary).
+        status: 그 전이의 결과 (ok/warn/fail).
+        source_key: 관련 소스 식별자. run 수준 event는 None.
+        stage: 관련 medallion stage. source fetch/run 수준 event는 None.
+        message: 사람이 읽는 bounded, 안전한 요약. 없으면 None — 임의 값을
+            지어내지 않는다.
+        metrics: JSON 직렬화 가능한 안전한 수치 요약(예: rows/check_count).
+            원본 provider 응답이나 임의 object를 담지 않는다.
+    """
+
+    seq: int
+    timestamp: datetime
+    run_id: str
+    event: EventName
+    status: EventStatus
+    source_key: str | None = None
+    stage: StageName | None = None
+    message: str | None = None
+    metrics: Mapping[str, JsonValue] | None = None
+
+
+__all__ = [
+    "BuildEvent",
+    "EventName",
+    "EventStatus",
+    "QualityEventName",
+    "RunEventName",
+    "SourceFetchEventName",
+    "StageEventName",
+    "StageName",
+]

--- a/src/kpubdata_builder/events/recorder.py
+++ b/src/kpubdata_builder/events/recorder.py
@@ -1,0 +1,218 @@
+"""Pipeline이 event를 안전하게 기록하기 위한 얇은 wrapper (#496).
+
+``pipeline.orchestrator``가 이 recorder를 통해서만 event를 남긴다 — store를
+직접 건드리지 않는다. 두 가지를 이 계층에서 강제한다.
+
+1. **message 길이 상한**: 어떤 호출부든 bounded, 안전한 message만 넘기지만,
+   방어적으로 한 곳에서 길이를 자른다(길이만 자르므로 새로운 정보를 만들어
+   내거나 숨겨진 내용을 드러내지 않는다).
+2. **append 실패가 이미 진행 중인 build의 실행/결과를 바꾸지 않는다**:
+   ``BuildEventStore`` 자체는 실패를 삼키지 않는다(#496, 이 store가 event의
+   유일한 정본) — 그러나 이 recorder가 감싸는 호출부는 대부분 실제 side
+   effect(bronze/silver/gold persist, source fetch)가 *이미 일어난 뒤*
+   호출된다(``stage_completed``, ``run_finished`` 등). 여기서 예외를 그대로
+   전파하면 event 저장소라는 **다른 subsystem**의 일시적 장애가 이미 성공한
+   소스를 실패로 뒤집거나(``_run_source_pipeline``의 공통 except가 모든
+   예외를 "이 소스 실패"로 해석한다), manifest 기록 전에 run_build를 중단시켜
+   ``manifest.json``이 아예 안 만들어지는 상태(AGENTS.md '매니페스트 누락
+   금지' 위반)를 만들 수 있다. 이건 ``BuildIndex`` write가 best-effort인
+   이유(ADR 0003 — 인덱스가 파생·재구축 가능하기 때문)와는 **다른** 이유다:
+   여기서는 event store가 파생물이라서가 아니라, event 기록 실패가 *다른
+   정본*(manifest/소스 outcome)을 침범하면 안 되기 때문에 흡수한다.
+   그렇다고 완전히 조용히 삼키지도 않는다 — ``logger.error``로 남기는 것에
+   더해, 실패한 호출을 ``dropped_events()``로 누적해 호출부(orchestrator)가
+   기존 ``BuildManifest.warnings``(#496 이전부터 존재하는, 아직 아무도 채우지
+   않던 authoritative 필드)에 실을 수 있게 한다 — API 소비자는
+   ``GET /builds/{run_id}/manifest``로 이 run의 event timeline에 실제로 구멍이
+   있었는지 확인할 수 있다. 새 API 필드나 새 상태값을 추가하지 않는다.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from typing import cast
+
+from ..quality.models import QualityCheckResult
+from ..spec.models import JsonValue
+from .models import BuildEvent, EventName, EventStatus, StageName
+from .store import BuildEventStore
+
+logger = logging.getLogger(__name__)
+
+# event message 방어적 상한. 임의로 큰 quality 실패 메시지 나열 등이 API/저장소를
+# 무제한으로 부풀리지 않게 한다. 길이만 자르므로 숨겨진 내용을 새로 드러내지 않는다.
+_MAX_MESSAGE_LENGTH = 500
+
+
+def _bounded_message(message: str | None) -> str | None:
+    if message is None:
+        return None
+    if len(message) <= _MAX_MESSAGE_LENGTH:
+        return message
+    return message[:_MAX_MESSAGE_LENGTH] + "…"
+
+
+def _quality_status(results: Sequence[QualityCheckResult]) -> EventStatus:
+    if any(r.status == "fail" for r in results):
+        return "fail"
+    if any(r.status == "warn" for r in results):
+        return "warn"
+    return "ok"
+
+
+class BuildEventRecorder:
+    """단일 run에 바인딩된, 절대 예외를 전파하지 않는 event 기록기.
+
+    ``store``가 ``None``이면(이벤트 저장소 없이 ``run_build``를 직접 호출하는
+    CLI/저수준 테스트 경로) 모든 메서드가 아무 것도 하지 않는다 — pipeline
+    코드가 recorder 유무를 매번 분기할 필요가 없다.
+
+    여러 source가 ``ThreadPoolExecutor``(#247)에서 동시에 같은 recorder
+    인스턴스로 event를 남기므로, ``dropped_events()``로 누적되는 실패 목록도
+    lock으로 보호한다.
+    """
+
+    def __init__(self, store: BuildEventStore | None, *, run_id: str) -> None:
+        self._store = store
+        self._run_id = run_id
+        self._dropped_lock = threading.Lock()
+        self._dropped_events: list[str] = []
+
+    def dropped_events(self) -> tuple[str, ...]:
+        """append에 실패한 event를 설명하는 bounded 경고 목록을 반환한다 (#496).
+
+        원본 예외 메시지(sqlite 오류 텍스트 등에 내부 경로가 섞일 수 있다)는
+        담지 않는다 — event/source_key/stage처럼 이미 안전하다고 확인된
+        식별자만으로 구성한다. 호출부(``run_build``)가 이 값을
+        ``BuildManifest.warnings``에 실어 API로 노출한다.
+        """
+        with self._dropped_lock:
+            return tuple(self._dropped_events)
+
+    def _record(
+        self,
+        event: str,
+        status: EventStatus,
+        *,
+        source_key: str | None = None,
+        stage: StageName | None = None,
+        message: str | None = None,
+        metrics: Mapping[str, JsonValue] | None = None,
+    ) -> None:
+        if self._store is None:
+            return
+        built = BuildEvent(
+            seq=0,
+            timestamp=datetime.now(tz=timezone.utc),
+            run_id=self._run_id,
+            event=cast(EventName, event),
+            status=status,
+            source_key=source_key,
+            stage=stage,
+            message=_bounded_message(message),
+            metrics=metrics,
+        )
+        try:
+            self._store.append(built)
+        except Exception:
+            logger.error(
+                "build event append failed (run_id=%s, event=%s, source_key=%s, stage=%s); "
+                "recorded as a manifest warning instead of failing the build (#496)",
+                self._run_id,
+                event,
+                source_key,
+                stage,
+                exc_info=True,
+            )
+            detail = f"event recording failed: {event}"
+            if source_key is not None:
+                detail += f" (source_key={source_key})"
+            if stage is not None:
+                detail += f" (stage={stage})"
+            with self._dropped_lock:
+                self._dropped_events.append(detail)
+
+    # --- run lifecycle -------------------------------------------------
+    #
+    # "run_submitted"는 여기 없다 — 이 recorder의 흡수(never-raise) 정책이
+    # 맞지 않는 유일한 event다: 이 event가 기록될 때는 아직 job이 executor에
+    # 큐잉되기 전이라(#496) 실제 side effect가 없고, 그래서 실패를 그대로
+    # 전파해도 다른 정본을 침범하지 않는다(오히려 job을 아예 큐잉하지 않게
+    # 막아야 한다). ``BuilderService.submit_build``가
+    # ``AsyncBuildExecutor.submit(on_accept=...)`` hook에서 store에 직접
+    # append해 그 전파를 그대로 활용한다.
+
+    def run_started(self) -> None:
+        self._record("run_started", "ok", message="pipeline execution started")
+
+    def run_finished(self) -> None:
+        self._record("run_finished", "ok", message="build completed")
+
+    def run_failed(self, *, failed_source_count: int) -> None:
+        self._record("run_failed", "fail", message=f"{failed_source_count} source(s) failed")
+
+    # --- source fetch (#498 resolver 경계: public_api/file/url 공통) ---
+
+    def source_fetch_started(self, source_key: str) -> None:
+        self._record("source_fetch_started", "ok", source_key=source_key)
+
+    def source_fetch_completed(self, source_key: str, *, record_count: int) -> None:
+        self._record(
+            "source_fetch_completed",
+            "ok",
+            source_key=source_key,
+            message="source fetched",
+            metrics={"records": record_count},
+        )
+
+    def source_fetch_failed(self, source_key: str, *, message: str) -> None:
+        self._record("source_fetch_failed", "fail", source_key=source_key, message=message)
+
+    # --- medallion stage -------------------------------------------------
+
+    def stage_started(self, source_key: str, stage: StageName) -> None:
+        self._record("stage_started", "ok", source_key=source_key, stage=stage)
+
+    def stage_completed(
+        self,
+        source_key: str,
+        stage: StageName,
+        *,
+        message: str,
+        metrics: Mapping[str, JsonValue] | None = None,
+    ) -> None:
+        self._record(
+            "stage_completed",
+            "ok",
+            source_key=source_key,
+            stage=stage,
+            message=message,
+            metrics=metrics,
+        )
+
+    def stage_failed(self, source_key: str, stage: StageName, *, message: str) -> None:
+        self._record("stage_failed", "fail", source_key=source_key, stage=stage, message=message)
+
+    # --- quality/schema checkpoint (#486 결과를 그대로 반영, 재판정하지 않음) --
+
+    def quality_evaluated(self, source_key: str, results: Sequence[QualityCheckResult]) -> None:
+        pass_count = sum(1 for r in results if r.status == "pass")
+        warn_count = sum(1 for r in results if r.status == "warn")
+        fail_count = sum(1 for r in results if r.status == "fail")
+        self._record(
+            "quality_evaluated",
+            _quality_status(results),
+            source_key=source_key,
+            metrics={
+                "check_count": len(results),
+                "pass_count": pass_count,
+                "warn_count": warn_count,
+                "fail_count": fail_count,
+            },
+        )
+
+
+__all__ = ["BuildEventRecorder"]

--- a/src/kpubdata_builder/events/store.py
+++ b/src/kpubdata_builder/events/store.py
@@ -1,0 +1,215 @@
+"""Append-only SQLite 기반 run event store (#496).
+
+``store.build_index.BuildIndex``(#309, ADR 0003)와 같은 SQLite 동시성 패턴
+(WAL 모드, busy_timeout, thread-local connection, 트랜잭션)을 재사용하지만
+failure policy는 다르다:
+
+- ``BuildIndex``는 ``manifest.json``의 **파생·재구축 가능한 인덱스**라서 쓰기
+  실패를 삼켜도 된다(ADR 0003) — 잃어도 파일시스템 스캔으로 다시 만들 수 있다.
+- 이 store는 run event timeline의 **유일한 정본**이다 — 다시 만들 수 있는
+  원본이 없다. 그래서 ``append()``는 실패를 삼키지 않고 그대로 전파한다
+  (#496 "lost event 없음"). 이 store를 감싸는 pipeline 쪽 호출부
+  (``events.recorder.BuildEventRecorder``)는 그 실패가 *다른* 정본(manifest,
+  소스 outcome)을 침범하지 않도록 흡수하되, ``BuildManifest.warnings``로
+  드러낸다 — store 자체는 절대 자기 실패를 조용히 숨기지 않는다.
+
+동시성: 여러 source가 ``ThreadPoolExecutor``(#247)로 병렬 실행되며 각자
+event를 append한다. ``AUTOINCREMENT`` 기본키는 SQLite가 커밋 순서대로 부여하는
+전역 monotonic sequence이므로, 이 값 하나로 서로 다른 스레드의 append 순서를
+손실 없이, causal ordering을 지어내지 않고 그대로 보존할 수 있다(#496 병렬
+ordering 정책).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import cast
+
+from ..spec.models import JsonValue
+from .models import BuildEvent, EventName, EventStatus, StageName
+
+SCHEMA_VERSION = 1
+
+_EVENTS_FILENAME = "_build_events.sqlite"
+
+_CREATE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS build_events (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id TEXT NOT NULL,
+    timestamp TEXT NOT NULL,
+    event TEXT NOT NULL,
+    status TEXT NOT NULL,
+    source_key TEXT,
+    stage TEXT,
+    message TEXT,
+    metrics TEXT
+)
+"""
+
+_SELECT_COLUMNS = "seq, run_id, timestamp, event, status, source_key, stage, message, metrics"
+
+
+class BuildEventStore:
+    """단일 output_root의 모든 run에 대한 append-only event 저장소.
+
+    ``BuildIndex``와 동일하게 output_root 아래 별도 SQLite 파일
+    (``_build_events.sqlite``)을 쓴다 — manifest.json/BuildIndex와 독립적인
+    파일이라 이 store의 스키마 변경이 다른 정본에 영향을 주지 않는다.
+    """
+
+    def __init__(self, output_root: Path, *, db_path: Path | None = None) -> None:
+        self._output_root = output_root
+        self._db_path = db_path if db_path is not None else output_root / _EVENTS_FILENAME
+        self._local = threading.local()
+        self._init_db()
+
+    @property
+    def _conn(self) -> sqlite3.Connection:
+        if not hasattr(self._local, "conn"):
+            self._local.conn = self._connect()
+        return cast(sqlite3.Connection, self._local.conn)
+
+    def _connect(self) -> sqlite3.Connection:
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(self._db_path), timeout=30.0)  # busy_timeout: 동시성 경합 대기
+        conn.execute("PRAGMA journal_mode=WAL")  # 동시 읽기 + 병렬 append 허용
+        return conn
+
+    def _init_db(self) -> None:
+        with self._transaction():
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS schema_version (
+                    version INTEGER PRIMARY KEY,
+                    applied_at TEXT DEFAULT (datetime('now'))
+                )
+                """
+            )
+            cur = self._conn.execute("SELECT version FROM schema_version")
+            if cur.fetchone() is None:
+                # v1은 첫 배포다 — 파괴적 마이그레이션(DROP)이 필요 없다. 이 store는
+                # append-only 정본이므로(BuildIndex와 달리) 스키마가 바뀌어도 절대
+                # 기존 event 행을 DROP하지 않는다 — 향후 버전은 ALTER/신규 컬럼
+                # 추가로만 마이그레이션해야 한다.
+                self._conn.execute(
+                    f"INSERT INTO schema_version (version) VALUES ({SCHEMA_VERSION})"
+                )
+            self._conn.execute(_CREATE_TABLE_SQL)
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_build_events_run_seq ON build_events(run_id, seq)"
+            )
+
+    @contextmanager
+    def _transaction(self) -> Iterator[None]:
+        try:
+            yield
+            self._conn.commit()
+        except Exception:
+            self._conn.rollback()
+            raise
+
+    def append(self, event: BuildEvent) -> BuildEvent:
+        """event를 append하고, store가 부여한 ``seq``가 채워진 새 인스턴스를 반환한다.
+
+        실패를 삼키지 않는다(#496) — 이 store는 event timeline의 유일한 정본이라
+        ``BuildIndex``(ADR 0003, 파생 인덱스)와 달리 쓰기 실패를 조용히
+        무시하면 event가 영구히 사라진다. 호출부가 실패 처리 정책을 정한다.
+
+        예외:
+            sqlite3.Error: 기록에 실패한 경우 그대로 전파된다.
+        """
+        timestamp = event.timestamp
+        if timestamp.tzinfo is None or timestamp.utcoffset() is None:
+            raise ValueError("event.timestamp must be timezone-aware")
+        metrics_json = json.dumps(event.metrics) if event.metrics is not None else None
+        with self._transaction():
+            cur = self._conn.execute(
+                """
+                INSERT INTO build_events
+                    (run_id, timestamp, event, status, source_key, stage, message, metrics)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    event.run_id,
+                    timestamp.astimezone(timezone.utc).isoformat(),
+                    event.event,
+                    event.status,
+                    event.source_key,
+                    event.stage,
+                    event.message,
+                    metrics_json,
+                ),
+            )
+            seq = cur.lastrowid
+        if seq is None:  # pragma: no cover - sqlite3 always assigns lastrowid on INSERT
+            raise RuntimeError("build event insert did not return a row id")
+        return replace(event, seq=seq)
+
+    def list_for_run(self, run_id: str, *, limit: int, tail: bool) -> tuple[BuildEvent, ...]:
+        """단일 run의 event를 chronological ascending 순서로 최대 ``limit``개 반환한다.
+
+        ``tail=False``(기본)는 run 시작부터 ``limit``개, ``tail=True``는 가장 최근
+        ``limit``개를 고르되 반환 자체는 항상 오름차순이다(#496 timeline
+        rendering 정책) — 클라이언트가 매번 뒤집을 필요가 없다. bounded query다:
+        limit이 항상 SQL ``LIMIT``으로 전달되어 테이블 전체를 읽지 않는다.
+        """
+        if tail:
+            cur = self._conn.execute(
+                f"SELECT {_SELECT_COLUMNS} FROM build_events "
+                "WHERE run_id = ? ORDER BY seq DESC LIMIT ?",
+                (run_id, limit),
+            )
+            rows = list(cur.fetchall())
+            rows.reverse()
+        else:
+            cur = self._conn.execute(
+                f"SELECT {_SELECT_COLUMNS} FROM build_events "
+                "WHERE run_id = ? ORDER BY seq ASC LIMIT ?",
+                (run_id, limit),
+            )
+            rows = list(cur.fetchall())
+        return tuple(_row_to_event(row) for row in rows)
+
+    def close(self) -> None:
+        """연결을 닫는다 (WAL을 메인 DB 파일로 체크포인트한 뒤).
+
+        ``BuildIndex.close()``와 동일한 패턴 — 테스트/재배치에서 파일을
+        안전하게 옮길 수 있게 한다.
+        """
+        if hasattr(self._local, "conn"):
+            self._local.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            self._local.conn.close()
+            delattr(self._local, "conn")
+
+
+def _row_to_event(row: tuple[object, ...]) -> BuildEvent:
+    seq, run_id, timestamp_text, event, status, source_key, stage, message, metrics_json = row
+    metrics: dict[str, JsonValue] | None = None
+    if metrics_json is not None:
+        try:
+            parsed = json.loads(cast(str, metrics_json))
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, dict):
+            metrics = cast(dict[str, JsonValue], parsed)
+    return BuildEvent(
+        seq=cast(int, seq),
+        timestamp=datetime.fromisoformat(cast(str, timestamp_text)),
+        run_id=cast(str, run_id),
+        event=cast(EventName, event),
+        status=cast(EventStatus, status),
+        source_key=cast("str | None", source_key),
+        stage=cast("StageName | None", stage),
+        message=cast("str | None", message),
+        metrics=metrics,
+    )
+
+
+__all__ = ["BuildEventStore", "SCHEMA_VERSION"]

--- a/src/kpubdata_builder/pipeline/orchestrator.py
+++ b/src/kpubdata_builder/pipeline/orchestrator.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 from ..artifact import ArtifactDataset
 from ..errors import DatasetValidationError, ValidationError
+from ..events import BuildEventRecorder, BuildEventStore
 from ..exporters import get_exporter
 from ..ingestion import IngestionError
 from ..manifest import (
@@ -217,6 +218,7 @@ def _run_source_pipeline(
     *,
     client: SourceClient,
     context: BuildContext,
+    recorder: BuildEventRecorder,
     upload_repository: UploadRepository | None = None,
     owner_id: str | None = None,
 ) -> _SourcePipelineResult:
@@ -227,6 +229,13 @@ def _run_source_pipeline(
 
     ``upload_repository``/``owner_id`` 는 ``kind="file"`` source에서만 쓰인다
     (#498) — 업로드 소유권 확인에 필요한 stable principal id다.
+
+    ``recorder``는 이 소스의 실제 실행 boundary(fetch/stage/quality)에서만
+    structured event를 남긴다(#496) — 실행되지 않은 단계를 완료로 가장하지
+    않는다. 어느 단계까지 성공했는지는 기존 ``completed`` 목록으로 판정하고,
+    export처럼 ``completed``에 반영되지 않는 단계는 ``export_started`` 플래그로
+    별도 추적한다 — 기존 partial-run outcome 계약(``stages_completed``)은
+    바꾸지 않는다.
     """
     output_key = _output_source_key(source)
     completed: list[str] = []
@@ -239,20 +248,39 @@ def _run_source_pipeline(
     quality_results: tuple[QualityCheckResult, ...] = ()
     quality_evaluated = False
     schema_drift: tuple[SchemaDriftFinding, ...] = ()
+    # completed 목록에 없는 export 단계 진행 여부를 별도로 추적한다(#496) —
+    # export는 gold 완료 후 실행되지만 기존 outcome 모델(stages_completed)에는
+    # 반영되지 않는다. fetch_completed는 "bronze" not in completed만으로는
+    # source fetch 성공 여부와 bronze persist 성공 여부를 구분할 수 없어서
+    # (persist가 fetch *이후*에 실패할 수 있다) 별도로 추적한다.
+    export_started = False
+    fetch_completed = False
     try:
         # kind(public_api/file/url)에 맞는 resolver로 원시 레코드를 가져온다
-        # (#498) — 이후 Silver/Gold는 kind를 전혀 알 필요가 없다.
+        # (#498) — 이후 Silver/Gold는 kind를 전혀 알 필요가 없다. bronze stage와
+        # source fetch는 이 호출을 공유 경계로 삼는다(#496) — public_api/file/url
+        # 모두 동일한 event 어휘를 쓴다.
+        recorder.stage_started(output_key, "bronze")
+        recorder.source_fetch_started(output_key)
         bronze = build_bronze_artifact_for_source(
             source,
             client=client,
             upload_repository=upload_repository,
             owner_id=owner_id,
         )
+        recorder.source_fetch_completed(output_key, record_count=len(bronze.raw_records))
+        fetch_completed = True
         bronze = _retag_bronze_artifact(bronze, output_key=output_key)
         bronze_paths = persist_bronze_artifact(
             bronze, output_root=context.output_root, run_id=context.run_id
         )
         completed.append("bronze")
+        recorder.stage_completed(
+            output_key,
+            "bronze",
+            message="Bronze written",
+            metrics={"records": len(bronze.raw_records)},
+        )
         _record_output_paths(outputs, bronze_paths.records_path, bronze_paths.metadata_path)
         # bronze 성공 직후 확정한다: 이후 단계가 실패해도(부분 실패) provenance는 남는다
         # (병렬화 이전 shared list에 즉시 append하던 것과 동일한 동작을 유지) (#247).
@@ -269,6 +297,7 @@ def _run_source_pipeline(
             params=bronze.fetch_params,
         )
 
+        recorder.stage_started(output_key, "silver")
         required_columns = source.schema.required if source.schema else ()
         column_dtypes = source.schema.dtypes if source.schema else None
         silver = build_silver_dataset(
@@ -290,6 +319,10 @@ def _run_source_pipeline(
             column_dtypes=column_dtypes,
         )
         quality_evaluated = True
+        # quality checkpoint event(#496)는 #486 판정 결과를 그대로 반영한다 —
+        # 이 아래에서 FAIL로 소스가 실패해도(quality gate) 평가가 실제로
+        # 일어났다는 사실과 그 결과는 이미 기록된다(partial run 가시성).
+        recorder.quality_evaluated(output_key, quality_results)
 
         # 검증에 실패한 Silver 데이터셋이 Gold/패키징으로 흘러가지 않도록 소스를
         # 실패 처리한다. 검증은 더 이상 권고용이 아니라 게이트다 (#189). 기존 오류
@@ -350,6 +383,12 @@ def _run_source_pipeline(
             silver, output_root=context.output_root, run_id=context.run_id
         )
         completed.append("silver")
+        recorder.stage_completed(
+            output_key,
+            "silver",
+            message="Silver written",
+            metrics={"row_count": evaluated_row_count},
+        )
         _record_output_paths(
             outputs,
             silver_paths.table_path,
@@ -359,6 +398,7 @@ def _run_source_pipeline(
             silver_paths.validation_path,
         )
 
+        recorder.stage_started(output_key, "gold")
         gold = build_gold_package(
             silver,
             dataset_name=output_key,
@@ -370,12 +410,21 @@ def _run_source_pipeline(
             gold, output_root=context.output_root, run_id=context.run_id
         )
         completed.append("gold")
+        recorder.stage_completed(
+            output_key, "gold", message="Gold written", metrics={"row_count": len(gold.table)}
+        )
         _record_output_paths(
             outputs,
             gold_paths.table_path,
             gold_paths.package_path,
             *gold_paths.splits_paths.values(),
         )
+
+        # export 단계(#496): SourceBuildOutcome.stages_completed에는 반영되지
+        # 않는 기존 모델을 유지하되(#488 stage API와 동일 계약), 실제 export
+        # 실행 boundary에서 started/completed/failed를 별도로 기록한다.
+        export_started = True
+        recorder.stage_started(output_key, "export")
         export_paths = export_gold_package(gold, output_dir=gold_paths.gold_dir)
         _record_output_paths(outputs, *export_paths)
 
@@ -407,6 +456,12 @@ def _run_source_pipeline(
             context.spec.exports,
         )
         _record_output_paths(outputs, *buildspec_export_paths)
+        recorder.stage_completed(
+            output_key,
+            "export",
+            message="Export written",
+            metrics={"file_count": len(export_paths) + len(buildspec_export_paths)},
+        )
 
         schema_summary = build_schema_summary(
             (column.name, column.dtype, column.nullable) for column in silver.schema.columns
@@ -442,6 +497,20 @@ def _run_source_pipeline(
                 exc_info=exc,
             )
             error_msg = f"pipeline failed for source {output_key!r}"
+        # 실제로 도달한 마지막 boundary 기준으로 실패 event를 남긴다(#496) —
+        # completed 목록이 이미 "어느 stage까지 성공했는지"의 정본이므로, 그
+        # 다음 stage가 실패한 stage다. 시도조차 되지 않은 stage는 실패로
+        # 가장하지 않는다(이벤트를 아예 남기지 않는다).
+        if "bronze" not in completed:
+            if not fetch_completed:
+                recorder.source_fetch_failed(output_key, message=error_msg)
+            recorder.stage_failed(output_key, "bronze", message=error_msg)
+        elif "silver" not in completed:
+            recorder.stage_failed(output_key, "silver", message=error_msg)
+        elif "gold" not in completed:
+            recorder.stage_failed(output_key, "gold", message=error_msg)
+        elif export_started:
+            recorder.stage_failed(output_key, "export", message=error_msg)
         return _SourcePipelineResult(
             outcome=SourceBuildOutcome(
                 source_key=output_key,
@@ -467,6 +536,7 @@ def run_build(
     created_by: str | None = None,
     owner_id: str | None = None,
     upload_repository: UploadRepository | None = None,
+    event_store: BuildEventStore | None = None,
 ) -> BuildResult:
     """BuildSpec을 Medallion 파이프라인으로 실행한다.
 
@@ -483,6 +553,9 @@ def run_build(
             항상 같은 사람이어야 한다.
         upload_repository: ``kind="file"`` source의 업로드 content를 조회할
             저장소 (#498). None이면 file source가 있는 build는 실패한다.
+        event_store: structured run event timeline 저장소 (#496). None이면
+            (CLI 직접 호출 등) event를 전혀 기록하지 않는다 — 기존 호출자는
+            아무 것도 바꾸지 않아도 된다.
 
     반환값:
         BuildResult: 전체 상태, 소스별 결과, 매니페스트 경로.
@@ -495,6 +568,12 @@ def run_build(
     # spec이 단계 깊숙이 들어가 cryptic 에러로 터지므로, 단계 진입 전에 막는다 (#212).
     validate_spec(spec)
     context = BuildContext.create(spec, output_root=output_root, run_id=run_id)
+    # run_id가 확정된(BuildContext.create가 생략 시 생성) 직후에만 recorder를
+    # 만들 수 있다 — "started"는 실제로 실행이 시작되는 이 지점의 실제 semantics다
+    # (#496). validate_spec 실패는 run_id/워크스페이스가 아예 없으므로 event를
+    # 남기지 않는다 — 기존에도 그 실패에 대해서는 워크스페이스가 만들어지지 않는다.
+    recorder = BuildEventRecorder(event_store, run_id=context.run_id)
+    recorder.run_started()
     # 검증된 실제 실행 입력을 pipeline보다 먼저 고정한다. 이후 source 단계가 실패해도
     # run 감사 정보는 남고, validation 실패 입력은 snapshot으로 기록되지 않는다.
     _, spec_digest = write_buildspec_snapshot(
@@ -506,6 +585,7 @@ def run_build(
             source,
             client=client,
             context=context,
+            recorder=recorder,
             upload_repository=upload_repository,
             owner_id=owner_id,
         )
@@ -550,6 +630,10 @@ def run_build(
         if outcome.status == "failed" and outcome.error is not None
     )
     status = "ok" if not errors else "failed"
+    if status == "ok":
+        recorder.run_finished()
+    else:
+        recorder.run_failed(failed_source_count=len(errors))
 
     manifest = BuildManifest(
         build_id=context.run_id,
@@ -557,6 +641,10 @@ def run_build(
         finished_at=utc_now(),
         inputs=tuple(_output_source_key(source) for source in spec.sources),
         outputs=tuple(outputs),
+        # recorder가 흡수한 event 기록 실패(#496)를 여기 싣는다 — 새 API 필드를
+        # 추가하지 않고 기존 authoritative warnings 채널을 재사용해, event
+        # timeline에 실제로 구멍이 있었는지 API 소비자가 알 수 있게 한다.
+        warnings=recorder.dropped_events(),
         errors=errors,
         row_counts=row_counts,
         schema_summaries=schema_summaries,

--- a/src/kpubdata_builder/pipeline/orchestrator.py
+++ b/src/kpubdata_builder/pipeline/orchestrator.py
@@ -535,6 +535,7 @@ def run_build(
     run_id: str | None = None,
     created_by: str | None = None,
     owner_id: str | None = None,
+    manifest_owner_id: str | None = None,
     upload_repository: UploadRepository | None = None,
     event_store: BuildEventStore | None = None,
 ) -> BuildResult:
@@ -546,11 +547,21 @@ def run_build(
         output_root: 실행 워크스페이스 루트.
         run_id: 실행 식별자. 생략 시 타임스탬프 기반으로 생성.
         created_by: 빌드를 요청한 principal의 display/legacy 라벨(#388).
-        owner_id: canonical stable persistent owner identity (#505). manifest에
-            created_by와 함께 additive로 기록된다. ``kind="file"`` source가
-            있으면 업로드 소유권 확인에도 이 값을 그대로 재사용한다(#498) —
-            "이 run을 요청한 principal"과 "이 run이 참조하는 업로드의 소유자"는
-            항상 같은 사람이어야 한다.
+        owner_id: ``kind="file"`` source resolver가 업로드 소유권 확인에
+            쓰는 canonical stable owner identity(#505/#498) — "이 run이
+            참조하는 업로드의 소유자"다. sync ``/build``는 언제나 제출
+            principal 본인이 곧 그 소유자이므로 그대로 재사용해도 안전하지만,
+            async ``/builds``는 지금까지처럼 ``None``으로 남겨 file-backed
+            source resolver에 stable identity를 노출하지 않는다(#498 async
+            limitation, 그대로 유지).
+        manifest_owner_id: persisted run manifest(및 그 manifest를 그대로
+            읽어 채우는 BuildIndex, #505 SSOT)에 기록할 canonical stable
+            owner identity — "이 run을 제출한 principal"이다. 생략(``None``)
+            하면 ``owner_id``를 그대로 쓴다(기존 sync 호출자와 100% 동일하게
+            동작). async 호출자는 file resolver용 ``owner_id``는 ``None``으로
+            둔 채 이 필드만 채워, "누가 이 run을 제출했는가"(persisted
+            ownership)와 "file resolver가 무엇을 소유권 확인에 쓸 수
+            있는가"를 서로 다른 값으로 분리한다.
         upload_repository: ``kind="file"`` source의 업로드 content를 조회할
             저장소 (#498). None이면 file source가 있는 build는 실패한다.
         event_store: structured run event timeline 저장소 (#496). None이면
@@ -564,6 +575,7 @@ def run_build(
         ValidationError: spec이 최소 실행 요건을 만족하지 못한 경우.
         ValueError: run_id에 안전하지 않은 문자가 포함된 경우.
     """
+    effective_manifest_owner_id = owner_id if manifest_owner_id is None else manifest_owner_id
     # 진입점에서 spec을 먼저 검증한다(fail-fast). 검증을 호출자에게만 맡기면 잘못된
     # spec이 단계 깊숙이 들어가 cryptic 에러로 터지므로, 단계 진입 전에 막는다 (#212).
     validate_spec(spec)
@@ -652,7 +664,7 @@ def run_build(
         build_environment=capture_build_environment(),
         inputs_fingerprint=compute_inputs_fingerprint(provenance),
         created_by=created_by,
-        owner_id=owner_id,
+        owner_id=effective_manifest_owner_id,
         quality_results=quality_results,
         schema_drift=schema_drift,
     )

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -36,6 +36,7 @@ from ..credentials import (
     SQLiteCredentialRepository,
 )
 from ..errors import SpecLoadError, ValidationError
+from ..events import BuildEvent, BuildEventStore
 from ..ingestion import IngestionError, parse_tabular_bytes
 from ..pipeline import DEFAULT_PREVIEW_SEED, SampleMode, preview_build, run_build
 from ..quality import QualityCheckResult
@@ -63,6 +64,7 @@ from ..uploads import (
     resolve_max_upload_bytes,
 )
 from . import datasets as datasets_service
+from . import events as events_service
 from . import monitoring as monitoring_service
 from . import ownership as ownership_module
 from . import quality as quality_service
@@ -231,7 +233,14 @@ def _strip_internal_fields(entries: list[_BuildListEntry]) -> list[_BuildListEnt
 # GET /uploads/{upload_id}, DELETE /uploads/{upload_id}를 추가한다(#498,
 # additive — 기존 엔드포인트/kind 없는 source는 변경되지 않는다). url source는
 # P0 범위(GET, Auth=None, https만 허용)로 SSRF를 방어하는 safe fetch를 거친다.
-API_CONTRACT_VERSION = "1.12.0"
+# 1.12.0 -> 1.13.0: GET /builds/{run_id}/events를 추가한다(#496, additive —
+# 기존 엔드포인트는 변경되지 않는다). run/source fetch/medallion
+# stage(bronze/silver/gold/export)/quality checkpoint의 structured event
+# append-only timeline을 raw logger 파싱 없이 조회할 수 있다. limit/tail
+# query parameter는 bounded(기본 200, 상한 1000)이며 반환은 항상 chronological
+# ascending이다. Monitoring(#516)의 시스템 aggregate와는 역할이 분리된다 — 이
+# endpoint는 단일 run의 이벤트만 다룬다.
+API_CONTRACT_VERSION = "1.13.0"
 
 
 def _quality_result_to_json(r: QualityCheckResult) -> dict[str, JsonValue]:
@@ -289,6 +298,13 @@ class BuilderService:
         self._output_root = output_root
         self._client_factory = client_factory
         self._build_index = BuildIndex(output_root)  # #309, ADR 0003
+        # run event timeline 저장소(#496). `_upload_repository`와 동일하게 지연
+        # 생성한다 — preview는 build를 전혀 실행하지 않아 event를 남길 일이
+        # 없으므로("Preview writes no files" 기존 계약, #497 범위 밖 #496도
+        # 동일), 실제로 처음 쓰일 때(build/submit_build/events 조회)까지
+        # `_build_events.sqlite` 흔적을 남기지 않는다.
+        self._event_store_lazy: BuildEventStore | None = None
+        self._event_store_lock = threading.Lock()
         # kind="file" source(#498)의 업로드 저장소. 명시적으로 주입되지 않으면
         # 실제로 처음 쓰일 때까지 SQLite 파일을 만들지 않는다(지연 생성,
         # `_upload_repository` property) — credential repository(마스터 키
@@ -316,6 +332,20 @@ class BuilderService:
             max_workers=async_max_workers,
             max_queue_size=async_max_queue_size,
         )
+
+    @property
+    def _event_store(self) -> BuildEventStore:
+        """run event timeline 저장소를 지연 생성해 반환한다 (#496).
+
+        처음 접근될 때만 ``_build_events.sqlite``를 만든다 — preview만 하는
+        워크스페이스에는 흔적을 남기지 않는다(기존 "Preview writes no files"
+        계약과 동일한 이유로 지연 생성한다).
+        """
+        if self._event_store_lazy is None:
+            with self._event_store_lock:
+                if self._event_store_lazy is None:
+                    self._event_store_lazy = BuildEventStore(self._output_root)
+        return self._event_store_lazy
 
     @property
     def _upload_repository(self) -> UploadRepository:
@@ -854,6 +884,7 @@ class BuilderService:
                 created_by=created_by,
                 owner_id=owner_id,
                 upload_repository=self._upload_repository_for(spec_or_error),
+                event_store=self._event_store,
             )
         finally:
             _close_request_client(client)
@@ -931,12 +962,75 @@ class BuilderService:
                     "run_id": resolved_run_id,
                 },
             )
-        result = self._async_builds.submit(
-            spec_yaml=spec_yaml,
-            run_id=resolved_run_id,
-            created_by=created_by,
-            runner=self._run_build_job,
-        )
+
+        def _record_run_submitted() -> None:
+            # AsyncBuildExecutor.submit()이 job을 worker pool에 큐잉하기 *전에*
+            # 호출된다(#496) — "existing"/"queue_full"이면 새 submission이 아니므로
+            # 아예 호출되지 않는다. store.append()는 실패를 삼키지 않고 그대로
+            # 전파한다(BuildEventStore, event timeline의 유일한 정본) — 여기서는
+            # 그 전파를 그대로 둔다. job이 아직 큐잉되지 않은 시점이라, 이 event가
+            # 기록되지 못하면 job도 만들어지지 않는다: "event는 유실됐는데 job은
+            # 이미 실행 중"이라는 모순이 생기지 않는다(recorder의 흡수 정책과
+            # 달리, 여기는 아직 다른 정본을 침범할 real side effect가 없다).
+            self._event_store.append(
+                BuildEvent(
+                    seq=0,
+                    timestamp=datetime.now(tz=timezone.utc),
+                    run_id=resolved_run_id,
+                    event="run_submitted",
+                    status="ok",
+                    message="build accepted for async execution",
+                )
+            )
+
+        def _record_enqueue_failure() -> None:
+            # registry.mark_failed() 직후, 예외 재전파 *전에* 호출된다(#496
+            # lifecycle 계약: timeline 자체도 이 실패를 표현해야 한다) —
+            # run_submitted는 이미 기록됐으니 지우지 않고(append-only), 기존
+            # "run_failed" vocabulary로 동일 run_id에 종결 event를 하나 더
+            # 남긴다. raw exception/stack trace는 담지 않는다 — bounded,
+            # 안전한 고정 message만 쓴다(recorder의 다른 event들과 동일한
+            # 방어 원칙). 이 append 자체가 실패해도 로그만 남기고 흡수한다 —
+            # 이미 registry가 "failed"로 확정된 뒤라, 이 부가 event 기록
+            # 실패가 원래 enqueue 실패(재전파될 예외)를 가리면 안 된다.
+            try:
+                self._event_store.append(
+                    BuildEvent(
+                        seq=0,
+                        timestamp=datetime.now(tz=timezone.utc),
+                        run_id=resolved_run_id,
+                        event="run_failed",
+                        status="fail",
+                        message="build could not be queued for execution",
+                    )
+                )
+            except Exception:
+                logger.error(
+                    "failed to record run_failed event after enqueue failure (run_id=%s)",
+                    resolved_run_id,
+                    exc_info=True,
+                )
+
+        try:
+            result = self._async_builds.submit(
+                spec_yaml=spec_yaml,
+                run_id=resolved_run_id,
+                created_by=created_by,
+                runner=self._run_build_job,
+                on_accept=_record_run_submitted,
+                on_enqueue_failure=_record_enqueue_failure,
+            )
+        except Exception:
+            # run_submitted event append 실패, 또는 event는 기록됐지만 이후
+            # worker pool 큐잉(executor.submit) 자체가 실패한 경우 둘 다
+            # 여기로 온다 — 두 경우 모두 job은 실행되지 않으므로 202를 주지
+            # 않는다(#496).
+            logger.error(
+                "failed to accept build submission; build was not queued (run_id=%s)",
+                resolved_run_id,
+                exc_info=True,
+            )
+            return ServiceResponse(500, {"error": "failed to accept build submission"})
         match result.status:
             case "accepted":
                 if result.snapshot is None:
@@ -1487,6 +1581,21 @@ class BuilderService:
             body["sample"] = None
             body["sample_available"] = False
 
+        return ServiceResponse(200, body)
+
+    def get_build_events(self, run_id: str, *, limit: int, tail: bool) -> ServiceResponse:
+        """run의 append-only structured event timeline을 조회한다 (#496).
+
+        호출 전에 run_id 검증·존재 확인·ownership 게이팅이 끝나 있어야 한다
+        (``/builds/{run_id}/stages``와 동일하게 dispatch route adapter가 먼저
+        처리한다). 반환은 항상 chronological ascending이다 — ``tail=True``도
+        최신 ``limit``개를 고르되 정렬 자체는 뒤집지 않는다(#496 ordering 정책).
+        """
+        events = self._event_store.list_for_run(run_id, limit=limit, tail=tail)
+        body: dict[str, JsonValue] = {
+            "run_id": run_id,
+            "events": cast(JsonValue, [events_service.event_to_json(e) for e in events]),
+        }
         return ServiceResponse(200, body)
 
     def _load_validated(self, spec_yaml: str) -> BuildSpec | ServiceResponse:

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -950,9 +950,20 @@ class BuilderService:
         return ServiceResponse(status_code, body)
 
     def submit_build(
-        self, spec_yaml: str, *, run_id: str | None = None, created_by: str | None = None
+        self,
+        spec_yaml: str,
+        *,
+        run_id: str | None = None,
+        created_by: str | None = None,
+        owner_id: str | None = None,
     ) -> ServiceResponse:
-        """비동기 build job을 큐에 넣고 초기 상태를 반환한다 (#482)."""
+        """비동기 build job을 큐에 넣고 초기 상태를 반환한다 (#482).
+
+        ``owner_id``는 active run ownership 판정(``check_active_run_access``,
+        #496 follow-up)을 위해 job registry snapshot까지만 전달된다 — wire
+        응답(``to_body()``)에는 노출되지 않고, ``_run_build_job``/build
+        pipeline에도 전달하지 않는다(#498 async owner propagation 한계 유지).
+        """
         resolved_run_id = run_id or generate_run_id()
         if self._build_index.get(resolved_run_id) is not None:
             return ServiceResponse(
@@ -1016,6 +1027,7 @@ class BuilderService:
                 spec_yaml=spec_yaml,
                 run_id=resolved_run_id,
                 created_by=created_by,
+                owner_id=owner_id,
                 runner=self._run_build_job,
                 on_accept=_record_run_submitted,
                 on_enqueue_failure=_record_enqueue_failure,

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -837,6 +837,7 @@ class BuilderService:
         run_id: str | None = None,
         created_by: str | None = None,
         owner_id: str | None = None,
+        manifest_owner_id: str | None = None,
         principal: Principal | None = None,
     ) -> ServiceResponse:
         """파이프라인을 실행하고 결과를 반환한다.
@@ -850,6 +851,14 @@ class BuilderService:
         ``owner_id``는 canonical stable owner identity다(#505). ``created_by``는
         기존(#388) display/legacy 라벨로 계속 함께 기록된다 — wire 계약은 바뀌지
         않는다.
+
+        ``manifest_owner_id``는 persisted manifest ownership(및 그 manifest를
+        읽어 채우는 BuildIndex, #505 SSOT)에만 쓰이는 별도 값이다 — ``owner_id``
+        (kind="file" source resolver의 업로드 소유권 확인용, #498)와 분리하기
+        위한 것으로, 생략하면 ``owner_id``를 그대로 쓴다(기존 동작과 동일).
+        async run(``_run_build_job``)이 이 필드로 submitting principal의
+        owner_id를 manifest/BuildIndex에는 기록하면서도 file resolver에는
+        여전히 owner_id를 넘기지 않는 데 쓴다(#496 follow-up).
         """
         spec_or_error = self._load_validated(spec_yaml)
         if isinstance(spec_or_error, ServiceResponse):
@@ -883,6 +892,7 @@ class BuilderService:
                 run_id=run_id,
                 created_by=created_by,
                 owner_id=owner_id,
+                manifest_owner_id=manifest_owner_id,
                 upload_repository=self._upload_repository_for(spec_or_error),
                 event_store=self._event_store,
             )
@@ -959,10 +969,14 @@ class BuilderService:
     ) -> ServiceResponse:
         """비동기 build job을 큐에 넣고 초기 상태를 반환한다 (#482).
 
-        ``owner_id``는 active run ownership 판정(``check_active_run_access``,
-        #496 follow-up)을 위해 job registry snapshot까지만 전달된다 — wire
-        응답(``to_body()``)에는 노출되지 않고, ``_run_build_job``/build
-        pipeline에도 전달하지 않는다(#498 async owner propagation 한계 유지).
+        ``owner_id``는 job registry snapshot에 보존된다 — wire 응답
+        (``to_body()``)에는 노출되지 않는다. registry에 남은 이 값은 두 곳에
+        쓰인다: (1) active run(``check_active_run_access``, #496 follow-up)
+        ownership 판정, (2) ``_run_build_job``이 이를 ``build()``의
+        ``manifest_owner_id``로 넘겨 persisted manifest/BuildIndex(#505 SSOT)
+        에 정확한 owner_id를 기록. ``build()``의 ``owner_id``(``kind="file"``
+        source resolver용, #498)에는 여전히 전달하지 않는다 — async
+        file-backed source owner propagation 한계는 그대로 유지된다.
         """
         resolved_run_id = run_id or generate_run_id()
         if self._build_index.get(resolved_run_id) is not None:
@@ -1071,7 +1085,22 @@ class BuilderService:
     def _run_build_job(
         self, spec_yaml: str, run_id: str, created_by: str | None
     ) -> ServiceResponse:
-        return self.build(spec_yaml, run_id=run_id, created_by=created_by)
+        """async job registry가 부르는 실제 실행 진입점 (#482, #496 follow-up).
+
+        ``build()``에 ``owner_id``는 전달하지 않는다(``None`` 그대로) —
+        ``kind="file"`` source resolver는 async 경로에서 여전히 stable owner
+        identity를 알지 못한다(#498 async limitation 유지). 대신
+        ``manifest_owner_id``로 registry snapshot에 이미 보존된(``submit_build``
+        가 채운) submitting principal의 owner_id를 넘긴다 — persisted manifest
+        (및 그 manifest를 그대로 읽어 채우는 BuildIndex, #505 SSOT)는
+        ``build()`` 내부에서 단 한 번의 write로 정확한 owner_id를 갖게 되고,
+        build 종료 후 manifest를 별도로 사후 수정할 필요가 없다.
+        """
+        snapshot = self._async_builds.get(run_id)
+        manifest_owner_id = snapshot.owner_id if snapshot is not None else None
+        return self.build(
+            spec_yaml, run_id=run_id, created_by=created_by, manifest_owner_id=manifest_owner_id
+        )
 
     def artifacts(self, run_id: str) -> ServiceResponse:
         """실행 워크스페이스의 산출물 파일 목록을 반환한다."""

--- a/src/kpubdata_builder/service/events.py
+++ b/src/kpubdata_builder/service/events.py
@@ -1,0 +1,36 @@
+"""Run event timeline HTTP API 서비스 로직 (#496).
+
+``GET /builds/{run_id}/events``가 쓰는 순수 조회/직렬화 로직을 담는다.
+run_id 형식 검증·존재 확인·ownership 게이팅은 service/app.py의
+dispatch/BuilderService가 먼저 처리하고, 이 모듈은 그 뒤(신뢰된 run_id)부터
+시작한다 — ``service.stages``와 동일한 책임 분리다.
+"""
+
+from __future__ import annotations
+
+from ..events import BuildEvent
+from ..spec import JsonValue
+
+# limit query parameter의 bounded 기본값/상한. 다른 route(``service.stages``의
+# DEFAULT_STAGE_PREVIEW_LIMIT/MAX_STAGE_PREVIEW_LIMIT)와 동일한 관례 — 상수를
+# 한 곳에만 두고 route/service 양쪽에서 재사용한다(magic number 중복 금지).
+DEFAULT_EVENTS_LIMIT = 200
+MAX_EVENTS_LIMIT = 1000
+
+
+def event_to_json(event: BuildEvent) -> dict[str, JsonValue]:
+    """``BuildEvent``를 wire JSON으로 변환한다."""
+    return {
+        "seq": event.seq,
+        "timestamp": event.timestamp.isoformat(),
+        "run_id": event.run_id,
+        "event": event.event,
+        "status": event.status,
+        "source_key": event.source_key,
+        "stage": event.stage,
+        "message": event.message,
+        "metrics": dict(event.metrics) if event.metrics is not None else None,
+    }
+
+
+__all__ = ["DEFAULT_EVENTS_LIMIT", "MAX_EVENTS_LIMIT", "event_to_json"]

--- a/src/kpubdata_builder/service/jobs.py
+++ b/src/kpubdata_builder/service/jobs.py
@@ -37,9 +37,11 @@ class BuildJobSnapshot:
     ``owner_id``는 active/terminal async run의 ownership 판정용 internal
     필드다(#496 follow-up, #505 canonical stable identity) — ``created_by``
     (Principal.label, display/legacy fallback)와 달리 신규 ownership 판정에
-    우선 쓰이는 값이지만, ``to_body()``가 wire로 절대 내보내지 않는다(#498
-    async owner propagation 한계를 그대로 유지 — run_build/source resolver에는
-    전달하지 않는다).
+    우선 쓰이는 값이고, ``BuilderService._run_build_job``이 persisted
+    manifest/BuildIndex(#505 SSOT) 기록용으로도 그대로 재사용한다. 다만
+    ``to_body()``가 wire로 절대 내보내지 않고, ``kind="file"`` source
+    resolver(#498)에는 여전히 전달되지 않는다 — async file-backed source
+    owner propagation 한계는 그대로 유지된다.
     """
 
     run_id: str

--- a/src/kpubdata_builder/service/jobs.py
+++ b/src/kpubdata_builder/service/jobs.py
@@ -32,13 +32,22 @@ SubmitStatus = Literal["accepted", "existing", "queue_full"]
 
 @dataclass(frozen=True, slots=True)
 class BuildJobSnapshot:
-    """외부에 노출 가능한 build job 상태 스냅샷."""
+    """build job 상태 스냅샷.
+
+    ``owner_id``는 active/terminal async run의 ownership 판정용 internal
+    필드다(#496 follow-up, #505 canonical stable identity) — ``created_by``
+    (Principal.label, display/legacy fallback)와 달리 신규 ownership 판정에
+    우선 쓰이는 값이지만, ``to_body()``가 wire로 절대 내보내지 않는다(#498
+    async owner propagation 한계를 그대로 유지 — run_build/source resolver에는
+    전달하지 않는다).
+    """
 
     run_id: str
     status: BuildJobStatus
     created_at: str
     updated_at: str
     created_by: str | None = None
+    owner_id: str | None = None
     response: dict[str, JsonValue] | None = None
     error: str | None = None
 
@@ -79,7 +88,9 @@ class AsyncBuildJobRegistry:
         self._lock = Lock()
         self._jobs: dict[str, BuildJobSnapshot] = {}
 
-    def create(self, *, run_id: str, created_by: str | None) -> BuildJobSnapshot:
+    def create(
+        self, *, run_id: str, created_by: str | None, owner_id: str | None = None
+    ) -> BuildJobSnapshot:
         now = _utc_now_text()
         snapshot = BuildJobSnapshot(
             run_id=run_id,
@@ -87,6 +98,7 @@ class AsyncBuildJobRegistry:
             created_at=now,
             updated_at=now,
             created_by=created_by,
+            owner_id=owner_id,
         )
         with self._lock:
             self._jobs[run_id] = snapshot
@@ -148,6 +160,7 @@ class AsyncBuildJobRegistry:
                 created_at=current.created_at,
                 updated_at=_utc_now_text(),
                 created_by=current.created_by,
+                owner_id=current.owner_id,
                 response=response,
                 error=error,
             )
@@ -201,11 +214,19 @@ class AsyncBuildExecutor:
         run_id: str,
         created_by: str | None,
         runner: BuildJobRunner,
+        owner_id: str | None = None,
         on_accept: Callable[[], None] | None = None,
         on_enqueue_failure: Callable[[], None] | None = None,
     ) -> BuildJobSubmitResult:
         """job을 큐잉한다. ``existing``/``queue_full``이면 새 submission이 아니므로
         ``on_accept``를 호출하지 않는다.
+
+        ``owner_id``는 ``registry.create()``까지만 전달되어 snapshot에
+        보존된다(#496 follow-up, active run ownership 판정용) — ``runner``
+        호출(아래 ``self._executor.submit(self._run, spec_yaml, run_id,
+        created_by, runner)``)에는 전달하지 않는다. run_build/source resolver
+        쪽 owner propagation은 #498에서 이미 별도 한계로 남겨졌고, 이번
+        변경에서 그 범위를 넓히지 않는다.
 
         ``on_accept``는 job이 실제로 worker pool에 큐잉되기(``self._executor.submit``)
         *전*에 호출된다(#496). 호출자(``BuilderService.submit_build``)는 이 hook으로
@@ -240,7 +261,7 @@ class AsyncBuildExecutor:
             return BuildJobSubmitResult(status="queue_full")
         if on_accept is not None:
             on_accept()
-        snapshot = self.registry.create(run_id=run_id, created_by=created_by)
+        snapshot = self.registry.create(run_id=run_id, created_by=created_by, owner_id=owner_id)
         try:
             self._executor.submit(self._run, spec_yaml, run_id, created_by, runner)
         except Exception:

--- a/src/kpubdata_builder/service/jobs.py
+++ b/src/kpubdata_builder/service/jobs.py
@@ -201,14 +201,53 @@ class AsyncBuildExecutor:
         run_id: str,
         created_by: str | None,
         runner: BuildJobRunner,
+        on_accept: Callable[[], None] | None = None,
+        on_enqueue_failure: Callable[[], None] | None = None,
     ) -> BuildJobSubmitResult:
+        """job을 큐잉한다. ``existing``/``queue_full``이면 새 submission이 아니므로
+        ``on_accept``를 호출하지 않는다.
+
+        ``on_accept``는 job이 실제로 worker pool에 큐잉되기(``self._executor.submit``)
+        *전*에 호출된다(#496). 호출자(``BuilderService.submit_build``)는 이 hook으로
+        "run_submitted" event를 append한다 — 그 append가 여기서 실패해 예외를
+        전파하면, job은 registry에 만들어지지도 worker에 큐잉되지도 않은 채
+        그대로 끝난다. 이 순서 덕분에 "event는 유실됐는데 job은 이미 실행
+        중"이라는 모순이 구조적으로 생기지 않는다 — job의 "accepted" 여부 자체가
+        이 event 기록 성공에 달려 있다. ``on_accept``가 없는 호출자(기존
+        monitoring 테스트 등)는 이전과 동일하게 아무 gating 없이 그대로 큐잉된다.
+
+        반대 방향(#496 self-review): ``on_accept``가 성공해 event는 기록됐는데
+        ``self._executor.submit()``(실제 worker pool 큐잉) 자체가 실패하면,
+        ``registry.create()``가 이미 만든 "queued" 항목이 아무도 실행하지 않을
+        phantom으로 영원히 남는다 — event(``run_submitted``)는 append-only라
+        지울 수 없으므로(#496 원칙), 이 항목을 "queued"로 방치하지 않고 실제
+        job 실행 실패에 이미 쓰이는 것과 동일한 ``registry.mark_failed()``로
+        정리한 뒤 예외를 그대로 전파한다 — 새 상태값을 만들지 않고 기존
+        terminal mechanism을 재사용한다.
+
+        ``on_enqueue_failure``는 ``registry.mark_failed()`` 직후, 예외를
+        재전파하기 *전*에 호출된다(#496 lifecycle 계약: timeline 자체도 이
+        실패를 표현해야 한다) — 호출자는 이 hook으로 같은 run_id에 기존
+        ``run_failed`` event를 append한다. ``on_accept`` 실패 경로(event 자체가
+        전혀 기록되지 못한 경우)와는 구별된다 — 그 경로는 ``registry.create()``
+        까지 가지도 못하므로 여기 도달하지 않고, ``run_submitted``도
+        ``run_failed``도 남기지 않는다.
+        """
         existing = self.registry.get(run_id)
         if existing is not None:
             return BuildJobSubmitResult(status="existing", snapshot=existing)
         if self.registry.queued_count() >= self._max_queue_size:
             return BuildJobSubmitResult(status="queue_full")
+        if on_accept is not None:
+            on_accept()
         snapshot = self.registry.create(run_id=run_id, created_by=created_by)
-        self._executor.submit(self._run, spec_yaml, run_id, created_by, runner)
+        try:
+            self._executor.submit(self._run, spec_yaml, run_id, created_by, runner)
+        except Exception:
+            self.registry.mark_failed(run_id, error="failed to queue build job")
+            if on_enqueue_failure is not None:
+                on_enqueue_failure()
+            raise
         return BuildJobSubmitResult(status="accepted", snapshot=snapshot)
 
     def get(self, run_id: str) -> BuildJobSnapshot | None:

--- a/src/kpubdata_builder/service/routes/__init__.py
+++ b/src/kpubdata_builder/service/routes/__init__.py
@@ -2,16 +2,30 @@
 
 from __future__ import annotations
 
-from . import artifacts, builds, core, datasets, monitoring, providers, quality, query, stages
+from . import (
+    artifacts,
+    builds,
+    core,
+    datasets,
+    events,
+    monitoring,
+    providers,
+    quality,
+    query,
+    stages,
+)
 from ._types import RouteAdapter
 
-# 순서는 기존 app.dispatch 조건문의 우선순위를 고정한다.
+# 순서는 기존 app.dispatch 조건문의 우선순위를 고정한다. events(#496)는
+# builds 바로 다음에 둔다 — 둘 다 "/builds/{run_id}/..." 경로를 다루므로 논리적
+# 이웃이다(실제 매칭은 각 adapter의 path suffix 검사로 서로 겹치지 않는다).
 ROUTE_ADAPTERS: tuple[RouteAdapter, ...] = (
     core.route,
     providers.route,
     query.route,
     datasets.route,
     builds.route,
+    events.route,
     quality.route,
     stages.route,
     artifacts.route,

--- a/src/kpubdata_builder/service/routes/_guards.py
+++ b/src/kpubdata_builder/service/routes/_guards.py
@@ -71,10 +71,12 @@ def check_active_run_access(
            ``ownership_allows``에 그대로 넘겨 우선순위 판단을 위임한다).
         3. 둘 다 없으면 404.
 
-    snapshot의 ``owner_id``는 ``BuilderService.submit_build``가 registry
-    저장 목적으로만 전달한다 - wire 응답이나 run_build/source resolver에는
-    전달되지 않는다(#498 async owner propagation 한계 유지, snapshot 자체에는
-    이 필드가 있지만 ``BuildJobSnapshot.to_body()``가 절대 노출하지 않는다).
+    snapshot의 ``owner_id``는 ``BuilderService.submit_build``가 registry에
+    보존해 둔 값이다 - wire 응답에는 노출되지 않는다(``BuildJobSnapshot.to_body()``
+    가 절대 내보내지 않는다). ``_run_build_job``이 이 값을 persisted
+    manifest/BuildIndex(#505 SSOT) 기록에도 재사용하지만, ``kind="file"``
+    source resolver(#498)에는 여전히 전달하지 않는다 - async file-backed
+    source owner propagation 한계는 그대로 유지된다.
 
     ``/manifest``, ``/stages`` 등 다른 route는 여전히 persisted run만 다루므로
     이 함수를 쓰지 않는다 - 영향 범위를 events endpoint로 좁게 유지한다.

--- a/src/kpubdata_builder/service/routes/_guards.py
+++ b/src/kpubdata_builder/service/routes/_guards.py
@@ -42,3 +42,53 @@ def check_run_exists(service: BuilderService, run_id: str) -> ServiceResponse | 
     if run_dir.is_dir():
         return None
     return ServiceResponse(404, {"error": f"run not found: {run_id}"})
+
+
+def check_active_run_access(
+    service: BuilderService, run_id: str, principal: Principal
+) -> ServiceResponse | None:
+    """``/builds/{run_id}/events`` 전용 존재·소유권 판정 (#496 follow-up: BLOCKER).
+
+    ``check_run_exists``/``check_ownership``은 run directory와 manifest.json이
+    이미 있다고 가정한다 - 하지만 async job은 ``run_submitted``가 worker
+    enqueue *이전에* event store에 기록되고(``BuilderService.submit_build``의
+    ``on_accept`` hook), run directory는 worker가 ``BuildContext.create()``에서,
+    manifest는 run이 끝나야 비로소 만들어진다. 그 사이(queued/running) 구간에는
+    ``check_run_exists``가 404를, ownership이 켜져 있으면 ``check_ownership``이
+    (manifest 부재로 created_by/owner_id 둘 다 None) fail-closed 403을 반환해
+    events polling이 아예 불가능해진다.
+
+    판정 순서(run directory 존재 여부는 전환 기준으로 쓰지 않는다 - manifest만
+    본다):
+        1. manifest.json이 있으면 기존 ``check_ownership``(manifest 기반,
+           stable ``owner_id`` 우선) 경로를 그대로 쓴다 - completed run은
+           registry에 terminal entry가 남아있어도 이 경로로만 판정한다.
+        2. manifest가 없고 async job registry(``AsyncBuildExecutor``, 프로세스
+           메모리 상주)에 snapshot이 있으면(active든, enqueue 실패 등으로
+           manifest 없이 종결된 terminal이든) 그 snapshot의 stable
+           ``owner_id``로 ownership을 판정한다(#505 canonical identity -
+           ``created_by``/``Principal.label``은 legacy fallback일 뿐이고,
+           ``ownership_allows``에 그대로 넘겨 우선순위 판단을 위임한다).
+        3. 둘 다 없으면 404.
+
+    snapshot의 ``owner_id``는 ``BuilderService.submit_build``가 registry
+    저장 목적으로만 전달한다 - wire 응답이나 run_build/source resolver에는
+    전달되지 않는다(#498 async owner propagation 한계 유지, snapshot 자체에는
+    이 필드가 있지만 ``BuildJobSnapshot.to_body()``가 절대 노출하지 않는다).
+
+    ``/manifest``, ``/stages`` 등 다른 route는 여전히 persisted run만 다루므로
+    이 함수를 쓰지 않는다 - 영향 범위를 events endpoint로 좁게 유지한다.
+    """
+    run_dir = service._output_root / run_id
+    ensure_within(service._output_root, run_dir, label="run directory")
+    manifest_path = run_dir / "manifest.json"
+    if manifest_path.exists():
+        return check_ownership(service, run_id, principal)
+    snapshot = service._async_builds.get(run_id)
+    if snapshot is not None:
+        if ownership_module.ownership_allows(
+            created_by=snapshot.created_by, owner_id=snapshot.owner_id, principal=principal
+        ):
+            return None
+        return ServiceResponse(403, {"error": "forbidden: not run owner"})
+    return ServiceResponse(404, {"error": f"run not found: {run_id}"})

--- a/src/kpubdata_builder/service/routes/builds.py
+++ b/src/kpubdata_builder/service/routes/builds.py
@@ -33,7 +33,9 @@ def route(
         run_id = optional_run_id(body)
         if isinstance(run_id, ServiceResponse):
             return run_id
-        return service.submit_build(spec, run_id=run_id, created_by=principal.label)
+        return service.submit_build(
+            spec, run_id=run_id, created_by=principal.label, owner_id=principal.owner_id
+        )
 
     if method == "GET" and path.startswith("/builds/") and "/" not in path[len("/builds/") :]:
         return service.build_status(path[len("/builds/") :])

--- a/src/kpubdata_builder/service/routes/events.py
+++ b/src/kpubdata_builder/service/routes/events.py
@@ -1,0 +1,97 @@
+"""Run event timeline route adapter (#496)."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
+from urllib.parse import parse_qs
+
+from ...spec import JsonValue
+from ...stages._path_safety import validate_path_segment
+from .. import events as events_service
+from ..auth import Principal
+from ..responses import ServiceResponse
+from ._guards import check_ownership, check_run_exists
+from ._types import RouteResponse
+
+if TYPE_CHECKING:
+    from ..app import BuilderService
+
+_PREFIX = "/builds/"
+_SUFFIX = "/events"
+
+
+def route(
+    service: BuilderService,
+    method: str,
+    path: str,
+    body: Mapping[str, JsonValue] | None,
+    query: str,
+    principal: Principal,
+) -> RouteResponse | None:
+    del body
+    # "/stages" route(service/routes/stages.py)와 동일한 순서를 따른다: run_id는
+    # segments[0]에서 바로 뽑아 path의 나머지 모양과 무관하게 먼저 검증한다 —
+    # "../escape/events"처럼 안전하지 않은 run_id는 이 adapter가 실제로 매칭되는
+    # 경로 모양인지와 상관없이 400으로 거부되어야 한다(#317 conformance와
+    # 동일한 path-traversal 방어 관례).
+    if method != "GET" or not path.startswith(_PREFIX) or _SUFFIX not in path:
+        return None
+    segments = path[len(_PREFIX) :].split("/")
+    run_id = segments[0]
+    try:
+        validate_path_segment(run_id, field_name="run_id")
+    except ValueError as exc:
+        return ServiceResponse(400, {"error": str(exc)})
+    if len(segments) != 2 or segments[1] != "events":
+        return None
+
+    limit_or_error = _parse_limit(query)
+    if isinstance(limit_or_error, ServiceResponse):
+        return limit_or_error
+    tail_or_error = _parse_tail(query)
+    if isinstance(tail_or_error, ServiceResponse):
+        return tail_or_error
+
+    # 순서는 다른 /builds/{run_id}/* route와 동일하다(#488 관례, #496도 따른다):
+    # run_id 검증 -> 존재 확인 -> ownership -> 실제 조회. cross-owner 접근이
+    # events 조회 로직에 도달하기 전에 403으로 막혀야 run 존재 여부가 이
+    # endpoint로 새어나가지 않는다.
+    error = check_run_exists(service, run_id)
+    if error is not None:
+        return error
+    error = check_ownership(service, run_id, principal)
+    return error or service.get_build_events(run_id, limit=limit_or_error, tail=tail_or_error)
+
+
+def _parse_limit(query: str) -> int | ServiceResponse:
+    query_params = parse_qs(query)
+    if "limit" not in query_params:
+        return events_service.DEFAULT_EVENTS_LIMIT
+    raw_limit = query_params["limit"][-1]
+    try:
+        limit = int(raw_limit)
+    except ValueError:
+        return ServiceResponse(400, {"error": "'limit' must be a positive integer"})
+    if limit < 1 or limit > events_service.MAX_EVENTS_LIMIT:
+        return ServiceResponse(
+            400,
+            {
+                "error": (
+                    f"'limit' must be a positive integer up to {events_service.MAX_EVENTS_LIMIT}"
+                )
+            },
+        )
+    return limit
+
+
+def _parse_tail(query: str) -> bool | ServiceResponse:
+    query_params = parse_qs(query)
+    if "tail" not in query_params:
+        return False
+    raw_tail = query_params["tail"][-1]
+    if raw_tail == "true":
+        return True
+    if raw_tail == "false":
+        return False
+    return ServiceResponse(400, {"error": "'tail' must be 'true' or 'false'"})

--- a/src/kpubdata_builder/service/routes/events.py
+++ b/src/kpubdata_builder/service/routes/events.py
@@ -11,7 +11,7 @@ from ...stages._path_safety import validate_path_segment
 from .. import events as events_service
 from ..auth import Principal
 from ..responses import ServiceResponse
-from ._guards import check_ownership, check_run_exists
+from ._guards import check_active_run_access
 from ._types import RouteResponse
 
 if TYPE_CHECKING:
@@ -54,13 +54,17 @@ def route(
         return tail_or_error
 
     # 순서는 다른 /builds/{run_id}/* route와 동일하다(#488 관례, #496도 따른다):
-    # run_id 검증 -> 존재 확인 -> ownership -> 실제 조회. cross-owner 접근이
+    # run_id 검증 -> 존재/ownership 확인 -> 실제 조회. cross-owner 접근이
     # events 조회 로직에 도달하기 전에 403으로 막혀야 run 존재 여부가 이
     # endpoint로 새어나가지 않는다.
-    error = check_run_exists(service, run_id)
-    if error is not None:
-        return error
-    error = check_ownership(service, run_id, principal)
+    #
+    # 존재/ownership 판정 자체는 check_active_run_access(#496 follow-up)가
+    # 맡는다 — persisted run(manifest 기반)뿐 아니라 아직 run
+    # directory/manifest가 없는 active async job(queued/running)도 async job
+    # registry로 인지해야 events polling이 그 구간에서 404/403으로 막히지
+    # 않는다. 다른 /builds/{run_id}/* route(manifest, stages 등)는 여전히
+    # persisted run만 다루므로 이 helper를 쓰지 않는다.
+    error = check_active_run_access(service, run_id, principal)
     return error or service.get_build_events(run_id, limit=limit_or_error, tail=tail_or_error)
 
 

--- a/tests/unit/test_event_store.py
+++ b/tests/unit/test_event_store.py
@@ -1,0 +1,246 @@
+"""BuildEvent 모델/BuildEventStore 저장소 단위 테스트 (#496).
+
+HTTP API/파이프라인 연동은 각각 test_events_api.py/test_pipeline_events.py가
+다룬다. 이 파일은 store 자체의 append-only 계약, ordering, 동시성, bounded
+query, timezone-aware timestamp를 순수하게 검증한다.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from kpubdata_builder.events import BuildEvent, BuildEventStore
+
+
+class _FailingConnection:
+    """``execute``가 항상 실패하는 가짜 연결 (sqlite3.Connection은 immutable)."""
+
+    def execute(self, *_args: object, **_kwargs: object) -> object:
+        raise sqlite3.OperationalError("simulated append failure")
+
+    def commit(self) -> None:
+        pass
+
+    def rollback(self) -> None:
+        pass
+
+
+class _SpyConnection:
+    """실제 연결에 위임하며 실행된 SQL 텍스트만 기록하는 wrapper."""
+
+    def __init__(self, real: sqlite3.Connection) -> None:
+        self._real = real
+        self.executed_sql: list[str] = []
+
+    def execute(self, sql: str, params: tuple[object, ...] = ()) -> sqlite3.Cursor:
+        self.executed_sql.append(sql)
+        return self._real.execute(sql, params)
+
+    def commit(self) -> None:
+        self._real.commit()
+
+    def rollback(self) -> None:
+        self._real.rollback()
+
+
+def _event(
+    run_id: str = "r1",
+    *,
+    event: str = "run_started",
+    status: str = "ok",
+    source_key: str | None = None,
+    stage: str | None = None,
+    message: str | None = None,
+    metrics: dict[str, object] | None = None,
+    timestamp: datetime | None = None,
+) -> BuildEvent:
+    return BuildEvent(
+        seq=0,
+        timestamp=timestamp or datetime.now(tz=timezone.utc),
+        run_id=run_id,
+        event=event,  # type: ignore[arg-type]
+        status=status,  # type: ignore[arg-type]
+        source_key=source_key,
+        stage=stage,  # type: ignore[arg-type]
+        message=message,
+        metrics=metrics,
+    )
+
+
+class TestAppend:
+    def test_append_assigns_monotonic_seq(self, tmp_path: Path) -> None:
+        store = BuildEventStore(tmp_path)
+        first = store.append(_event())
+        second = store.append(_event())
+        assert first.seq == 1
+        assert second.seq == 2
+
+    def test_append_many_events_all_persisted(self, tmp_path: Path) -> None:
+        store = BuildEventStore(tmp_path)
+        for i in range(50):
+            store.append(_event(message=f"event-{i}"))
+        events = store.list_for_run("r1", limit=1000, tail=False)
+        assert len(events) == 50
+        assert [e.message for e in events] == [f"event-{i}" for i in range(50)]
+
+    def test_append_does_not_overwrite_previous_events(self, tmp_path: Path) -> None:
+        """append는 절대 기존 행을 덮어쓰지 않는다 — 매번 새 행이 추가된다."""
+        store = BuildEventStore(tmp_path)
+        store.append(_event(message="first"))
+        store.append(_event(message="second"))
+        events = store.list_for_run("r1", limit=10, tail=False)
+        assert [e.message for e in events] == ["first", "second"]
+
+    def test_timestamp_round_trips_as_timezone_aware(self, tmp_path: Path) -> None:
+        store = BuildEventStore(tmp_path)
+        store.append(_event())
+        (event,) = store.list_for_run("r1", limit=10, tail=False)
+        assert event.timestamp.tzinfo is not None
+        assert event.timestamp.utcoffset() is not None
+
+    def test_naive_timestamp_is_rejected(self, tmp_path: Path) -> None:
+        store = BuildEventStore(tmp_path)
+        naive = _event(timestamp=datetime.now())  # noqa: DTZ005 - 의도적으로 naive
+        with pytest.raises(ValueError, match="timezone-aware"):
+            store.append(naive)
+
+    def test_metrics_round_trip(self, tmp_path: Path) -> None:
+        store = BuildEventStore(tmp_path)
+        store.append(_event(metrics={"rows": 84321, "ok": True}))
+        (event,) = store.list_for_run("r1", limit=10, tail=False)
+        assert event.metrics == {"rows": 84321, "ok": True}
+
+    def test_metrics_none_round_trips_as_none(self, tmp_path: Path) -> None:
+        store = BuildEventStore(tmp_path)
+        store.append(_event(metrics=None))
+        (event,) = store.list_for_run("r1", limit=10, tail=False)
+        assert event.metrics is None
+
+    def test_append_failure_propagates_not_swallowed(self, tmp_path: Path) -> None:
+        """store.append()는 event timeline의 유일한 정본이라 실패를 삼키지 않는다.
+
+        BuildIndex(ADR 0003, 파생 인덱스)와 달리, 이 store는 실패해도 조용히
+        넘어가지 않고 예외를 그대로 전파한다 — recorder(파이프라인 쪽 wrapper)가
+        그 실패를 어떻게 다룰지 결정한다 (#496, test_pipeline_events.py의
+        recorder swallow 테스트와 짝을 이룬다).
+
+        ``sqlite3.Connection``/``Cursor``는 C 확장 타입이라 속성을 직접
+        monkeypatch할 수 없으므로(immutable type), thread-local 연결 슬롯을
+        가짜 연결로 교체해 실패를 주입한다.
+        """
+        store = BuildEventStore(tmp_path)
+        store._local.conn = _FailingConnection()
+        with pytest.raises(sqlite3.OperationalError, match="simulated append failure"):
+            store.append(_event())
+
+
+class TestOrdering:
+    def test_same_timestamp_events_still_ordered_by_seq(self, tmp_path: Path) -> None:
+        store = BuildEventStore(tmp_path)
+        same_ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        store.append(_event(message="a", timestamp=same_ts))
+        store.append(_event(message="b", timestamp=same_ts))
+        store.append(_event(message="c", timestamp=same_ts))
+        events = store.list_for_run("r1", limit=10, tail=False)
+        assert [e.message for e in events] == ["a", "b", "c"]
+        assert [e.seq for e in events] == sorted(e.seq for e in events)
+
+    def test_events_from_different_runs_are_isolated(self, tmp_path: Path) -> None:
+        store = BuildEventStore(tmp_path)
+        store.append(_event(run_id="r1", message="r1-a"))
+        store.append(_event(run_id="r2", message="r2-a"))
+        store.append(_event(run_id="r1", message="r1-b"))
+        r1_events = store.list_for_run("r1", limit=10, tail=False)
+        assert [e.message for e in r1_events] == ["r1-a", "r1-b"]
+
+    def test_concurrent_append_no_lost_events(self, tmp_path: Path) -> None:
+        """여러 스레드가 동시에 append해도 event가 유실되지 않는다 (#496).
+
+        ThreadPoolExecutor로 병렬 실행되는 source worker(#247)를 흉내낸다.
+        """
+        store = BuildEventStore(tmp_path)
+        threads_count = 8
+        events_per_thread = 25
+        errors: list[BaseException] = []
+
+        def _worker(worker_id: int) -> None:
+            try:
+                for i in range(events_per_thread):
+                    store.append(_event(message=f"w{worker_id}-{i}", source_key=f"w{worker_id}"))
+            except BaseException as exc:  # noqa: BLE001 - 스레드에서 발생한 예외를 수집
+                errors.append(exc)
+
+        threads = [threading.Thread(target=_worker, args=(i,)) for i in range(threads_count)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        events = store.list_for_run("r1", limit=10_000, tail=False)
+        assert len(events) == threads_count * events_per_thread
+        seqs = [e.seq for e in events]
+        assert len(seqs) == len(set(seqs))  # 모든 seq가 유일하다 — 유실/중복 없음
+        assert seqs == sorted(seqs)  # append 순서(전역 monotonic order)가 보존된다
+
+        for worker_id in range(threads_count):
+            worker_messages = [e.message for e in events if e.source_key == f"w{worker_id}"]
+            assert worker_messages == [f"w{worker_id}-{i}" for i in range(events_per_thread)]
+
+
+class TestLimitAndTail:
+    def _seed(self, store: BuildEventStore, count: int) -> None:
+        for i in range(count):
+            store.append(_event(message=f"e{i}"))
+
+    def test_default_returns_from_start_ascending(self, tmp_path: Path) -> None:
+        store = BuildEventStore(tmp_path)
+        self._seed(store, 10)
+        events = store.list_for_run("r1", limit=5, tail=False)
+        assert [e.message for e in events] == [f"e{i}" for i in range(5)]
+
+    def test_tail_returns_most_recent_but_ascending(self, tmp_path: Path) -> None:
+        store = BuildEventStore(tmp_path)
+        self._seed(store, 10)
+        events = store.list_for_run("r1", limit=3, tail=True)
+        assert [e.message for e in events] == ["e7", "e8", "e9"]
+        assert [e.seq for e in events] == sorted(e.seq for e in events)
+
+    def test_limit_larger_than_available_returns_all(self, tmp_path: Path) -> None:
+        store = BuildEventStore(tmp_path)
+        self._seed(store, 3)
+        events = store.list_for_run("r1", limit=1000, tail=False)
+        assert len(events) == 3
+
+    def test_empty_run_returns_empty_tuple(self, tmp_path: Path) -> None:
+        store = BuildEventStore(tmp_path)
+        events = store.list_for_run("no-such-run", limit=100, tail=False)
+        assert events == ()
+
+    def test_bounded_query_uses_sql_limit(self, tmp_path: Path) -> None:
+        """큰 run이어도 limit이 SQL 레벨에서 적용되어 전체 테이블을 읽지 않는다.
+
+        ``sqlite3.Connection``이 immutable C 타입이라 직접 monkeypatch할 수
+        없으므로, 실제 연결에 위임하며 실행된 SQL만 기록하는 spy로 thread-local
+        연결 슬롯을 교체한다.
+        """
+        store = BuildEventStore(tmp_path)
+        self._seed(store, 500)
+        spy = _SpyConnection(store._conn)
+        store._local.conn = spy
+
+        events = store.list_for_run("r1", limit=5, tail=False)
+        assert len(events) == 5
+        assert any("LIMIT" in sql for sql in spy.executed_sql)
+
+
+class TestModelVocabulary:
+    def test_build_event_is_frozen(self, tmp_path: Path) -> None:
+        event = _event()
+        with pytest.raises(AttributeError):
+            event.status = "fail"  # type: ignore[misc]

--- a/tests/unit/test_events_api.py
+++ b/tests/unit/test_events_api.py
@@ -9,13 +9,14 @@ ownership/bounded query(limit/tail)/secret 비노출 — 을 실제
 from __future__ import annotations
 
 import json
+import threading
 from pathlib import Path
 from typing import cast
 
 import pytest
 
 import kpubdata_builder.service.app as app_module
-from kpubdata_builder.service import BuilderService, dispatch
+from kpubdata_builder.service import BuilderService, ServiceResponse, dispatch
 from kpubdata_builder.service.auth import Principal
 from kpubdata_builder.service.ownership import _OWNERSHIP_ENV
 from kpubdata_builder.spec import JsonValue
@@ -77,6 +78,51 @@ def _service(tmp_path: Path, *, rows: int = 2) -> BuilderService:
 def _build(service: BuilderService, run_id: str, spec_yaml: str = VALID_SPEC_YAML) -> int:
     resp = dispatch(service, "POST", "/build", {"spec": spec_yaml, "run_id": run_id})
     return resp.status_code
+
+
+class _BlockingAsyncService(BuilderService):
+    """async worker를 ``release``까지 붙잡아둔다.
+
+    ``_run_build_job``(worker pool의 실제 실행 진입점)이 ``entered``를 set한
+    뒤 ``release``를 기다린다 — 그 사이 registry 상태는 이미 "running"이지만
+    (``AsyncBuildExecutor._run``이 runner 호출 *전에* ``mark_running``한다)
+    run directory/manifest는 아직 만들어지지 않는다(``BuilderService.build()``
+    가 아직 호출되지 않았으므로). ``release`` 이후에는 실제 ``build()``를
+    그대로 호출해 정상적으로 완료시키고 ``completed``를 set한다 — active
+    상태와 완료 상태 둘 다 이 클래스 하나로 결정론적으로 재현한다(#496
+    follow-up).
+    """
+
+    def __init__(
+        self,
+        *,
+        output_root: Path,
+        client_factory: object,
+        entered: threading.Event,
+        release: threading.Event,
+        completed: threading.Event,
+        async_max_workers: int = 1,
+        async_max_queue_size: int = 10,
+    ) -> None:
+        super().__init__(
+            output_root=output_root,
+            client_factory=client_factory,  # type: ignore[arg-type]
+            async_max_workers=async_max_workers,
+            async_max_queue_size=async_max_queue_size,
+        )
+        self._entered = entered
+        self._release = release
+        self._completed = completed
+
+    def _run_build_job(
+        self, spec_yaml: str, run_id: str, created_by: str | None
+    ) -> ServiceResponse:
+        self._entered.set()
+        self._release.wait(timeout=5)
+        try:
+            return super()._run_build_job(spec_yaml, run_id, created_by)
+        finally:
+            self._completed.set()
 
 
 class TestGetBuildEventsRouting:
@@ -316,3 +362,316 @@ class TestSecurityNoSecretLeak:
         body_text = json.dumps(resp.body)
         assert "SUPER-SECRET-API-KEY" not in body_text
         assert "SUPER-SECRET-EXPORT-KEY" not in body_text
+
+
+class TestActiveAsyncRunEvents:
+    """``POST /builds``(비동기)로 제출된 run의 events를 실행 중에도 조회할 수
+    있는지 검증한다 (#496 follow-up: BLOCKER).
+
+    ``check_run_exists``/``check_ownership``은 run directory·manifest.json이
+    이미 있다고 가정하지만, async run은 worker가 시작하기 전까지 run
+    directory조차 없고 manifest는 run이 끝나야 생긴다. 그 구간(queued/running)
+    에도 event store에는 이미 ``run_submitted``(및 이후 event)가 쌓여있으므로
+    이 endpoint가 404/403을 내면 안 된다.
+    """
+
+    def _submit(
+        self, service: BuilderService, run_id: str, spec_yaml: str = VALID_SPEC_YAML
+    ) -> ServiceResponse:
+        resp = dispatch(service, "POST", "/builds", {"spec": spec_yaml, "run_id": run_id})
+        assert isinstance(resp, ServiceResponse)
+        return resp
+
+    def test_queued_run_returns_200_with_run_submitted(self, tmp_path: Path) -> None:
+        """단일 worker가 다른 run으로 이미 바쁠 때 큐잉된 run도 조회 가능해야 한다."""
+        entered = threading.Event()
+        release = threading.Event()
+        completed = threading.Event()
+        service = _BlockingAsyncService(
+            output_root=tmp_path,
+            client_factory=lambda: _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}]}),
+            entered=entered,
+            release=release,
+            completed=completed,
+            async_max_workers=1,
+        )
+        first = self._submit(service, "run1")
+        assert first.status_code == 202
+        assert entered.wait(timeout=5)  # worker가 run1을 붙잡고 있다.
+
+        second = self._submit(service, "run2")
+        assert second.status_code == 202
+        assert second.body["status"] == "queued"
+        # run2는 아직 run directory조차 없다 — 기존 check_run_exists라면 404.
+        assert not (tmp_path / "run2").exists()
+
+        resp = dispatch(service, "GET", "/builds/run2/events", None)
+        release.set()
+        assert resp.status_code == 200
+        events = cast(list[dict[str, object]], resp.body["events"])
+        assert [e["event"] for e in events] == ["run_submitted"]
+        assert completed.wait(timeout=5)
+
+    def test_running_run_returns_200_before_manifest_exists(self, tmp_path: Path) -> None:
+        entered = threading.Event()
+        release = threading.Event()
+        completed = threading.Event()
+        service = _BlockingAsyncService(
+            output_root=tmp_path,
+            client_factory=lambda: _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}]}),
+            entered=entered,
+            release=release,
+            completed=completed,
+        )
+        submitted = self._submit(service, "run1")
+        assert submitted.status_code == 202
+        assert entered.wait(timeout=5)
+        assert not (tmp_path / "run1" / "manifest.json").exists()
+
+        resp = dispatch(service, "GET", "/builds/run1/events", None)
+        release.set()
+        assert resp.status_code == 200
+        events = cast(list[dict[str, object]], resp.body["events"])
+        assert [e["event"] for e in events] == ["run_submitted"]
+        assert completed.wait(timeout=5)
+
+    def test_ownership_enforced_active_owner_can_read(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(_OWNERSHIP_ENV, "true")
+        entered = threading.Event()
+        release = threading.Event()
+        completed = threading.Event()
+        service = _BlockingAsyncService(
+            output_root=tmp_path,
+            client_factory=lambda: _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}]}),
+            entered=entered,
+            release=release,
+            completed=completed,
+        )
+        monkeypatch.setattr(
+            app_module, "authenticate", lambda **_kwargs: Principal(kind="oidc", identifier="a")
+        )
+        submitted = self._submit(service, "run1")
+        assert submitted.status_code == 202
+        assert entered.wait(timeout=5)
+
+        resp = dispatch(service, "GET", "/builds/run1/events", None)
+        release.set()
+        assert resp.status_code == 200
+        assert completed.wait(timeout=5)
+
+    def test_ownership_enforced_other_principal_gets_403(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(_OWNERSHIP_ENV, "true")
+        entered = threading.Event()
+        release = threading.Event()
+        completed = threading.Event()
+        service = _BlockingAsyncService(
+            output_root=tmp_path,
+            client_factory=lambda: _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}]}),
+            entered=entered,
+            release=release,
+            completed=completed,
+        )
+        monkeypatch.setattr(
+            app_module, "authenticate", lambda **_kwargs: Principal(kind="oidc", identifier="a")
+        )
+        submitted = self._submit(service, "run1")
+        assert submitted.status_code == 202
+        assert entered.wait(timeout=5)
+
+        monkeypatch.setattr(
+            app_module, "authenticate", lambda **_kwargs: Principal(kind="oidc", identifier="b")
+        )
+        resp = dispatch(service, "GET", "/builds/run1/events", None)
+        release.set()
+        assert resp.status_code == 403
+        assert completed.wait(timeout=5)
+
+    def test_unknown_run_still_404_when_not_in_async_registry(self, tmp_path: Path) -> None:
+        """async registry에도 persisted run에도 없으면 여전히 404다."""
+        service = _service(tmp_path)
+        resp = dispatch(service, "GET", "/builds/nope/events", None)
+        assert resp.status_code == 404
+
+    def test_completed_async_run_still_uses_manifest_ownership_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """완료된 run은 async registry에 terminal entry로 남아있어도, 기존
+        completed persisted run 조회(#496 원래 API)가 계속 정상 동작해야 한다."""
+        monkeypatch.setenv(_OWNERSHIP_ENV, "true")
+        entered = threading.Event()
+        release = threading.Event()
+        completed = threading.Event()
+        service = _BlockingAsyncService(
+            output_root=tmp_path,
+            client_factory=lambda: _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}]}),
+            entered=entered,
+            release=release,
+            completed=completed,
+        )
+        monkeypatch.setattr(
+            app_module, "authenticate", lambda **_kwargs: Principal(kind="oidc", identifier="a")
+        )
+        submitted = self._submit(service, "run1")
+        assert submitted.status_code == 202
+        assert entered.wait(timeout=5)
+        release.set()
+        assert completed.wait(timeout=5)
+
+        assert (tmp_path / "run1" / "manifest.json").exists()
+
+        resp = dispatch(service, "GET", "/builds/run1/events", None)
+        assert resp.status_code == 200
+        events = cast(list[dict[str, object]], resp.body["events"])
+        event_names = [e["event"] for e in events]
+        assert "run_submitted" in event_names
+        assert "run_finished" in event_names
+
+    def test_same_label_different_owner_id_active_run_returns_403(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """created_by/label(legacy)이 같아도 stable owner_id(#505)가 다르면
+        거부해야 한다 — active run access가 owner_id를 우선 비교해야 하는
+        핵심 사례."""
+        monkeypatch.setenv(_OWNERSHIP_ENV, "true")
+        entered = threading.Event()
+        release = threading.Event()
+        completed = threading.Event()
+        service = _BlockingAsyncService(
+            output_root=tmp_path,
+            client_factory=lambda: _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}]}),
+            entered=entered,
+            release=release,
+            completed=completed,
+        )
+        monkeypatch.setattr(
+            app_module,
+            "authenticate",
+            lambda **_kwargs: Principal(kind="oidc", identifier="same", owner_id="oidc:owner-a"),
+        )
+        submitted = self._submit(service, "run1")
+        assert submitted.status_code == 202
+        assert entered.wait(timeout=5)
+
+        # label("oidc:same")은 앞의 principal과 동일하지만 owner_id는 다르다.
+        monkeypatch.setattr(
+            app_module,
+            "authenticate",
+            lambda **_kwargs: Principal(kind="oidc", identifier="same", owner_id="oidc:owner-b"),
+        )
+        resp = dispatch(service, "GET", "/builds/run1/events", None)
+        release.set()
+        assert resp.status_code == 403
+        assert completed.wait(timeout=5)
+
+    def test_matching_owner_id_active_run_returns_200(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(_OWNERSHIP_ENV, "true")
+        entered = threading.Event()
+        release = threading.Event()
+        completed = threading.Event()
+        service = _BlockingAsyncService(
+            output_root=tmp_path,
+            client_factory=lambda: _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}]}),
+            entered=entered,
+            release=release,
+            completed=completed,
+        )
+        monkeypatch.setattr(
+            app_module,
+            "authenticate",
+            lambda **_kwargs: Principal(kind="oidc", identifier="a", owner_id="oidc:owner-a"),
+        )
+        submitted = self._submit(service, "run1")
+        assert submitted.status_code == 202
+        assert entered.wait(timeout=5)
+
+        resp = dispatch(service, "GET", "/builds/run1/events", None)
+        release.set()
+        assert resp.status_code == 200
+        assert completed.wait(timeout=5)
+
+    def test_owner_id_never_leaks_into_build_status_or_events_wire(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        entered = threading.Event()
+        release = threading.Event()
+        completed = threading.Event()
+        service = _BlockingAsyncService(
+            output_root=tmp_path,
+            client_factory=lambda: _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}]}),
+            entered=entered,
+            release=release,
+            completed=completed,
+        )
+        secret_owner_id = "oidc:super-secret-owner-hash"
+        monkeypatch.setattr(
+            app_module,
+            "authenticate",
+            lambda **_kwargs: Principal(kind="oidc", identifier="a", owner_id=secret_owner_id),
+        )
+        submitted = self._submit(service, "run1")
+        assert submitted.status_code == 202
+        assert "owner_id" not in submitted.body
+        assert secret_owner_id not in json.dumps(submitted.body)
+        assert entered.wait(timeout=5)
+
+        status = dispatch(service, "GET", "/builds/run1", None)
+        assert "owner_id" not in status.body
+        assert secret_owner_id not in json.dumps(status.body)
+
+        resp = dispatch(service, "GET", "/builds/run1/events", None)
+        release.set()
+        assert resp.status_code == 200
+        assert "owner_id" not in json.dumps(resp.body)
+        assert secret_owner_id not in json.dumps(resp.body)
+        assert completed.wait(timeout=5)
+
+    def test_enqueue_failed_terminal_without_manifest_only_owner_can_read(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """worker pool enqueue 자체가 실패해 manifest 없이 종결된 terminal job도
+        (build()가 전혀 호출되지 않아 run directory조차 없다) 소유자만
+        조회할 수 있어야 한다 — registry snapshot의 owner_id가 유일한
+        판정 근거다."""
+        monkeypatch.setenv(_OWNERSHIP_ENV, "true")
+        service = BuilderService(
+            output_root=tmp_path,
+            client_factory=lambda: _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}]}),
+        )
+
+        def _broken_executor_submit(*_args: object, **_kwargs: object) -> object:
+            raise RuntimeError("simulated worker pool rejection")
+
+        monkeypatch.setattr(service._async_builds._executor, "submit", _broken_executor_submit)
+
+        owner = Principal(kind="oidc", identifier="a", owner_id="oidc:owner-a")
+        response = service.submit_build(
+            VALID_SPEC_YAML, run_id="run1", created_by=owner.label, owner_id=owner.owner_id
+        )
+        assert response.status_code >= 500
+        assert not (tmp_path / "run1").exists()
+
+        monkeypatch.setattr(app_module, "authenticate", lambda **_kwargs: owner)
+        resp_owner = dispatch(service, "GET", "/builds/run1/events", None)
+        assert resp_owner.status_code == 200
+        events = cast(list[dict[str, object]], resp_owner.body["events"])
+        assert [e["event"] for e in events] == ["run_submitted", "run_failed"]
+
+        monkeypatch.setattr(
+            app_module,
+            "authenticate",
+            lambda **_kwargs: Principal(kind="oidc", identifier="b", owner_id="oidc:owner-b"),
+        )
+        resp_other = dispatch(service, "GET", "/builds/run1/events", None)
+        assert resp_other.status_code == 403
+
+        monkeypatch.setattr(
+            app_module, "authenticate", lambda **_kwargs: Principal(kind="oidc", identifier="b")
+        )
+        resp2 = dispatch(service, "GET", "/builds/run1/events", None)
+        assert resp2.status_code == 403

--- a/tests/unit/test_events_api.py
+++ b/tests/unit/test_events_api.py
@@ -1,0 +1,318 @@
+"""``GET /builds/{run_id}/events`` HTTP API 테스트 (#496).
+
+Event 방출 자체(어느 boundary에서 어떤 event가 나오는지)는
+test_pipeline_events.py가 다룬다. 이 파일은 route adapter 계층 — 존재/
+ownership/bounded query(limit/tail)/secret 비노출 — 을 실제
+``BuilderService.build()``/``dispatch``를 통해 검증한다.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+import kpubdata_builder.service.app as app_module
+from kpubdata_builder.service import BuilderService, dispatch
+from kpubdata_builder.service.auth import Principal
+from kpubdata_builder.service.ownership import _OWNERSHIP_ENV
+from kpubdata_builder.spec import JsonValue
+
+VALID_SPEC_YAML = (
+    "dataset_id: dataset.events\n"
+    "title: Events Fixture\n"
+    "description: fixture\n"
+    "sources:\n"
+    "  - provider: datago\n"
+    "    dataset: air_quality\n"
+    "    alias: air\n"
+    "    params:\n"
+    "      api_key: SUPER-SECRET-API-KEY\n"
+    "exports:\n"
+    "  - kind: jsonl\n"
+    "    output_path: out/data.jsonl\n"
+    "    options:\n"
+    "      kaggle_key: SUPER-SECRET-EXPORT-KEY\n"
+)
+
+# fetch 자체가 실패하는 spec (FakeClient가 모르는 dataset).
+FETCH_FAILURE_SPEC_YAML = VALID_SPEC_YAML.replace("dataset: air_quality", "dataset: missing")
+
+
+class _FakeResult:
+    def __init__(self, items: list[dict[str, JsonValue]]) -> None:
+        self._items = items
+
+    @property
+    def items(self) -> list[dict[str, JsonValue]]:
+        return self._items
+
+
+class _FakeDataset:
+    def __init__(self, items: list[dict[str, JsonValue]]) -> None:
+        self._items = items
+
+    def list(self, **params: JsonValue) -> _FakeResult:
+        return _FakeResult(self._items)
+
+
+class _FakeClient:
+    def __init__(self, data: dict[str, list[dict[str, JsonValue]]]) -> None:
+        self._data = data
+
+    def dataset(self, source_key: str) -> _FakeDataset:
+        if source_key not in self._data:
+            raise KeyError(f"unknown source: {source_key}")
+        return _FakeDataset(self._data[source_key])
+
+
+def _service(tmp_path: Path, *, rows: int = 2) -> BuilderService:
+    records = [{"id": str(i), "v": i * 10} for i in range(1, rows + 1)]
+    client = _FakeClient({"datago.air_quality": records})
+    return BuilderService(output_root=tmp_path, client_factory=lambda: client)
+
+
+def _build(service: BuilderService, run_id: str, spec_yaml: str = VALID_SPEC_YAML) -> int:
+    resp = dispatch(service, "POST", "/build", {"spec": spec_yaml, "run_id": run_id})
+    return resp.status_code
+
+
+class TestGetBuildEventsRouting:
+    def test_completed_run_returns_ordered_events(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        assert _build(service, "r1") == 200
+
+        resp = dispatch(service, "GET", "/builds/r1/events", None)
+        assert resp.status_code == 200
+        assert resp.body["run_id"] == "r1"
+        events = cast(list[dict[str, object]], resp.body["events"])
+        assert events[0]["event"] == "run_started"
+        assert events[-1]["event"] == "run_finished"
+        seqs = [cast(int, e["seq"]) for e in events]
+        assert seqs == sorted(seqs)
+
+    def test_failed_run_still_returns_200_with_failure_events(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        assert _build(service, "r1", FETCH_FAILURE_SPEC_YAML) == 502
+
+        resp = dispatch(service, "GET", "/builds/r1/events", None)
+        assert resp.status_code == 200
+        events = cast(list[dict[str, object]], resp.body["events"])
+        assert events[-1]["event"] == "run_failed"
+        assert events[-1]["status"] == "fail"
+
+    def test_partial_run_shows_success_then_failure(self, tmp_path: Path) -> None:
+        """실패했다고 이전 성공 event가 사라지지 않는다(append-only, #496)."""
+        service = _service(tmp_path)
+        spec_yaml = (
+            "dataset_id: dataset.partial\n"
+            "title: Partial Fixture\n"
+            "description: fixture\n"
+            "sources:\n"
+            "  - provider: datago\n"
+            "    dataset: air_quality\n"
+            "    alias: good\n"
+            "  - provider: datago\n"
+            "    dataset: missing\n"
+            "    alias: bad\n"
+            "exports:\n"
+            "  - kind: jsonl\n"
+            "    output_path: out/data.jsonl\n"
+        )
+        assert _build(service, "r1", spec_yaml) == 502
+
+        resp = dispatch(service, "GET", "/builds/r1/events", None)
+        assert resp.status_code == 200
+        events = cast(list[dict[str, object]], resp.body["events"])
+        good_events = [e["event"] for e in events if e.get("source_key") == "good"]
+        bad_events = [e["event"] for e in events if e.get("source_key") == "bad"]
+        assert "stage_completed" in good_events
+        assert "stage_failed" in bad_events
+
+    def test_empty_timeline_for_run_with_no_events(self, tmp_path: Path) -> None:
+        """BuilderService.build()를 거치지 않고 만들어진 run(존재하지만 event 없음)."""
+        run_dir = tmp_path / "legacy"
+        run_dir.mkdir()
+        (run_dir / "manifest.json").write_text("{}", encoding="utf-8")
+
+        resp = dispatch(_service(tmp_path), "GET", "/builds/legacy/events", None)
+        assert resp.status_code == 200
+        assert resp.body["events"] == []
+
+    def test_unknown_run_returns_404(self, tmp_path: Path) -> None:
+        resp = dispatch(_service(tmp_path), "GET", "/builds/nope/events", None)
+        assert resp.status_code == 404
+
+    def test_unsafe_run_id_returns_400(self, tmp_path: Path) -> None:
+        resp = dispatch(_service(tmp_path), "GET", "/builds/../escape/events", None)
+        assert resp.status_code == 400
+
+    def test_does_not_shadow_other_builds_subroutes(self, tmp_path: Path) -> None:
+        """다른 /builds/{run_id}/* route(예: manifest)가 여전히 정상 동작한다."""
+        service = _service(tmp_path)
+        assert _build(service, "r1") == 200
+        resp = dispatch(service, "GET", "/builds/r1/manifest", None)
+        assert resp.status_code == 200
+        resp2 = dispatch(service, "GET", "/builds/r1/stages", None)
+        assert resp2.status_code == 200
+
+
+class TestLimitAndTail:
+    def _build_many_sources(self, service: BuilderService, run_id: str, count: int) -> int:
+        sources = "\n".join(
+            f"  - provider: datago\n    dataset: air_quality\n    alias: s{i}\n"
+            for i in range(count)
+        )
+        spec_yaml = (
+            "dataset_id: dataset.many\n"
+            "title: Many Fixture\n"
+            "description: fixture\n"
+            f"sources:\n{sources}"
+            "exports:\n"
+            "  - kind: jsonl\n"
+            "    output_path: out/data.jsonl\n"
+        )
+        return _build(service, run_id, spec_yaml)
+
+    def test_default_limit_returns_from_start(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        assert _build(service, "r1") == 200
+        resp = dispatch(service, "GET", "/builds/r1/events", None, query="limit=1")
+        assert resp.status_code == 200
+        events = cast(list[dict[str, object]], resp.body["events"])
+        assert len(events) == 1
+        assert events[0]["event"] == "run_started"
+
+    def test_tail_true_returns_most_recent_ascending(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        assert _build(service, "r1") == 200
+        resp = dispatch(service, "GET", "/builds/r1/events", None, query="limit=1&tail=true")
+        assert resp.status_code == 200
+        events = cast(list[dict[str, object]], resp.body["events"])
+        assert len(events) == 1
+        assert events[0]["event"] == "run_finished"
+
+    def test_invalid_limit_zero_returns_400(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        assert _build(service, "r1") == 200
+        resp = dispatch(service, "GET", "/builds/r1/events", None, query="limit=0")
+        assert resp.status_code == 400
+
+    def test_invalid_limit_non_integer_returns_400(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        assert _build(service, "r1") == 200
+        resp = dispatch(service, "GET", "/builds/r1/events", None, query="limit=abc")
+        assert resp.status_code == 400
+
+    def test_limit_above_max_returns_400(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        assert _build(service, "r1") == 200
+        resp = dispatch(service, "GET", "/builds/r1/events", None, query="limit=1001")
+        assert resp.status_code == 400
+
+    def test_invalid_tail_value_returns_400(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        assert _build(service, "r1") == 200
+        resp = dispatch(service, "GET", "/builds/r1/events", None, query="tail=yes")
+        assert resp.status_code == 400
+
+    def test_bool_as_int_limit_is_rejected_like_other_routes(self, tmp_path: Path) -> None:
+        """query string은 항상 문자열이라 bool 우회는 애초에 불가능하지만,
+        비정상 문자열이 그대로 400이 되는지 다른 route와 동일하게 확인한다."""
+        service = _service(tmp_path)
+        assert _build(service, "r1") == 200
+        resp = dispatch(service, "GET", "/builds/r1/events", None, query="limit=true")
+        assert resp.status_code == 400
+
+
+class TestOwnership:
+    def test_cross_owner_returns_403_before_query(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(_OWNERSHIP_ENV, "true")
+        service = _service(tmp_path)
+        monkeypatch.setattr(
+            app_module, "authenticate", lambda **_kwargs: Principal(kind="oidc", identifier="a")
+        )
+        assert _build(service, "r1") == 200
+
+        monkeypatch.setattr(
+            app_module, "authenticate", lambda **_kwargs: Principal(kind="oidc", identifier="b")
+        )
+        resp = dispatch(service, "GET", "/builds/r1/events", None)
+        assert resp.status_code == 403
+
+        # ownership 거부 시 event store 조회 로직까지 도달하지 않는다.
+        monkeypatch.setattr(
+            service._event_store,
+            "list_for_run",
+            lambda *a, **kw: pytest.fail("event store leaked past 403"),
+        )
+        resp2 = dispatch(service, "GET", "/builds/r1/events", None)
+        assert resp2.status_code == 403
+
+    def test_owner_can_read_own_run_events(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(_OWNERSHIP_ENV, "true")
+        service = _service(tmp_path)
+        monkeypatch.setattr(
+            app_module, "authenticate", lambda **_kwargs: Principal(kind="oidc", identifier="a")
+        )
+        assert _build(service, "r1") == 200
+
+        resp = dispatch(service, "GET", "/builds/r1/events", None)
+        assert resp.status_code == 200
+        assert cast(list[object], resp.body["events"])
+
+    def test_unknown_run_404_before_ownership_leak(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """존재하지 않는 run은 cross-owner와 구분 없이 404다(존재 여부 미노출)."""
+        monkeypatch.setenv(_OWNERSHIP_ENV, "true")
+        service = _service(tmp_path)
+        monkeypatch.setattr(
+            app_module, "authenticate", lambda **_kwargs: Principal(kind="oidc", identifier="a")
+        )
+        resp = dispatch(service, "GET", "/builds/nope/events", None)
+        assert resp.status_code == 404
+
+
+class TestSecurityNoSecretLeak:
+    def test_no_credential_or_path_in_events_response(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        assert _build(service, "r1") == 200
+
+        resp = dispatch(service, "GET", "/builds/r1/events", None)
+        body_text = json.dumps(resp.body)
+        assert "SUPER-SECRET-API-KEY" not in body_text
+        assert "SUPER-SECRET-EXPORT-KEY" not in body_text
+        assert str(tmp_path) not in body_text
+        assert "Authorization" not in body_text
+        assert "Bearer" not in body_text
+
+    def test_no_stack_trace_or_exception_repr_on_failure(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        assert _build(service, "r1", FETCH_FAILURE_SPEC_YAML) == 502
+
+        resp = dispatch(service, "GET", "/builds/r1/events", None)
+        body_text = json.dumps(resp.body)
+        assert "Traceback" not in body_text
+        assert "KeyError" not in body_text
+        assert str(tmp_path) not in body_text
+
+    def test_no_credential_leak_even_on_failed_source(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        # silver 검증 실패를 유발해 stage_failed event에 실린 message도 확인한다.
+        silver_failure_spec = VALID_SPEC_YAML.replace(
+            "    alias: air\n",
+            "    alias: air\n    schema:\n      required: [does_not_exist]\n",
+        )
+        assert _build(service, "r1", silver_failure_spec) == 502
+
+        resp = dispatch(service, "GET", "/builds/r1/events", None)
+        body_text = json.dumps(resp.body)
+        assert "SUPER-SECRET-API-KEY" not in body_text
+        assert "SUPER-SECRET-EXPORT-KEY" not in body_text

--- a/tests/unit/test_events_api.py
+++ b/tests/unit/test_events_api.py
@@ -80,6 +80,54 @@ def _build(service: BuilderService, run_id: str, spec_yaml: str = VALID_SPEC_YAM
     return resp.status_code
 
 
+def _file_source_spec_yaml(upload_id: str) -> str:
+    return (
+        f"""
+dataset_id: dataset.async-uploaded
+title: Async Uploaded Fixture
+description: file source build (#498 async owner propagation regression)
+sources:
+  - kind: file
+    upload_id: {upload_id}
+    format: csv
+    encoding: utf-8
+exports:
+  - kind: jsonl
+    output_path: out/data.jsonl
+""".strip()
+        + "\n"
+    )
+
+
+class _ObservedAsyncService(BuilderService):
+    """``_run_build_job``(``build()`` 호출 + owner_id manifest 보정까지 전부)이
+    끝난 뒤 ``completed``를 set한다 — async build가 실제로 완료된(manifest 보정
+    까지 반영된) 시점을 폴링/sleep 없이 결정론적으로 기다리기 위한 헬퍼다."""
+
+    def __init__(
+        self,
+        *,
+        output_root: Path,
+        client_factory: object,
+        completed: threading.Event,
+        async_max_workers: int = 1,
+    ) -> None:
+        super().__init__(
+            output_root=output_root,
+            client_factory=client_factory,  # type: ignore[arg-type]
+            async_max_workers=async_max_workers,
+        )
+        self._completed = completed
+
+    def _run_build_job(
+        self, spec_yaml: str, run_id: str, created_by: str | None
+    ) -> ServiceResponse:
+        try:
+            return super()._run_build_job(spec_yaml, run_id, created_by)
+        finally:
+            self._completed.set()
+
+
 class _BlockingAsyncService(BuilderService):
     """async worker를 ``release``까지 붙잡아둔다.
 
@@ -675,3 +723,256 @@ class TestActiveAsyncRunEvents:
         )
         resp2 = dispatch(service, "GET", "/builds/run1/events", None)
         assert resp2.status_code == 403
+
+
+class TestAsyncManifestOwnerIdPropagation:
+    """async run 완료 후 persisted manifest.owner_id가 제출 principal의 stable
+    owner_id를 담아야 한다 (#496 follow-up: security BLOCKER).
+
+    수정 전에는 ``_run_build_job``이 ``build()``에 owner_id를 전혀 넘기지
+    않아 async run의 manifest.owner_id가 항상 None이었다 — manifest가 써지는
+    순간 ``check_active_run_access``가 manifest 경로로 전환되면서 stable
+    owner_id 비교(#505) 대신 legacy created_by/label 비교로 되돌아갔다. 같은
+    label(OIDC sub 앞 8자 truncation 충돌 등)을 쓰는 서로 다른 owner_id의
+    principal 두 명이 있으면, "완료된" run에서만 그 fallback이 cross-owner
+    접근을 허용해버릴 수 있었다 — 아래 A/B 시나리오가 그 재현이다.
+    """
+
+    def _submit(
+        self, service: BuilderService, run_id: str, spec_yaml: str = VALID_SPEC_YAML
+    ) -> ServiceResponse:
+        resp = dispatch(service, "POST", "/builds", {"spec": spec_yaml, "run_id": run_id})
+        assert isinstance(resp, ServiceResponse)
+        return resp
+
+    def test_completed_manifest_records_submitting_principals_stable_owner_id(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A(``oidc:same``/``oidc:owner-A``)가 async build → 완료 → manifest 생성.
+
+        요구사항 시나리오 1: persisted manifest 내부 owner_id == oidc:owner-A.
+        """
+        completed = threading.Event()
+        service = _ObservedAsyncService(
+            output_root=tmp_path,
+            client_factory=lambda: _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}]}),
+            completed=completed,
+        )
+        principal_a = Principal(kind="oidc", identifier="same", owner_id="oidc:owner-A")
+        monkeypatch.setattr(app_module, "authenticate", lambda **_kwargs: principal_a)
+
+        submitted = self._submit(service, "run1")
+        assert submitted.status_code == 202
+        assert completed.wait(timeout=5)
+
+        manifest_data = json.loads(
+            (tmp_path / "run1" / "manifest.json").read_text(encoding="utf-8")
+        )
+        assert manifest_data["owner_id"] == "oidc:owner-A"
+
+    def test_completed_run_owner_gets_200_other_same_label_principal_gets_403(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """요구사항 시나리오 2/3: A는 200, 같은 label을 쓰는 B(다른 owner_id)는 403."""
+        monkeypatch.setenv(_OWNERSHIP_ENV, "true")
+        completed = threading.Event()
+        service = _ObservedAsyncService(
+            output_root=tmp_path,
+            client_factory=lambda: _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}]}),
+            completed=completed,
+        )
+        principal_a = Principal(kind="oidc", identifier="same", owner_id="oidc:owner-A")
+        principal_b = Principal(kind="oidc", identifier="same", owner_id="oidc:owner-B")
+        assert principal_a.label == principal_b.label  # 회귀의 전제조건: legacy label이 같다.
+
+        monkeypatch.setattr(app_module, "authenticate", lambda **_kwargs: principal_a)
+        submitted = self._submit(service, "run1")
+        assert submitted.status_code == 202
+        assert completed.wait(timeout=5)
+        assert (tmp_path / "run1" / "manifest.json").exists()
+
+        resp_owner = dispatch(service, "GET", "/builds/run1/events", None)
+        assert resp_owner.status_code == 200
+
+        monkeypatch.setattr(app_module, "authenticate", lambda **_kwargs: principal_b)
+        resp_other = dispatch(service, "GET", "/builds/run1/events", None)
+        assert resp_other.status_code == 403
+
+    def test_active_same_label_different_owner_still_returns_403(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """회귀 방지: manifest가 아직 없는 active 구간(#496 이전 라운드 fix)도
+        여전히 동작해야 한다 — 이번 수정이 그 경로를 깨지 않았는지 확인."""
+        monkeypatch.setenv(_OWNERSHIP_ENV, "true")
+        entered = threading.Event()
+        release = threading.Event()
+        completed = threading.Event()
+        service = _BlockingAsyncService(
+            output_root=tmp_path,
+            client_factory=lambda: _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}]}),
+            entered=entered,
+            release=release,
+            completed=completed,
+        )
+        monkeypatch.setattr(
+            app_module,
+            "authenticate",
+            lambda **_kwargs: Principal(kind="oidc", identifier="same", owner_id="oidc:owner-A"),
+        )
+        submitted = self._submit(service, "run1")
+        assert submitted.status_code == 202
+        assert entered.wait(timeout=5)
+        assert not (tmp_path / "run1" / "manifest.json").exists()
+
+        monkeypatch.setattr(
+            app_module,
+            "authenticate",
+            lambda **_kwargs: Principal(kind="oidc", identifier="same", owner_id="oidc:owner-B"),
+        )
+        resp = dispatch(service, "GET", "/builds/run1/events", None)
+        release.set()
+        assert resp.status_code == 403
+        assert completed.wait(timeout=5)
+
+    def test_owner_id_not_exposed_via_wire_after_completion(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """manifest 보정 이후에도 owner_id는 build_status/events/manifest 응답
+        어디에도 노출되지 않는다 — public API/OpenAPI 계약은 바뀌지 않는다."""
+        completed = threading.Event()
+        service = _ObservedAsyncService(
+            output_root=tmp_path,
+            client_factory=lambda: _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}]}),
+            completed=completed,
+        )
+        secret_owner_id = "oidc:super-secret-owner-hash"
+        monkeypatch.setattr(
+            app_module,
+            "authenticate",
+            lambda **_kwargs: Principal(kind="oidc", identifier="a", owner_id=secret_owner_id),
+        )
+        submitted = self._submit(service, "run1")
+        assert submitted.status_code == 202
+        assert completed.wait(timeout=5)
+
+        status = dispatch(service, "GET", "/builds/run1", None)
+        assert "owner_id" not in status.body
+        assert secret_owner_id not in json.dumps(status.body)
+
+        events_resp = dispatch(service, "GET", "/builds/run1/events", None)
+        assert events_resp.status_code == 200
+        assert "owner_id" not in json.dumps(events_resp.body)
+        assert secret_owner_id not in json.dumps(events_resp.body)
+
+        manifest_resp = dispatch(service, "GET", "/builds/run1/manifest", None)
+        assert manifest_resp.status_code == 200
+        assert "owner_id" not in manifest_resp.body
+        assert secret_owner_id not in json.dumps(manifest_resp.body)
+
+    def test_async_file_source_resolver_still_does_not_receive_owner_id(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#498 known limitation 유지 확인: async 경로로 제출된 ``kind=file``
+        build는, manifest owner_id가 이제 올바르게 채워지더라도, 여전히 file
+        source resolver에는 owner_id를 넘기지 않는다 — 업로드 소유자 본인이
+        제출해도 async 경로에서는 그 업로드를 찾지 못해 build가 실패해야
+        한다(동기 ``/build``와 달리)."""
+        completed = threading.Event()
+        service = _ObservedAsyncService(
+            output_root=tmp_path,
+            client_factory=lambda: _FakeClient({}),
+            completed=completed,
+        )
+        owner = Principal(kind="oidc", identifier="a", owner_id="oidc:owner-a")
+
+        created = service.create_upload(
+            b"id,amount\n1,1000\n",
+            format="csv",
+            encoding="utf-8",
+            original_filename="trades.csv",
+            principal=owner,
+        )
+        assert created.status_code == 200
+        upload_id = created.body["upload_id"]
+        assert isinstance(upload_id, str)
+
+        monkeypatch.setattr(app_module, "authenticate", lambda **_kwargs: owner)
+        submitted = self._submit(service, "run1", _file_source_spec_yaml(upload_id))
+        assert submitted.status_code == 202
+        assert completed.wait(timeout=5)
+
+        # manifest ownership은 이번 수정으로 정확하다 — 그러나 file resolver는
+        # 여전히 owner_id를 받지 않으므로 업로드를 찾지 못해 build 자체는 실패한다
+        # (#498 async limitation, 그대로 유지).
+        manifest_data = json.loads(
+            (tmp_path / "run1" / "manifest.json").read_text(encoding="utf-8")
+        )
+        assert manifest_data["owner_id"] == "oidc:owner-a"
+        assert manifest_data["errors"], "file resolver가 owner_id 없이 업로드를 찾지 못해야 한다"
+
+        status = dispatch(service, "GET", "/builds/run1", None)
+        assert status.body["status"] == "failed"
+
+    def test_completed_run_build_index_records_stable_owner_id(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """manifest뿐 아니라 BuildIndex(#505 SSOT, ``GET /builds`` 목록이 우선
+        조회하는 경로)도 같은 stable owner_id를 가져야 한다 — 두 저장소가
+        서로 다른 값을 갖는 SSOT 불일치를 만들지 않는다."""
+        completed = threading.Event()
+        service = _ObservedAsyncService(
+            output_root=tmp_path,
+            client_factory=lambda: _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}]}),
+            completed=completed,
+        )
+        principal_a = Principal(kind="oidc", identifier="same", owner_id="oidc:owner-A")
+        monkeypatch.setattr(app_module, "authenticate", lambda **_kwargs: principal_a)
+
+        submitted = self._submit(service, "run1")
+        assert submitted.status_code == 202
+        assert completed.wait(timeout=5)
+
+        manifest_data = json.loads(
+            (tmp_path / "run1" / "manifest.json").read_text(encoding="utf-8")
+        )
+        index_entry = service._build_index.get("run1")
+        assert index_entry is not None
+        assert index_entry.owner_id == "oidc:owner-A"
+        assert index_entry.owner_id == manifest_data["owner_id"]
+
+    def test_build_list_hides_completed_run_from_different_owner_with_same_label(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """BuildIndex를 사용하는 persisted ownership 경로(``GET /builds`` 목록)도
+        같은 label의 다른 owner_id principal을 통과시키지 않는다."""
+        monkeypatch.setenv(_OWNERSHIP_ENV, "true")
+        completed = threading.Event()
+        service = _ObservedAsyncService(
+            output_root=tmp_path,
+            client_factory=lambda: _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}]}),
+            completed=completed,
+        )
+        principal_a = Principal(kind="oidc", identifier="same", owner_id="oidc:owner-A")
+        principal_b = Principal(kind="oidc", identifier="same", owner_id="oidc:owner-B")
+        assert principal_a.label == principal_b.label
+
+        monkeypatch.setattr(app_module, "authenticate", lambda **_kwargs: principal_a)
+        submitted = self._submit(service, "run1")
+        assert submitted.status_code == 202
+        assert completed.wait(timeout=5)
+
+        list_as_owner = dispatch(service, "GET", "/builds", None)
+        assert list_as_owner.status_code == 200
+        owner_run_ids = [
+            b["run_id"] for b in cast(list[dict[str, object]], list_as_owner.body["builds"])
+        ]
+        assert "run1" in owner_run_ids
+
+        monkeypatch.setattr(app_module, "authenticate", lambda **_kwargs: principal_b)
+        list_as_other = dispatch(service, "GET", "/builds", None)
+        assert list_as_other.status_code == 200
+        other_run_ids = [
+            b["run_id"] for b in cast(list[dict[str, object]], list_as_other.body["builds"])
+        ]
+        assert "run1" not in other_run_ids
+        assert "owner_id" not in json.dumps(list_as_other.body)

--- a/tests/unit/test_openapi_examples.py
+++ b/tests/unit/test_openapi_examples.py
@@ -175,7 +175,7 @@ def test_extraction_script_emits_documented_json_shape() -> None:
         text=True,
     )
     payload = json.loads(completed.stdout)
-    assert payload["contract_version"] == "1.12.0"
+    assert payload["contract_version"] == "1.13.0"
     assert len(payload["examples"]) >= 50
     assert set(payload["examples"][0]) == {
         "path",

--- a/tests/unit/test_pipeline_events.py
+++ b/tests/unit/test_pipeline_events.py
@@ -1,0 +1,443 @@
+"""``pipeline.orchestrator.run_build``의 structured event 방출 테스트 (#496).
+
+HTTP route/ownership/bounded query는 test_events_api.py가 다룬다. 이 파일은
+실제 실행 boundary(run/source fetch/medallion stage/quality checkpoint)에서만
+event가 발생하는지, 실행되지 않은 stage를 완료로 가장하지 않는지, 실패해도
+이전 성공 event가 남아 있는지를 orchestrator 수준에서 직접 검증한다.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Iterable
+from pathlib import Path
+
+import pytest
+
+from kpubdata_builder.events import BuildEvent, BuildEventStore
+from kpubdata_builder.pipeline import run_build
+from kpubdata_builder.spec import BuildSpec, ExportTarget, JsonValue, SourceRef
+from kpubdata_builder.spec.models import SchemaContract
+
+
+class _FakeResult:
+    def __init__(self, items: list[dict[str, JsonValue]]) -> None:
+        self._items = items
+
+    @property
+    def items(self) -> Iterable[dict[str, JsonValue]]:
+        return self._items
+
+
+class _FakeDataset:
+    def __init__(self, items: list[dict[str, JsonValue]]) -> None:
+        self._items = items
+
+    def list(self, **_params: JsonValue) -> _FakeResult:
+        return _FakeResult(self._items)
+
+
+class _FakeClient:
+    def __init__(self, data: dict[str, list[dict[str, JsonValue]]]) -> None:
+        self._data = data
+
+    def dataset(self, source_key: str) -> _FakeDataset:
+        if source_key not in self._data:
+            raise KeyError(f"unknown source: {source_key}")
+        return _FakeDataset(self._data[source_key])
+
+
+def _spec(*sources: SourceRef, quality: object = None) -> BuildSpec:
+    kwargs: dict[str, object] = {}
+    if quality is not None:
+        kwargs["quality"] = quality
+    return BuildSpec(
+        dataset_id="events.fixture",
+        title="Events Fixture",
+        description="fixture",
+        sources=tuple(sources),
+        exports=(ExportTarget(kind="jsonl", output_path="data.jsonl"),),
+        **kwargs,
+    )
+
+
+def _names(events: tuple[BuildEvent, ...]) -> list[str]:
+    return [e.event for e in events]
+
+
+class TestRunLifecycle:
+    def test_successful_run_emits_started_then_finished(self, tmp_path: Path) -> None:
+        client = _FakeClient({"datago.air": [{"id": "1"}]})
+        store = BuildEventStore(tmp_path)
+        spec = _spec(SourceRef(provider="datago", dataset="air", alias="air"))
+
+        result = run_build(
+            spec, client=client, output_root=tmp_path, run_id="r1", event_store=store
+        )
+
+        assert result.status == "ok"
+        events = store.list_for_run("r1", limit=100, tail=False)
+        assert events[0].event == "run_started"
+        assert events[-1].event == "run_finished"
+        assert events[-1].status == "ok"
+
+    def test_failed_run_emits_run_failed_with_status_fail(self, tmp_path: Path) -> None:
+        client = _FakeClient({})  # 모든 source가 fetch 실패
+        store = BuildEventStore(tmp_path)
+        spec = _spec(SourceRef(provider="datago", dataset="missing", alias="air"))
+
+        result = run_build(
+            spec, client=client, output_root=tmp_path, run_id="r1", event_store=store
+        )
+
+        assert result.status == "failed"
+        events = store.list_for_run("r1", limit=100, tail=False)
+        assert events[-1].event == "run_failed"
+        assert events[-1].status == "fail"
+
+    def test_no_event_store_does_not_raise(self, tmp_path: Path) -> None:
+        """event_store를 생략한 기존 호출자(CLI 등)는 아무 것도 바뀌지 않는다."""
+        client = _FakeClient({"datago.air": [{"id": "1"}]})
+        spec = _spec(SourceRef(provider="datago", dataset="air", alias="air"))
+
+        result = run_build(spec, client=client, output_root=tmp_path, run_id="r1")
+
+        assert result.status == "ok"
+
+    def test_run_events_are_timezone_aware_utc(self, tmp_path: Path) -> None:
+        client = _FakeClient({"datago.air": [{"id": "1"}]})
+        store = BuildEventStore(tmp_path)
+        spec = _spec(SourceRef(provider="datago", dataset="air", alias="air"))
+
+        run_build(spec, client=client, output_root=tmp_path, run_id="r1", event_store=store)
+
+        events = store.list_for_run("r1", limit=100, tail=False)
+        assert events
+        for event in events:
+            assert event.timestamp.tzinfo is not None
+
+
+class TestSourceFetchLifecycle:
+    def test_fetch_success_emits_started_then_completed(self, tmp_path: Path) -> None:
+        client = _FakeClient({"datago.air": [{"id": "1"}, {"id": "2"}]})
+        store = BuildEventStore(tmp_path)
+        spec = _spec(SourceRef(provider="datago", dataset="air", alias="air"))
+
+        run_build(spec, client=client, output_root=tmp_path, run_id="r1", event_store=store)
+
+        events = store.list_for_run("r1", limit=100, tail=False)
+        fetch_events = [e for e in events if e.event.startswith("source_fetch")]
+        assert [e.event for e in fetch_events] == ["source_fetch_started", "source_fetch_completed"]
+        assert fetch_events[0].source_key == "air"
+        assert fetch_events[1].metrics == {"records": 2}
+
+    def test_fetch_failure_emits_failed_not_completed(self, tmp_path: Path) -> None:
+        client = _FakeClient({})
+        store = BuildEventStore(tmp_path)
+        spec = _spec(SourceRef(provider="datago", dataset="missing", alias="air"))
+
+        run_build(spec, client=client, output_root=tmp_path, run_id="r1", event_store=store)
+
+        events = store.list_for_run("r1", limit=100, tail=False)
+        fetch_events = [e for e in events if e.event.startswith("source_fetch")]
+        assert [e.event for e in fetch_events] == ["source_fetch_started", "source_fetch_failed"]
+        assert fetch_events[1].status == "fail"
+
+    def test_source_key_is_output_facing_alias(self, tmp_path: Path) -> None:
+        client = _FakeClient({"datago.air": [{"id": "1"}]})
+        store = BuildEventStore(tmp_path)
+        spec = _spec(SourceRef(provider="datago", dataset="air", alias="my-alias"))
+
+        run_build(spec, client=client, output_root=tmp_path, run_id="r1", event_store=store)
+
+        events = store.list_for_run("r1", limit=100, tail=False)
+        source_keys = {e.source_key for e in events if e.source_key is not None}
+        assert source_keys == {"my-alias"}
+
+
+class TestStageLifecycle:
+    def test_full_success_emits_all_four_stages_in_order(self, tmp_path: Path) -> None:
+        client = _FakeClient({"datago.air": [{"id": "1"}]})
+        store = BuildEventStore(tmp_path)
+        spec = _spec(SourceRef(provider="datago", dataset="air", alias="air"))
+
+        run_build(spec, client=client, output_root=tmp_path, run_id="r1", event_store=store)
+
+        events = store.list_for_run("r1", limit=100, tail=False)
+        stage_events = [(e.stage, e.event) for e in events if e.stage is not None]
+        assert stage_events == [
+            ("bronze", "stage_started"),
+            ("bronze", "stage_completed"),
+            ("silver", "stage_started"),
+            ("silver", "stage_completed"),
+            ("gold", "stage_started"),
+            ("gold", "stage_completed"),
+            ("export", "stage_started"),
+            ("export", "stage_completed"),
+        ]
+
+    def test_bronze_failure_does_not_emit_silver_or_gold(self, tmp_path: Path) -> None:
+        client = _FakeClient({})
+        store = BuildEventStore(tmp_path)
+        spec = _spec(SourceRef(provider="datago", dataset="missing", alias="air"))
+
+        run_build(spec, client=client, output_root=tmp_path, run_id="r1", event_store=store)
+
+        events = store.list_for_run("r1", limit=100, tail=False)
+        stages_seen = {e.stage for e in events if e.stage is not None}
+        assert stages_seen == {"bronze"}
+        bronze_events = [e.event for e in events if e.stage == "bronze"]
+        assert bronze_events == ["stage_started", "stage_failed"]
+
+    def test_silver_validation_failure_bronze_stays_completed(self, tmp_path: Path) -> None:
+        """silver가 실패해도 bronze의 성공 event는 삭제되지 않는다(append-only)."""
+        client = _FakeClient({"datago.air": [{"id": "1"}]})
+        store = BuildEventStore(tmp_path)
+        # required column이 실제로 존재하지 않는 컬럼이라 silver validation이 실패한다.
+        spec = BuildSpec(
+            dataset_id="events.fixture",
+            title="Events Fixture",
+            description="fixture",
+            sources=(
+                SourceRef(
+                    provider="datago",
+                    dataset="air",
+                    alias="air",
+                    schema=SchemaContract(required=("does_not_exist",)),
+                ),
+            ),
+            exports=(ExportTarget(kind="jsonl", output_path="data.jsonl"),),
+        )
+
+        result = run_build(
+            spec, client=client, output_root=tmp_path, run_id="r1", event_store=store
+        )
+
+        assert result.status == "failed"
+        events = store.list_for_run("r1", limit=100, tail=False)
+        bronze_events = [e.event for e in events if e.stage == "bronze"]
+        assert bronze_events == ["stage_started", "stage_completed"]
+        silver_events = [e.event for e in events if e.stage == "silver"]
+        assert silver_events == ["stage_started", "stage_failed"]
+        assert "gold" not in {e.stage for e in events}
+
+    def test_not_reached_stage_never_marked_completed(self, tmp_path: Path) -> None:
+        """도달하지 못한 stage는 completed/failed 어느 쪽으로도 기록되지 않는다."""
+        client = _FakeClient({})
+        store = BuildEventStore(tmp_path)
+        spec = _spec(SourceRef(provider="datago", dataset="missing", alias="air"))
+
+        run_build(spec, client=client, output_root=tmp_path, run_id="r1", event_store=store)
+
+        events = store.list_for_run("r1", limit=100, tail=False)
+        for stage in ("silver", "gold", "export"):
+            assert stage not in {e.stage for e in events}
+
+
+class TestQualityCheckpoint:
+    def test_quality_evaluated_emitted_once_per_source(self, tmp_path: Path) -> None:
+        client = _FakeClient({"datago.air": [{"id": "1"}]})
+        store = BuildEventStore(tmp_path)
+        spec = _spec(SourceRef(provider="datago", dataset="air", alias="air"))
+
+        run_build(spec, client=client, output_root=tmp_path, run_id="r1", event_store=store)
+
+        events = store.list_for_run("r1", limit=100, tail=False)
+        quality_events = [e for e in events if e.event == "quality_evaluated"]
+        assert len(quality_events) == 1
+        assert quality_events[0].status == "ok"
+
+    def test_quality_evaluated_survives_downstream_gate_failure(self, tmp_path: Path) -> None:
+        """quality FAIL로 소스가 실패해도 quality_evaluated event 자체는 남는다."""
+        from kpubdata_builder.spec.models import QualityPolicy
+
+        client = _FakeClient({"datago.air": [{"id": "1"}, {"id": "2"}]})
+        store = BuildEventStore(tmp_path)
+        spec = _spec(
+            SourceRef(provider="datago", dataset="air", alias="air"),
+            quality=QualityPolicy(min_rows=100, min_rows_severity="fail"),
+        )
+
+        result = run_build(
+            spec, client=client, output_root=tmp_path, run_id="r1", event_store=store
+        )
+
+        assert result.status == "failed"
+        events = store.list_for_run("r1", limit=100, tail=False)
+        quality_events = [e for e in events if e.event == "quality_evaluated"]
+        assert len(quality_events) == 1
+        assert quality_events[0].status == "fail"
+        assert quality_events[0].metrics is not None
+        assert quality_events[0].metrics["fail_count"] >= 1
+
+
+class TestPartialRunMultiSource:
+    def test_one_success_one_failure_timeline_shows_both(self, tmp_path: Path) -> None:
+        client = _FakeClient({"datago.good": [{"id": "1"}]})
+        store = BuildEventStore(tmp_path)
+        spec = _spec(
+            SourceRef(provider="datago", dataset="good", alias="good"),
+            SourceRef(provider="datago", dataset="bad", alias="bad"),
+        )
+
+        result = run_build(
+            spec, client=client, output_root=tmp_path, run_id="r1", event_store=store
+        )
+
+        assert result.status == "failed"
+        events = store.list_for_run("r1", limit=100, tail=False)
+        good_events = [e.event for e in events if e.source_key == "good"]
+        bad_events = [e.event for e in events if e.source_key == "bad"]
+        assert "stage_completed" in good_events  # 성공한 source의 event가 살아남는다
+        assert "stage_failed" in bad_events
+        assert events[-1].event == "run_failed"
+
+
+def _selective_failing_append(
+    monkeypatch: pytest.MonkeyPatch, should_fail: Callable[[BuildEvent], bool]
+) -> None:
+    """``event``가 ``should_fail``에 해당할 때만 append를 실패시키는 fault injection.
+
+    나머지 event는 원래 구현(``BuildEventStore.append``)에 그대로 위임한다 —
+    특정 boundary 하나만 장애를 겪고 나머지 timeline은 정상 기록되는, 실제
+    transient 장애(디스크 hiccup 등)에 가까운 상황을 흉내낸다.
+    """
+    original_append = BuildEventStore.append
+
+    def _append(self: BuildEventStore, event: BuildEvent) -> BuildEvent:
+        if should_fail(event):
+            raise RuntimeError(f"simulated event store outage for {event.event}")
+        return original_append(self, event)
+
+    monkeypatch.setattr(BuildEventStore, "append", _append)
+
+
+def _manifest_warnings(manifest_path: Path) -> list[str]:
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    return list(manifest["warnings"])
+
+
+class TestRecorderFailureIsolation:
+    def test_event_append_failure_does_not_fail_otherwise_successful_build(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """event 기록 인프라 장애가 이미 성공한 build를 실패시키지 않는다 (#496).
+
+        BuildEventStore.append() 자체는 실패를 삼키지 않지만(test_event_store.py),
+        recorder가 그 실패를 흡수해 build 진행에는 영향을 주지 않는다 — 그러나
+        (ADR 0003의 "파생 인덱스라 잃어도 된다"는 이유가 아니라) event 기록
+        실패가 manifest/소스 outcome이라는 *다른* 정본을 침범하지 않기 위해서다.
+        그 흡수가 조용한 실종이 아니라는 것은 아래 fault-injection 테스트들이
+        ``BuildManifest.warnings``를 통해 확인한다.
+        """
+        client = _FakeClient({"datago.air": [{"id": "1"}]})
+        store = BuildEventStore(tmp_path)
+
+        def _broken_append(self: BuildEventStore, event: BuildEvent) -> BuildEvent:
+            raise RuntimeError("simulated event store outage")
+
+        monkeypatch.setattr(BuildEventStore, "append", _broken_append)
+        spec = _spec(SourceRef(provider="datago", dataset="air", alias="air"))
+
+        result = run_build(
+            spec, client=client, output_root=tmp_path, run_id="r1", event_store=store
+        )
+
+        assert result.status == "ok"
+        assert result.outcomes[0].status == "ok"
+        assert _manifest_warnings(result.manifest_path)  # 실패가 완전히 사라지지 않는다
+
+    def test_run_started_append_failure_still_builds_and_warns(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """run_started append가 실패해도 build는 계속 진행되고 manifest에 남는다 (#496)."""
+        client = _FakeClient({"datago.air": [{"id": "1"}]})
+        store = BuildEventStore(tmp_path)
+        _selective_failing_append(monkeypatch, lambda e: e.event == "run_started")
+        spec = _spec(SourceRef(provider="datago", dataset="air", alias="air"))
+
+        result = run_build(
+            spec, client=client, output_root=tmp_path, run_id="r1", event_store=store
+        )
+
+        assert result.status == "ok"
+        assert result.manifest_path.exists()  # AGENTS.md '매니페스트 누락 금지'
+        warnings = _manifest_warnings(result.manifest_path)
+        assert any("run_started" in w for w in warnings)
+        # 이후 event(run_finished 등)는 store가 복구됐으므로 정상 기록된다 —
+        # 하나의 장애가 나머지 timeline까지 지워버리지 않는다(append-only).
+        events = store.list_for_run("r1", limit=100, tail=False)
+        assert events[-1].event == "run_finished"
+
+    def test_stage_completed_append_failure_does_not_flip_successful_source_to_failed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """bronze stage_completed append 실패가 실제로 성공한 source를 실패로 뒤집지 않는다.
+
+        stage_completed는 실제 persist(``persist_bronze_artifact``)가 *이미 끝난 뒤*
+        호출된다 — 여기서 예외가 파이프라인 제어 흐름으로 새어나가면
+        ``_run_source_pipeline``의 공통 except가 "이 source 실패"로 잘못 해석해
+        실제로는 디스크에 이미 쓰인 bronze 산출물을 실패로 보고하게 된다(#496).
+        """
+        client = _FakeClient({"datago.air": [{"id": "1"}]})
+        store = BuildEventStore(tmp_path)
+        _selective_failing_append(
+            monkeypatch, lambda e: e.event == "stage_completed" and e.stage == "bronze"
+        )
+        spec = _spec(SourceRef(provider="datago", dataset="air", alias="air"))
+
+        result = run_build(
+            spec, client=client, output_root=tmp_path, run_id="r1", event_store=store
+        )
+
+        assert result.status == "ok"
+        assert result.outcomes[0].status == "ok"
+        assert result.outcomes[0].stages_completed == ("bronze", "silver", "gold")
+        bronze_dir = tmp_path / "r1" / "bronze"
+        assert bronze_dir.exists() and any(bronze_dir.iterdir())  # 실제 산출물이 살아있다
+        warnings = _manifest_warnings(result.manifest_path)
+        assert any("stage_completed" in w and "bronze" in w for w in warnings)
+
+    def test_run_finished_append_failure_still_writes_manifest(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """run_finished append 실패가 manifest 기록 자체를 막지 않는다 (#496).
+
+        recorder.run_finished()은 manifest_writer보다 먼저 호출된다
+        (pipeline/orchestrator.py) — 만약 이 실패가 그대로 전파돼 run_build를
+        중단시키면 manifest.json이 아예 생기지 않는, AGENTS.md '매니페스트
+        누락 금지'를 위반하는 훨씬 나쁜 상태가 된다.
+        """
+        client = _FakeClient({"datago.air": [{"id": "1"}]})
+        store = BuildEventStore(tmp_path)
+        _selective_failing_append(monkeypatch, lambda e: e.event == "run_finished")
+        spec = _spec(SourceRef(provider="datago", dataset="air", alias="air"))
+
+        result = run_build(
+            spec, client=client, output_root=tmp_path, run_id="r1", event_store=store
+        )
+
+        assert result.status == "ok"
+        assert result.manifest_path.exists()
+        manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+        assert manifest["errors"] == []  # 실제 소스 실행은 전혀 실패하지 않았다
+        assert any("run_finished" in w for w in manifest["warnings"])
+
+    def test_run_failed_append_failure_still_writes_manifest_with_real_errors(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """run_failed append 실패도 manifest 기록과 실제 실패 사유를 가리지 않는다 (#496)."""
+        client = _FakeClient({})  # 모든 source가 fetch 실패
+        store = BuildEventStore(tmp_path)
+        _selective_failing_append(monkeypatch, lambda e: e.event == "run_failed")
+        spec = _spec(SourceRef(provider="datago", dataset="missing", alias="air"))
+
+        result = run_build(
+            spec, client=client, output_root=tmp_path, run_id="r1", event_store=store
+        )
+
+        assert result.status == "failed"
+        assert result.manifest_path.exists()
+        manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+        assert manifest["errors"]  # 진짜 실패 사유는 event 기록 실패와 무관하게 남는다
+        assert any("run_failed" in w for w in manifest["warnings"])

--- a/tests/unit/test_service_contract.py
+++ b/tests/unit/test_service_contract.py
@@ -60,6 +60,7 @@ _DISPATCH_ROUTES: dict[tuple[str, str], str] = {
     ("/builds/{run_id}/stages", "GET"): "listBuildStages",
     ("/builds/{run_id}/stages/{stage}", "GET"): "getBuildStageDetail",
     ("/builds/{run_id}/quality", "GET"): "getBuildQuality",
+    ("/builds/{run_id}/events", "GET"): "getBuildEvents",
     ("/monitoring/summary", "GET"): "getMonitoringSummary",
     ("/monitoring/builds", "GET"): "getMonitoringBuilds",
     ("/uploads", "POST"): "createUpload",
@@ -94,6 +95,7 @@ _REQUIRED_OPERATIONS = [
     ("/builds/{run_id}/stages", "get"),
     ("/builds/{run_id}/stages/{stage}", "get"),
     ("/builds/{run_id}/quality", "get"),
+    ("/builds/{run_id}/events", "get"),
     ("/monitoring/summary", "get"),
     ("/monitoring/builds", "get"),
     ("/uploads", "post"),
@@ -384,6 +386,7 @@ _IMPLEMENTED_OPERATIONS = {
     "listBuildStages",
     "getBuildStageDetail",
     "getBuildQuality",
+    "getBuildEvents",
     "getMonitoringSummary",
     "getMonitoringBuilds",
     "createUpload",
@@ -606,6 +609,7 @@ _OPERATION_STATUS_CODES: dict[str, set[int]] = {
     "listBuildStages": {200, 400, 403, 404},
     "getBuildStageDetail": {200, 400, 403, 404},
     "getBuildQuality": {200, 400, 403, 404},
+    "getBuildEvents": {200, 400, 403, 404},
     "getMonitoringSummary": {200},
     "getMonitoringBuilds": {200, 400},
     "createUpload": {200, 400, 403, 413},
@@ -1154,6 +1158,57 @@ class TestResponseConformance:
         resp = dispatch(_conform_service(tmp_path), "GET", "/builds/nope/quality", None)
         assert resp.status_code == 404
         _assert_conforms(resp, "/builds/{run_id}/quality", "GET")
+
+    # -------------------------------------------------------------------
+    # Run Event Timeline API conformance (#496)
+    # -------------------------------------------------------------------
+
+    def test_build_events_200(self, tmp_path: Path) -> None:
+        service = _conform_service(tmp_path)
+        dispatch(service, "POST", "/build", {"spec": _CONFORM_SPEC_YAML, "run_id": "conform-ev"})
+        resp = dispatch(service, "GET", "/builds/conform-ev/events", None)
+        assert resp.status_code == 200
+        _assert_conforms(resp, "/builds/{run_id}/events", "GET")
+
+    def test_build_events_200_with_limit_and_tail(self, tmp_path: Path) -> None:
+        service = _conform_service(tmp_path)
+        dispatch(
+            service, "POST", "/build", {"spec": _CONFORM_SPEC_YAML, "run_id": "conform-ev-tail"}
+        )
+        resp = dispatch(
+            service,
+            "GET",
+            "/builds/conform-ev-tail/events",
+            None,
+            query="limit=2&tail=true",
+        )
+        assert resp.status_code == 200
+        _assert_conforms(resp, "/builds/{run_id}/events", "GET")
+
+    def test_build_events_404_missing(self, tmp_path: Path) -> None:
+        resp = dispatch(_conform_service(tmp_path), "GET", "/builds/nope/events", None)
+        assert resp.status_code == 404
+        _assert_conforms(resp, "/builds/{run_id}/events", "GET")
+
+    def test_build_events_400_bad_limit(self, tmp_path: Path) -> None:
+        service = _conform_service(tmp_path)
+        dispatch(
+            service, "POST", "/build", {"spec": _CONFORM_SPEC_YAML, "run_id": "conform-ev-400"}
+        )
+        resp = dispatch(service, "GET", "/builds/conform-ev-400/events", None, query="limit=0")
+        assert resp.status_code == 400
+        _assert_conforms(resp, "/builds/{run_id}/events", "GET")
+
+    def test_build_events_400_bad_tail(self, tmp_path: Path) -> None:
+        service = _conform_service(tmp_path)
+        dispatch(
+            service, "POST", "/build", {"spec": _CONFORM_SPEC_YAML, "run_id": "conform-ev-tail-400"}
+        )
+        resp = dispatch(
+            service, "GET", "/builds/conform-ev-tail-400/events", None, query="tail=yes"
+        )
+        assert resp.status_code == 400
+        _assert_conforms(resp, "/builds/{run_id}/events", "GET")
 
     def test_monitoring_summary_200(self, tmp_path: Path) -> None:
         resp = dispatch(_conform_service(tmp_path), "GET", "/monitoring/summary", None)

--- a/tests/unit/test_service_jobs.py
+++ b/tests/unit/test_service_jobs.py
@@ -296,9 +296,7 @@ class TestRunSubmittedEventFailure:
         # 실제 파이프라인이 전혀 실행되지 않았다 — run 디렉터리조차 생기지 않는다.
         assert not (tmp_path / "run1").exists()
 
-    def test_unrelated_run_id_is_unaffected_by_a_prior_failure(
-        self, tmp_path: Path
-    ) -> None:
+    def test_unrelated_run_id_is_unaffected_by_a_prior_failure(self, tmp_path: Path) -> None:
         """이 run_id 하나만 겪은 실패가 다른 run_id의 정상 submission을 막지 않는다."""
         completed = threading.Event()
         service = _ObservedBuildService(

--- a/tests/unit/test_service_jobs.py
+++ b/tests/unit/test_service_jobs.py
@@ -10,6 +10,7 @@ import pytest
 
 from kpubdata_builder.events import BuildEvent
 from kpubdata_builder.service import BuilderService, ServiceResponse, dispatch
+from kpubdata_builder.service.auth import Principal
 from kpubdata_builder.spec import JsonValue
 
 VALID_SPEC_YAML = (
@@ -75,10 +76,24 @@ class _ObservedBuildService(BuilderService):
         self._completed = completed
 
     def build(
-        self, spec_yaml: str, *, run_id: str | None = None, created_by: str | None = None
+        self,
+        spec_yaml: str,
+        *,
+        run_id: str | None = None,
+        created_by: str | None = None,
+        owner_id: str | None = None,
+        manifest_owner_id: str | None = None,
+        principal: Principal | None = None,
     ) -> ServiceResponse:
         try:
-            return super().build(spec_yaml, run_id=run_id, created_by=created_by)
+            return super().build(
+                spec_yaml,
+                run_id=run_id,
+                created_by=created_by,
+                owner_id=owner_id,
+                manifest_owner_id=manifest_owner_id,
+                principal=principal,
+            )
         finally:
             self._completed.set()
 

--- a/tests/unit/test_service_jobs.py
+++ b/tests/unit/test_service_jobs.py
@@ -6,6 +6,9 @@ import threading
 from collections.abc import Callable, Iterable
 from pathlib import Path
 
+import pytest
+
+from kpubdata_builder.events import BuildEvent
 from kpubdata_builder.service import BuilderService, ServiceResponse, dispatch
 from kpubdata_builder.spec import JsonValue
 
@@ -257,3 +260,134 @@ class TestAsyncBuildJobs:
         assert isinstance(response, ServiceResponse)
         assert response.status_code == 400
         assert service.build_status("bad").status_code == 404
+
+
+class TestRunSubmittedEventFailure:
+    """``run_submitted`` event append 실패는 job을 아예 큐잉하지 않는다 (#496).
+
+    job이 executor에 이미 큐잉된 *뒤에* event를 append하면, "event는 유실됐는데
+    job은 이미 실행 중"이라는 모순이 생긴다(사용자 요구사항 C). 이를 피하기
+    위해 ``AsyncBuildExecutor.submit()``의 ``on_accept`` hook이 event append를
+    job 큐잉보다 먼저 실행한다 — 여기서 실패하면 job은 registry에도 worker
+    pool에도 전혀 등록되지 않는다.
+    """
+
+    def test_append_failure_prevents_job_from_being_queued(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client = _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}]})
+        service = BuilderService(output_root=tmp_path, client_factory=lambda: client)
+        # lazy event store를 강제로 초기화한 뒤 append만 고장낸다.
+        event_store = service._event_store
+
+        def _broken_append(event: BuildEvent) -> BuildEvent:
+            raise RuntimeError("simulated event store outage")
+
+        monkeypatch.setattr(event_store, "append", _broken_append)
+
+        response = service.submit_build(VALID_SPEC_YAML, run_id="run1", created_by="tester")
+
+        # HTTP는 실패를 정직하게 보고한다 — 202(accepted)가 아니다.
+        assert response.status_code != 202
+        assert response.status_code >= 500
+        # job이 registry/worker pool 어디에도 등록되지 않았다 — "이미 실행
+        # 중"이라는 모순이 없다.
+        assert service.build_status("run1").status_code == 404
+        # 실제 파이프라인이 전혀 실행되지 않았다 — run 디렉터리조차 생기지 않는다.
+        assert not (tmp_path / "run1").exists()
+
+    def test_unrelated_run_id_is_unaffected_by_a_prior_failure(
+        self, tmp_path: Path
+    ) -> None:
+        """이 run_id 하나만 겪은 실패가 다른 run_id의 정상 submission을 막지 않는다."""
+        completed = threading.Event()
+        service = _ObservedBuildService(
+            output_root=tmp_path,
+            client_factory=lambda: _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}]}),
+            completed=completed,
+            async_max_workers=1,
+        )
+
+        response = service.submit_build(VALID_SPEC_YAML, run_id="run-ok", created_by="tester")
+
+        assert response.status_code == 202
+        assert completed.wait(timeout=5)
+        assert service.build_status("run-ok").body["status"] == "succeeded"
+
+
+class TestExecutorEnqueueFailure:
+    """``on_accept``(event append)는 성공했는데 실제 worker pool 큐잉 자체가
+    실패하는 반대 방향 실패를 다룬다 (#496 self-review).
+
+    ``AsyncBuildExecutor.submit()``은 ``registry.create()``로 job을 "queued"로
+    등록한 *뒤에* ``self._executor.submit()``으로 실제 worker pool에 큐잉한다.
+    후자가 실패하면 event(``run_submitted``)는 이미 기록됐고 registry 항목도
+    이미 만들어진 상태라, 아무 조치가 없으면 "queued"가 영원히 남는 phantom
+    job이 된다 — 아무도 실행하지 않는데 정상 진행 중처럼 보인다. event는
+    append-only라 지우지 않고(#496 원칙), 대신 job 실행 실패에 이미 쓰이는
+    ``registry.mark_failed()``로 정리한다. #496 lifecycle 계약상 timeline 자체도
+    이 실패를 표현해야 하므로, 기존 ``run_failed`` vocabulary로 같은 run_id에
+    종결 event를 하나 더 남긴다(새 event type/state/API field 없음).
+    """
+
+    def test_enqueue_failure_leaves_registry_failed_not_phantom_queued(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client = _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}]})
+        service = BuilderService(output_root=tmp_path, client_factory=lambda: client)
+
+        def _broken_executor_submit(*_args: object, **_kwargs: object) -> object:
+            raise RuntimeError("simulated worker pool rejection")
+
+        monkeypatch.setattr(service._async_builds._executor, "submit", _broken_executor_submit)
+
+        response = service.submit_build(VALID_SPEC_YAML, run_id="run1", created_by="tester")
+
+        # HTTP는 실패를 정직하게 보고한다 — 202(accepted)가 아니다.
+        assert response.status_code != 202
+        assert response.status_code >= 500
+
+        # registry는 "queued" phantom으로 남지 않는다 — 실제 job 실행 실패에
+        # 쓰이는 것과 동일한 terminal("failed") 상태로 정리된다. HTTP(500)와
+        # 상태 조회(failed) 둘 다 "성공하지 않았다"로 일치한다 — 모순이 없다.
+        status = service.build_status("run1")
+        assert status.status_code == 200
+        assert status.body["status"] == "failed"
+
+        # timeline 자체도 실패를 표현한다: run_submitted(append-only라 지워지지
+        # 않는다) 뒤에 기존 run_failed vocabulary로 종결 event가 남아, event만
+        # 보고도 "정상 진행 중"으로 오해할 수 없다. chronological order도
+        # run_submitted -> run_failed 그대로다.
+        events = service._event_store.list_for_run("run1", limit=100, tail=False)
+        assert [e.event for e in events] == ["run_submitted", "run_failed"]
+        assert events[-1].status == "fail"
+        # raw exception/stack trace가 event message에 섞이지 않는다 — bounded,
+        # 고정된 안전한 message만 쓴다.
+        assert events[-1].message == "build could not be queued for execution"
+        assert "RuntimeError" not in (events[-1].message or "")
+        assert "simulated worker pool rejection" not in (events[-1].message or "")
+
+        # 실제 파이프라인은 전혀 실행되지 않았다 — run 디렉터리조차 생기지 않는다.
+        assert not (tmp_path / "run1").exists()
+
+    def test_resubmission_after_enqueue_failure_reports_existing_failed_job(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """실패로 정리된 job에 재제출해도 새로 accepted(202)되는 phantom이 아니라
+        기존 failed 상태를 그대로 반환한다(기존 "existing" 재제출 semantics 재사용).
+        """
+        client = _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}]})
+        service = BuilderService(output_root=tmp_path, client_factory=lambda: client)
+
+        def _broken_executor_submit(*_args: object, **_kwargs: object) -> object:
+            raise RuntimeError("simulated worker pool rejection")
+
+        monkeypatch.setattr(service._async_builds._executor, "submit", _broken_executor_submit)
+        first = service.submit_build(VALID_SPEC_YAML, run_id="run1", created_by="tester")
+        assert first.status_code >= 500
+
+        second = service.submit_build(VALID_SPEC_YAML, run_id="run1", created_by="tester")
+
+        assert second.status_code == 200
+        assert second.body["run_id"] == "run1"
+        assert second.body["status"] == "failed"


### PR DESCRIPTION
## 개요

Closes #496

> Stacked on #538 (`feat/issue-498-source-ingestion`).
> #538 merge 후 최신 `main` 기준으로 base/rebase 및 API contract version만 재확인합니다.

Build 실행 과정을 raw logger parsing 없이 조회할 수 있도록
run 단위의 append-only structured event timeline을 추가합니다.

실제 pipeline execution boundary에서 Run / Source Fetch /
Bronze / Silver / Quality / Gold / Export lifecycle event를 기록하고,
`GET /builds/{run_id}/events`로 조회할 수 있도록 구현했습니다.

## 주요 변경사항

### Structured Run Events

지원 lifecycle:

- Run
  - `run_submitted`
  - `run_started`
  - `run_finished`
  - `run_failed`
- Source Fetch
  - started / completed / failed
- Stage
  - Bronze / Silver / Gold / Export
  - started / completed / failed
- Quality
  - `quality_evaluated`

실제 cancellation transition은 아직 없으므로
`run_cancelled`는 이번 범위에 포함하지 않았습니다.

### Append-only Event Store

- SQLite 기반 event persistence
- WAL mode / thread-local connection / busy timeout
- append-only `INSERT`
- monotonic `seq` 기반 ordering
- 병렬 source 실행 지원
- raw logger parsing 및 in-memory timeline을 SSOT로 사용하지 않음

### Pipeline Integration

기존 pipeline의 실제 실행 경계에 event recorder를 연결했습니다.

```text
Run
 ↓
Source Fetch
 ↓
Bronze
 ↓
Silver
 ↓
Quality
 ↓
Gold
 ↓
Export
````

#498의 Public API / File / URL 공통 Source Resolver를 그대로 재사용하며
source kind별 별도 pipeline/event contract는 추가하지 않았습니다.

Quality event도 #486의 기존 평가 결과를 그대로 사용하며
별도 재판정 로직을 추가하지 않았습니다.

### Event API

추가 endpoint:

```http
GET /builds/{run_id}/events
```

지원:

* chronological event 조회
* `limit` 기본 200 / 최대 1000
* `tail=true|false`
* `tail=true`도 chronological ascending 반환
* queued/running async run polling
* invalid / unknown / cross-owner 처리

### Async Failure Semantics

Async submission과 event timeline 사이의 상태 불일치를 방지했습니다.

* `run_submitted` 기록 실패

  * job enqueue 안 함
  * HTTP 500
* executor enqueue 실패

  * registry → `failed`
  * timeline → `run_submitted → run_failed`
  * phantom `queued` 상태 방지
* pipeline 진행 중 event 저장 실패

  * 이미 성공한 artifact/build 결과를 거짓 실패로 변경하지 않음
  * event 유실 여부는 기존 `BuildManifest.warnings`에 기록

### Stable Ownership

#505의 stable `owner_id`를 async event 조회에도 적용했습니다.

* queued/running run

  * async registry snapshot의 stable `owner_id` 사용
* completed run

  * manifest / BuildIndex에 stable `owner_id` 일관되게 저장
* 동일 display label이라도 stable `owner_id`가 다르면 접근 거부
* `owner_id`는 HTTP response에 노출하지 않음

Persistent run ownership과 File source resolver ownership은 분리했습니다.

따라서 async run의 manifest/BuildIndex에는 stable owner가 기록되지만,
File source resolver에는 계속 owner가 전달되지 않아
#498의 async file-backed source limitation은 그대로 유지됩니다.

## API Contract

* `BuildEvent` schema 추가
* `BuildEventsResponse` 추가
* `GET /builds/{run_id}/events` 추가
* `limit` / `tail` query contract 추가
* additive contract version 반영

현재 stacked base #538의 `1.12.0` 기준으로 `1.13.0`입니다.

#537/#538 merge 순서에 따라 minor version이 달라질 수 있으므로
main 전환 직전에 최신 contract version만 다시 확인합니다.

## 검증

### Tests

* ownership/job targeted: **50 passed**
* broader relevant suites: **296 passed**
* full pytest: **1330 passed, 6 skipped, 6 deselected**

검증 범위:

* append-only persistence / ordering / concurrency
* Run / Source Fetch / Stage / Quality lifecycle
* failed / partial run
* queued/running async polling
* event append / executor enqueue fault injection
* active/completed stable owner isolation
* same label + different owner_id 접근 차단
* manifest / BuildIndex owner consistency
* owner_id wire non-disclosure
* async File source limitation 유지
* limit / tail / secret / path regression

### Static checks

* `ruff` — PASS
* `mypy` — PASS

## 제외 범위

* cancellation state machine (#481)
* Composition / Join events (#506)
* Monitoring aggregation (#516)
* Studio Runs timeline UI (#255)
* raw log viewer
* WebSocket / SSE
* event retention / archival
* alerting
* retry queue / event broker