### PR TITLE
fix(tests): Windows 크로스플랫폼 테스트 실패 정리 — tzdata/symlink skip/cp949/spawn 배율 (#553)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,9 @@ dev = [
   "pytest-cov>=5,<8",
   "ruff>=0.5,<1",
   "types-PyYAML>=6.0",
+  # Windows에서 zoneinfo가 시스템 tz 데이터베이스를 찾지 못하는 경우를
+  # 대비해 tzdata wheel을 보장한다(#553). Linux에서는 no-op다.
+  "tzdata>=2024.1",
   # auth extra를 dev에 포함해 CI(mypy/ruff/pytest)에서 항상 타입 체크 가능 (#385).
   "pyjwt[crypto]>=2.9,<3",
 ]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,15 +1,51 @@
 """테스트 설정 fixture (#326).
 
 이 모듈은 모든 테스트에서 공통으로 사용하는 fixture를 정의한다.
+Windows 크로스플랫폼 판정 헬퍼(#553)도 여기에 둔다.
 """
 
 from __future__ import annotations
 
+import sys
+import tempfile
 from collections.abc import Iterator
+from pathlib import Path
 
 import pytest
 
 from kpubdata_builder.exporters import EXPORTER_REGISTRY
+
+
+def symlinks_supported() -> bool:
+    """현재 권한/파일시스템에서 symlink 생성이 가능한지 (#553).
+
+    Windows는 관리자 권한 또는 Developer Mode 없이는 symlink_to가
+    OSError를 낸다 — symlink 동작 자체가 주제인 테스트는 이 값으로 skip한다.
+    """
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "target"
+            target.mkdir()
+            link = Path(tmp) / "link"
+            link.symlink_to(target, target_is_directory=True)
+            return True
+    except OSError:
+        return False
+
+
+def spawn_timeout_multiplier() -> float:
+    """process spawn 기반 테스트의 timeout 배율 (#553).
+
+    Windows spawn은 자식 인터프리터가 모듈(polars 포함)을 새로 import하므로
+    Linux 대비 수 초 이상 느릴 수 있다 — 시간 자체가 주제가 아닌 테스트의
+    timeout을 플랫폼 배율로 넉넉하게 잡는다.
+    """
+    return 3.0 if sys.platform == "win32" else 1.0
+
+
+requires_symlinks = pytest.mark.skipif(
+    not symlinks_supported(), reason="symlink creation is not permitted on this platform (#553)"
+)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_build_index.py
+++ b/tests/unit/test_build_index.py
@@ -10,6 +10,8 @@ import pytest
 
 from kpubdata_builder.store import SCHEMA_VERSION, BuildIndex, rebuild_index
 
+from .conftest import requires_symlinks
+
 
 class TestBuildIndex:
     """BuildIndex 단위 테스트."""
@@ -597,6 +599,7 @@ class TestRebuildIndex:
         assert entry is not None
         assert entry.dataset_id is None
 
+    @requires_symlinks
     def test_rebuild_skips_symlinked_snapshot(self, tmp_path: Path) -> None:
         run_dir = tmp_path / "run1"
         run_dir.mkdir()

--- a/tests/unit/test_openapi_examples.py
+++ b/tests/unit/test_openapi_examples.py
@@ -173,6 +173,9 @@ def test_extraction_script_emits_documented_json_shape() -> None:
         check=True,
         capture_output=True,
         text=True,
+        # 스크립트가 ensure_ascii=False(한글 원문)로 출력하므로 Windows cp949
+        # 기본 디코딩을 쓰지 않는다(#553).
+        encoding="utf-8",
     )
     payload = json.loads(completed.stdout)
     assert payload["contract_version"] == "1.18.0"

--- a/tests/unit/test_path_safety.py
+++ b/tests/unit/test_path_safety.py
@@ -14,6 +14,8 @@ from kpubdata_builder.stages._path_safety import (
     validate_path_segment,
 )
 
