### PR TITLE
feat(publish): add idempotent build publish service (#491)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,11 @@
 
 FROM python:3.12-slim
 
+# 베이스 이미지에 포함된 Debian 패키지의 보안 패치를 적용한다.
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
+
 # uv 바이너리를 Astral 공식 이미지에서 복사한다 (pip 설치 불필요).
 # 0.11.8 = 이 저장소의 uv.lock을 생성한 uv 버전.
 COPY --from=ghcr.io/astral-sh/uv:0.11.8 /uv /uvx /bin/

--- a/contract/builder-api.yaml
+++ b/contract/builder-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: KPubData Builder Service API
-  version: "1.16.0"
+  version: "1.17.0"
   description: >-
     Builder 중심 서비스 계약. BuildSpec 검증, preview, build 실행, artifact 조회,
     계약 버전 조회를 제공한다. CLI와 HTTP service mode(#36)가 동일한 도메인 계약을
@@ -1426,6 +1426,198 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+
+  /builds/{run_id}/publish/readiness:
+    get:
+      operationId: getPublishReadiness
+      summary: >-
+        run이 target에 게시 가능한지 side-effect-free로 확인한다 (#491). Publisher를
+        호출하거나 원격 dataset을 만들지 않는다. `ready`는 항상 `blockers`가
+        비어 있는지로 deterministic하게 계산되며, `warnings`는 게시 자체를
+        막지 않는다. `POST .../publish`가 같은 판정을 서버에서 다시 수행하므로,
+        이 응답을 신뢰해 blocker 재검증을 건너뛰면 안 된다(TOCTOU).
+      parameters:
+        - $ref: "#/components/parameters/RunId"
+        - name: target
+          in: query
+          required: true
+          description: 게시 대상 (기존 publisher registry의 HTTP-safe 부분집합)
+          schema:
+            type: string
+            enum: [huggingface]
+      responses:
+        "200":
+          description: readiness 판정
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PublishReadinessResponse"
+              examples:
+                Ready:
+                  summary: Gold + license + credential이 모두 준비된 run
+                  value:
+                    run_id: air-quality-20260815
+                    target: huggingface
+                    ready: true
+                    blockers: []
+                    warnings: []
+                Blocked:
+                  summary: license 미선언 + credential 미설정
+                  value:
+                    run_id: air-quality-20260815
+                    target: huggingface
+                    ready: false
+                    blockers:
+                      - code: license_missing
+                        message: >-
+                          BuildSpec.license must be declared before this dataset
+                          can be published (#443)
+                      - code: credential_unavailable
+                        message: no server-side credential is configured for target 'huggingface'
+                    warnings: []
+        "400":
+          description: 경로 안전하지 않은 run_id, target 누락, 또는 지원하지 않는 target
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                UnsupportedTarget:
+                  summary: local은 HTTP publish target에서 제외된다(#491)
+                  value:
+                    error: "target 'local' is not available over the publish HTTP API"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: 해당 run의 소유자가 아님
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: 해당 run을 찾을 수 없음
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /builds/{run_id}/publish:
+    post:
+      operationId: publishBuild
+      summary: >-
+        readiness와 완전히 같은 검사를 서버에서 다시 수행한 뒤 기존 Publisher를
+        호출한다 (#491). blocker가 하나라도 있으면 Publisher는 호출되지 않는다
+        (호출 횟수 0). 새 Publisher를 만들지 않으며, `publishers.PUBLISHER_REGISTRY`
+        (huggingface)의 기존 구현을 그대로 재사용한다. `destination`은
+        filesystem path로 해석되지 않고 target별 canonical identifier(`owner/name`)
+        형태만 허용된다.
+      parameters:
+        - $ref: "#/components/parameters/RunId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PublishRequest"
+            examples:
+              HuggingFace:
+                value:
+                  target: huggingface
+                  destination: kpubdata/air-quality
+                  options:
+                    private: true
+      responses:
+        "200":
+          description: 게시 성공
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PublishResponse"
+              examples:
+                Published:
+                  value:
+                    run_id: air-quality-20260815
+                    target: huggingface
+                    publisher: huggingface
+                    destination: kpubdata/air-quality
+                    reference: https://huggingface.co/datasets/kpubdata/air-quality
+                    artifact_count: 3
+                    status: ok
+        "400":
+          description: >-
+            경로 안전하지 않은 run_id, 잘못된 요청 본문, 지원하지 않는 target,
+            잘못된 destination 형태, 또는 target이 지원하지 않는 option
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                InvalidDestination:
+                  summary: destination이 filesystem path처럼 보임(path traversal)
+                  value:
+                    error: "'destination' must not contain path traversal segments"
+                UnknownOption:
+                  summary: huggingface가 지원하지 않는 option
+                  value:
+                    error: "unsupported option for target 'huggingface': 'visibility'"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: 해당 run의 소유자가 아님
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: 해당 run을 찾을 수 없음
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: >-
+            readiness blocker가 있거나, 동일 operation이 진행/결과 불명 상태이거나,
+            같은 run/target/destination이 다른 options로 이미 게시됨
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/PublishBlockedResponse"
+                  - $ref: "#/components/schemas/Error"
+              examples:
+                Blocked:
+                  value:
+                    error: "run is not ready to publish to 'huggingface'"
+                    blockers:
+                      - code: gold_unavailable
+                        message: no successful Gold output is available for this run
+                InProgress:
+                  value:
+                    error: publish operation is already in progress
+                    code: publish_in_progress
+                UnknownState:
+                  value:
+                    error: publish operation outcome is unknown; automatic retry is blocked
+                    code: publish_state_unknown
+                Conflict:
+                  value:
+                    error: this run and destination were already published with different options
+                    code: publish_conflict
+        "502":
+          description: >-
+            기존 Publisher 호출이 실패함(원격 인증/네트워크/provider 오류).
+            Publisher가 던진 예외의 원문 메시지(secret/절대 filesystem path를
+            담을 수 있음)는 절대 그대로 반환하지 않는다(#491) — 항상 이
+            stable generic 메시지와 code만 나간다.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                RemoteFailure:
+                  value:
+                    error: "publish failed due to an unexpected error"
+                    code: publish_failed
 
   /builds/{run_id}/stages:
     get:
@@ -3447,6 +3639,130 @@ components:
         not_run(상위 단계가 끝나지 못해 시도되지 않음) / unavailable(디렉터리는
         있지만 불완전·손상됨, legacy 형식 등)
       enum: [completed, failed, not_run, unavailable]
+
+    PublishTarget:
+      type: string
+      description: >-
+        HTTP publish API가 노출하는 target(#491). Local은 안전한 publish-root
+        계약이 없고, Kaggle은 정상 pipeline packaging의 metadata.id가 publish
+        destination과 정합하지 않아 이번 HTTP 계약에서 제외한다.
+      enum: [huggingface]
+
+    PublishIssue:
+      type: object
+      description: 안정적인 code + 사람이 읽는 message. UI가 문자열 파싱을 하지 않아도 된다.
+      required: [code, message]
+      additionalProperties: false
+      properties:
+        code:
+          type: string
+          description: >-
+            run_not_terminal / run_failed / run_cancelled / gold_unavailable /
+            artifact_missing / artifact_invalid / license_missing /
+            pii_allow_with_publish / credential_unavailable 중 하나(#491).
+            artifact_invalid는 canonical
+            manifest.outputs 항목이 gold root를 벗어나거나(symlink escape
+            포함) resolve할 수 없을 때 fail-closed로 반환된다.
+        message:
+          type: string
+
+    PublishReadinessResponse:
+      type: object
+      description: >-
+        side-effect-free readiness 판정. `ready`는 항상 `blockers`가 비어
+        있는지로 계산된다. `warnings`는 게시 자체를 막지 않는다.
+      required: [run_id, target, ready, blockers, warnings]
+      additionalProperties: false
+      properties:
+        run_id:
+          type: string
+        target:
+          $ref: "#/components/schemas/PublishTarget"
+        ready:
+          type: boolean
+        blockers:
+          type: array
+          items:
+            $ref: "#/components/schemas/PublishIssue"
+        warnings:
+          type: array
+          items:
+            $ref: "#/components/schemas/PublishIssue"
+
+    PublishRequest:
+      type: object
+      description: >-
+        게시 요청. destination은 filesystem path로 해석되지 않고 target별
+        canonical identifier("owner/name")만 허용된다. options는 target이
+        실제로 지원하는 키만 허용하며(#491), 미지원 키는 조용히 무시되지 않고
+        400으로 거부된다.
+      required: [target, destination]
+      additionalProperties: false
+      properties:
+        target:
+          $ref: "#/components/schemas/PublishTarget"
+        destination:
+          type: string
+          description: "target별 owner/name 형태의 게시 대상 식별자."
+        options:
+          $ref: "#/components/schemas/PublishHuggingFaceOptions"
+
+    PublishHuggingFaceOptions:
+      type: object
+      description: >-
+        신규 Hugging Face dataset repo 생성 시 visibility. 기존 repo의
+        visibility는 변경하지 않는다. 생략 시 안전한 기본값 private=true다.
+      additionalProperties: false
+      properties:
+        private:
+          type: boolean
+          default: true
+
+    PublishResponse:
+      type: object
+      description: >-
+        기존 Publisher(PublishResult, publishers/base.py)의 결과를 그대로
+        노출한다. 서버 절대 경로는 담지 않는다 — reference는 안전한 외부
+        참조(URL 등)만 담는다.
+      required:
+        - run_id
+        - target
+        - publisher
+        - destination
+        - reference
+        - artifact_count
+        - status
+      additionalProperties: false
+      properties:
+        run_id:
+          type: string
+        target:
+          $ref: "#/components/schemas/PublishTarget"
+        publisher:
+          type: string
+        destination:
+          type: string
+        reference:
+          type: string
+          description: 게시 위치에 대한 안전한 외부 참조(URL 등). 서버 내부 경로가 아니다.
+        artifact_count:
+          type: integer
+          minimum: 0
+        status:
+          type: string
+
+    PublishBlockedResponse:
+      type: object
+      description: readiness 재검증에서 blocker가 발견되어 Publisher를 호출하지 않았음.
+      required: [error, blockers]
+      additionalProperties: false
+      properties:
+        error:
+          type: string
+        blockers:
+          type: array
+          items:
+            $ref: "#/components/schemas/PublishIssue"
 
     DatasetStageMap:
       type: object

--- a/src/kpubdata_builder/publishers/huggingface.py
+++ b/src/kpubdata_builder/publishers/huggingface.py
@@ -30,12 +30,20 @@ class HuggingFacePublisher(BasePublisher):
     def name(self) -> str:
         return "huggingface"
 
-    def publish(self, artifact_paths: tuple[Path, ...], *, destination: str) -> PublishResult:
+    def publish(
+        self,
+        artifact_paths: tuple[Path, ...],
+        *,
+        destination: str,
+        private: bool = True,
+    ) -> PublishResult:
         """artifact를 HuggingFace 데이터셋 레포지토리에 게시한다.
 
         매개변수:
             artifact_paths: 업로드할 파일 또는 디렉토리 목록.
             destination: HF 레포지토리 ID (예: "kpubdata/air-quality").
+            private: 신규 repo 생성 시 visibility. ``exist_ok=True``이므로 기존
+                repo의 visibility는 변경하지 않는다.
         """
         try:
             from huggingface_hub import HfApi  # type: ignore[import-not-found]
@@ -53,6 +61,15 @@ class HuggingFacePublisher(BasePublisher):
             )
 
         api = HfApi(token=token)
+        # 먼저 신규 dataset repo가 존재하도록 보장한다. exist_ok=True인 기존
+        # repo에는 visibility mutation을 수행하지 않으며 update_repo_settings도
+        # 호출하지 않는다(#491).
+        api.create_repo(
+            repo_id=destination,
+            repo_type="dataset",
+            private=private,
+            exist_ok=True,
+        )
         count = 0
 
         # 파일 artifact의 공통 상위 디렉터리를 기준으로 repo 내 경로를 정한다.

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -21,6 +21,7 @@ import os
 import threading
 import time
 from collections.abc import Callable, Iterable, Mapping
+from contextlib import suppress
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Protocol, cast, runtime_checkable
@@ -39,6 +40,7 @@ from ..errors import SpecLoadError, ValidationError
 from ..events import BuildEvent, BuildEventStore
 from ..ingestion import IngestionError, parse_tabular_bytes
 from ..pipeline import DEFAULT_PREVIEW_SEED, SampleMode, preview_build, run_build
+from ..publishers import PUBLISHER_REGISTRY
 from ..quality import QualityCheckResult
 from ..query.engine import QueryExecutionError, QueryTimeoutError
 from ..query.models import QueryRequest, QueryStage
@@ -67,6 +69,7 @@ from . import datasets as datasets_service
 from . import events as events_service
 from . import monitoring as monitoring_service
 from . import ownership as ownership_module
+from . import publish as publish_service
 from . import quality as quality_service
 from . import stages as stages_service
 from .auth import AuthError, Principal, authenticate
@@ -280,7 +283,7 @@ def _strip_internal_fields(entries: list[_BuildListEntry]) -> list[_BuildListEnt
 # idempotent/409/429)와 GET /builds/{run_id}(잡 상태 polling) 추가(#480). 잡 상태
 # 조회에 ownership 게이트를 적용해 cross-owner의 build 출력(response) 노출을
 # 차단한다(behavioral tightening — 이전에는 미검사).
-API_CONTRACT_VERSION = "1.16.0"
+API_CONTRACT_VERSION = "1.17.0"
 
 
 def _quality_result_to_json(r: QualityCheckResult) -> dict[str, JsonValue]:
@@ -317,6 +320,35 @@ def _parse_spec_text(spec_yaml: str) -> BuildSpec:
     if not isinstance(raw, dict):
         raise SpecLoadError("top-level YAML must be a mapping")
     return parse_spec(cast(dict[str, object], raw))
+
+
+def _publish_receipt_response(
+    claim_status: publish_service.PublishClaimStatus,
+    receipt: publish_service.PublishReceipt,
+) -> ServiceResponse | None:
+    """기존 receipt 상태를 replay/409 wire response로 변환한다."""
+    if claim_status == "claimed":
+        return None
+    if claim_status == "replay" and receipt.result is not None:
+        return ServiceResponse(200, cast(dict[str, JsonValue], receipt.result))
+    if claim_status == "replay":
+        claim_status = "state_unknown"
+    conflict_codes = {
+        "in_progress": (
+            "publish_in_progress",
+            "publish operation is already in progress",
+        ),
+        "state_unknown": (
+            "publish_state_unknown",
+            "publish operation outcome is unknown; automatic retry is blocked",
+        ),
+        "conflict": (
+            "publish_conflict",
+            "this run and destination were already published with different options",
+        ),
+    }
+    code, message = conflict_codes[claim_status]
+    return ServiceResponse(409, {"error": message, "code": code})
 
 
 class BuilderService:
@@ -356,6 +388,9 @@ class BuilderService:
         # Monitoring API용 bounded latency recorder (#516). dispatch()가 매 요청
         # 처리 시간을 기록한다 — 인스턴스별로 분리해 테스트 간 상태가 섞이지 않는다.
         self._latency_recorder = monitoring_service.LatencyRecorder()
+        # 외부 publish side effect의 durable idempotency receipt. 객체 생성은
+        # 파일을 만들지 않으며 최초 POST claim 때 SQLite를 지연 초기화한다.
+        self._publish_receipts = publish_service.PublishReceiptStore(output_root)
         self._query_service = query_service or QueryService()
         repository = credential_repository or _credential_repository_from_env(output_root)
         self._credential_resolver = CredentialResolver(repository)
@@ -1676,6 +1711,245 @@ class BuilderService:
             body["sample_available"] = False
 
         return ServiceResponse(200, body)
+
+    def _publish_context(
+        self, run_id: str
+    ) -> tuple[publish_service.RunStatus, dict[str, JsonValue] | None, BuildSpec | None]:
+        """publish readiness/POST가 공유하는 (status, manifest, spec) 조회.
+
+        route adapter가 이미 존재/ownership을 판정했다는 전제 아래(``/stages``,
+        ``/quality``와 동일한 패턴) 호출된다. manifest가 있으면 그것이 정본
+        (terminal run)이고, 없으면 async job registry(#482)에서 active/terminal
+        상태를 읽는다 — ``routes._guards.check_active_run_access``와 동일한
+        두 소스를 쓴다(#496 follow-up 패턴 재사용).
+        """
+        manifest = cast(
+            "dict[str, JsonValue] | None", datasets_service.read_manifest(self._output_root, run_id)
+        )
+        if manifest is not None:
+            status: publish_service.RunStatus = "failed" if manifest.get("errors") else "succeeded"
+            spec = datasets_service.read_snapshot_spec(self._output_root, run_id)
+            return status, manifest, spec
+        snapshot = self._async_builds.get(run_id)
+        if snapshot is not None:
+            return snapshot.status, None, None
+        # route adapter의 check_active_run_access가 이미 존재를 보장했으므로
+        # 이론상 도달하지 않는다 — fail-closed로 failed 취급한다.
+        return "failed", None, None
+
+    def publish_readiness(self, run_id: str, target: str) -> ServiceResponse:
+        """GET /builds/{run_id}/publish/readiness (#491).
+
+        side-effect-free다 — Publisher를 호출하거나 원격 dataset을 만들지
+        않는다. ready == blockers가 하나도 없음으로 deterministic하게 계산한다.
+        """
+        resolved_target, error = publish_service.resolve_target(target)
+        if resolved_target is None:
+            return ServiceResponse(
+                400,
+                {"error": error or "invalid target", "code": "unsupported_target"},
+            )
+
+        status, manifest, spec = self._publish_context(run_id)
+        result = publish_service.build_readiness(
+            run_id=run_id,
+            target=resolved_target,
+            status=status,
+            manifest=cast("dict[str, object] | None", manifest),
+            spec=spec,
+            output_root=self._output_root,
+        )
+        return ServiceResponse(
+            200,
+            {
+                "run_id": run_id,
+                "target": result.target,
+                "ready": result.ready,
+                "blockers": cast(JsonValue, [b.to_body() for b in result.blockers]),
+                "warnings": cast(JsonValue, [w.to_body() for w in result.warnings]),
+            },
+        )
+
+    def publish(
+        self,
+        run_id: str,
+        body: Mapping[str, JsonValue] | None,
+        *,
+        principal: Principal,
+    ) -> ServiceResponse:
+        """POST /builds/{run_id}/publish (#491).
+
+        readiness와 완전히 같은 deterministic 검사를 다시 수행한다 — 호출자가
+        먼저 GET readiness를 불렀다고 신뢰하지 않는다(TOCTOU: readiness 통과
+        이후 상태가 바뀌어도 여기서 다시 막힌다). blocker가 하나라도 있으면
+        기존 Publisher를 절대 호출하지 않는다.
+        """
+        if not isinstance(body, Mapping):
+            return ServiceResponse(400, {"error": "request body must be a JSON object"})
+
+        unknown_fields = sorted(
+            str(key) for key in body if key not in {"target", "destination", "options"}
+        )
+        if unknown_fields:
+            return ServiceResponse(
+                400, {"error": f"unsupported request field(s): {unknown_fields!r}"}
+            )
+
+        resolved_target, error = publish_service.resolve_target(body.get("target"))
+        if resolved_target is None:
+            return ServiceResponse(
+                400,
+                {"error": error or "invalid target", "code": "unsupported_target"},
+            )
+
+        destination_error = publish_service.validate_destination(
+            resolved_target, body.get("destination")
+        )
+        if destination_error is not None:
+            return ServiceResponse(400, {"error": destination_error})
+        destination = cast(str, body["destination"])
+
+        options_error, options = publish_service.validate_options(
+            resolved_target, body.get("options")
+        )
+        if options_error is not None:
+            return ServiceResponse(400, {"error": options_error})
+
+        owner_key = principal.owner_id or principal.label
+        try:
+            existing = self._publish_receipts.lookup(
+                owner_key=owner_key,
+                run_id=run_id,
+                target=resolved_target,
+                destination=destination,
+                options=options,
+            )
+        except Exception as exc:
+            logger.error(
+                "publish receipt lookup failed: run_id=%s target=%s error_type=%s",
+                run_id,
+                resolved_target,
+                type(exc).__name__,
+            )
+            return ServiceResponse(
+                409,
+                {
+                    "error": "publish operation state is unavailable; retry is blocked",
+                    "code": "publish_state_unknown",
+                },
+            )
+        if existing is not None:
+            existing_response = _publish_receipt_response(*existing)
+            if existing_response is not None:
+                return existing_response
+
+        status, manifest, spec = self._publish_context(run_id)
+        readiness = publish_service.build_readiness(
+            run_id=run_id,
+            target=resolved_target,
+            status=status,
+            manifest=cast("dict[str, object] | None", manifest),
+            spec=spec,
+            output_root=self._output_root,
+        )
+        if not readiness.ready or readiness.artifacts is None:
+            return ServiceResponse(
+                409,
+                {
+                    "error": f"run is not ready to publish to {resolved_target!r}",
+                    "blockers": cast(JsonValue, [b.to_body() for b in readiness.blockers]),
+                },
+            )
+
+        try:
+            claim_status, receipt = self._publish_receipts.claim(
+                owner_key=owner_key,
+                run_id=run_id,
+                target=resolved_target,
+                destination=destination,
+                options=options,
+            )
+        except Exception as exc:
+            logger.error(
+                "publish receipt claim failed: run_id=%s target=%s error_type=%s",
+                run_id,
+                resolved_target,
+                type(exc).__name__,
+            )
+            return ServiceResponse(
+                409,
+                {
+                    "error": "publish operation state is unavailable; retry is blocked",
+                    "code": "publish_state_unknown",
+                },
+            )
+
+        claimed_response = _publish_receipt_response(claim_status, receipt)
+        if claimed_response is not None:
+            return claimed_response
+
+        publisher = PUBLISHER_REGISTRY[resolved_target]
+        publish_kwargs: dict[str, object] = {"destination": destination, **options}
+        try:
+            result = publisher.publish(readiness.artifacts.paths, **publish_kwargs)  # type: ignore[arg-type]
+        except Exception as exc:
+            # Publisher가 던지는 예외(PublishError, credential/dependency
+            # RuntimeError, 그 외 검토하지 않은 예외 포함)는 어떤 것도 "안전한
+            # known exception"으로 취급하지 않는다 — 외부 SDK 예외 메시지에는
+            # 원격 응답 원문이나(#491 지침 1) 로컬 filesystem 절대 경로가 섞일
+            # 수 있다. client에는 항상 stable generic 메시지만 보낸다.
+            #
+            # 서버 log도 str(exc)/repr(exc)나 traceback(로그에 다시 raw
+            # message를 남기는 logger.exception())을 쓰지 않는다 — exception
+            # type과 이미 안전하다고 확인된 context만 남긴다.
+            logger.error(
+                "publish failed: run_id=%s target=%s error_type=%s",
+                run_id,
+                resolved_target,
+                type(exc).__name__,
+            )
+            try:
+                self._publish_receipts.mark_unknown(receipt.fingerprint)
+            except Exception as receipt_exc:
+                logger.error(
+                    "publish receipt unknown-state persist failed: "
+                    "run_id=%s target=%s error_type=%s",
+                    run_id,
+                    resolved_target,
+                    type(receipt_exc).__name__,
+                )
+            return ServiceResponse(
+                502,
+                {"error": "publish failed due to an unexpected error", "code": "publish_failed"},
+            )
+
+        response_body: dict[str, JsonValue] = {
+            "run_id": run_id,
+            "target": resolved_target,
+            "publisher": result.publisher,
+            "destination": destination,
+            "reference": result.reference,
+            "artifact_count": result.artifact_count,
+            "status": result.status,
+        }
+        try:
+            self._publish_receipts.mark_succeeded(
+                receipt.fingerprint, cast(dict[str, object], response_body)
+            )
+        except Exception as exc:
+            logger.error(
+                "publish receipt success persist failed: run_id=%s target=%s error_type=%s",
+                run_id,
+                resolved_target,
+                type(exc).__name__,
+            )
+            with suppress(Exception):
+                self._publish_receipts.mark_unknown(receipt.fingerprint)
+            return ServiceResponse(
+                502,
+                {"error": "publish failed due to an unexpected error", "code": "publish_failed"},
+            )
+        return ServiceResponse(200, response_body)
 
     def get_build_events(self, run_id: str, *, limit: int, tail: bool) -> ServiceResponse:
         """run의 append-only structured event timeline을 조회한다 (#496).

--- a/src/kpubdata_builder/service/publish.py
+++ b/src/kpubdata_builder/service/publish.py
@@ -1,0 +1,633 @@
+"""Build publish readiness/실행 서비스 로직 (#491).
+
+Studio가 완료된 Gold build를 바로 게시하지 않고, readiness(ready/blockers/
+warnings)를 먼저 확인한 뒤 실제 publish를 요청할 수 있게 하는 순수 로직을
+담는다. 새 Publisher는 만들지 않는다 — HTTP에서는
+``publishers.PUBLISHER_REGISTRY``의 기존 Hugging Face publisher만 재사용한다.
+Kaggle/Local registry와 CLI 동작은 유지하되 HTTP target에서는 제외한다(#28/#491).
+
+핵심 원칙:
+    - readiness(GET)는 side-effect-free다: Publisher를 호출하거나 원격
+      dataset을 만들지 않는다.
+    - POST도 readiness와 완전히 같은 deterministic 검사를 서버에서 다시
+      수행한다 — 호출자가 GET을 먼저 불렀다고 신뢰하지 않는다(TOCTOU 방지).
+    - Publisher에 넘기는 artifact 목록은 항상 ``manifest.outputs``(정본,
+      pipeline이 실제로 쓴 파일만 기록)와 ``gold_source_dir``(정본 stage
+      경로 helper, #488)의 교집합에서만 만든다 — 임의 디렉터리를 glob하지
+      않는다.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import sqlite3
+import threading
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Literal, cast
+
+from ..errors import ValidationError
+from ..publishers import PUBLISHER_REGISTRY
+from ..spec import BuildSpec
+from ..spec.validator import validate_spec
+from ..stages._path_safety import ensure_within
+from ..stages._stage_reader import gold_source_dir
+from . import stages as stages_service
+
+# HTTP로 안전하게 노출 가능한 publish target. PUBLISHER_REGISTRY에는 "local"도
+# 있지만, LocalPublisher는 caller-provided destination을 그대로 로컬
+# 파일시스템 Path로 써서 복사한다(publishers/local.py) — 이 저장소에는 그
+# destination을 안전하게 한정할 configured publish-root/allowlist 계약이
+# 아직 없다(검색 확인: publish_root/local publish 관련 서버 설정이 없음).
+# 그런 계약이 생기기 전까지 "local"을 HTTP publish target에서 제외한다.
+# Kaggle도 정상 pipeline packaging의 metadata.id가 destination-aware해질 때까지
+# 제외한다. PUBLISHER_REGISTRY에 있다는 사실만으로 HTTP에 안전하고 실제로
+# publish 가능하다고 가정하지 않는다(#491).
+HTTP_PUBLISH_TARGETS: tuple[str, ...] = ("huggingface",)
+
+RunStatus = Literal["queued", "running", "cancelling", "succeeded", "failed", "cancelled"]
+
+_DESTINATION_PATTERN = re.compile(
+    r"^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?/[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$"
+)
+
+# target별로 실제 Publisher.publish()가 받는 kwarg만 허용한다. Hugging Face는
+# 신규 repo visibility를 위한 private만 노출하고 그 밖의 option은 거부한다.
+_ALLOWED_OPTIONS: dict[str, dict[str, type]] = {
+    "huggingface": {"private": bool},
+}
+
+_DEFAULT_OPTIONS: dict[str, dict[str, object]] = {
+    "huggingface": {"private": True},
+}
+
+PublishReceiptState = Literal["pending", "succeeded", "unknown"]
+PublishClaimStatus = Literal["claimed", "replay", "in_progress", "state_unknown", "conflict"]
+
+
+@dataclass(frozen=True)
+class PublishReceipt:
+    """credential/path를 포함하지 않는 durable publish operation 영수증."""
+
+    fingerprint: str
+    state: PublishReceiptState
+    target: str
+    destination: str
+    options: dict[str, object]
+    result: dict[str, object] | None
+
+
+class PublishReceiptStore:
+    """SQLite UNIQUE claim으로 duplicate remote side effect를 막는 receipt 저장소.
+
+    DB는 ``output_root/_publish_receipts.sqlite``에 있으며 run workspace 밖의 내부
+    service state다. artifact API는 run 디렉터리만 열거하므로 public artifact나
+    ``manifest.outputs``에 포함되지 않는다.
+    """
+
+    _FILENAME = "_publish_receipts.sqlite"
+
+    def __init__(self, output_root: Path) -> None:
+        self.path = output_root / self._FILENAME
+        self._init_lock = threading.Lock()
+        self._initialized = False
+
+    def _connect(self) -> sqlite3.Connection:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        connection = sqlite3.connect(self.path, timeout=30.0)
+        connection.execute("PRAGMA journal_mode=WAL")
+        connection.execute("PRAGMA foreign_keys=ON")
+        return connection
+
+    def _initialize(self) -> None:
+        if self._initialized:
+            return
+        with self._init_lock:
+            if self._initialized:
+                return
+            with self._connect() as connection:
+                connection.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS publish_receipts (
+                        owner_key TEXT NOT NULL,
+                        run_id TEXT NOT NULL,
+                        target TEXT NOT NULL,
+                        destination TEXT NOT NULL,
+                        fingerprint TEXT NOT NULL UNIQUE,
+                        options_json TEXT NOT NULL,
+                        state TEXT NOT NULL
+                            CHECK (state IN ('pending', 'succeeded', 'unknown')),
+                        result_json TEXT,
+                        PRIMARY KEY (owner_key, run_id, target, destination)
+                    )
+                    """
+                )
+            self._initialized = True
+
+    @staticmethod
+    def fingerprint(
+        *,
+        owner_key: str,
+        run_id: str,
+        target: str,
+        destination: str,
+        options: dict[str, object],
+    ) -> str:
+        canonical = json.dumps(
+            {
+                "owner": owner_key,
+                "run_id": run_id,
+                "target": target,
+                "destination": destination,
+                "options": options,
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return f"sha256:{hashlib.sha256(canonical).hexdigest()}"
+
+    @staticmethod
+    def _row_to_receipt(row: tuple[object, ...]) -> PublishReceipt:
+        options = json.loads(cast(str, row[4]))
+        result = json.loads(cast(str, row[6])) if row[6] is not None else None
+        if not isinstance(options, dict) or (result is not None and not isinstance(result, dict)):
+            raise ValueError("invalid publish receipt JSON")
+        return PublishReceipt(
+            fingerprint=cast(str, row[0]),
+            state=cast(PublishReceiptState, row[5]),
+            target=cast(str, row[2]),
+            destination=cast(str, row[3]),
+            options=cast(dict[str, object], options),
+            result=cast(dict[str, object] | None, result),
+        )
+
+    def claim(
+        self,
+        *,
+        owner_key: str,
+        run_id: str,
+        target: str,
+        destination: str,
+        options: dict[str, object],
+    ) -> tuple[PublishClaimStatus, PublishReceipt]:
+        """operation을 durable pending으로 선점하거나 기존 상태를 반환한다."""
+        self._initialize()
+        fingerprint = self.fingerprint(
+            owner_key=owner_key,
+            run_id=run_id,
+            target=target,
+            destination=destination,
+            options=options,
+        )
+        options_json = json.dumps(
+            options, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        )
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                """
+                SELECT fingerprint, owner_key, target, destination, options_json, state,
+                       result_json
+                FROM publish_receipts
+                WHERE owner_key = ? AND run_id = ? AND target = ? AND destination = ?
+                """,
+                (owner_key, run_id, target, destination),
+            ).fetchone()
+            if row is None:
+                connection.execute(
+                    """
+                    INSERT INTO publish_receipts(
+                        owner_key, run_id, target, destination, fingerprint,
+                        options_json, state, result_json
+                    ) VALUES (?, ?, ?, ?, ?, ?, 'pending', NULL)
+                    """,
+                    (owner_key, run_id, target, destination, fingerprint, options_json),
+                )
+                connection.commit()
+                return (
+                    "claimed",
+                    PublishReceipt(
+                        fingerprint=fingerprint,
+                        state="pending",
+                        target=target,
+                        destination=destination,
+                        options=dict(options),
+                        result=None,
+                    ),
+                )
+
+            receipt = self._row_to_receipt(cast(tuple[object, ...], row))
+            connection.commit()
+            if receipt.fingerprint != fingerprint:
+                return "conflict", receipt
+            if receipt.state == "succeeded":
+                return "replay", receipt
+            if receipt.state == "unknown":
+                return "state_unknown", receipt
+            return "in_progress", receipt
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+    def lookup(
+        self,
+        *,
+        owner_key: str,
+        run_id: str,
+        target: str,
+        destination: str,
+        options: dict[str, object],
+    ) -> tuple[PublishClaimStatus, PublishReceipt] | None:
+        """side effect 없이 기존 operation receipt와 replay 결정을 조회한다."""
+        self._initialize()
+        fingerprint = self.fingerprint(
+            owner_key=owner_key,
+            run_id=run_id,
+            target=target,
+            destination=destination,
+            options=options,
+        )
+        with self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT fingerprint, owner_key, target, destination, options_json, state,
+                       result_json
+                FROM publish_receipts
+                WHERE owner_key = ? AND run_id = ? AND target = ? AND destination = ?
+                """,
+                (owner_key, run_id, target, destination),
+            ).fetchone()
+        if row is None:
+            return None
+        receipt = self._row_to_receipt(cast(tuple[object, ...], row))
+        if receipt.fingerprint != fingerprint:
+            return "conflict", receipt
+        if receipt.state == "succeeded":
+            return "replay", receipt
+        if receipt.state == "unknown":
+            return "state_unknown", receipt
+        return "in_progress", receipt
+
+    def mark_succeeded(self, fingerprint: str, result: dict[str, object]) -> None:
+        self._set_terminal(fingerprint, state="succeeded", result=result)
+
+    def mark_unknown(self, fingerprint: str) -> None:
+        self._set_terminal(fingerprint, state="unknown", result=None)
+
+    def _set_terminal(
+        self,
+        fingerprint: str,
+        *,
+        state: Literal["succeeded", "unknown"],
+        result: dict[str, object] | None,
+    ) -> None:
+        self._initialize()
+        result_json = (
+            json.dumps(result, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+            if result is not None
+            else None
+        )
+        with self._connect() as connection:
+            cursor = connection.execute(
+                """
+                UPDATE publish_receipts
+                SET state = ?, result_json = ?
+                WHERE fingerprint = ? AND state = 'pending'
+                """,
+                (state, result_json, fingerprint),
+            )
+            if cursor.rowcount != 1:
+                raise RuntimeError("publish receipt is not pending")
+
+
+@dataclass(frozen=True)
+class PublishIssue:
+    """구조화된 blocker/warning. UI가 문자열 파싱을 하지 않도록 code+message로 나눈다."""
+
+    code: str
+    message: str
+
+    def to_body(self) -> dict[str, str]:
+        return {"code": self.code, "message": self.message}
+
+
+@dataclass(frozen=True)
+class ResolvedArtifacts:
+    """target에 실제로 전달할 canonical Gold artifact 경로.
+
+    ``paths``는 항상 manifest.outputs(정본)에 실제로 기록된, 그리고 이 run의
+    gold_source_dir 아래에 있는 파일만 담는다 — BuildSpec snapshot, credential,
+    임시 파일, silver/bronze 파일은 절대 섞이지 않는다.
+    """
+
+    paths: tuple[Path, ...]
+    expects_directory: bool
+
+
+@dataclass(frozen=True)
+class ReadinessResult:
+    target: str
+    ready: bool
+    blockers: tuple[PublishIssue, ...]
+    warnings: tuple[PublishIssue, ...]
+    artifacts: ResolvedArtifacts | None = None
+
+
+def resolve_target(value: object) -> tuple[str | None, str | None]:
+    """(target, error_message) — target이 None이면 error_message가 채워진다."""
+    if not isinstance(value, str) or not value:
+        return None, "'target' must be a non-empty string"
+    if value in HTTP_PUBLISH_TARGETS:
+        return value, None
+    if value in PUBLISHER_REGISTRY:
+        return None, f"target {value!r} is not available over the publish HTTP API"
+    return None, f"unknown publish target: {value!r}"
+
+
+def run_status_blocker(status: RunStatus) -> PublishIssue | None:
+    """Run 상태 자체가 publish를 막는지 판정한다. 기존 상태 어휘만 쓴다."""
+    if status in ("queued", "running", "cancelling"):
+        return PublishIssue("run_not_terminal", f"run is not finished yet (status={status})")
+    if status == "failed":
+        return PublishIssue("run_failed", "run finished with errors and cannot be published")
+    if status == "cancelled":
+        return PublishIssue("run_cancelled", "run was cancelled and cannot be published")
+    return None
+
+
+def license_blocker(spec: BuildSpec | None) -> PublishIssue | None:
+    """#443 license/redistribution gate를 재사용한다 — 새 license 정책을 만들지 않는다.
+
+    BuildSpec.license가 선언되어 있지 않으면(빈 문자열 포함) publish를 막는다.
+    unknown license를 자동 허용하지 않는다 — 선언 자체가 유일한 재배포
+    가능성 근거다(#443 원칙 그대로).
+
+    ``spec.license``가 whitespace만으로 이루어진 문자열(spec loader는 이를
+    타입 검사만 하고 통과시킨다, spec/loader.py)이면 사람이 실제로 아무것도
+    선언하지 않은 것과 같으므로 "선언됨"으로 인정하지 않는다(#491 지침 4) —
+    새 SPDX allowlist/registry는 추가하지 않는다, blank 판정만 보강한다.
+    """
+    if spec is None or not spec.license or not spec.license.strip():
+        return PublishIssue(
+            "license_missing",
+            "BuildSpec.license must be declared before this dataset can be published (#443)",
+        )
+    return None
+
+
+def effective_publish_policy_blockers(spec: BuildSpec | None) -> tuple[PublishIssue, ...]:
+    """저장된 spec을 실제 외부 publish와 같은 ``publish=True``로 재검증한다.
+
+    PII/license 규칙을 service에 복제하지 않고 canonical ``validate_spec``의
+    structured problems를 사용한다. whitespace-only license는 validator의 기존
+    truthiness 검사보다 엄격한 #491 gate인 ``license_blocker``가 보완한다.
+    """
+    if spec is None:
+        return ()
+    try:
+        validate_spec(replace(spec, publish=True))
+    except ValidationError as exc:
+        structured = exc.structured_problems or ()
+        return tuple(
+            PublishIssue(problem.code, problem.message)
+            for problem in structured
+            if problem.code != "missing_license_for_publish"
+        )
+    return ()
+
+
+def _huggingface_credential_configured() -> bool:
+    return bool(os.environ.get("HF_TOKEN"))
+
+
+def credential_blocker(target: str) -> PublishIssue | None:
+    """target publish credential이 서버에 설정돼 있는지만 boolean으로 확인한다.
+
+    원문 credential은 절대 읽거나 반환하지 않는다. 설정 여부를 확인할 수 없으면
+    (지원 불가능한 credential shape 포함) ready=true로 추정하지 않고 명시적으로
+    unavailable로 처리한다(#491 지침 7).
+    """
+    configured = _huggingface_credential_configured()
+    if configured:
+        return None
+    return PublishIssue(
+        "credential_unavailable",
+        f"no server-side credential is configured for target {target!r}",
+    )
+
+
+def resolve_gold_artifacts(
+    output_root: Path, run_id: str, manifest: dict[str, object]
+) -> ResolvedArtifacts | PublishIssue:
+    """이 run의 canonical Gold artifact 파일을 해석한다.
+
+    ``manifest.outputs``에 실제로 기록된 파일 중, 알려진(실패하지 않은)
+    source의 ``gold_source_dir`` 아래에 있는 파일만 후보로 삼는다(#488 stage
+    helper 재사용) — output_root를 recursive glob하지 않는다.
+
+    manifest.outputs에는 gold 산출물뿐 아니라 이 run의 bronze/silver 원본,
+    dataset card, BuildSpec snapshot 등 다른 stage의 정당한 산출물도 함께
+    기록된다(pipeline/orchestrator.py `_record_output_paths` 호출부 참고) —
+    이런 항목은 gold_source_dir 밖에 있는 것이 "정상"이므로 조용히 후보에서
+    제외한다(publish 대상은 gold 파일만). 반면 canonical manifest.outputs
+    항목이 이 run 자신의 workspace(``{output_root}/{run_id}``) 밖을
+    가리키면(gold root escape, symlink escape, invalid/resolve 불가 경로
+    포함) — 그건 정당한 다른 stage 산출물일 수 없으므로 fail-closed다(#491
+    지침 2). 유효한 gold artifact가 함께 있어도 그 무효 항목만 조용히
+    건너뛰고 나머지만 publish하지 않는다 — canonical publish artifact set
+    전체가 유효해야 한다.
+    """
+    known = stages_service.known_source_keys(manifest)
+    failed = stages_service.failed_source_keys(manifest)
+    candidate_sources = [key for key in known if key not in failed]
+
+    outputs_raw = manifest.get("outputs")
+    output_paths = (
+        [Path(p) for p in outputs_raw if isinstance(p, str)]
+        if isinstance(outputs_raw, list)
+        else []
+    )
+
+    run_dir = output_root / run_id
+
+    gold_dirs: list[Path] = []
+    for source_key in candidate_sources:
+        try:
+            gold_dir = gold_source_dir(output_root, run_id, source_key)
+        except ValueError:
+            continue
+        if gold_dir.is_dir():
+            gold_dirs.append(gold_dir)
+
+    if not gold_dirs:
+        return PublishIssue(
+            "gold_unavailable", "no successful Gold output is available for this run"
+        )
+
+    # 모든 output path를 이 run에 실제로 존재하는 gold_dir 전체에 대해
+    # 먼저 분류한다(source별로 nested 검사하지 않는다) — 그래야 source A의
+    # gold_dir과 비교할 때 source B 소유 경로가 "무효"로 오판되지 않는다.
+    gold_files: list[Path] = []
+    for path in output_paths:
+        matched = False
+        for gold_dir in gold_dirs:
+            try:
+                ensure_within(gold_dir, path, label="gold artifact")
+            except ValueError:
+                continue
+            matched = True
+            break
+        if matched:
+            if not path.is_file():
+                return PublishIssue(
+                    "artifact_missing",
+                    f"expected Gold artifact is missing on disk: {path.name}",
+                )
+            gold_files.append(path)
+            continue
+
+        try:
+            ensure_within(run_dir, path, label="run output")
+        except ValueError:
+            # 이 run 자신의 workspace 밖을 가리키는 canonical output이다
+            # (경로 정책 위반, symlink escape, resolve 불가 포함) — 정당한
+            # 다른 stage 산출물일 수 없으므로 조용히 건너뛰지 않고 즉시
+            # fail-closed 처리한다.
+            return PublishIssue(
+                "artifact_invalid",
+                "a canonical manifest output failed the path-safety check and cannot be published",
+            )
+        # run_dir 안에는 있지만 어느 gold_dir에도 속하지 않는다 — bronze/
+        # silver 산출물, dataset card, BuildSpec snapshot 등 정당한 비-gold
+        # 산출물이다. publish 대상이 아니므로(gold만) 조용히 제외한다.
+
+    if not gold_files:
+        return PublishIssue(
+            "gold_unavailable", "no successful Gold output is available for this run"
+        )
+
+    unique_sorted_files = sorted(set(gold_files))
+
+    return ResolvedArtifacts(paths=tuple(unique_sorted_files), expects_directory=False)
+
+
+def validate_destination(target: str, destination: object) -> str | None:
+    """target이 요구하는 canonical 'owner/name' identifier 형태만 허용한다.
+
+    filesystem path로 절대 해석하지 않는다 — URL, scheme, 절대/상대 경로,
+    상위 이동(``..``), 제어 문자, 앞뒤 공백을 모두 거부한다(#491 지침 6).
+    """
+    if not isinstance(destination, str):
+        return "'destination' must be a string"
+    if not destination:
+        return "'destination' must not be empty"
+    if destination != destination.strip():
+        return "'destination' must not have leading/trailing whitespace"
+    if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in destination):
+        return "'destination' must not contain control characters"
+    if "://" in destination:
+        return "'destination' must not be a URL"
+    if destination.startswith(("/", "\\")):
+        return "'destination' must not be an absolute path"
+    if ".." in destination.replace("\\", "/").split("/"):
+        return "'destination' must not contain path traversal segments"
+    if not _DESTINATION_PATTERN.match(destination):
+        return f"'destination' must look like 'owner/name' for target {target!r}"
+    return None
+
+
+def validate_options(target: str, options: object) -> tuple[str | None, dict[str, object]]:
+    """(error_message, normalized_options). 미지원 option은 조용히 무시하지 않는다."""
+    if options is None:
+        return None, dict(_DEFAULT_OPTIONS.get(target, {}))
+    if not isinstance(options, dict):
+        return "'options' must be an object", {}
+    allowed = _ALLOWED_OPTIONS.get(target, {})
+    for key, value in options.items():
+        if not isinstance(key, str) or key not in allowed:
+            return f"unsupported option for target {target!r}: {key!r}", {}
+        expected_type = allowed[key]
+        if expected_type is bool and not isinstance(value, bool):
+            return f"option {key!r} must be a boolean", {}
+    normalized = dict(_DEFAULT_OPTIONS.get(target, {}))
+    normalized.update(options)
+    return None, normalized
+
+
+def build_readiness(
+    *,
+    run_id: str,
+    target: str,
+    status: RunStatus,
+    manifest: dict[str, object] | None,
+    spec: BuildSpec | None,
+    output_root: Path,
+) -> ReadinessResult:
+    """readiness/POST가 공유하는 단일 deterministic 판정.
+
+    ``ready``는 항상 ``not blockers``다 — 별도 계산 경로가 없다. GET과 POST
+    모두 이 함수 하나만 호출해 같은 결론에 도달한다(TOCTOU 재검증, #491 지침 3/4).
+    """
+    blockers: list[PublishIssue] = []
+
+    status_issue = run_status_blocker(status)
+    if status_issue is not None:
+        blockers.append(status_issue)
+
+    artifacts: ResolvedArtifacts | None = None
+    if manifest is None:
+        if status_issue is None:
+            # 비정상 상태: terminal(succeeded)인데 manifest가 없음 — fail-closed.
+            blockers.append(PublishIssue("gold_unavailable", "run manifest is unavailable"))
+    else:
+        resolved = resolve_gold_artifacts(output_root, run_id, manifest)
+        if isinstance(resolved, PublishIssue):
+            blockers.append(resolved)
+        else:
+            artifacts = resolved
+
+        blockers.extend(effective_publish_policy_blockers(spec))
+
+        license_issue = license_blocker(spec)
+        if license_issue is not None:
+            blockers.append(license_issue)
+
+    credential_issue = credential_blocker(target)
+    if credential_issue is not None:
+        blockers.append(credential_issue)
+
+    return ReadinessResult(
+        target=target,
+        ready=not blockers,
+        blockers=tuple(blockers),
+        warnings=(),
+        artifacts=artifacts,
+    )
+
+
+__all__ = [
+    "HTTP_PUBLISH_TARGETS",
+    "PublishClaimStatus",
+    "PublishIssue",
+    "PublishReceipt",
+    "PublishReceiptStore",
+    "ReadinessResult",
+    "ResolvedArtifacts",
+    "RunStatus",
+    "build_readiness",
+    "credential_blocker",
+    "effective_publish_policy_blockers",
+    "license_blocker",
+    "resolve_gold_artifacts",
+    "resolve_target",
+    "run_status_blocker",
+    "validate_destination",
+    "validate_options",
+]

--- a/src/kpubdata_builder/service/routes/__init__.py
+++ b/src/kpubdata_builder/service/routes/__init__.py
@@ -10,14 +10,15 @@ from . import (
     events,
     monitoring,
     providers,
+    publish,
     quality,
     query,
     stages,
 )
 from ._types import RouteAdapter
 
-# 순서는 기존 app.dispatch 조건문의 우선순위를 고정한다. events(#496)는
-# builds 바로 다음에 둔다 — 둘 다 "/builds/{run_id}/..." 경로를 다루므로 논리적
+# 순서는 기존 app.dispatch 조건문의 우선순위를 고정한다. events(#496)/publish(#491)는
+# builds 바로 다음에 둔다 — 모두 "/builds/{run_id}/..." 경로를 다루므로 논리적
 # 이웃이다(실제 매칭은 각 adapter의 path suffix 검사로 서로 겹치지 않는다).
 ROUTE_ADAPTERS: tuple[RouteAdapter, ...] = (
     core.route,
@@ -26,6 +27,7 @@ ROUTE_ADAPTERS: tuple[RouteAdapter, ...] = (
     datasets.route,
     builds.route,
     events.route,
+    publish.route,
     quality.route,
     stages.route,
     artifacts.route,

--- a/src/kpubdata_builder/service/routes/publish.py
+++ b/src/kpubdata_builder/service/routes/publish.py
@@ -1,0 +1,71 @@
+"""Build publish readiness/실행 route adapter (#491)."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
+from urllib.parse import parse_qs
+
+from ...spec import JsonValue
+from ...stages._path_safety import validate_path_segment
+from ..auth import Principal
+from ..responses import ServiceResponse
+from ._guards import check_active_run_access
+from ._types import RouteResponse
+
+if TYPE_CHECKING:
+    from ..app import BuilderService
+
+_READINESS_SUFFIX = "/publish/readiness"
+_PUBLISH_SUFFIX = "/publish"
+
+
+def route(
+    service: BuilderService,
+    method: str,
+    path: str,
+    body: Mapping[str, JsonValue] | None,
+    query: str,
+    principal: Principal,
+) -> RouteResponse | None:
+    if not path.startswith("/builds/"):
+        return None
+    rest = path[len("/builds/") :]
+
+    if method == "GET" and rest.endswith(_READINESS_SUFFIX):
+        run_id = rest[: -len(_READINESS_SUFFIX)]
+        error = _validate_run_id(run_id)
+        if error is not None:
+            return error
+        query_params = parse_qs(query)
+        target_values = query_params.get("target")
+        if not target_values or not target_values[-1]:
+            return ServiceResponse(400, {"error": "'target' query parameter is required"})
+        target = target_values[-1]
+        # #496 follow-up과 동일하게 manifest 유무와 무관하게(queued/running도)
+        # 존재/소유권을 판정한다 — publish readiness는 running/queued run도
+        # 404가 아니라 "아직 안 끝남" blocker로 보고해야 한다(#491).
+        access_error = check_active_run_access(service, run_id, principal)
+        if access_error is not None:
+            return access_error
+        return service.publish_readiness(run_id, target)
+
+    if method == "POST" and rest.endswith(_PUBLISH_SUFFIX):
+        run_id = rest[: -len(_PUBLISH_SUFFIX)]
+        error = _validate_run_id(run_id)
+        if error is not None:
+            return error
+        access_error = check_active_run_access(service, run_id, principal)
+        if access_error is not None:
+            return access_error
+        return service.publish(run_id, body, principal=principal)
+
+    return None
+
+
+def _validate_run_id(run_id: str) -> ServiceResponse | None:
+    try:
+        validate_path_segment(run_id, field_name="run_id")
+    except ValueError as exc:
+        return ServiceResponse(400, {"error": str(exc)})
+    return None

--- a/tests/unit/test_openapi_examples.py
+++ b/tests/unit/test_openapi_examples.py
@@ -175,7 +175,7 @@ def test_extraction_script_emits_documented_json_shape() -> None:
         text=True,
     )
     payload = json.loads(completed.stdout)
-    assert payload["contract_version"] == "1.16.0"
+    assert payload["contract_version"] == "1.17.0"
     assert len(payload["examples"]) >= 50
     assert set(payload["examples"][0]) == {
         "path",

--- a/tests/unit/test_publishers.py
+++ b/tests/unit/test_publishers.py
@@ -97,13 +97,30 @@ class TestLocalPublisherFailurePolicy:
             LocalPublisher().publish((artifact,), destination=str(tmp_path / "registry"))
 
 
-def _install_fake_hf(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[dict[str, str]]]:
+def _install_fake_hf(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[dict[str, object]]]:
     """huggingface_hub.HfApi를 가짜로 주입하고 업로드 호출을 기록한다."""
-    calls: dict[str, list[dict[str, str]]] = {"files": [], "folders": []}
+    calls: dict[str, list[dict[str, object]]] = {"repos": [], "files": [], "folders": []}
 
     class FakeHfApi:
         def __init__(self, token: str | None = None) -> None:
             self._token = token
+
+        def create_repo(
+            self,
+            *,
+            repo_id: str,
+            repo_type: str,
+            private: bool,
+            exist_ok: bool,
+        ) -> None:
+            calls["repos"].append(
+                {
+                    "repo_id": repo_id,
+                    "repo_type": repo_type,
+                    "private": private,
+                    "exist_ok": exist_ok,
+                }
+            )
 
         def upload_file(
             self,
@@ -154,6 +171,39 @@ class TestHuggingFacePublisher:
         repo_paths = {c["path_in_repo"] for c in calls["files"]}
         assert repo_paths == {"README.md", "data/train.parquet"}
         assert result.artifact_count == 2
+
+    @pytest.mark.parametrize("private", [True, False])
+    def test_create_repo_uses_requested_new_repo_visibility(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        private: bool,
+    ) -> None:
+        calls = _install_fake_hf(monkeypatch)
+        artifact = tmp_path / "data.parquet"
+        artifact.write_text("x", encoding="utf-8")
+
+        HuggingFacePublisher().publish((artifact,), destination="org/ds", private=private)
+
+        assert calls["repos"] == [
+            {
+                "repo_id": "org/ds",
+                "repo_type": "dataset",
+                "private": private,
+                "exist_ok": True,
+            }
+        ]
+
+    def test_create_repo_defaults_to_private(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls = _install_fake_hf(monkeypatch)
+        artifact = tmp_path / "data.parquet"
+        artifact.write_text("x", encoding="utf-8")
+
+        HuggingFacePublisher().publish((artifact,), destination="org/ds")
+
+        assert calls["repos"][0]["private"] is True
 
     def test_same_basename_different_dirs_do_not_collide(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/test_service_contract.py
+++ b/tests/unit/test_service_contract.py
@@ -63,6 +63,8 @@ _DISPATCH_ROUTES: dict[tuple[str, str], str] = {
     ("/builds/{run_id}/stages/{stage}", "GET"): "getBuildStageDetail",
     ("/builds/{run_id}/quality", "GET"): "getBuildQuality",
     ("/builds/{run_id}/events", "GET"): "getBuildEvents",
+    ("/builds/{run_id}/publish/readiness", "GET"): "getPublishReadiness",
+    ("/builds/{run_id}/publish", "POST"): "publishBuild",
     ("/monitoring/summary", "GET"): "getMonitoringSummary",
     ("/monitoring/builds", "GET"): "getMonitoringBuilds",
     ("/uploads", "POST"): "createUpload",
@@ -100,6 +102,8 @@ _REQUIRED_OPERATIONS = [
     ("/builds/{run_id}/stages/{stage}", "get"),
     ("/builds/{run_id}/quality", "get"),
     ("/builds/{run_id}/events", "get"),
+    ("/builds/{run_id}/publish/readiness", "get"),
+    ("/builds/{run_id}/publish", "post"),
     ("/monitoring/summary", "get"),
     ("/monitoring/builds", "get"),
     ("/uploads", "post"),
@@ -393,6 +397,8 @@ _IMPLEMENTED_OPERATIONS = {
     "getBuildStageDetail",
     "getBuildQuality",
     "getBuildEvents",
+    "getPublishReadiness",
+    "publishBuild",
     "getMonitoringSummary",
     "getMonitoringBuilds",
     "createUpload",
@@ -618,6 +624,8 @@ _OPERATION_STATUS_CODES: dict[str, set[int]] = {
     "getBuildStageDetail": {200, 400, 403, 404},
     "getBuildQuality": {200, 400, 403, 404},
     "getBuildEvents": {200, 400, 403, 404},
+    "getPublishReadiness": {200, 400, 403, 404},
+    "publishBuild": {200, 400, 403, 404, 409, 502},
     "getMonitoringSummary": {200},
     "getMonitoringBuilds": {200, 400},
     "createUpload": {200, 400, 403, 413},
@@ -673,6 +681,36 @@ def test_declared_status_codes_match_implementation() -> None:
             f"  실제 구현: {sorted(all_implemented_codes)}\n"
             f"  차이: {sorted(declared_codes ^ all_implemented_codes)}"
         )
+
+
+def test_publish_request_contract_matches_huggingface_runtime() -> None:
+    """#491 HTTP target/options와 실제 fail-closed runtime 계약을 고정한다."""
+    contract = _load_contract()
+    schemas = contract["components"]["schemas"]
+    assert schemas["PublishTarget"]["enum"] == ["huggingface"]
+    assert schemas["PublishRequest"]["additionalProperties"] is False
+    hf_options = schemas["PublishHuggingFaceOptions"]
+    assert hf_options["additionalProperties"] is False
+    assert hf_options["properties"]["private"] == {
+        "type": "boolean",
+        "default": True,
+    }
+
+    operation = contract["paths"]["/builds/{run_id}/publish"]["post"]
+    example = operation["requestBody"]["content"]["application/json"]["examples"]["HuggingFace"][
+        "value"
+    ]
+    schema = operation["requestBody"]["content"]["application/json"]["schema"]
+    assert validate(example, schema, contract) == []
+    assert validate(
+        {
+            "target": "huggingface",
+            "destination": "owner/dataset",
+            "options": {"visibility": "private"},
+        },
+        schema,
+        contract,
+    )
 
 
 def _extract_response_schema_required_fields(

--- a/tests/unit/test_service_publish.py
+++ b/tests/unit/test_service_publish.py
@@ -1,0 +1,1083 @@
+"""Build publish readiness/실행 HTTP API 검증 (#491).
+
+새 Publisher를 만들지 않고 기존 publishers.PUBLISHER_REGISTRY(huggingface/
+kaggle)를 재사용하는 service 계약을 검증한다. 실제 HuggingFace/Kaggle
+네트워크 호출은 절대 하지 않는다 — 모든 publisher는 in-memory spy로 대체한다.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import sys
+import threading
+import types
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+import kpubdata_builder.service.app as app_module
+from kpubdata_builder.errors import PublishError
+from kpubdata_builder.publishers.base import BasePublisher, PublishResult
+from kpubdata_builder.publishers.huggingface import HuggingFacePublisher
+from kpubdata_builder.service import BuilderService, ServiceResponse, dispatch
+from kpubdata_builder.service.auth import Principal
+from kpubdata_builder.service.ownership import _OWNERSHIP_ENV
+from kpubdata_builder.spec import JsonValue
+
+from ._openapi import response_schema, validate
+from .test_service import _FakeClient
+from .test_service_contract import _load_contract
+
+LICENSED_SPEC_YAML = (
+    """
+dataset_id: dataset.publish
+title: Publish Fixture
+description: publish readiness fixture
+sources:
+  - provider: datago
+    dataset: air_quality
+exports:
+  - kind: jsonl
+    output_path: out/data.jsonl
+license: CC-BY-4.0
+""".strip()
+    + "\n"
+)
+
+UNLICENSED_SPEC_YAML = LICENSED_SPEC_YAML.replace("license: CC-BY-4.0\n", "")
+
+# spec loader는 license가 문자열이기만 하면 통과시킨다(spec/loader.py) — 사람이
+# 아무것도 선언하지 않은 것과 같은 whitespace-only 값이 여기로 들어올 수 있다
+# (#491 지침 4). 새 SPDX allowlist를 만들지 않고 blank 판정만 확인한다.
+BLANK_LICENSE_SPEC_YAML = LICENSED_SPEC_YAML.replace("license: CC-BY-4.0\n", 'license: "   "\n')
+
+PII_ALLOW_SPEC_YAML = LICENSED_SPEC_YAML.replace(
+    "license: CC-BY-4.0\n", "pii:\n  mode: allow\nlicense: CC-BY-4.0\n"
+)
+
+FAILING_SPEC_YAML = LICENSED_SPEC_YAML.replace("dataset: air_quality\n", "dataset: missing\n")
+
+
+class _SpyPublisher(BasePublisher):
+    """실제 네트워크를 호출하지 않는 fake publisher. 호출 인자를 기록한다."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        expects_directory: bool = False,
+        error: Exception | None = None,
+    ) -> None:
+        self._name = name
+        self._expects_directory = expects_directory
+        self._error = error
+        self.calls: list[tuple[tuple[Path, ...], dict[str, object]]] = []
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def expects_directory(self) -> bool:
+        return self._expects_directory
+
+    def publish(
+        self, artifact_paths: tuple[Path, ...], *, destination: str, **kwargs: object
+    ) -> PublishResult:
+        self.calls.append((artifact_paths, {"destination": destination, **kwargs}))
+        if self._error is not None:
+            raise self._error
+        return PublishResult(
+            publisher=self._name,
+            reference=f"https://example.test/{self._name}/{destination}",
+            artifact_count=len(artifact_paths),
+        )
+
+
+class _DeferredPublisher(_SpyPublisher):
+    """첫 remote call을 Event로 멈춰 pending receipt 동시성을 결정적으로 검증한다."""
+
+    def __init__(self) -> None:
+        super().__init__("huggingface")
+        self.entered = threading.Event()
+        self.release = threading.Event()
+
+    def publish(
+        self, artifact_paths: tuple[Path, ...], *, destination: str, **kwargs: object
+    ) -> PublishResult:
+        self.calls.append((artifact_paths, {"destination": destination, **kwargs}))
+        self.entered.set()
+        if not self.release.wait(timeout=5):
+            raise RuntimeError("test release event was not set")
+        return PublishResult(
+            publisher=self.name,
+            reference=f"https://example.test/huggingface/{destination}",
+            artifact_count=len(artifact_paths),
+        )
+
+
+def _service(tmp_path: Path) -> BuilderService:
+    client = _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}, {"id": "2", "v": 20}]})
+    return BuilderService(output_root=tmp_path, client_factory=lambda: client)
+
+
+def _build(service: BuilderService, run_id: str, spec_yaml: str) -> ServiceResponse:
+    return dispatch(service, "POST", "/build", {"spec": spec_yaml, "run_id": run_id})
+
+
+def _readiness(
+    service: BuilderService, run_id: str, target: str = "huggingface"
+) -> ServiceResponse:
+    return dispatch(
+        service, "GET", f"/builds/{run_id}/publish/readiness", None, query=f"target={target}"
+    )
+
+
+def _publish(
+    service: BuilderService,
+    run_id: str,
+    *,
+    target: str = "huggingface",
+    destination: str = "kpubdata/air-quality",
+    options: dict[str, object] | None = None,
+) -> ServiceResponse:
+    body: dict[str, JsonValue] = {"target": target, "destination": destination}
+    if options is not None:
+        body["options"] = cast(JsonValue, options)
+    return dispatch(service, "POST", f"/builds/{run_id}/publish", body)
+
+
+def _blocker_codes(resp: ServiceResponse) -> list[str]:
+    blockers = cast(list[dict[str, object]], resp.body["blockers"])
+    return [cast(str, b["code"]) for b in blockers]
+
+
+@pytest.fixture(autouse=True)
+def _no_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    """credential_unavailable을 기본으로 재현 가능하게, 명시적으로 unset한다."""
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.delenv("KAGGLE_USERNAME", raising=False)
+    monkeypatch.delenv("KAGGLE_KEY", raising=False)
+    monkeypatch.delenv("KAGGLE_CONFIG_DIR", raising=False)
+
+
+def _with_credentials(monkeypatch: pytest.MonkeyPatch, target: str) -> None:
+    assert target == "huggingface"
+    monkeypatch.setenv("HF_TOKEN", "hf_super_secret_token_value")
+
+
+class TestReadiness:
+    def test_ready_when_succeeded_gold_license_and_credential(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        service = _service(tmp_path)
+        built = _build(service, "run-ready", LICENSED_SPEC_YAML)
+        assert built.status_code == 200
+
+        resp = _readiness(service, "run-ready", "huggingface")
+        assert resp.status_code == 200
+        assert resp.body["ready"] is True
+        assert resp.body["blockers"] == []
+        assert resp.body["target"] == "huggingface"
+        assert resp.body["run_id"] == "run-ready"
+
+    def test_running_job_is_blocker_not_404(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        service = _service(tmp_path)
+        snapshot = service._async_builds.registry.create(run_id="run-running", created_by="dev")
+        service._async_builds.registry.mark_running(snapshot.run_id)
+
+        resp = _readiness(service, "run-running")
+        assert resp.status_code == 200
+        assert resp.body["ready"] is False
+        assert _blocker_codes(resp) == ["run_not_terminal"]
+
+    def test_queued_job_is_blocker(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        service = _service(tmp_path)
+        service._async_builds.registry.create(run_id="run-queued", created_by="dev")
+
+        resp = _readiness(service, "run-queued")
+        assert resp.status_code == 200
+        assert resp.body["ready"] is False
+        assert _blocker_codes(resp) == ["run_not_terminal"]
+
+    def test_failed_run_is_blocker(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        built = _build(service, "run-failed", FAILING_SPEC_YAML)
+        assert built.status_code == 502
+
+        resp = _readiness(service, "run-failed")
+        assert resp.status_code == 200
+        assert resp.body["ready"] is False
+        assert "run_failed" in _blocker_codes(resp)
+
+    def test_gold_deleted_after_success_is_blocker(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        _build(service, "run-gold-gone", LICENSED_SPEC_YAML)
+        import shutil
+
+        shutil.rmtree(tmp_path / "run-gold-gone" / "gold")
+
+        resp = _readiness(service, "run-gold-gone")
+        assert resp.body["ready"] is False
+        assert "gold_unavailable" in _blocker_codes(resp)
+
+    def test_missing_artifact_file_is_blocker(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        _build(service, "run-artifact-gone", LICENSED_SPEC_YAML)
+        table_path = next((tmp_path / "run-artifact-gone" / "gold").rglob("table.parquet"))
+        table_path.unlink()
+
+        resp = _readiness(service, "run-artifact-gone")
+        assert resp.body["ready"] is False
+        assert "artifact_missing" in _blocker_codes(resp)
+
+    def test_missing_license_is_blocker(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        service = _service(tmp_path)
+        _build(service, "run-no-license", UNLICENSED_SPEC_YAML)
+
+        resp = _readiness(service, "run-no-license")
+        assert resp.body["ready"] is False
+        assert "license_missing" in _blocker_codes(resp)
+
+    def test_blank_license_is_not_recognized_as_declared(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#491 지침 4: spec loader는 license가 문자열이기만 하면 통과시키므로
+        whitespace-only 값이 BuildSpec.license에 들어올 수 있다 — #443 정책은
+        바꾸지 않되, 그런 값을 "선언됨"으로 인정하지 않는지만 확인한다."""
+        _with_credentials(monkeypatch, "huggingface")
+        service = _service(tmp_path)
+        _build(service, "run-blank-license", BLANK_LICENSE_SPEC_YAML)
+
+        resp = _readiness(service, "run-blank-license")
+        assert resp.body["ready"] is False
+        assert "license_missing" in _blocker_codes(resp)
+
+    def test_missing_credential_is_blocker(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        _build(service, "run-no-cred", LICENSED_SPEC_YAML)
+
+        resp = _readiness(service, "run-no-cred", "huggingface")
+        assert resp.body["ready"] is False
+        assert "credential_unavailable" in _blocker_codes(resp)
+
+    def test_kaggle_target_is_not_available_over_http(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        _build(service, "run-kaggle-http-disabled", LICENSED_SPEC_YAML)
+
+        resp = _readiness(service, "run-kaggle-http-disabled", "kaggle")
+        assert resp.status_code == 400
+        assert resp.body["code"] == "unsupported_target"
+
+    def test_effective_publish_policy_blocks_pii_allow(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        service = _service(tmp_path)
+        built = _build(service, "run-pii-allow", PII_ALLOW_SPEC_YAML)
+        assert built.status_code == 200
+
+        resp = _readiness(service, "run-pii-allow")
+        assert resp.body["ready"] is False
+        assert "pii_allow_with_publish" in _blocker_codes(resp)
+
+    def test_local_target_rejected_before_readiness_body(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        _build(service, "run-local", LICENSED_SPEC_YAML)
+
+        resp = _readiness(service, "run-local", "local")
+        assert resp.status_code == 400
+        assert "local" in cast(str, resp.body["error"])
+
+    def test_unknown_target_returns_400(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        _build(service, "run-unknown-target", LICENSED_SPEC_YAML)
+
+        resp = _readiness(service, "run-unknown-target", "s3")
+        assert resp.status_code == 400
+
+    def test_missing_target_query_param_returns_400(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        _build(service, "run-no-target", LICENSED_SPEC_YAML)
+
+        resp = dispatch(service, "GET", "/builds/run-no-target/publish/readiness", None)
+        assert resp.status_code == 400
+
+    def test_invalid_run_id_returns_400(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        resp = dispatch(
+            service,
+            "GET",
+            "/builds/../etc/publish/readiness",
+            None,
+            query="target=huggingface",
+        )
+        assert resp.status_code == 400
+
+    def test_run_not_found_returns_404(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        resp = _readiness(service, "does-not-exist")
+        assert resp.status_code == 404
+
+    def test_cross_owner_returns_403(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_OWNERSHIP_ENV, "true")
+        owner = Principal(kind="oidc", identifier="a", owner_id="oidc:owner-a")
+        monkeypatch.setattr(app_module, "authenticate", lambda **_kwargs: owner)
+        service = _service(tmp_path)
+        _build(service, "run-owned", LICENSED_SPEC_YAML)
+
+        other = Principal(kind="oidc", identifier="b", owner_id="oidc:owner-b")
+        monkeypatch.setattr(app_module, "authenticate", lambda **_kwargs: other)
+        resp = _readiness(service, "run-owned")
+        assert resp.status_code == 403
+
+    def test_readiness_never_calls_publisher(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        spy = _SpyPublisher("huggingface")
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", spy)
+        service = _service(tmp_path)
+        _build(service, "run-side-effect-free", LICENSED_SPEC_YAML)
+
+        resp = _readiness(service, "run-side-effect-free", "huggingface")
+        assert resp.body["ready"] is True
+        assert spy.calls == []
+
+
+class TestPublish:
+    def test_successful_publish_returns_structured_result(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        spy = _SpyPublisher("huggingface")
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", spy)
+        service = _service(tmp_path)
+        _build(service, "run-publish-ok", LICENSED_SPEC_YAML)
+
+        resp = _publish(service, "run-publish-ok", destination="kpubdata/air-quality")
+        assert resp.status_code == 200
+        assert resp.body["target"] == "huggingface"
+        assert resp.body["publisher"] == "huggingface"
+        assert resp.body["destination"] == "kpubdata/air-quality"
+        assert resp.body["artifact_count"] and resp.body["artifact_count"] > 0
+        assert resp.body["status"] == "ok"
+        assert len(spy.calls) == 1
+        artifact_paths, kwargs = spy.calls[0]
+        assert kwargs["destination"] == "kpubdata/air-quality"
+        assert kwargs["private"] is True
+        assert all(p.is_file() for p in artifact_paths)
+
+    def test_post_reverifies_independently_of_prior_get(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """GET을 아예 호출하지 않아도 POST 자체가 모든 검사를 한다."""
+        spy = _SpyPublisher("huggingface")
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", spy)
+        service = _service(tmp_path)
+        _build(service, "run-no-license-post", UNLICENSED_SPEC_YAML)
+        monkeypatch.setenv("HF_TOKEN", "token")
+
+        resp = _publish(service, "run-no-license-post")
+        assert resp.status_code == 409
+        assert "license_missing" in _blocker_codes(resp)
+        assert spy.calls == []
+
+    def test_blocked_publish_never_calls_publisher(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        spy = _SpyPublisher("huggingface")
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", spy)
+        service = _service(tmp_path)
+        _build(service, "run-blocked", LICENSED_SPEC_YAML)
+        # HF_TOKEN 미설정 → credential_unavailable blocker.
+
+        resp = _publish(service, "run-blocked")
+        assert resp.status_code == 409
+        assert spy.calls == []
+
+    def test_running_run_cannot_be_published(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        service = _service(tmp_path)
+        snapshot = service._async_builds.registry.create(
+            run_id="run-running-post", created_by="dev"
+        )
+        service._async_builds.registry.mark_running(snapshot.run_id)
+
+        resp = _publish(service, "run-running-post")
+        assert resp.status_code == 409
+        assert "run_not_terminal" in _blocker_codes(resp)
+
+    def test_failed_run_cannot_be_published(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        _build(service, "run-failed-post", FAILING_SPEC_YAML)
+
+        resp = _publish(service, "run-failed-post")
+        assert resp.status_code == 409
+        assert "run_failed" in _blocker_codes(resp)
+
+    def test_cross_owner_cannot_publish(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(_OWNERSHIP_ENV, "true")
+        owner = Principal(kind="oidc", identifier="a", owner_id="oidc:owner-a")
+        monkeypatch.setattr(app_module, "authenticate", lambda **_kwargs: owner)
+        service = _service(tmp_path)
+        _build(service, "run-owned-post", LICENSED_SPEC_YAML)
+
+        other = Principal(kind="oidc", identifier="b", owner_id="oidc:owner-b")
+        monkeypatch.setattr(app_module, "authenticate", lambda **_kwargs: other)
+        resp = _publish(service, "run-owned-post")
+        assert resp.status_code == 403
+
+    def test_invalid_target_returns_400(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        _build(service, "run-bad-target", LICENSED_SPEC_YAML)
+        resp = _publish(service, "run-bad-target", target="s3")
+        assert resp.status_code == 400
+
+    def test_local_target_returns_400(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        _build(service, "run-local-post", LICENSED_SPEC_YAML)
+        resp = _publish(service, "run-local-post", target="local", destination="/tmp/x")
+        assert resp.status_code == 400
+
+    @pytest.mark.parametrize(
+        "destination",
+        [
+            "",
+            "   ",
+            "https://huggingface.co/owner/name",
+            "/etc/passwd",
+            "../outside/name",
+            "owner/../name",
+            "C:\\Windows\\System32",
+            "owner",
+            "owner/name/extra",
+            "owner/name\x00",
+        ],
+    )
+    def test_unsafe_destination_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, destination: str
+    ) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        spy = _SpyPublisher("huggingface")
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", spy)
+        service = _service(tmp_path)
+        _build(service, "run-unsafe-dest", LICENSED_SPEC_YAML)
+
+        resp = _publish(service, "run-unsafe-dest", destination=destination)
+        assert resp.status_code == 400
+        assert spy.calls == []
+
+    def test_unknown_option_rejected(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        spy = _SpyPublisher("huggingface")
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", spy)
+        service = _service(tmp_path)
+        _build(service, "run-unknown-option", LICENSED_SPEC_YAML)
+
+        resp = _publish(service, "run-unknown-option", options={"visibility": "private"})
+        assert resp.status_code == 400
+        assert spy.calls == []
+
+    @pytest.mark.parametrize("private", [True, False])
+    def test_private_option_is_passed_to_huggingface(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        private: bool,
+    ) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        spy = _SpyPublisher("huggingface")
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", spy)
+        service = _service(tmp_path)
+        _build(service, f"run-private-{private}", LICENSED_SPEC_YAML)
+
+        resp = _publish(service, f"run-private-{private}", options={"private": private})
+        assert resp.status_code == 200
+        assert spy.calls[0][1]["private"] is private
+
+    def test_wrong_option_type_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        spy = _SpyPublisher("huggingface")
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", spy)
+        service = _service(tmp_path)
+        _build(service, "run-bad-option-type", LICENSED_SPEC_YAML)
+
+        resp = _publish(
+            service,
+            "run-bad-option-type",
+            options={"private": "yes"},
+        )
+        assert resp.status_code == 400
+        assert spy.calls == []
+
+    def test_options_not_object_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        service = _service(tmp_path)
+        _build(service, "run-bad-options-type", LICENSED_SPEC_YAML)
+
+        resp = dispatch(
+            service,
+            "POST",
+            "/builds/run-bad-options-type/publish",
+            {"target": "huggingface", "destination": "kpubdata/air-quality", "options": "nope"},
+        )
+        assert resp.status_code == 400
+
+    def test_unknown_top_level_request_field_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        service = _service(tmp_path)
+        _build(service, "run-unknown-field", LICENSED_SPEC_YAML)
+
+        resp = dispatch(
+            service,
+            "POST",
+            "/builds/run-unknown-field/publish",
+            {
+                "target": "huggingface",
+                "destination": "kpubdata/air-quality",
+                "unexpected": True,
+            },
+        )
+        assert resp.status_code == 400
+
+    def test_publish_error_maps_to_502(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        spy = _SpyPublisher("huggingface", error=PublishError("remote rejected the upload"))
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", spy)
+        service = _service(tmp_path)
+        _build(service, "run-publish-error", LICENSED_SPEC_YAML)
+
+        resp = _publish(service, "run-publish-error")
+        assert resp.status_code == 502
+        # #491 blocker 1: PublishError도 "안전한 known exception"으로 취급해
+        # str(exc)를 그대로 돌려주지 않는다 — stable generic 메시지만 나간다.
+        assert resp.body["error"] == "publish failed due to an unexpected error"
+        assert resp.body["code"] == "publish_failed"
+        assert "remote rejected the upload" not in json.dumps(resp.body)
+
+    def test_runtime_error_maps_to_502(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        spy = _SpyPublisher("huggingface", error=RuntimeError("HF_TOKEN is not set"))
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", spy)
+        service = _service(tmp_path)
+        _build(service, "run-publish-runtime-error", LICENSED_SPEC_YAML)
+
+        resp = _publish(service, "run-publish-runtime-error")
+        assert resp.status_code == 502
+        assert resp.body["error"] == "publish failed due to an unexpected error"
+        assert resp.body["code"] == "publish_failed"
+        assert "HF_TOKEN is not set" not in json.dumps(resp.body)
+
+    def test_huggingface_create_repo_failure_is_sanitized_and_not_retried(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        secret = "create_repo failed with token=hf_create_secret"
+        create_calls = 0
+
+        class FailingHfApi:
+            def __init__(self, token: str | None = None) -> None:
+                del token
+
+            def create_repo(self, **_kwargs: object) -> None:
+                nonlocal create_calls
+                create_calls += 1
+                raise RuntimeError(secret)
+
+        fake_module = types.ModuleType("huggingface_hub")
+        fake_module.HfApi = FailingHfApi  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "huggingface_hub", fake_module)
+        _with_credentials(monkeypatch, "huggingface")
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", HuggingFacePublisher())
+        service = _service(tmp_path)
+        _build(service, "run-create-repo-failure", LICENSED_SPEC_YAML)
+
+        first = _publish(service, "run-create-repo-failure")
+        second = _publish(service, "run-create-repo-failure")
+        assert first.status_code == 502
+        assert secret not in json.dumps(first.body)
+        assert second.status_code == 409
+        assert second.body["code"] == "publish_state_unknown"
+        assert create_calls == 1
+
+    def test_unexpected_exception_does_not_leak_message(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        secret_bearing_message = "connection failed for token=hf_leak_me_1234567890"
+        spy = _SpyPublisher("huggingface", error=ValueError(secret_bearing_message))
+        _with_credentials(monkeypatch, "huggingface")
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", spy)
+        service = _service(tmp_path)
+        _build(service, "run-publish-unexpected", LICENSED_SPEC_YAML)
+
+        resp = _publish(service, "run-publish-unexpected")
+        assert resp.status_code == 502
+        assert "hf_leak_me_1234567890" not in json.dumps(resp.body)
+        assert secret_bearing_message not in json.dumps(resp.body)
+
+    @pytest.mark.parametrize(
+        "secret_message",
+        [
+            "leak: super-secret-value",
+            "artifact write failed at /tmp/private/artifact",
+            "artifact write failed at C:\\Users\\private\\artifact",
+        ],
+    )
+    def test_exception_message_never_leaks_to_response_or_log(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        secret_message: str,
+    ) -> None:
+        """#491 blocker 1 필수 테스트: fake publisher가 secret/절대경로가 섞인
+        예외를 던져도 HTTP response와 서버 log 어디에도 원문이 남지 않는다."""
+        _with_credentials(monkeypatch, "huggingface")
+        spy = _SpyPublisher("huggingface", error=PublishError(secret_message))
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", spy)
+        service = _service(tmp_path)
+        _build(service, "run-publish-secret-leak", LICENSED_SPEC_YAML)
+
+        caplog.set_level(logging.INFO)
+        resp = _publish(service, "run-publish-secret-leak")
+
+        assert resp.status_code == 502
+        assert resp.body == {
+            "error": "publish failed due to an unexpected error",
+            "code": "publish_failed",
+        }
+        body_text = json.dumps(resp.body)
+        assert secret_message not in body_text
+        assert "super-secret-value" not in body_text
+        assert "/tmp/private/artifact" not in body_text
+        assert "C:\\Users\\private\\artifact" not in body_text
+
+        log_text = caplog.text
+        assert secret_message not in log_text
+        assert "super-secret-value" not in log_text
+        assert "/tmp/private/artifact" not in log_text
+        assert "C:\\Users\\private\\artifact" not in log_text
+
+    def test_exact_retry_replays_persisted_success_without_remote_call(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        spy = _SpyPublisher("huggingface")
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", spy)
+        service = _service(tmp_path)
+        _build(service, "run-retry", LICENSED_SPEC_YAML)
+
+        first = _publish(service, "run-retry")
+        # 성공 operation의 exact retry는 현재 credential/artifact 상태를 다시
+        # 요구하지 않고 durable 성공 응답을 재생한다.
+        monkeypatch.delenv("HF_TOKEN")
+        next((tmp_path / "run-retry" / "gold").rglob("table.parquet")).unlink()
+        second = _publish(service, "run-retry")
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert second.body == first.body
+        assert len(spy.calls) == 1
+
+    def test_success_receipt_replays_after_service_restart(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        spy = _SpyPublisher("huggingface")
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", spy)
+        first_service = _service(tmp_path)
+        _build(first_service, "run-restart-replay", LICENSED_SPEC_YAML)
+        first = _publish(first_service, "run-restart-replay")
+
+        restarted = _service(tmp_path)
+        replay = _publish(restarted, "run-restart-replay")
+        assert replay.status_code == 200
+        assert replay.body == first.body
+        assert len(spy.calls) == 1
+
+    def test_concurrent_exact_duplicate_calls_publisher_at_most_once(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        publisher = _DeferredPublisher()
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", publisher)
+        service = _service(tmp_path)
+        _build(service, "run-concurrent", LICENSED_SPEC_YAML)
+        first_responses: list[ServiceResponse] = []
+
+        worker = threading.Thread(
+            target=lambda: first_responses.append(_publish(service, "run-concurrent"))
+        )
+        worker.start()
+        assert publisher.entered.wait(timeout=5)
+
+        duplicate = _publish(service, "run-concurrent")
+        assert duplicate.status_code == 409
+        assert duplicate.body["code"] == "publish_in_progress"
+        assert len(publisher.calls) == 1
+
+        publisher.release.set()
+        worker.join(timeout=5)
+        assert not worker.is_alive()
+        assert first_responses[0].status_code == 200
+        assert len(publisher.calls) == 1
+
+    def test_changed_options_conflict_without_remote_call(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        spy = _SpyPublisher("huggingface")
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", spy)
+        service = _service(tmp_path)
+        _build(service, "run-options-conflict", LICENSED_SPEC_YAML)
+
+        first = _publish(service, "run-options-conflict", options={"private": True})
+        second = _publish(service, "run-options-conflict", options={"private": False})
+        assert first.status_code == 200
+        assert second.status_code == 409
+        assert second.body["code"] == "publish_conflict"
+        assert len(spy.calls) == 1
+
+    def test_publisher_exception_becomes_unknown_and_blocks_retry(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        spy = _SpyPublisher("huggingface", error=RuntimeError("remote outcome unknown"))
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", spy)
+        service = _service(tmp_path)
+        _build(service, "run-unknown-outcome", LICENSED_SPEC_YAML)
+
+        first = _publish(service, "run-unknown-outcome")
+        second = _publish(service, "run-unknown-outcome")
+        assert first.status_code == 502
+        assert second.status_code == 409
+        assert second.body["code"] == "publish_state_unknown"
+        assert len(spy.calls) == 1
+
+        with sqlite3.connect(tmp_path / "_publish_receipts.sqlite") as connection:
+            state = connection.execute(
+                "SELECT state FROM publish_receipts WHERE run_id = ?",
+                ("run-unknown-outcome",),
+            ).fetchone()
+        assert state == ("unknown",)
+
+    def test_kaggle_publish_is_rejected_before_publisher_call(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        spy = _SpyPublisher("kaggle", expects_directory=True)
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "kaggle", spy)
+        service = _service(tmp_path)
+        _build(service, "run-kaggle-disabled-post", LICENSED_SPEC_YAML)
+
+        resp = _publish(service, "run-kaggle-disabled-post", target="kaggle")
+        assert resp.status_code == 400
+        assert resp.body["code"] == "unsupported_target"
+        assert spy.calls == []
+
+    def test_effective_pii_policy_blocks_post_before_publisher_call(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        spy = _SpyPublisher("huggingface")
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", spy)
+        service = _service(tmp_path)
+        _build(service, "run-pii-post", PII_ALLOW_SPEC_YAML)
+
+        resp = _publish(service, "run-pii-post")
+        assert resp.status_code == 409
+        assert "pii_allow_with_publish" in _blocker_codes(resp)
+        assert spy.calls == []
+
+
+class TestSecurity:
+    def test_credential_secret_never_in_readiness_body(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        token = "hf_super_secret_token_value"
+        monkeypatch.setenv("HF_TOKEN", token)
+        service = _service(tmp_path)
+        _build(service, "run-secret-readiness", LICENSED_SPEC_YAML)
+
+        resp = _readiness(service, "run-secret-readiness")
+        assert token not in json.dumps(resp.body)
+
+    def test_credential_secret_never_in_publish_body(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        token = "hf_super_secret_token_value"
+        monkeypatch.setenv("HF_TOKEN", token)
+        spy = _SpyPublisher("huggingface")
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", spy)
+        service = _service(tmp_path)
+        _build(service, "run-secret-publish", LICENSED_SPEC_YAML)
+
+        resp = _publish(service, "run-secret-publish")
+        assert token not in json.dumps(resp.body)
+
+    def test_no_raw_absolute_path_in_publish_response(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        spy = _SpyPublisher("huggingface")
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", spy)
+        service = _service(tmp_path)
+        _build(service, "run-no-path-leak", LICENSED_SPEC_YAML)
+
+        resp = _publish(service, "run-no-path-leak")
+        assert str(tmp_path) not in json.dumps(resp.body)
+
+    def test_no_raw_absolute_path_in_readiness_response(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        service = _service(tmp_path)
+        _build(service, "run-no-path-leak-ready", LICENSED_SPEC_YAML)
+
+        resp = _readiness(service, "run-no-path-leak-ready")
+        assert str(tmp_path) not in json.dumps(resp.body)
+
+    def test_receipt_contains_no_secret_or_artifact_path_and_is_not_public_artifact(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        token = "hf_receipt_secret_value"
+        monkeypatch.setenv("HF_TOKEN", token)
+        spy = _SpyPublisher("huggingface")
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", spy)
+        service = _service(tmp_path)
+        _build(service, "run-receipt-security", LICENSED_SPEC_YAML)
+
+        response = _publish(service, "run-receipt-security")
+        assert response.status_code == 200
+        with sqlite3.connect(tmp_path / "_publish_receipts.sqlite") as connection:
+            row = connection.execute(
+                "SELECT target, destination, options_json, state, result_json "
+                "FROM publish_receipts WHERE run_id = ?",
+                ("run-receipt-security",),
+            ).fetchone()
+        assert row is not None
+        receipt_text = json.dumps(row)
+        assert token not in receipt_text
+        assert str(tmp_path) not in receipt_text
+        assert row[3] == "succeeded"
+
+        artifacts = service.artifacts("run-receipt-security")
+        assert artifacts.status_code == 200
+        assert "_publish_receipts.sqlite" not in cast(list[str], artifacts.body["files"])
+
+
+class TestArtifactScope:
+    def test_only_gold_files_are_passed_to_publisher(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        spy = _SpyPublisher("huggingface")
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", spy)
+        service = _service(tmp_path)
+        _build(service, "run-artifact-scope", LICENSED_SPEC_YAML)
+
+        resp = _publish(service, "run-artifact-scope")
+        assert resp.status_code == 200
+        artifact_paths, _ = spy.calls[0]
+        run_dir = tmp_path / "run-artifact-scope"
+        for path in artifact_paths:
+            assert path.is_relative_to(run_dir / "gold"), path
+        # BuildSpec snapshot과 manifest는 절대 섞이지 않는다.
+        assert not any(p.name == "manifest.json" for p in artifact_paths)
+        assert not any("buildspec" in p.name.lower() for p in artifact_paths)
+
+    def test_untracked_file_in_gold_dir_is_not_published(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """manifest.outputs에 없는 파일(파이프라인이 쓰지 않은 파일)은
+        gold 디렉터리 안에 있어도 절대 publish되지 않는다 — glob하지 않는다."""
+        _with_credentials(monkeypatch, "huggingface")
+        spy = _SpyPublisher("huggingface")
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", spy)
+        service = _service(tmp_path)
+        _build(service, "run-decoy", LICENSED_SPEC_YAML)
+
+        gold_dirs = list((tmp_path / "run-decoy" / "gold").iterdir())
+        decoy = gold_dirs[0] / "decoy-not-in-manifest.txt"
+        decoy.write_text("should never be published", encoding="utf-8")
+
+        resp = _publish(service, "run-decoy")
+        assert resp.status_code == 200
+        artifact_paths, _ = spy.calls[0]
+        assert decoy not in artifact_paths
+
+    def test_artifact_path_escape_blocks_publish_even_with_valid_artifacts(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#491 blocker 2 필수 테스트: manifest.outputs에 유효한 gold artifact와
+        gold_dir 밖(``..``) artifact가 함께 있으면, 무효 artifact만 조용히
+        건너뛰고 나머지를 publish하는 것이 아니라 전체를 fail-closed로 막는다
+        — readiness가 false, artifact blocker가 있고, POST는 409, Publisher는
+        0회 호출된다."""
+        _with_credentials(monkeypatch, "huggingface")
+        spy = _SpyPublisher("huggingface")
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", spy)
+        service = _service(tmp_path)
+        _build(service, "run-escape", LICENSED_SPEC_YAML)
+
+        outside = tmp_path / "outside-workspace-secret.txt"
+        outside.write_text("must not be published", encoding="utf-8")
+        manifest_path = tmp_path / "run-escape" / "manifest.json"
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        assert data["outputs"], "fixture must already have at least one valid gold output"
+        data["outputs"].append(str(outside))
+        manifest_path.write_text(json.dumps(data), encoding="utf-8")
+
+        readiness = _readiness(service, "run-escape")
+        assert readiness.body["ready"] is False
+        assert "artifact_invalid" in _blocker_codes(readiness)
+
+        resp = _publish(service, "run-escape")
+        assert resp.status_code == 409
+        assert "artifact_invalid" in _blocker_codes(resp)
+        assert spy.calls == []
+
+    def test_symlink_escape_artifact_blocks_publish(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """gold_dir 안의 symlink가 gold root 밖을 가리키면(#46/#47 기존
+        path-safety 정책이 이미 다루는 범위, ``ensure_within``이 resolve 후
+        검사) 같은 fail-closed 경로를 탄다."""
+        _with_credentials(monkeypatch, "huggingface")
+        spy = _SpyPublisher("huggingface")
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", spy)
+        service = _service(tmp_path)
+        _build(service, "run-symlink-escape", LICENSED_SPEC_YAML)
+
+        outside_dir = tmp_path / "outside-symlink-target"
+        outside_dir.mkdir()
+        secret_file = outside_dir / "secret.parquet"
+        secret_file.write_text("must not be published", encoding="utf-8")
+
+        gold_dirs = list((tmp_path / "run-symlink-escape" / "gold").iterdir())
+        link = gold_dirs[0] / "linked-escape"
+        try:
+            link.symlink_to(outside_dir, target_is_directory=True)
+        except OSError:
+            pytest.skip("symlink creation is not permitted in this environment")
+
+        manifest_path = tmp_path / "run-symlink-escape" / "manifest.json"
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        data["outputs"].append(str(link / "secret.parquet"))
+        manifest_path.write_text(json.dumps(data), encoding="utf-8")
+
+        resp = _publish(service, "run-symlink-escape")
+        assert resp.status_code == 409
+        assert "artifact_invalid" in _blocker_codes(resp)
+        assert spy.calls == []
+
+
+def _assert_conforms(resp: ServiceResponse, path: str, method: str) -> None:
+    contract = _load_contract()
+    schema = response_schema(contract, path, method, resp.status_code)
+    assert schema is not None, (
+        f"{method} {path}: status {resp.status_code} is not declared in the contract"
+    )
+    errors = validate(resp.body, schema, contract)
+    assert not errors, (
+        f"{method} {path} {resp.status_code} response drifts from contract:\n  "
+        + "\n  ".join(errors)
+    )
+
+
+class TestOpenApiConformance:
+    """실제 dispatch() wire 응답이 OpenAPI 스키마와 정확히 일치하는지 (ADR-0005 방식)."""
+
+    def test_readiness_200_ready_conforms(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        service = _service(tmp_path)
+        _build(service, "conform-ready", LICENSED_SPEC_YAML)
+        resp = _readiness(service, "conform-ready")
+        assert resp.status_code == 200
+        _assert_conforms(resp, "/builds/{run_id}/publish/readiness", "GET")
+
+    def test_readiness_200_blocked_conforms(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        _build(service, "conform-blocked", LICENSED_SPEC_YAML)
+        resp = _readiness(service, "conform-blocked")
+        assert resp.status_code == 200
+        assert resp.body["ready"] is False
+        _assert_conforms(resp, "/builds/{run_id}/publish/readiness", "GET")
+
+    def test_readiness_400_conforms(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        _build(service, "conform-400", LICENSED_SPEC_YAML)
+        resp = _readiness(service, "conform-400", "local")
+        assert resp.status_code == 400
+        _assert_conforms(resp, "/builds/{run_id}/publish/readiness", "GET")
+
+    def test_readiness_404_conforms(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        resp = _readiness(service, "nope")
+        assert resp.status_code == 404
+        _assert_conforms(resp, "/builds/{run_id}/publish/readiness", "GET")
+
+    def test_publish_200_conforms(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        spy = _SpyPublisher("huggingface")
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", spy)
+        service = _service(tmp_path)
+        _build(service, "conform-publish-ok", LICENSED_SPEC_YAML)
+        resp = _publish(service, "conform-publish-ok")
+        assert resp.status_code == 200
+        _assert_conforms(resp, "/builds/{run_id}/publish", "POST")
+
+    def test_publish_400_conforms(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        _build(service, "conform-publish-400", LICENSED_SPEC_YAML)
+        resp = _publish(service, "conform-publish-400", destination="../escape")
+        assert resp.status_code == 400
+        _assert_conforms(resp, "/builds/{run_id}/publish", "POST")
+
+    def test_publish_404_conforms(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        resp = _publish(service, "nope")
+        assert resp.status_code == 404
+        _assert_conforms(resp, "/builds/{run_id}/publish", "POST")
+
+    def test_publish_409_conforms(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        _build(service, "conform-publish-409", LICENSED_SPEC_YAML)
+        resp = _publish(service, "conform-publish-409")
+        assert resp.status_code == 409
+        _assert_conforms(resp, "/builds/{run_id}/publish", "POST")
+
+    def test_publish_502_conforms(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        spy = _SpyPublisher("huggingface", error=PublishError("boom"))
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", spy)
+        service = _service(tmp_path)
+        _build(service, "conform-publish-502", LICENSED_SPEC_YAML)
+        resp = _publish(service, "conform-publish-502")
+        assert resp.status_code == 502
+        _assert_conforms(resp, "/builds/{run_id}/publish", "POST")


### PR DESCRIPTION
Closes #491

## 변경 요약

완료된 Gold build를 Studio에서 안전하게 게시할 수 있도록
**Publish readiness + HTTP publish service**를 추가했습니다.

새 Publisher를 구현하지 않고 기존 Publisher를 재사용하며,
실제 publish 전에 run/Gold/license/PII/credential/destination 상태를
Builder에서 검증하도록 구성했습니다.

### API

```http
GET  /builds/{run_id}/publish/readiness?target=huggingface
POST /builds/{run_id}/publish
````

POST 예시:

```json
{
  "target": "huggingface",
  "destination": "owner/dataset",
  "options": {
    "private": true
  }
}
```

## 주요 구현

### 1. Publish readiness

`GET /builds/{run_id}/publish/readiness`에서 실제 publish 전에 다음을 검증합니다.

* run 존재 및 ownership
* build 성공 여부
* Gold 결과 존재 여부
* canonical Gold artifact 유효성
* artifact path escape / missing artifact
* license 및 PII publish policy
* publish credential readiness
* target 지원 여부

응답은 `ready / blockers / warnings / target` 구조이며,
GET readiness에서는 Publisher를 호출하지 않습니다.

POST에서도 readiness 결과를 신뢰하지 않고 동일 조건을 다시 검증하여
TOCTOU 상황에서도 fail-closed로 동작합니다.

### 2. HTTP Publish target

현재 HTTP publish target은 **Hugging Face만 지원**합니다.

* Hugging Face: 지원
* Kaggle: HTTP 미지원
* Local: HTTP 미지원

Kaggle은 현재 Gold packaging의 `dataset-metadata.json.id`가
publish destination과 정합되지 않는 기존 한계가 있어,
정상 사용자 경로가 준비되기 전까지 HTTP surface에서 제외했습니다.

LocalPublisher는 caller-provided filesystem destination을 사용하지만
현재 안전한 publish-root 계약이 없으므로 HTTP에서 제외했습니다.

기존 Kaggle/Local Publisher 및 CLI 동작은 변경하지 않았습니다.

### 3. Persistent publish idempotency

동일한 publish 요청이 원격 side effect를 중복 생성하지 않도록
persistent receipt 기반 idempotency를 추가했습니다.

operation identity:

```text
owner
+ run_id
+ target
+ destination
+ canonical options
```

상태:

```text
new → pending → succeeded
              ↘ unknown
```

동작:

* 최초 요청 → Publisher 1회 실행
* 동일 성공 요청 retry → 저장된 성공 응답 재사용, Publisher 재호출 없음
* `pending` → `409 publish_in_progress`
* 결과가 불명확한 실패 → `unknown`
* `unknown` retry → `409 publish_state_unknown`
* 같은 destination에 다른 options → `409 publish_conflict`

Publisher 호출 전 `pending`을 durable하게 기록하므로,
remote timeout이나 응답 유실 이후 blind retry로 중복 게시하지 않습니다.

receipt는:

```text
{output_root}/_publish_receipts.sqlite
```

에 저장하며:

* SQLite WAL
* `BEGIN IMMEDIATE`
* UNIQUE operation key
* SHA-256 fingerprint

를 사용합니다.

credential이나 absolute artifact path는 저장하지 않으며
manifest/artifact HTTP surface에도 노출되지 않습니다.

### 4. 기존 publish policy 재사용

새 PII/license 규칙을 만들지 않고 canonical validator를 재사용합니다.

HTTP publish 시 저장된 BuildSpec을:

```python
dataclasses.replace(spec, publish=True)
```

로 평가한 뒤 기존 `validate_spec()`을 실행합니다.

따라서 원래 BuildSpec이 `publish: false`였더라도 실제 HTTP publish 시:

* `pii.mode=allow`
* license 미선언
* blank/whitespace license

등 기존 publish 정책 위반을 우회할 수 없습니다.

### 5. Hugging Face private option

Hugging Face에서 다음 옵션을 지원합니다.

```json
{
  "private": true
}
```

* `true` / `false` 지원
* 생략 시 `true`
* 잘못된 type → 400
* unknown option → 400

신규 repository 생성 시:

```python
create_repo(
    repo_id=destination,
    repo_type="dataset",
    private=private,
    exist_ok=True,
)
```

후 기존 upload 로직을 실행합니다.

`private`은 **신규 repository 생성 시 visibility**만 제어하며,
기존 repository의 visibility를 자동 변경하지 않습니다.

### 6. Security / artifact boundary

* 다른 사용자의 run publish 차단
* succeeded Gold run만 publish
* canonical Gold artifact만 Publisher에 전달
* Gold/run workspace 밖 artifact fail-closed
* valid + invalid artifact 혼합 시 전체 publish 차단
* raw credential response/log 비노출
* Publisher raw exception message 비노출
* server absolute path 응답 비노출
* unsupported target/destination/options fail-closed
* blocker 존재 시 Publisher 호출 0회

Publisher 실행 실패는 내부 exception 내용을 노출하지 않고
stable `publish_failed` 오류로 반환합니다.

## OpenAPI

`contract/builder-api.yaml`을 `1.17.0`으로 갱신했습니다.

추가:

* `GET /builds/{run_id}/publish/readiness`
* `POST /builds/{run_id}/publish`
* readiness/blocker schemas
* Publish request/response schemas
* Hugging Face options schema
* 409 idempotency 상태

`PublishTarget`은 현재 실제 HTTP 지원 범위에 맞춰:

```yaml
enum:
  - huggingface
```

만 허용합니다.

`PublishRequest`와 Hugging Face options 모두
`additionalProperties: false`로 runtime validation과 정합화했습니다.

## 테스트

### Targeted

* publish/service/contract/publisher:

  * **187 passed, 1 skipped, 1 deselected**
* validator/path:

  * **42 passed**
  * Windows symlink 권한 관련 기존 환경 실패 1건

추가 검증 범위:

* readiness happy/blocker paths
* ownership
* Gold artifact/path safety
* PII/license gate
* Hugging Face private true/false/default
* invalid/unknown options
* exact retry replay
* persistent retry after service restart
* concurrent duplicate publish
* pending/unknown/conflict
* Publisher failure → unknown receipt
* response/log secret sanitization
* OpenAPI/runtime conformance

### 전체

```text
pytest -q
1529 passed, 9 failed, 7 skipped
```

실패 중 8건은 unmodified `main`에서도 재현되는 기존 Windows 환경 실패입니다.

* tzdata
* symlink privilege
* cp949 console encoding
* 기존 checkpoint/publisher fixture

추가 query timeout 1건은 단독 재실행 시 통과하여
Windows process spawn 지연으로 확인했습니다.

정적 검사:

```text
ruff check .             PASS
ruff format --check .    PASS
mypy src                 PASS
git diff --check         PASS
```

## 의도적 제한 / 후속

### Kaggle HTTP publish

현재 Kaggle Gold packaging이 destination-aware한
`dataset-metadata.json.id`를 생성하지 못하므로 HTTP 지원에서 제외했습니다.

후속 작업에서:

```text
publish destination
→ Kaggle package metadata.id
→ KagglePublisher
```

정합화가 필요합니다.

### unknown publish receipt

Publisher 호출 결과가 불명확한 경우 receipt를 `unknown`으로 유지하고
자동 retry하지 않습니다.

manual reconcile/reset API는 이번 #491 범위에 포함하지 않았습니다.

## 변경 파일

* `contract/builder-api.yaml`
* `src/kpubdata_builder/publishers/huggingface.py`
* `src/kpubdata_builder/service/app.py`
* `src/kpubdata_builder/service/publish.py`
* `src/kpubdata_builder/service/routes/publish.py`
* `src/kpubdata_builder/service/routes/__init__.py`
* `tests/unit/test_publishers.py`
* `tests/unit/test_service_publish.py`
* `tests/unit/test_service_contract.py`