### PR TITLE
docs: ADR 0015 — email/password-capable OIDC IdP(Keycloak) 전환 결정 (#515)

### DIFF
--- a/docs/adrs/0009-user-authentication-google-oidc.md
+++ b/docs/adrs/0009-user-authentication-google-oidc.md
@@ -1,6 +1,6 @@
 # ADR 0009 — 사용자 인증 모델: Google OIDC ID 토큰 검증
 
-- 상태: 제안됨(Proposed)
+- 상태: 대체됨(Superseded by [ADR 0015](./0015-email-password-oidc-idp-keycloak.md)) — 검증 계약·Bearer 전송·allowlist fail-closed·internal ingress는 0015가 승계
 - 관련 이슈: #383, #312(ADR 0006), #384(B2 Principal), #385(B3 Google 검증), #386(B4 허용 목록), #387(B5 계약 1.1.0)
 - 관련 문서: [ADR 0006](./0006-service-auth-and-deployment.md), [API_CONTRACT.md](../API_CONTRACT.md), [BOUNDARY.md](../BOUNDARY.md)
 

--- a/docs/adrs/0015-email-password-oidc-idp-keycloak.md
+++ b/docs/adrs/0015-email-password-oidc-idp-keycloak.md
@@ -1,0 +1,102 @@
+# ADR 0015 — 사용자 인증 IdP: 이메일/비밀번호-capable OIDC(Keycloak) 전환
+
+- 상태: 승인됨(Accepted)
+- 관련 이슈: #515(본 결정), #383(ADR 0009), #505(Stable Principal ID)
+- 선행 문서: [ADR 0006](./0006-service-auth-and-deployment.md), [ADR 0009](./0009-user-authentication-google-oidc.md)(본 ADR로 대체됨)
+- 관련 문서: [BOUNDARY.md](../BOUNDARY.md), [deploy.md](../deploy.md)
+
+> ADR 0009가 "제안됨" 상태로 둔 Google OIDC 기준선과 UI vNext(#246, Studio #263)가
+> 요구하는 email/password Login/Signup이 충돌한다. 본 ADR은 **사람 사용자 인증의
+> IdP를 확정**하고 ADR 0009의 대체 정책을 정의한다. 인가(run 소유권)는
+> #505(Stable Principal ID, CLOSED)가 이미 정본을 마련했다.
+
+## 결정 사항 (이슈 #515)
+
+1. **Builder 검증 계약은 표준 OIDC를 유지한다** — Builder는 특정 IdP를 가정하지
+   않는다. 이미 구현된 `OIDC_ISSUER` + `OIDC_AUDIENCE`(필수, fail-closed) +
+   JWKS/discovery 캐시(#435) + RS256 고정 검증이 그대로 사용자 인증의 정본 계약이다.
+   본 전환은 Builder 코드가 아니라 **설정(issuer/audience 값)** 만 바꾼다.
+2. **IdP: self-hosted Keycloak** — email/password Signup·Login, email verification,
+   password reset, refresh, logout을 Keycloak이 담당한다(§검토한 대안 참조).
+   Google 로그인은 Keycloak의 identity broker(선택적)로 수용해 기존 Google 사용자
+   경로를 보존할 수 있다.
+3. **인증 플로우: Authorization Code + PKCE** — Studio(public SPA client)는
+   Keycloak hosted login 페이지로 이동해 code 교환으로 ID token을 받는다.
+   ID token을 `Authorization: Bearer`로 Builder에 전송하는 하부 계약은 ADR 0009와
+   동일하다. Resource Owner Password Credentials(ROPC) grant는 사용 금지
+   (deprecated, MFA/SSO/세션 관리 불가).
+4. **password/secret 책임 경계(원칙 재확정)** — Builder와 Studio 어느 쪽도
+   password 원문·해시를 저장·검증·전송하지 않는다. Studio의
+   `mockAuthProvider`(#289)는 실연동 전 로컬 개발용 mock일 뿐 실 IdP가 아니다.
+5. **allowlist는 2층으로 유지** — (1) Keycloak realm 정책이 signup·계정 수명을
+   관리한다(기본 public signup **OFF**, 관리자 초대/이메일 도메인 제한).
+   (2) Builder env allowlist(`OIDC_ALLOWED_SUBJECTS`/`OIDC_ALLOWED_EMAILS`,
+   fail-closed)를 심층 방어로 유지한다. 공개 IdP가 아니게 되므로 Google 전용
+   `OIDC_ALLOWED_HD`는 `hd` claim 의존을 제거하고 이메일 도메인 판정으로
+   일반화한다(구현 후속 이슈에서 반영).
+6. **profile metadata 최소 PII** — Builder는 stable principal(`sha256(issuer‖sub)`,
+   #505)과 표시용 `name`/`email`(ID token claim)만 다룬다.
+   `account_type`/`organization_name`은 IdP 커스텀 claim 또는 principal-keyed
+   Builder 프로필 후속 이슈에서 정의하되, 본 ADR은 "password 없음 + 최소 수집"만
+   확정한다.
+7. **service principal(`X-API-Key`) 병행 유지** — 스케줄 워크플로는 사람 로그인이
+   불가하므로 ADR 0006의 서비스 키 경로를 그대로 유지한다. 두 경로 모두
+   `Principal`(`oidc`/`service`/`dev`)로 정규화된다(변경 없음).
+
+## 배경
+
+- Studio vNext는 email/password Login/Signup UX를 요구한다(Studio #263, #289 —
+  generic `AuthProvider` 계약은 이미 본 결정을 기다리도록 설계됨).
+- ADR 0009의 Google OIDC 기준선은 공개 IdP 특성상 허용 목록이 유일 방어선이며,
+  이메일/비밀번호 가입 정책·계정 수명 관리를 Builder가 통제할 수 없다.
+- ADR 0009 결정 3(Internal ingress — Builder는 공개 인그레스를 갖지 않음)은
+  유지한다. 따라서 IdP도 내부망에서 운영 가능해야 한다.
+
+## 검토한 대안 (IdP)
+
+| 대안 | 판정 | 근거 |
+| :--- | :--- | :--- |
+| **Keycloak(self-hosted)** | **채택** | 완전한 OIDC OP. email/password·verification·reset·logout 기본 제공. internal ingress 원칙과 정합(같은 VPC). Google broker 내장. 운영 부담(컨테이너+DB)은 단일 realm 수준으로 억제 가능. |
+| Auth0/Clerk/Okta(SaaS) | 기각 | 외부 SaaS 의존·데이터 주권·비용. internal ingress 모델과 어긋남(로그인 페이지가 공개 인터넷 경유). |
+| Zitadel(self-hosted, Go) | 기각 | Keycloak 대비 경량이나 생태계·레퍼런스 부족, 한국어 자료 희소. |
+| Supabase Auth/Firebase Auth | 기각 | 완전한 OIDC OP가 아니거나(lock-in) 이메일 정책 커스텀 한계. |
+| Builder 자체 계정(비밀번호 저장) | 기각 | ADR 0009 대안 1A와 동일한 기각 사유 — password 저장·해시·로테이션 부담과 취약면. |
+
+## Studio ↔ Builder 설정 분리
+
+| 항목 | Studio(public, 번들 포함 가능) | Builder(secret/서버 env) |
+| :--- | :--- | :--- |
+| issuer | `VITE_OIDC_ISSUER`(Keycloak realm URL) | `OIDC_ISSUER`(동일 값) |
+| client/audience | `VITE_OIDC_CLIENT_ID` | `OIDC_AUDIENCE`(Builder를 가리키는 audience) |
+| allowlist | — | `OIDC_ALLOWED_SUBJECTS`/`OIDC_ALLOWED_EMAILS`(최소 1개 필수, fail-closed) |
+| secret | **없음**(public client + PKCE) | API 키/시크릿 기존 정책 유지 |
+
+## ADR 0009와의 관계(전환 정책)
+
+- ADR 0009는 **대체됨(Superseded by 0015)**. 단, 대체되는 것은 "Google 공개 IdC를
+  직접 audience로 쓴다"는 부분뿐이고, 아래는 그대로 승계된다.
+  - ID token 오프라인 검증 원칙(JWKS·RS256·iss/aud/exp, `pyjwt[crypto]`)
+  - Bearer 전송 계약과 401/403/503 의미론
+  - env allowlist fail-closed 정책
+  - internal ingress 기본 배포형
+  - `X-API-Key` 서비스 경로 병행
+- 전환 절차(구현 후속): (1) Keycloak realm 구축 + `kpubdata-builder` audience
+  등록 → (2) Builder env 교체(issuer/audience/allowlist) → (3) Studio
+  `AuthProviderId`에 keycloak provider 추가(`"google" \| "mock"` 어휘 확장) →
+  (4) 기존 Google 사용자는 broker 또는 이메일 기반 계정 연결로 마이그레이션.
+    기존 run 소유권은 issuer+sub 해시(#505)로 귀속되므로, Keycloak 전환 후
+    **principal이 달라지면 기존 run이 새 계정에서 보이지 않는다** — 마이그레이션
+    시 구 owner_key → 신 owner_key 매핑 작업이 별도 필요하다(후속 이슈).
+
+## 영향
+
+- Builder: 코드 변경 없음(설정 값만 교체). `OIDC_ALLOWED_HD` 일반화는 후속.
+- Studio: `AuthProvider` 구현체 추가(keycloak), 로그인 UX는 hosted login 위임.
+- 인프라: Keycloak 컨테이너 + 영구 볼륨(또는 managed DB)이 내부망에 추가된다.
+- API 계약: 변경 없음(bearerAuth 스키마 동일).
+
+## 미해결 질문 (후속 이슈로 분리)
+
+- owner_key 마이그레이션 매핑 방식(일괄 스크립트 vs 이중 허용 기간) — 전환 시점에 결정.
+- Keycloak 고가용성/백업 정책 — 운영 도입 시 `deploy.md`에 보강.
+- `account_type`/`organization_name`의 저장 위치(IdP claim vs Builder 프로필).

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -12,13 +12,13 @@ KPubData Builder의 주요 설계 결정을 기록합니다. 각 ADR은 배경·
 | [0006](./0006-service-auth-and-deployment.md) | 서비스 인증 & 배포(Docker) 스토리 | 승인됨 | #312 |
 | [0007](./0007-kpubdata-version-compatibility-policy.md) | kpubdata 버전 호환성 정책 및 핀 강화 | 승인됨 | #213 |
 | [0008](./0008-async-build-job-model.md) | 비동기 build job 모델: 상태·실패·취소·멱등성·부분 산출물 | 제안됨 | #334 |
-| [0009](./0009-user-authentication-google-oidc.md) | 사용자 인증 모델: Google OIDC ID 토큰 검증 | 제안됨 | #383 |
+| [0009](./0009-user-authentication-google-oidc.md) | 사용자 인증 모델: Google OIDC ID 토큰 검증 | 대체됨(0015) | #383 |
 | [0010](./0010-artifactstore-state-backend.md) | ArtifactStore 추상화 + BuildIndex 백엔드 분리 | 제안됨 | #375 |
 | [0011](./0011-buildspec-assistant-grounding.md) | BuildSpec 어시스턴트 그라운딩 계약 | 제안됨 | #415 |
-| [0012](./0012-provider-credential-boundary.md) | Provider credential 저장·주입 경계 | 승인됨 | #492 |
+| [0012](./0012-provider-credential-boundary.md) | Provider credential 저장·주입 경계 | 승인됨 | #492, #505 |
 | [0013](./0013-api-contract-release-policy.md) | API 계약 버전과 릴리스 경계 정책 | 승인됨 | #521 |
-| [0012](./0012-provider-credential-boundary.md) | 사용자별 Provider Credential 저장과 Client 격리 | 승인됨 | #492, #505 |
 | [0014](./0014-source-ingestion-file-url-boundary.md) | Public API·File·URL Source 통합 경계 | 승인됨 | #498 |
+| [0015](./0015-email-password-oidc-idp-keycloak.md) | 사용자 인증 IdP: 이메일/비밀번호-capable OIDC(Keycloak) 전환 | 승인됨 | #515 |
 
 ## 작성 규칙
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,6 +1,6 @@
 # 배포 가이드
 
-Builder HTTP 서비스를 로컬 개발 이상으로 운영하기 위한 배포·인증 스토리. 본 문서는 [ADR 0006](./adrs/0006-service-auth-and-deployment.md)(인증·배포)과 ADR 0009(사용자 인증, PR #398)의 운영 가이드를 통합한다.
+Builder HTTP 서비스를 로컬 개발 이상으로 운영하기 위한 배포·인증 스토리. 본 문서는 [ADR 0006](./adrs/0006-service-auth-and-deployment.md)(인증·배포), ADR 0009(사용자 인증, PR #398 — [ADR 0015](./adrs/0015-email-password-oidc-idp-keycloak.md)로 대체됨)의 운영 가이드를 통합한다.
 
 > **상태**: ADR 0009는 제안됨(Proposed). 인증(Bearer) 구현은 B3(#385)/B4(#386) 진행 중이며, 본 문서의 Bearer 관련 절은 구현 완료 후 적용된다. 컨테이너 배포(fail-closed, HEALTHCHECK)는 이미 구현되었다.
 
@@ -22,6 +22,8 @@ Builder HTTP 서비스를 로컬 개발 이상으로 운영하기 위한 배포�
 두 경로 모두 `Principal`(`service`/`oidc`/`dev`)로 정규화된다 (B2/#384).
 
 ## 3. Google OAuth client 설정
+
+> **전환 안내(ADR 0015)**: 사람 사용자 인증 IdP는 self-hosted Keycloak(email/password-capable OIDC)로 확정되었고 본 절의 Google 직접 audience 구성은 대체되었다. IdP 전환 절차·설정 분리는 [ADR 0015](./adrs/0015-email-password-oidc-idp-keycloak.md)를 따른다. 아래는 ADR 0009 시대의 기록으로 남긴다.
 
 1. Google Cloud Console → APIs & Services → Credentials → **OAuth client ID**.
 2. **Web application** 타입으로 생성.


### PR DESCRIPTION
## 목적
이슈 #515(P0)의 설계 결정: Google OIDC 중심 ADR 0009와 Studio vNext email/password 요구의 충돌을 해소한다.

## 결정 요약
1. **Builder 검증 계약은 표준 OIDC 유지** — 이미 구현된 `OIDC_ISSUER`+`OIDC_AUDIENCE`(fail-closed)+JWKS/discovery(#435)가 정본. 전환은 설정 값만 교체
2. **IdP: self-hosted Keycloak** — email/password·verification·reset·logout 담당, internal ingress 원칙과 정합, Google은 broker로 선택 수용
3. **Authorization Code + PKCE** — ROPC 금지, Bearer 전송 계약은 ADR 0009 승계
4. **password 책임 경계** — Builder/Studio 모두 password 원문·해시 미접급
5. **allowlist 2층** — Keycloak realm 정책(기본 public signup OFF) + Builder env allowlist(심층 방어)
6. **profile 최소 PII** — stable principal(#505) + name/email 표시용만
7. **X-API-Key 병행 유지**

## ADR 0009 관계
대체됨(Superseded) 표기 — 검증 원칙·Bearer 계약·fail-closed allowlist·internal ingress는 승계. owner_key 마이그레이션(issuer+sub 해시 변경)은 미해결 질문으로 분리.

## 변경 파일
- `docs/adrs/0015-email-password-oidc-idp-keycloak.md` (신규)
- `docs/adrs/README.md` — 0015 추가, 0009 대체 표기, 중복 0012 행 정리
- `docs/adrs/0009-...` — 상태 헤더 갱신
- `docs/deploy.md` — §3 전환 안내

Closes #515