### PR TITLE
feat(publish): unknown receipt reconcile/reset 운영 경로 (#551)

### DIFF
--- a/contract/builder-api.yaml
+++ b/contract/builder-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: KPubData Builder Service API
-  version: "1.18.0"
+  version: "1.19.0"
   description: >-
     Builder 중심 서비스 계약. BuildSpec 검증, preview, build 실행, artifact 조회,
     계약 버전 조회를 제공한다. CLI와 HTTP service mode(#36)가 동일한 도메인 계약을
@@ -75,6 +75,7 @@ info:
     cross-owner의 build 출력 노출을 차단한다(behavioral tightening — 이전에는
     미검사였음).
     v1.17.0은 build publish 표면을 추가한다(#491) — `GET /builds/{run_id}/publish/readiness`(ready/blockers/warnings)와 `POST /builds/{run_id}/publish`(idempotent publish receipt, TOCTOU 재검사)를 추가한다(additive). HTTP target은 `huggingface`로 한정한다.
+    v1.19.0은 publish receipt 운영 경로를 추가한다(#551, additive) — `GET /builds/{run_id}/publish/receipt`(상태 조회, 소유자 불일치는 404), `POST /builds/{run_id}/publish/reconcile`(원격 상태 확인 후 `succeeded` 확정 또는 reset으로 재게시 허용; 판단 불가 시 503로 무변경), `DELETE /builds/{run_id}/publish/receipt`(명시적 reset, 감사 로그 기록).
     v1.18.0은 ADR 0008의 협력적 취소(cooperative cancellation)를 구현한다 —
     `POST /builds/{run_id}/cancel`을 추가한다(#481, additive). `queued` job은
     worker가 runner를 실행하기 전에 곧바로 `cancelled`로 종결되고(파이프라인

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -299,7 +299,12 @@ def _strip_internal_fields(entries: list[_BuildListEntry]) -> list[_BuildListEnt
 # 함께 additive로: BuildManifest에 status/partial(부분 산출물 표시),
 # BuildEventName에 run_cancelled, BuildSummary.status enum에 cancelled(이미
 # BuildIndex/dataset 계약이 쓰던 값이 이제 실제로 관측 가능해진다).
-API_CONTRACT_VERSION = "1.18.0"
+# 1.18.0 -> 1.19.0: publish receipt 운영 경로를 추가한다(#551, additive) —
+# GET /builds/{run_id}/publish/receipt(unknown 상태 조회),
+# POST /builds/{run_id}/publish/reconcile(원격 상태 확인 후 succeeded 확정 또는
+# reset으로 재게시 허용), DELETE /builds/{run_id}/publish/receipt(명시적 reset,
+# 감사 로그 기록). reconcile은 원격 판단 불가 시 503로 아무 것도 변경하지 않는다.
+API_CONTRACT_VERSION = "1.19.0"
 
 
 def _quality_result_to_json(r: QualityCheckResult) -> dict[str, JsonValue]:
@@ -2060,6 +2065,237 @@ class BuilderService:
                 {"error": "publish failed due to an unexpected error", "code": "publish_failed"},
             )
         return ServiceResponse(200, response_body)
+
+    def get_publish_receipt(
+        self,
+        run_id: str,
+        target: str,
+        destination: str,
+        *,
+        principal: Principal,
+    ) -> ServiceResponse:
+        """GET /builds/{run_id}/publish/receipt (#551).
+
+        unknown receipt로 영구 차단된 운영자가 상태를 조회한다. 소유자 불일치는
+        404로 응답해 다른 owner의 receipt 존재 자체를 노출하지 않는다.
+        """
+        owner_key = principal.owner_id or principal.label
+        receipt = self._publish_receipts.get_by_key(
+            owner_key=owner_key, run_id=run_id, target=target, destination=destination
+        )
+        if receipt is None:
+            return ServiceResponse(
+                404, {"error": "publish receipt not found", "code": "receipt_not_found"}
+            )
+        body: dict[str, JsonValue] = {
+            "run_id": run_id,
+            "target": receipt.target,
+            "destination": receipt.destination,
+            "state": receipt.state,
+            "fingerprint": receipt.fingerprint,
+            "options": cast(JsonValue, receipt.options),
+            "reconcilable": receipt.state == "unknown",
+        }
+        if receipt.result is not None:
+            body["result"] = cast(JsonValue, receipt.result)
+        return ServiceResponse(200, body)
+
+    def reconcile_publish(
+        self,
+        run_id: str,
+        body: Mapping[str, JsonValue] | None,
+        *,
+        principal: Principal,
+    ) -> ServiceResponse:
+        """POST /builds/{run_id}/publish/reconcile (#551).
+
+        unknown receipt를 원격 상태 확인으로 확정한다. 원격에 결과가 있으면
+        succeeded로 확정하고, 확실히 없으면 receipt를 reset해 재게시(새 claim)를
+        허용한다. 원격 확인 자체가 불가능하면 503 — 아무 것도 변경하지 않는다.
+        """
+        if not isinstance(body, Mapping):
+            return ServiceResponse(400, {"error": "request body must be a JSON object"})
+        unknown_fields = sorted(str(key) for key in body if key not in {"target", "destination"})
+        if unknown_fields:
+            return ServiceResponse(
+                400, {"error": f"unsupported request field(s): {unknown_fields!r}"}
+            )
+
+        resolved_target, target_error = publish_service.resolve_target(body.get("target"))
+        if resolved_target is None:
+            return ServiceResponse(
+                400, {"error": target_error or "invalid target", "code": "unsupported_target"}
+            )
+        destination_error = publish_service.validate_destination(
+            resolved_target, body.get("destination")
+        )
+        if destination_error is not None:
+            return ServiceResponse(400, {"error": destination_error})
+        destination = cast(str, body["destination"])
+
+        owner_key = principal.owner_id or principal.label
+        receipt = self._publish_receipts.get_by_key(
+            owner_key=owner_key, run_id=run_id, target=resolved_target, destination=destination
+        )
+        if receipt is None:
+            return ServiceResponse(
+                404, {"error": "publish receipt not found", "code": "receipt_not_found"}
+            )
+
+        if receipt.state == "succeeded":
+            # 이미 확정된 receipt는 멱등하게 그 상태를 돌려준다(원격 재조회 없음).
+            body_out: dict[str, JsonValue] = {
+                "run_id": run_id,
+                "state": "succeeded",
+                "reconciled": False,
+                "fingerprint": receipt.fingerprint,
+            }
+            if receipt.result is not None:
+                body_out["result"] = cast(JsonValue, receipt.result)
+            return ServiceResponse(200, body_out)
+
+        probe = self._probe_remote_publish_target(resolved_target, destination)
+        if probe is None:
+            return ServiceResponse(
+                503,
+                {
+                    "error": "remote state could not be determined; nothing was changed",
+                    "code": "reconcile_unavailable",
+                },
+            )
+        remote_exists = probe
+
+        if remote_exists:
+            result: dict[str, object] = {
+                "run_id": run_id,
+                "target": resolved_target,
+                "destination": destination,
+                "reconciled": True,
+                "status": "succeeded",
+            }
+            try:
+                self._publish_receipts.reconcile_succeeded(receipt.fingerprint, result)
+            except Exception as exc:
+                logger.error(
+                    "publish receipt reconcile persist failed: run_id=%s target=%s error_type=%s",
+                    run_id,
+                    resolved_target,
+                    type(exc).__name__,
+                )
+                return ServiceResponse(
+                    503,
+                    {
+                        "error": "reconcile outcome could not be persisted; nothing was changed",
+                        "code": "reconcile_unavailable",
+                    },
+                )
+            return ServiceResponse(
+                200,
+                {
+                    "run_id": run_id,
+                    "state": "succeeded",
+                    "reconciled": True,
+                    "fingerprint": receipt.fingerprint,
+                },
+            )
+
+        # 원격에 결과가 없다 — 게시가 실제로 일어나지 않았다고 확정할 수 없어도
+        # receipt를 reset해 운영자 판단으로 재게시를 허용한다(감사 로그에 남긴다).
+        reset_ok = self._publish_receipts.reset(
+            receipt.fingerprint, action="reconcile_absent_reset"
+        )
+        if not reset_ok:
+            return ServiceResponse(
+                503,
+                {
+                    "error": "reconcile reset could not be persisted; nothing was changed",
+                    "code": "reconcile_unavailable",
+                },
+            )
+        return ServiceResponse(
+            200,
+            {
+                "run_id": run_id,
+                "state": "reset",
+                "reconciled": True,
+                "retry_allowed": True,
+                "fingerprint": receipt.fingerprint,
+            },
+        )
+
+    def reset_publish_receipt(
+        self,
+        run_id: str,
+        target: str,
+        destination: str,
+        *,
+        principal: Principal,
+    ) -> ServiceResponse:
+        """DELETE /builds/{run_id}/publish/receipt (#551) — 명시적 reset.
+
+        어떤 상태든 receipt를 삭제해 새 claim을 허용한다. 원격 부작용은 전혀
+        발생하지 않는다(이미 게시된 결과를 되돌리지 않는다). 감사 로그에 남긴다.
+        """
+        owner_key = principal.owner_id or principal.label
+        receipt = self._publish_receipts.get_by_key(
+            owner_key=owner_key, run_id=run_id, target=target, destination=destination
+        )
+        if receipt is None:
+            return ServiceResponse(
+                404, {"error": "publish receipt not found", "code": "receipt_not_found"}
+            )
+        reset_ok = self._publish_receipts.reset(receipt.fingerprint, action="manual_reset")
+        if not reset_ok:
+            return ServiceResponse(
+                503,
+                {
+                    "error": "receipt reset could not be persisted; nothing was changed",
+                    "code": "reconcile_unavailable",
+                },
+            )
+        return ServiceResponse(
+            200,
+            {
+                "run_id": run_id,
+                "state": "reset",
+                "retry_allowed": True,
+                "fingerprint": receipt.fingerprint,
+            },
+        )
+
+    def _probe_remote_publish_target(self, target: str, destination: str) -> bool | None:
+        """원격에 publish 결과가 존재하는지 조사한다 (#551).
+
+        반환값: True(존재)/False(부재)/None(판단 불가 — credential·네트워크 문제).
+        조사 자체가 credential을 소비하거나 원격을 변경하지 않는 read-only다.
+        """
+        if target == "huggingface":
+            token = os.environ.get("HF_TOKEN", "").strip()
+            if not token:
+                return None
+            try:
+                from huggingface_hub import HfApi  # type: ignore[import-not-found]
+            except ImportError:
+                return None
+            try:
+                api = HfApi(token=token)
+                api.dataset_info(repo_id=destination, repo_type="dataset")
+            except Exception as exc:
+                # repo 부재(gated 401/404 계열)와 접근 실패를 구분한다 —
+                # huggingface_hub는 부재를 RepositoryNotFoundError로 알려준다.
+                name = type(exc).__name__
+                if name in ("RepositoryNotFoundError", "GatedRepoError"):
+                    return False
+                if getattr(exc, "status_code", None) in (401, 403):
+                    # 존재하지 않는 private repo도 401로 보이는 HF 특성상
+                    # 소유자라면 부재로 간주한다(asset이 내 credential로
+                    # 생성됐다면 접근 가능해야 하기 때문).
+                    return False
+                if getattr(exc, "status_code", None) == 404:
+                    return False
+                return None
+            return True
+        return None
 
     def get_build_events(self, run_id: str, *, limit: int, tail: bool) -> ServiceResponse:
         """run의 append-only structured event timeline을 조회한다 (#496).

--- a/src/kpubdata_builder/service/publish.py
+++ b/src/kpubdata_builder/service/publish.py
@@ -26,6 +26,8 @@ import re
 import sqlite3
 import threading
 from dataclasses import dataclass, replace
+from datetime import datetime as datetime_module
+from datetime import timezone
 from pathlib import Path
 from typing import Literal, cast
 
@@ -122,6 +124,19 @@ class PublishReceiptStore:
                             CHECK (state IN ('pending', 'succeeded', 'unknown')),
                         result_json TEXT,
                         PRIMARY KEY (owner_key, run_id, target, destination)
+                    )
+                    """
+                )
+                # reconcile/reset 감사 로그(#551) — credential/path/원문을 담지
+                # 않는 최소 필드만 append한다.
+                connection.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS publish_receipt_audit (
+                        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+                        fingerprint TEXT NOT NULL,
+                        action TEXT NOT NULL,
+                        actor TEXT NOT NULL,
+                        recorded_at TEXT NOT NULL
                     )
                     """
                 )
@@ -281,12 +296,99 @@ class PublishReceiptStore:
     def mark_unknown(self, fingerprint: str) -> None:
         self._set_terminal(fingerprint, state="unknown", result=None)
 
+    def get_by_key(
+        self,
+        *,
+        owner_key: str,
+        run_id: str,
+        target: str,
+        destination: str,
+    ) -> PublishReceipt | None:
+        """operation key로 receipt를 직접 조회한다(#551 조회 API용, side effect 없음)."""
+        self._initialize()
+        with self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT fingerprint, owner_key, target, destination, options_json, state,
+                       result_json
+                FROM publish_receipts
+                WHERE owner_key = ? AND run_id = ? AND target = ? AND destination = ?
+                """,
+                (owner_key, run_id, target, destination),
+            ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_receipt(cast(tuple[object, ...], row))
+
+    def reconcile_succeeded(self, fingerprint: str, result: dict[str, object]) -> None:
+        """원격 상태 확인으로 unknown을 succeeded로 확정한다(#551). 감사 로그를 남긴다."""
+        self._initialize()
+        self._set_terminal(
+            fingerprint,
+            state="succeeded",
+            result=result,
+            allowed_source_states=("pending", "unknown"),
+        )
+        self._append_audit(fingerprint, "reconcile_succeeded")
+
+    def reset(self, fingerprint: str, *, action: str = "reset") -> bool:
+        """receipt를 삭제해 재시도(새 claim)를 허용한다(#551). 감사 로그를 남긴다.
+
+        삭제가 실제로 일어났으면 True, 해당 fingerprint가 없으면 False.
+        """
+        self._initialize()
+        with self._connect() as connection:
+            cursor = connection.execute(
+                "DELETE FROM publish_receipts WHERE fingerprint = ?",
+                (fingerprint,),
+            )
+            deleted = cursor.rowcount == 1
+        if deleted:
+            self._append_audit(fingerprint, action)
+        return deleted
+
+    def _append_audit(self, fingerprint: str, action: str, *, actor: str = "operator") -> None:
+        recorded_at = datetime_module.now(timezone.utc).isoformat(timespec="seconds")
+        with self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO publish_receipt_audit(fingerprint, action, actor, recorded_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                (fingerprint, action, actor, recorded_at),
+            )
+
+    def audit_entries(self, *, owner_key: str, run_id: str) -> list[dict[str, str]]:
+        """해당 owner/run의 감사 로그를 시간순으로 반환한다(조회 API용)."""
+        self._initialize()
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT a.fingerprint, a.action, a.actor, a.recorded_at
+                FROM publish_receipt_audit a
+                JOIN publish_receipts r ON r.fingerprint = a.fingerprint
+                WHERE r.owner_key = ? AND r.run_id = ?
+                ORDER BY a.seq
+                """,
+                (owner_key, run_id),
+            ).fetchall()
+        return [
+            {
+                "fingerprint": cast(str, row[0]),
+                "action": cast(str, row[1]),
+                "actor": cast(str, row[2]),
+                "recorded_at": cast(str, row[3]),
+            }
+            for row in rows
+        ]
+
     def _set_terminal(
         self,
         fingerprint: str,
         *,
         state: Literal["succeeded", "unknown"],
         result: dict[str, object] | None,
+        allowed_source_states: tuple[str, ...] = ("pending",),
     ) -> None:
         self._initialize()
         result_json = (
@@ -294,14 +396,15 @@ class PublishReceiptStore:
             if result is not None
             else None
         )
+        placeholders = ", ".join("?" for _ in allowed_source_states)
         with self._connect() as connection:
             cursor = connection.execute(
-                """
+                f"""
                 UPDATE publish_receipts
                 SET state = ?, result_json = ?
-                WHERE fingerprint = ? AND state = 'pending'
+                WHERE fingerprint = ? AND state IN ({placeholders})
                 """,
-                (state, result_json, fingerprint),
+                (state, result_json, fingerprint, *allowed_source_states),
             )
             if cursor.rowcount != 1:
                 raise RuntimeError("publish receipt is not pending")

--- a/src/kpubdata_builder/service/routes/publish.py
+++ b/src/kpubdata_builder/service/routes/publish.py
@@ -18,6 +18,8 @@ if TYPE_CHECKING:
 
 _READINESS_SUFFIX = "/publish/readiness"
 _PUBLISH_SUFFIX = "/publish"
+_RECEIPT_SUFFIX = "/publish/receipt"
+_RECONCILE_SUFFIX = "/publish/reconcile"
 
 
 def route(
@@ -49,6 +51,50 @@ def route(
         if access_error is not None:
             return access_error
         return service.publish_readiness(run_id, target)
+
+    if method == "GET" and rest.endswith(_RECEIPT_SUFFIX):
+        run_id = rest[: -len(_RECEIPT_SUFFIX)]
+        error = _validate_run_id(run_id)
+        if error is not None:
+            return error
+        query_params = parse_qs(query)
+        target = (query_params.get("target") or [""])[-1]
+        destination = (query_params.get("destination") or [""])[-1]
+        if not target or not destination:
+            return ServiceResponse(
+                400, {"error": "'target' and 'destination' query parameters are required"}
+            )
+        access_error = check_active_run_access(service, run_id, principal)
+        if access_error is not None:
+            return access_error
+        return service.get_publish_receipt(run_id, target, destination, principal=principal)
+
+    if method == "POST" and rest.endswith(_RECONCILE_SUFFIX):
+        run_id = rest[: -len(_RECONCILE_SUFFIX)]
+        error = _validate_run_id(run_id)
+        if error is not None:
+            return error
+        access_error = check_active_run_access(service, run_id, principal)
+        if access_error is not None:
+            return access_error
+        return service.reconcile_publish(run_id, body, principal=principal)
+
+    if method == "DELETE" and rest.endswith(_RECEIPT_SUFFIX):
+        run_id = rest[: -len(_RECEIPT_SUFFIX)]
+        error = _validate_run_id(run_id)
+        if error is not None:
+            return error
+        query_params = parse_qs(query)
+        target = (query_params.get("target") or [""])[-1]
+        destination = (query_params.get("destination") or [""])[-1]
+        if not target or not destination:
+            return ServiceResponse(
+                400, {"error": "'target' and 'destination' query parameters are required"}
+            )
+        access_error = check_active_run_access(service, run_id, principal)
+        if access_error is not None:
+            return access_error
+        return service.reset_publish_receipt(run_id, target, destination, principal=principal)
 
     if method == "POST" and rest.endswith(_PUBLISH_SUFFIX):
         run_id = rest[: -len(_PUBLISH_SUFFIX)]

--- a/tests/unit/test_openapi_examples.py
+++ b/tests/unit/test_openapi_examples.py
@@ -175,7 +175,7 @@ def test_extraction_script_emits_documented_json_shape() -> None:
         text=True,
     )
     payload = json.loads(completed.stdout)
-    assert payload["contract_version"] == "1.18.0"
+    assert payload["contract_version"] == "1.19.0"
     assert len(payload["examples"]) >= 50
     assert set(payload["examples"][0]) == {
         "path",

--- a/tests/unit/test_service_publish.py
+++ b/tests/unit/test_service_publish.py
@@ -1008,6 +1008,213 @@ def _assert_conforms(resp: ServiceResponse, path: str, method: str) -> None:
     )
 
 
+class TestReceiptReconcile:
+    """unknown receipt의 조회/reconcile/reset 운영 경로 (#551)."""
+
+    def _unknown_receipt_service(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, run_id: str
+    ) -> BuilderService:
+        """publish가 실패해 receipt가 unknown인 service를 만든다."""
+        _with_credentials(monkeypatch, "huggingface")
+        failing = _SpyPublisher("huggingface", error=RuntimeError("remote blew up"))
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", failing)
+        service = _service(tmp_path)
+        _build(service, run_id, LICENSED_SPEC_YAML)
+        resp = _publish(service, run_id)
+        assert resp.status_code == 502
+        return service
+
+    def test_get_receipt_reports_unknown_state(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        service = self._unknown_receipt_service(tmp_path, monkeypatch, "run-unknown")
+        resp = dispatch(
+            service,
+            "GET",
+            "/builds/run-unknown/publish/receipt",
+            None,
+            query="target=huggingface&destination=kpubdata%2Fair-quality",
+        )
+        assert resp.status_code == 200
+        assert resp.body["state"] == "unknown"
+        assert resp.body["reconcilable"] is True
+        assert resp.body["target"] == "huggingface"
+
+    def test_get_receipt_missing_returns_404(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        resp = dispatch(
+            service,
+            "GET",
+            "/builds/run-none/publish/receipt",
+            None,
+            query="target=huggingface&destination=kpubdata%2Fair-quality",
+        )
+        assert resp.status_code == 404
+
+    def test_reconcile_remote_exists_confirms_succeeded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        service = self._unknown_receipt_service(tmp_path, monkeypatch, "run-exists")
+        monkeypatch.setattr(service, "_probe_remote_publish_target", lambda *_args: True)
+
+        resp = dispatch(
+            service,
+            "POST",
+            "/builds/run-exists/publish/reconcile",
+            {"target": "huggingface", "destination": "kpubdata/air-quality"},
+        )
+        assert resp.status_code == 200
+        assert resp.body["state"] == "succeeded"
+        assert resp.body["reconciled"] is True
+
+        # 이후 동일 publish 요청은 receipt 결과를 replay한다(중복 게시 없음).
+        ok_publisher = _SpyPublisher("huggingface")
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", ok_publisher)
+        replay = _publish(service, "run-exists")
+        assert replay.status_code == 200
+        assert ok_publisher.calls == []
+
+    def test_reconcile_remote_absent_resets_and_allows_retry(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        service = self._unknown_receipt_service(tmp_path, monkeypatch, "run-absent")
+        monkeypatch.setattr(service, "_probe_remote_publish_target", lambda *_args: False)
+
+        resp = dispatch(
+            service,
+            "POST",
+            "/builds/run-absent/publish/reconcile",
+            {"target": "huggingface", "destination": "kpubdata/air-quality"},
+        )
+        assert resp.status_code == 200
+        assert resp.body["state"] == "reset"
+        assert resp.body["retry_allowed"] is True
+
+        # reset 이후 같은 operation을 다시 게시할 수 있다(새 claim).
+        ok_publisher = _SpyPublisher("huggingface")
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", ok_publisher)
+        retry = _publish(service, "run-absent")
+        assert retry.status_code == 200
+        assert len(ok_publisher.calls) == 1
+
+    def test_reconcile_probe_unavailable_changes_nothing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        service = self._unknown_receipt_service(tmp_path, monkeypatch, "run-probe-down")
+        monkeypatch.setattr(service, "_probe_remote_publish_target", lambda *_args: None)
+
+        resp = dispatch(
+            service,
+            "POST",
+            "/builds/run-probe-down/publish/reconcile",
+            {"target": "huggingface", "destination": "kpubdata/air-quality"},
+        )
+        assert resp.status_code == 503
+        assert resp.body["code"] == "reconcile_unavailable"
+
+        blocked = _publish(service, "run-probe-down")
+        assert blocked.status_code == 409
+        assert blocked.body["code"] == "publish_state_unknown"
+
+    def test_reconcile_succeeded_receipt_is_idempotent_noop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _with_credentials(monkeypatch, "huggingface")
+        spy = _SpyPublisher("huggingface")
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", spy)
+        service = _service(tmp_path)
+        _build(service, "run-done", LICENSED_SPEC_YAML)
+        assert _publish(service, "run-done").status_code == 200
+        probes: list[tuple[str, str]] = []
+        monkeypatch.setattr(
+            service,
+            "_probe_remote_publish_target",
+            lambda target, destination: probes.append((target, destination)),
+        )
+
+        resp = dispatch(
+            service,
+            "POST",
+            "/builds/run-done/publish/reconcile",
+            {"target": "huggingface", "destination": "kpubdata/air-quality"},
+        )
+        assert resp.status_code == 200
+        assert resp.body["state"] == "succeeded"
+        assert resp.body["reconciled"] is False
+        assert probes == []
+
+    def test_delete_receipt_resets_with_audit(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        service = self._unknown_receipt_service(tmp_path, monkeypatch, "run-manual")
+        # reset 전 receipt에서 fingerprint와 owner를 읽어 감사 로그를 결정적으로 검증한다.
+        receipts = service._publish_receipts
+        import sqlite3
+
+        with sqlite3.connect(receipts.path) as conn:
+            fingerprint, owner_key = conn.execute(
+                "SELECT fingerprint, owner_key FROM publish_receipts WHERE run_id = 'run-manual'"
+            ).fetchone()
+
+        resp = dispatch(
+            service,
+            "DELETE",
+            "/builds/run-manual/publish/receipt",
+            None,
+            query="target=huggingface&destination=kpubdata%2Fair-quality",
+        )
+        assert resp.status_code == 200
+        assert resp.body["state"] == "reset"
+
+        gone = dispatch(
+            service,
+            "GET",
+            "/builds/run-manual/publish/receipt",
+            None,
+            query="target=huggingface&destination=kpubdata%2Fair-quality",
+        )
+        assert gone.status_code == 404
+
+        with sqlite3.connect(receipts.path) as conn:
+            audit_rows = conn.execute(
+                "SELECT fingerprint, action FROM publish_receipt_audit"
+            ).fetchall()
+        assert audit_rows == [(fingerprint, "manual_reset")]
+
+    def test_cross_owner_receipt_is_404(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(_OWNERSHIP_ENV, "true")
+        owner = Principal(kind="oidc", identifier="a", owner_id="oidc:owner-a")
+        monkeypatch.setattr(app_module, "authenticate", lambda **_kwargs: owner)
+        _with_credentials(monkeypatch, "huggingface")
+        failing = _SpyPublisher("huggingface", error=RuntimeError("boom"))
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "huggingface", failing)
+        service = _service(tmp_path)
+        _build(service, "run-owned-reconcile", LICENSED_SPEC_YAML)
+        assert _publish(service, "run-owned-reconcile").status_code == 502
+
+        other = Principal(kind="oidc", identifier="b", owner_id="oidc:owner-b")
+        monkeypatch.setattr(app_module, "authenticate", lambda **_kwargs: other)
+        # publish/readiness 라우트와 동일하게 run 소유권 게이트가 403으로 차단한다.
+        resp = dispatch(
+            service,
+            "GET",
+            "/builds/run-owned-reconcile/publish/receipt",
+            None,
+            query="target=huggingface&destination=kpubdata%2Fair-quality",
+        )
+        assert resp.status_code == 403
+        reset_resp = dispatch(
+            service,
+            "DELETE",
+            "/builds/run-owned-reconcile/publish/receipt",
+            None,
+            query="target=huggingface&destination=kpubdata%2Fair-quality",
+        )
+        assert reset_resp.status_code == 403
+
+
 class TestOpenApiConformance:
     """실제 dispatch() wire 응답이 OpenAPI 스키마와 정확히 일치하는지 (ADR-0005 방식)."""
 


### PR DESCRIPTION
## 목적
이슈 #551 — #547의 idempotency 설계에서 Publisher 결과가 불명확하면 receipt가 `unknown`으로 남아 동일 operation이 영구 409 차단된다. 이를 운영자가 안전하게 해소하는 경로를 추가한다.

## API (계약 1.19.0, additive)
| Method | Path | 동작 |
|---|---|---|
| GET | `/builds/{run_id}/publish/receipt?target=&destination=` | 상태 조회(`reconcilable` 힌트 포함). 미존재 404 |
| POST | `/builds/{run_id}/publish/reconcile` | HF 원격 repo 존재 probe → 존재 시 `succeeded` 확정 / 부재 시 receipt reset(재게시 허용) / 판단 불가 시 **503 무변경** |
| DELETE | `/builds/{run_id}/publish/receipt?target=&destination=` | 명시적 reset(원격 부작용 없음) |

## 설계 원칙 (#491 승계)
- **blind retry 금지 유지**: reconcile은 원격 상태를 확인한 뒤에만 상태를 바꾼다
- **무결정 = 무변경**: probe 실패(HF_TOKEN 부재·네트워크)는 503, receipt 그대로
- **감사 로그**: `publish_receipt_audit` 테이블에 `reconcile_succeeded`/`reconcile_absent_reset`/`manual_reset` append (credential/경로 미포함)
- **소유권**: 기존 publish 라우트와 동일한 run 소유권 게이트(403) + receipt owner 키 조회
- **reset 후 semantics**: 새 claim으로 재게시 가능, 이미 게시된 원격 결과는 되돌리지 않음

## 검증
- 신규 테스트 8개 (조회/404/reconcile 3분기/멱등 noop/감사로그/교차소유자)
- ruff ✅ mypy ✅ 계약·OpenAPI 핀 갱신 ✅

Closes #551