+from .conftest import requires_symlinks
+
 
 class TestStripWindowsExtendedPrefix:
     """Windows ``\\\\?\\`` 확장 경로 프리픽스 제거 (#506).
@@ -103,6 +105,7 @@ class TestEnsureWithin:
 
         ensure_within(root, target, label="silver directory")  # 예외 없음
 
+    @requires_symlinks
     def test_rejects_escape_via_existing_symlink(self, tmp_path: Path) -> None:
         root = tmp_path / "root"
         root.mkdir()

--- a/tests/unit/test_query_engine.py
+++ b/tests/unit/test_query_engine.py
@@ -13,6 +13,8 @@ import pytest
 import kpubdata_builder.query.engine as engine_module
 from kpubdata_builder.query.engine import QueryEngine, QueryExecutionError, QueryTimeoutError
 
+from .conftest import spawn_timeout_multiplier
+
 
 def _sleeping_worker(
     connection: Connection,
@@ -54,7 +56,8 @@ def test_timeout_leaves_child_not_alive(tmp_path: Path) -> None:
     pid_file = tmp_path / "child.pid"
     # Windows spawn imports the test module in a fresh interpreter, so leave
     # enough time for the worker to publish its PID before exercising timeout.
-    engine = QueryEngine(timeout_seconds=5, worker=_sleeping_worker)
+    timeout_seconds = 5 * spawn_timeout_multiplier()
+    engine = QueryEngine(timeout_seconds=timeout_seconds, worker=_sleeping_worker)
 
     with pytest.raises(QueryTimeoutError):
         engine.execute(pid_file, "SELECT * FROM dataset", limit=1)
@@ -73,7 +76,7 @@ def test_real_engine_executes_canonical_sql_and_hard_limit(
     sql = "SELECT value FROM dataset ORDER BY value"
     caplog.set_level(logging.INFO, logger=engine_module.__name__)
 
-    result = QueryEngine(timeout_seconds=5).execute(
+    result = QueryEngine(timeout_seconds=5 * spawn_timeout_multiplier()).execute(
         table_path,
         sql,
         limit=2,
@@ -109,7 +112,7 @@ def test_real_engine_raises_execution_error_for_unresolvable_column(tmp_path: Pa
     pl.DataFrame({"value": [1, 2, 3]}).write_parquet(table_path)
 
     with pytest.raises(QueryExecutionError):
-        QueryEngine(timeout_seconds=5).execute(
+        QueryEngine(timeout_seconds=5 * spawn_timeout_multiplier()).execute(
             table_path,
             "SELECT nonexistent_column FROM dataset",
             limit=1,

--- a/tests/unit/test_service_publish.py
+++ b/tests/unit/test_service_publish.py
@@ -28,6 +28,7 @@ from kpubdata_builder.service.ownership import _OWNERSHIP_ENV
 from kpubdata_builder.spec import JsonValue
 
 from ._openapi import response_schema, validate
+from .conftest import requires_symlinks
 from .test_service import _FakeClient
 from .test_service_contract import _load_contract
 
@@ -960,6 +961,7 @@ class TestArtifactScope:
         assert "artifact_invalid" in _blocker_codes(resp)
         assert spy.calls == []
 
+    @requires_symlinks
     def test_symlink_escape_artifact_blocks_publish(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -783,6 +783,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "types-pyyaml" },
+    { name = "tzdata" },
 ]
 docs = [
     { name = "mkdocs" },
@@ -823,6 +824,7 @@ requires-dist = [
     { name = "sqlglot", specifier = ">=30.17,<31" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "typing-extensions", specifier = ">=4.5,<5" },
+    { name = "tzdata", marker = "extra == 'dev'", specifier = ">=2024.1" },
     { name = "urllib3", specifier = ">=2.7.0,<3" },
     { name = "xmltodict", marker = "extra == 'publish'", specifier = ">=0.13,<2" },
 ]
@@ -1766,6 +1768,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 목적
이슈 #553 — Windows 로컬 전체 실행에서 반복 재현되던 사전 존재 실패 9건(+#548 7건)을 결정적으로 통과시키거나 명시적으로 skip한다.

## 수정 (Linux 동작 무변경)
| 원인 | 수정 |
|---|---|
| tzdata/UTC zoneinfo 부재 | dev extra에 `tzdata>=2024.1` — Windows에서 zoneinfo가 시스템 tz DB를 못 찾을 때 wheel이 해결. Linux no-op |
| symlink 생성 권한 | `tests/unit/conftest.py`에 `symlinks_supported()` probe + `requires_symlinks` marker. symlink 테스트 3건(path_safety·build_index·service_publish)에 적용 |
| cp949 콘솔 인코딩 | `extract_openapi_examples.py`가 `ensure_ascii=False`(한글 원문)로 출력하는데 테스트가 `subprocess.run(text=True)` 기본 인코딩(cp949)으로 읽음 → `encoding="utf-8"` 명시 |
| spawn 지연 간헐 timeout | `spawn_timeout_multiplier()`(win32 3x)를 query engine timeout 3곳에 적용 — 시간이 주제가 아닌 테스트만 |

## 제외
- CI Windows matrix 추가: **워크플로 파일 수정은 현재 토큰의 `workflow` 스코프 제약으로 머지 불가**(#542-546와 동일 사유). 리포지토리 설정에서 스코프 확장 후 별도 PR 권장.

## 검증
- Linux에서 유닛 테스트 1,515 전부 통과(동작 무변경 확인), ruff/mypy ✅

Closes #553