### PR TITLE
feat: expose discovery metadata in /catalog (#490)

### DIFF
--- a/contract/builder-api.yaml
+++ b/contract/builder-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: KPubData Builder Service API
-  version: "1.14.0"
+  version: "1.15.0"
   description: >-
     Builder 중심 서비스 계약. BuildSpec 검증, preview, build 실행, artifact 조회,
     계약 버전 조회를 제공한다. CLI와 HTTP service mode(#36)가 동일한 도메인 계약을
@@ -64,7 +64,10 @@ info:
     값이라 병렬 source 간 실제 append 순서를 손실 없이 보존한다. Monitoring
     (#516, `GET /monitoring/summary`·`GET /monitoring/builds`)은 시스템/집계
     observability를 다루고, 이 endpoint는 단일 run의 event만 다룬다 — 역할이
-    분리되어 있다.
+    분리되어 있다. v1.15.0은 `/catalog` 응답(CatalogDataset)에 탐색용
+    metadata(`description`/`tags`/`source_url`/`representation`/`operations`/
+    `query_support`)를 추가한다(#490, additive — 기존 필드는 유지되며
+    raw_metadata는 노출하지 않는다).
 servers:
   - url: http://localhost:8000
     description: 로컬 builder 개발 서버
@@ -114,21 +117,44 @@ paths:
                 $ref: "#/components/schemas/CatalogResponse"
               examples:
                 PublicDataCatalog:
-                  summary: 인증 필요 여부를 포함한 공공데이터 카탈로그
+                  summary: 탐색용 metadata를 포함한 공공데이터 카탈로그
                   value:
                     providers:
                       - name: datago
                         datasets:
                           - name: air_quality
                             title: 대기오염정보
+                            description: 측정소별 대기오염 물질 농도 조회
+                            tags: [environment, air]
+                            source_url: https://www.data.go.kr/data/15073861/openapi
+                            representation: api_json
+                            operations: [get, list]
+                            query_support:
+                              pagination: offset
+                              filterable_fields: [station_name]
+                              sortable_fields: []
+                              time_range: true
+                              max_page_size: 1000
                             requires_service_key: true
                           - name: village_fcst
                             title: 단기예보
+                            description: null
+                            tags: []
+                            source_url: null
+                            representation: api_json
+                            operations: [list]
+                            query_support: null
                             requires_service_key: true
                       - name: ecos
                         datasets:
                           - name: key_statistic_list
                             title: 주요 경제지표
+                            description: 한국은행 주요 경제지표 시계열
+                            tags: [economy]
+                            source_url: null
+                            representation: api_json
+                            operations: [list]
+                            query_support: null
                             requires_service_key: false
         "401":
           $ref: "#/components/responses/Unauthorized"
@@ -2338,14 +2364,76 @@ components:
 
     CatalogDataset:
       type: object
-      required: [name, title, requires_service_key]
+      required:
+        [
+          name,
+          title,
+          description,
+          tags,
+          source_url,
+          representation,
+          operations,
+          query_support,
+          requires_service_key,
+        ]
+      description: >
+        DatasetRef의 public/canonical metadata를 allowlist로 직렬화한다 (#490).
+        raw_metadata는 provider 내부 정보/secret이 섞일 수 있어 노출하지 않는다.
+        metadata가 없는 dataset은 description/source_url/query_support가 null,
+        tags/operations가 빈 배열이다.
       properties:
         name:
           type: string
         title:
           type: string
+        description:
+          type: [string, "null"]
+          description: 사람이 읽는 데이터셋 설명 (없으면 null)
+        tags:
+          type: array
+          items:
+            type: string
+          description: 탐색용 분류 태그 (정렬된 문자열 배열, 없으면 빈 배열)
+        source_url:
+          type: [string, "null"]
+          description: 원본 API 문서/데이터 포털 URL (없으면 null)
+        representation:
+          type: string
+          enum: [api_json, api_xml, file_csv, file_excel, sheet, other]
+        operations:
+          type: array
+          items:
+            type: string
+            enum: [list, get, schema, raw, download]
+          description: 지원 작업 (정렬된 문자열 배열, 없으면 빈 배열)
+        query_support:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/CatalogQuerySupport"
+          description: 목록 질의 capability (알려진 경우만, 없으면 null)
         requires_service_key:
           type: boolean
+
+    CatalogQuerySupport:
+      type: object
+      required: [pagination, filterable_fields, sortable_fields, time_range, max_page_size]
+      properties:
+        pagination:
+          type: string
+          enum: [offset, index, cursor, none]
+        filterable_fields:
+          type: array
+          items:
+            type: string
+        sortable_fields:
+          type: array
+          items:
+            type: string
+        time_range:
+          type: boolean
+        max_page_size:
+          type: [integer, "null"]
+          minimum: 1
 
     ProviderListResponse:
       type: object

--- a/docs/guides/openapi-examples.md
+++ b/docs/guides/openapi-examples.md
@@ -1,7 +1,7 @@
 # OpenAPI 예제 추출
 
 `contract/builder-api.yaml`의 각 JSON media type에는 Studio와 사람이 함께 사용할 수 있는
-named request/response example이 있다. 예제는 API 계약 `1.14.0`의 wire schema를 따르며,
+named request/response example이 있다. 예제는 API 계약 `1.15.0`의 wire schema를 따르며,
 credential 원문, 실제 secret, 내부 절대 경로를 포함하지 않는다.
 
 Studio 같은 소비자는 저장소 루트에서 다음 명령으로 예제를 단일 JSON 문서로 추출할 수 있다.

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -166,6 +166,36 @@ def _requires_service_key(dataset: DatasetRef, auth_provider_names: frozenset[st
     )
 
 
+def _catalog_dataset_body(dataset: DatasetRef, requires_service_key: bool) -> dict[str, JsonValue]:
+    """DatasetRef의 public/canonical metadata만 allowlist로 직렬화한다 (#490).
+
+    ``raw_metadata``는 provider 내부 정보와 secret-like 값이 섞일 수 있어
+    절대 그대로 노출하지 않는다 — UI 탐색에 필요한 필드만 명시적으로 골라
+    담는다. metadata가 없는 dataset은 description/source_url/query_support가
+    null, tags/operations가 빈 배열로 직렬화된다(응답 전체를 깨지 않는다).
+    """
+    query_support: JsonValue = None
+    if dataset.query_support is not None:
+        query_support = {
+            "pagination": dataset.query_support.pagination.value,
+            "filterable_fields": sorted(dataset.query_support.filterable_fields),
+            "sortable_fields": sorted(dataset.query_support.sortable_fields),
+            "time_range": dataset.query_support.time_range,
+            "max_page_size": dataset.query_support.max_page_size,
+        }
+    return {
+        "name": dataset.dataset_key,
+        "title": dataset.name,
+        "description": dataset.description,
+        "tags": sorted(dataset.tags),
+        "source_url": dataset.source_url,
+        "representation": dataset.representation.value,
+        "operations": sorted(op.value for op in dataset.operations),
+        "query_support": query_support,
+        "requires_service_key": requires_service_key,
+    }
+
+
 def _enforce_ownership() -> bool:
     """run 소유권 강제가 활성화되어 있는지 (#389). 기본 off — 하위 호환."""
     return ownership_module.enforce_ownership()
@@ -243,7 +273,10 @@ def _strip_internal_fields(entries: list[_BuildListEntry]) -> list[_BuildListEnt
 # query parameter는 bounded(기본 200, 상한 1000)이며 반환은 항상 chronological
 # ascending이다. Monitoring(#516)의 시스템 aggregate와는 역할이 분리된다 — 이
 # endpoint는 단일 run의 이벤트만 다룬다.
-API_CONTRACT_VERSION = "1.14.0"
+# 1.14.0 -> 1.15.0: /catalog 응답(CatalogDataset)에 탐색용 metadata(description/
+# tags/source_url/representation/operations/query_support)를 추가한다(#490,
+# additive — 기존 필드는 유지되며 raw_metadata는 노출하지 않는다).
+API_CONTRACT_VERSION = "1.15.0"
 
 
 def _quality_result_to_json(r: QualityCheckResult) -> dict[str, JsonValue]:
@@ -688,11 +721,10 @@ class BuilderService:
             {
                 "name": provider_name,
                 "datasets": [
-                    {
-                        "name": item.dataset_key,
-                        "title": item.name,
-                        "requires_service_key": _requires_service_key(item, auth_provider_names),
-                    }
+                    _catalog_dataset_body(
+                        item,
+                        _requires_service_key(item, auth_provider_names),
+                    )
                     for item in items
                 ],
             }

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -178,8 +178,8 @@ def _catalog_dataset_body(dataset: DatasetRef, requires_service_key: bool) -> di
     if dataset.query_support is not None:
         query_support = {
             "pagination": dataset.query_support.pagination.value,
-            "filterable_fields": sorted(dataset.query_support.filterable_fields),
-            "sortable_fields": sorted(dataset.query_support.sortable_fields),
+            "filterable_fields": cast(JsonValue, sorted(dataset.query_support.filterable_fields)),
+            "sortable_fields": cast(JsonValue, sorted(dataset.query_support.sortable_fields)),
             "time_range": dataset.query_support.time_range,
             "max_page_size": dataset.query_support.max_page_size,
         }
@@ -187,10 +187,10 @@ def _catalog_dataset_body(dataset: DatasetRef, requires_service_key: bool) -> di
         "name": dataset.dataset_key,
         "title": dataset.name,
         "description": dataset.description,
-        "tags": sorted(dataset.tags),
+        "tags": cast(JsonValue, sorted(dataset.tags)),
         "source_url": dataset.source_url,
         "representation": dataset.representation.value,
-        "operations": sorted(op.value for op in dataset.operations),
+        "operations": cast(JsonValue, sorted(op.value for op in dataset.operations)),
         "query_support": query_support,
         "requires_service_key": requires_service_key,
     }

--- a/tests/unit/test_openapi_examples.py
+++ b/tests/unit/test_openapi_examples.py
@@ -175,7 +175,7 @@ def test_extraction_script_emits_documented_json_shape() -> None:
         text=True,
     )
     payload = json.loads(completed.stdout)
-    assert payload["contract_version"] == "1.14.0"
+    assert payload["contract_version"] == "1.15.0"
     assert len(payload["examples"]) >= 50
     assert set(payload["examples"][0]) == {
         "path",

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -1895,17 +1895,43 @@ class TestStableOwnerIdOwnership:
 
 
 class _FakeCatalogRef:
-    """DatasetRef 흉내 — catalog() 가 접근하는 속성만 노출."""
+    """DatasetRef 흉내 — catalog() 가 접근하는 속성만 노출.
+
+    기본값은 실제 DatasetRef의 기본값과 같다(metadata 없는 dataset — #490
+    null/empty 직렬화 규칙 검증에 그대로 쓴다).
+    """
 
     def __init__(
-        self, provider: str, dataset_key: str, name: str, *, service_key: bool = False
+        self,
+        provider: str,
+        dataset_key: str,
+        name: str,
+        *,
+        service_key: bool = False,
+        description: str | None = None,
+        tags: tuple[str, ...] = (),
+        source_url: str | None = None,
+        representation: object = None,
+        operations: frozenset[object] = frozenset(),
+        query_support: object = None,
+        raw_metadata_extra: dict[str, object] | None = None,
     ) -> None:
+        from kpubdata.core.models import Representation
+
         self.provider = provider
         self.dataset_key = dataset_key
         self.name = name
+        self.description = description
+        self.tags = tags
+        self.source_url = source_url
+        self.representation = representation or Representation.API_JSON
+        self.operations = operations
+        self.query_support = query_support
         self.raw_metadata: dict[str, object] = (
             {"service_key_param": "serviceKey"} if service_key else {}
         )
+        if raw_metadata_extra:
+            self.raw_metadata.update(raw_metadata_extra)
 
 
 class TestCatalog:
@@ -1965,6 +1991,103 @@ class TestCatalog:
         resp = self._service_with_catalog(tmp_path, []).catalog()
         assert resp.status_code == 200
         assert resp.body["providers"] == []
+
+    def test_catalog_serializes_discovery_metadata(self, tmp_path: Path) -> None:
+        """DatasetRef의 탐색용 metadata가 allowlist로 직렬화된다 (#490)."""
+        from kpubdata.core.capability import PaginationMode, QuerySupport
+        from kpubdata.core.models import Operation, Representation
+
+        ref = _FakeCatalogRef(
+            "datago",
+            "air_quality",
+            "대기오염",
+            description="측정소별 대기오염 물질 농도",
+            tags=("environment", "air"),
+            source_url="https://www.data.go.kr/data/15073861/openapi",
+            representation=Representation.API_JSON,
+            operations=frozenset({Operation.GET, Operation.LIST}),
+            query_support=QuerySupport(
+                pagination=PaginationMode.OFFSET,
+                filterable_fields=frozenset({"station_name"}),
+                sortable_fields=frozenset(),
+                time_range=True,
+                max_page_size=1000,
+            ),
+        )
+        resp = self._service_with_catalog(tmp_path, [ref]).catalog()
+
+        assert resp.status_code == 200
+        providers = cast(list[dict[str, object]], resp.body["providers"])
+        dataset = cast(dict[str, object], providers[0]["datasets"][0])
+        assert dataset["description"] == "측정소별 대기오염 물질 농도"
+        assert dataset["tags"] == ["air", "environment"]
+        assert dataset["source_url"] == "https://www.data.go.kr/data/15073861/openapi"
+        assert dataset["representation"] == "api_json"
+        assert dataset["operations"] == ["get", "list"]
+        query_support = cast(dict[str, object], dataset["query_support"])
+        assert query_support["pagination"] == "offset"
+        assert query_support["filterable_fields"] == ["station_name"]
+        assert query_support["sortable_fields"] == []
+        assert query_support["time_range"] is True
+        assert query_support["max_page_size"] == 1000
+
+    def test_catalog_metadata_less_dataset_serializes_null_and_empty(self, tmp_path: Path) -> None:
+        """metadata 없는 dataset은 null/empty로 직렬화되고 응답이 깨지지 않는다 (#490)."""
+        resp = self._service_with_catalog(
+            tmp_path, [_FakeCatalogRef("datago", "air_quality", "대기오염")]
+        ).catalog()
+
+        assert resp.status_code == 200
+        providers = cast(list[dict[str, object]], resp.body["providers"])
+        dataset = cast(dict[str, object], providers[0]["datasets"][0])
+        assert dataset["description"] is None
+        assert dataset["tags"] == []
+        assert dataset["source_url"] is None
+        assert dataset["representation"] == "api_json"
+        assert dataset["operations"] == []
+        assert dataset["query_support"] is None
+        assert dataset["requires_service_key"] is False
+
+    def test_catalog_never_exposes_raw_metadata_or_secrets(self, tmp_path: Path) -> None:
+        """raw_metadata와 secret-like 값은 응답에 절대 노출되지 않는다 (#490)."""
+        ref = _FakeCatalogRef(
+            "datago",
+            "air_quality",
+            "대기오염",
+            service_key=True,
+            raw_metadata_extra={
+                "internal_note": "provider private",
+                "api_key": "sk-secret-value",
+                "service_key": "raw-secret",
+                "endpoint_template": "/openapi/{serviceKey}",
+            },
+        )
+        resp = self._service_with_catalog(tmp_path, [ref]).catalog()
+
+        assert resp.status_code == 200
+        serialized = json.dumps(resp.body, ensure_ascii=False)
+        assert "internal_note" not in serialized
+        assert "provider private" not in serialized
+        assert "sk-secret-value" not in serialized
+        assert "raw-secret" not in serialized
+        assert "endpoint_template" not in serialized
+        # allowlist 필드만 존재한다.
+        providers = cast(list[dict[str, object]], resp.body["providers"])
+        dataset = cast(dict[str, object], providers[0]["datasets"][0])
+        assert set(dataset) == {
+            "name",
+            "title",
+            "description",
+            "tags",
+            "source_url",
+            "representation",
+            "operations",
+            "query_support",
+            "requires_service_key",
+        }
+        # service_key_param 존재 여부는 requires_service_key 불리언으로만 전달된다.
+        assert dataset["requires_service_key"] is True
+        assert "service_key_param" not in serialized
 
     def test_catalog_closes_request_client(self, tmp_path: Path) -> None:
         client = _CloseTrackingClient(


### PR DESCRIPTION
Closes #490

- CatalogDataset에 description/tags/source_url/representation/operations/query_support를 allowlist 방식으로 추가(계약 1.15.0, additive)
- raw_metadata·secret-like 값 비노출 회귀 테스트, metadata 없는 dataset의 null/empty 직렬화 테스트
- 기존 name/title/requires_service_key 소비자 호환 유지, OpenAPI 예시·스키마 갱신