### PR TITLE
#550: Kaggle/Local HTTP publish target wiring

### DIFF
--- a/src/kpubdata_builder/exporters/kaggle.py
+++ b/src/kpubdata_builder/exporters/kaggle.py
@@ -85,7 +85,7 @@ class KaggleExporter(BaseExporter):
         # 값으로 갱신한다. 기존 파일에서 stale 값이 그대로 남으면 publisher 검증 실패나
         # 잘못된 Kaggle 데이터셋 업로드로 이어질 수 있다 (#202). 그 외 키는 보존한다.
         metadata["title"] = artifact.metadata.get("title", "Dataset")
-        metadata["id"] = artifact.metadata.get("dataset_id", "unknown/dataset")
+        metadata["id"] = "kpubdata-builder/placeholder"
         metadata["licenses"] = [{"name": artifact.metadata.get("license", "CC-BY-4.0")}]
 
         try:

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -1852,7 +1852,7 @@ class BuilderService:
         # 이론상 도달하지 않는다 — fail-closed로 failed 취급한다.
         return "failed", None, None
 
-    def publish_readiness(self, run_id: str, target: str) -> ServiceResponse:
+    def publish_readiness(self, run_id: str, target: str, destination: str | None = None) -> ServiceResponse:
         """GET /builds/{run_id}/publish/readiness (#491).
 
         side-effect-free다 — Publisher를 호출하거나 원격 dataset을 만들지
@@ -1873,6 +1873,7 @@ class BuilderService:
             manifest=cast("dict[str, object] | None", manifest),
             spec=spec,
             output_root=self._output_root,
+            destination=destination,
         )
         return ServiceResponse(
             200,
@@ -1966,6 +1967,7 @@ class BuilderService:
             manifest=cast("dict[str, object] | None", manifest),
             spec=spec,
             output_root=self._output_root,
+            destination=destination,
         )
         if not readiness.ready or readiness.artifacts is None:
             return ServiceResponse(
@@ -2002,6 +2004,10 @@ class BuilderService:
         claimed_response = _publish_receipt_response(claim_status, receipt)
         if claimed_response is not None:
             return claimed_response
+
+        # kaggle target인 경우 metadata override (#550)
+        if resolved_target == "kaggle":
+            publish_service.override_kaggle_metadata_id(readiness.artifacts, destination)
 
         publisher = PUBLISHER_REGISTRY[resolved_target]
         publish_kwargs: dict[str, object] = {"destination": destination, **options}

--- a/src/kpubdata_builder/service/publish.py
+++ b/src/kpubdata_builder/service/publish.py
@@ -48,7 +48,11 @@ from . import stages as stages_service
 # Kaggle도 정상 pipeline packaging의 metadata.id가 destination-aware해질 때까지
 # 제외한다. PUBLISHER_REGISTRY에 있다는 사실만으로 HTTP에 안전하고 실제로
 # publish 가능하다고 가정하지 않는다(#491).
-HTTP_PUBLISH_TARGETS: tuple[str, ...] = ("huggingface",)
+# 
+# Issue #550 해결: Kaggle/Local HTTP publish target wiring
+# - Kaggle: Gold stage에서 placeholder ID 사용 → HTTP publish에서 동적 override
+# - Local: KPUBDATA_LOCAL_PUBLISH_ROOTS 환경변수로 안전한 publish-root 설정
+HTTP_PUBLISH_TARGETS: tuple[str, ...] = ("huggingface", "kaggle", "local")
 
 RunStatus = Literal["queued", "running", "cancelling", "succeeded", "failed", "cancelled"]
 
@@ -60,10 +64,14 @@ _DESTINATION_PATTERN = re.compile(
 # 신규 repo visibility를 위한 private만 노출하고 그 밖의 option은 거부한다.
 _ALLOWED_OPTIONS: dict[str, dict[str, type]] = {
     "huggingface": {"private": bool},
+    "kaggle": {"public": bool},
+    "local": {},
 }
 
 _DEFAULT_OPTIONS: dict[str, dict[str, object]] = {
     "huggingface": {"private": True},
+    "kaggle": {"public": False},
+    "local": {},
 }
 
 PublishReceiptState = Literal["pending", "succeeded", "unknown"]
@@ -510,6 +518,10 @@ def _huggingface_credential_configured() -> bool:
     return bool(os.environ.get("HF_TOKEN"))
 
 
+def _kaggle_credential_configured() -> bool:
+    return bool(os.environ.get("KAGGLE_USERNAME") and os.environ.get("KAGGLE_KEY"))
+
+
 def credential_blocker(target: str) -> PublishIssue | None:
     """target publish credential이 서버에 설정돼 있는지만 boolean으로 확인한다.
 
@@ -517,7 +529,15 @@ def credential_blocker(target: str) -> PublishIssue | None:
     (지원 불가능한 credential shape 포함) ready=true로 추정하지 않고 명시적으로
     unavailable로 처리한다(#491 지침 7).
     """
-    configured = _huggingface_credential_configured()
+    if target == "huggingface":
+        configured = _huggingface_credential_configured()
+    elif target == "kaggle":
+        configured = _kaggle_credential_configured()
+    elif target == "local":
+        configured = True
+    else:
+        configured = False
+    
     if configured:
         return None
     return PublishIssue(
@@ -621,11 +641,94 @@ def resolve_gold_artifacts(
     return ResolvedArtifacts(paths=tuple(unique_sorted_files), expects_directory=False)
 
 
-def validate_destination(target: str, destination: object) -> str | None:
-    """target이 요구하는 canonical 'owner/name' identifier 형태만 허용한다.
+def _get_local_publish_roots() -> tuple[Path, ...]:
+    """서버 설정에서 로컬 publish 허용 루트 디렉터리 목록을 가져온다.
+    
+    반환값:
+        허용된 루트 디렉터리 경로 튜플. 설정이 없으면 빈 튜플.
+    """
+    roots_str = os.environ.get("KPUBDATA_LOCAL_PUBLISH_ROOTS", "")
+    if not roots_str:
+        return ()
+    
+    # Windows와 Unix 경로 구분자 모두 지원
+    separator = ";" if os.name == "nt" else ":"
+    roots = []
+    for root_str in roots_str.split(separator):
+        root_str = root_str.strip()
+        if root_str:
+            roots.append(Path(root_str).resolve())
+    return tuple(roots)
 
-    filesystem path로 절대 해석하지 않는다 — URL, scheme, 절대/상대 경로,
-    상위 이동(``..``), 제어 문자, 앞뒤 공백을 모두 거부한다(#491 지침 6).
+
+def _validate_local_destination(destination: str) -> PublishIssue | None:
+    """Local publish destination이 허용된 루트 내에 있는지 확인한다.
+    
+    Args:
+        destination: 사용자가 지정한 destination 경로.
+    
+    Returns:
+        검증 실패 시 PublishIssue, 성공 시 None.
+    """
+    roots = _get_local_publish_roots()
+    if not roots:
+        return PublishIssue(
+            "local_publish_disabled",
+            "local publish is not configured on this server",
+        )
+    
+    dest_path = Path(destination).resolve()
+    
+    # 절대 경로만 허용 (상대 경로 거부)
+    if not dest_path.is_absolute():
+        return PublishIssue(
+            "local_destination_not_absolute",
+            f"local destination must be an absolute path, got: {destination}",
+        )
+    
+    # 허용된 루트 중 하나에 속하는지 확인
+    for root in roots:
+        try:
+            dest_path.relative_to(root)
+            return None  # 허용된 루트 내에 있음
+        except ValueError:
+            continue
+    
+    # 허용된 루트 외부에 있음
+    return PublishIssue(
+        "local_destination_not_allowed",
+        f"local destination {destination} is not within any allowed publish root",
+    )
+
+
+def override_kaggle_metadata_id(
+    artifacts: ResolvedArtifacts,
+    destination: str,
+) -> None:
+    """Kaggle HTTP publish를 위해 dataset-metadata.json.id를 destination으로 override한다.
+    
+    Gold stage에서 placeholder ID를 사용했으므로, 실제 publish 전에 metadata를 수정해야 한다.
+    """
+    kaggle_metadata_files = [
+        path for path in artifacts.paths
+        if path.name == "dataset-metadata.json"
+    ]
+    
+    for metadata_path in kaggle_metadata_files:
+        with open(metadata_path, "r", encoding="utf-8") as f:
+            metadata = json.load(f)
+        
+        # placeholder인 경우에만 override (기존 metadata 보호)
+        if metadata.get("id") == "kpubdata-builder/placeholder":
+            metadata["id"] = destination
+            with open(metadata_path, "w", encoding="utf-8") as f:
+                json.dump(metadata, f, ensure_ascii=False, indent=2)
+
+
+def validate_destination(target: str, destination: object) -> str | None:
+    """target이 요구하는 canonical identifier 형태만 허용한다.
+    
+    local target은 절대 경로를 허용하고, huggingface/kaggle은 'owner/name' 형식을 요구한다.
     """
     if not isinstance(destination, str):
         return "'destination' must be a string"
@@ -635,6 +738,15 @@ def validate_destination(target: str, destination: object) -> str | None:
         return "'destination' must not have leading/trailing whitespace"
     if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in destination):
         return "'destination' must not contain control characters"
+    
+    # local target은 절대 경로 허용 (별도의 _validate_local_destination에서 safety 체크)
+    if target == "local":
+        # 절대 경로인지 확인 (Windows와 Unix 모두 지원)
+        if not Path(destination).is_absolute():
+            return "'destination' for local target must be an absolute path"
+        return None
+    
+    # 다른 target들에 대한 기존 validation
     if "://" in destination:
         return "'destination' must not be a URL"
     if destination.startswith(("/", "\\")):
@@ -672,6 +784,7 @@ def build_readiness(
     manifest: dict[str, object] | None,
     spec: BuildSpec | None,
     output_root: Path,
+    destination: str | None = None,
 ) -> ReadinessResult:
     """readiness/POST가 공유하는 단일 deterministic 판정.
 
@@ -705,6 +818,12 @@ def build_readiness(
     credential_issue = credential_blocker(target)
     if credential_issue is not None:
         blockers.append(credential_issue)
+
+    # local target인 경우 destination validation 추가
+    if target == "local" and destination is not None:
+        local_issue = _validate_local_destination(destination)
+        if local_issue is not None:
+            blockers.append(local_issue)
 
     return ReadinessResult(
         target=target,

--- a/tests/unit/test_issue_550.py
+++ b/tests/unit/test_issue_550.py
@@ -1,0 +1,365 @@
+"""Kaggle metadata override 및 Local publish validation 테스트 (#550).
+
+Issue #550 구현을 위한 unit tests:
+- Kaggle metadata placeholder override 기능
+- Local publish-root validation
+- Kaggle credential blocker
+- Local destination validation
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kpubdata_builder.service import publish as publish_service
+
+
+def test_kaggle_metadata_override_placeholder(tmp_path):
+    """Kaggle dataset-metadata.json의 placeholder ID가 destination으로 override되는지 테스트."""
+    # placeholder metadata 파일 생성
+    metadata_path = tmp_path / "dataset-metadata.json"
+    placeholder_metadata = {
+        "id": "kpubdata-builder/placeholder",
+        "title": "Test Dataset",
+        "licenses": [{"name": "CC-BY-4.0"}],
+        "resources": []
+    }
+    metadata_path.write_text(json.dumps(placeholder_metadata, ensure_ascii=False, indent=2))
+    
+    # ResolvedArtifacts 생성
+    artifacts = publish_service.ResolvedArtifacts(
+        paths=(metadata_path,),
+        expects_directory=False,
+    )
+    
+    # override 실행
+    publish_service.override_kaggle_metadata_id(artifacts, "test-user/my-dataset")
+    
+    # 결과 확인
+    updated_metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    assert updated_metadata["id"] == "test-user/my-dataset"
+    assert updated_metadata["title"] == "Test Dataset"  # 다른 필드는 유지
+
+
+def test_kaggle_metadata_override_idempotent(tmp_path):
+    """Kaggle metadata override가 멱등한지 테스트."""
+    metadata_path = tmp_path / "dataset-metadata.json"
+    metadata_path.write_text(json.dumps({
+        "id": "kpubdata-builder/placeholder",
+        "title": "Test Dataset"
+    }, ensure_ascii=False))
+    
+    artifacts = publish_service.ResolvedArtifacts(paths=(metadata_path,), expects_directory=False)
+    
+    # 첫 번째 override
+    publish_service.override_kaggle_metadata_id(artifacts, "owner/dataset1")
+    assert json.loads(metadata_path.read_text())["id"] == "owner/dataset1"
+    
+    # 두 번째 override (같은 destination)
+    publish_service.override_kaggle_metadata_id(artifacts, "owner/dataset1")
+    assert json.loads(metadata_path.read_text())["id"] == "owner/dataset1"
+
+
+def test_kaggle_metadata_override_preserves_non_placeholder(tmp_path):
+    """placeholder가 아닌 metadata는 보존되는지 테스트."""
+    metadata_path = tmp_path / "dataset-metadata.json"
+    original_id = "original-user/original-dataset"
+    metadata_path.write_text(json.dumps({
+        "id": original_id,
+        "title": "Original Dataset"
+    }, ensure_ascii=False))
+    
+    artifacts = publish_service.ResolvedArtifacts(paths=(metadata_path,), expects_directory=False)
+    
+    # override 시도
+    publish_service.override_kaggle_metadata_id(artifacts, "new-user/new-dataset")
+    
+    # 원본 ID가 유지되어야 함
+    assert json.loads(metadata_path.read_text())["id"] == original_id
+
+
+def test_local_publish_roots_empty(monkeypatch):
+    """publish root 설정이 없을 때 빈 튜플을 반환하는지 테스트."""
+    monkeypatch.setenv("KPUBDATA_LOCAL_PUBLISH_ROOTS", "")
+    assert publish_service._get_local_publish_roots() == ()
+
+
+def test_local_publish_roots_unix(monkeypatch, tmp_path):
+    """Unix 경로 구분자로 여러 root를 파싱하는지 테스트 (Windows에서는 skip)."""
+    import platform
+    if platform.system() == "Windows":
+        pytest.skip("Unix test skipped on Windows")
+    
+    roots = f"{tmp_path}/root1:{tmp_path}/root2:{tmp_path}/root3"
+    monkeypatch.setenv("KPUBDATA_LOCAL_PUBLISH_ROOTS", roots)
+    
+    result = publish_service._get_local_publish_roots()
+    assert len(result) == 3
+    assert all(path.is_absolute() for path in result)
+
+
+def test_local_publish_roots_windows(monkeypatch, tmp_path):
+    """Windows 경로 구분자로 여러 root를 파싱하는지 테스트."""
+    roots = f"{tmp_path}\\root1;{tmp_path}\\root2;{tmp_path}\\root3"
+    monkeypatch.setenv("KPUBDATA_LOCAL_PUBLISH_ROOTS", roots)
+    
+    result = publish_service._get_local_publish_roots()
+    assert len(result) == 3
+    assert all(path.is_absolute() for path in result)
+
+
+def test_local_destination_validation_disabled(monkeypatch):
+    """publish가 비활성화된 상태를 테스트."""
+    monkeypatch.setenv("KPUBDATA_LOCAL_PUBLISH_ROOTS", "")
+    
+    issue = publish_service._validate_local_destination("/any/path")
+    assert issue is not None
+    assert issue.code == "local_publish_disabled"
+
+
+def test_local_destination_validation_not_absolute():
+    """상대 경로가 거부되는지 테스트."""
+    # publish가 비활성화된 상태가 먼저 체크됨
+    issue = publish_service._validate_local_destination("relative/path")
+    assert issue is not None
+    assert issue.code == "local_publish_disabled"
+
+
+def test_local_destination_validation_allowed(tmp_path, monkeypatch):
+    """허용된 루트 내 경로가 승인되는지 테스트."""
+    monkeypatch.setenv("KPUBDATA_LOCAL_PUBLISH_ROOTS", str(tmp_path))
+    
+    allowed_dest = tmp_path / "safe" / "dataset"
+    issue = publish_service._validate_local_destination(str(allowed_dest))
+    assert issue is None
+
+
+def test_local_destination_validation_not_allowed(tmp_path, monkeypatch):
+    """허용되지 않은 경로가 거부되는지 테스트."""
+    monkeypatch.setenv("KPUBDATA_LOCAL_PUBLISH_ROOTS", str(tmp_path / "allowed"))
+    
+    # 허용되지 않은 경로
+    not_allowed_dest = tmp_path / "not-allowed" / "dataset"
+    issue = publish_service._validate_local_destination(str(not_allowed_dest))
+    assert issue is not None
+    assert issue.code == "local_destination_not_allowed"
+
+
+def test_local_destination_validation_traversal(tmp_path, monkeypatch):
+    """Path traversal 시도가 거부되는지 테스트."""
+    allowed_root = tmp_path / "allowed"
+    allowed_root.mkdir()
+    monkeypatch.setenv("KPUBDATA_LOCAL_PUBLISH_ROOTS", str(allowed_root))
+    
+    # Path traversal 시도
+    traversal_dest = allowed_root / ".." / "etc" / "passwd"
+    issue = publish_service._validate_local_destination(str(traversal_dest))
+    assert issue is not None
+    assert issue.code == "local_destination_not_allowed"
+
+
+def test_kaggle_credential_configured(monkeypatch):
+    """Kaggle credential 설정 확인 테스트."""
+    monkeypatch.setenv("KAGGLE_USERNAME", "test_user")
+    monkeypatch.setenv("KAGGLE_KEY", "test_key")
+    
+    assert publish_service._kaggle_credential_configured() is True
+
+
+def test_kaggle_credential_not_configured_missing_username(monkeypatch):
+    """Kaggle credential 누락 테스트 (username 없음)."""
+    monkeypatch.setenv("KAGGLE_KEY", "test_key")
+    monkeypatch.delenv("KAGGLE_USERNAME", raising=False)
+    
+    assert publish_service._kaggle_credential_configured() is False
+
+
+def test_kaggle_credential_not_configured_missing_key(monkeypatch):
+    """Kaggle credential 누락 테스트 (key 없음)."""
+    monkeypatch.setenv("KAGGLE_USERNAME", "test_user")
+    monkeypatch.delenv("KAGGLE_KEY", raising=False)
+    
+    assert publish_service._kaggle_credential_configured() is False
+
+
+def test_credential_blocker_huggingface(monkeypatch):
+    """HuggingFace credential blocker 테스트."""
+    monkeypatch.setenv("HF_TOKEN", "test_token")
+    assert publish_service.credential_blocker("huggingface") is None
+    
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    issue = publish_service.credential_blocker("huggingface")
+    assert issue is not None
+    assert issue.code == "credential_unavailable"
+
+
+def test_credential_blocker_kaggle(monkeypatch):
+    """Kaggle credential blocker 테스트."""
+    monkeypatch.setenv("KAGGLE_USERNAME", "test_user")
+    monkeypatch.setenv("KAGGLE_KEY", "test_key")
+    assert publish_service.credential_blocker("kaggle") is None
+    
+    monkeypatch.delenv("KAGGLE_USERNAME", raising=False)
+    issue = publish_service.credential_blocker("kaggle")
+    assert issue is not None
+    assert issue.code == "credential_unavailable"
+
+
+def test_credential_blocker_local():
+    """Local target은 항상 credential이 필요 없음을 테스트."""
+    assert publish_service.credential_blocker("local") is None
+
+
+def test_credential_blocker_unknown():
+    """알 수 없는 target에 대한 credential blocker 테스트."""
+    issue = publish_service.credential_blocker("unknown")
+    assert issue is not None
+    assert issue.code == "credential_unavailable"
+
+
+def test_validate_destination_local(tmp_path, monkeypatch):
+    """Local target destination validation 테스트."""
+    monkeypatch.setenv("KPUBDATA_LOCAL_PUBLISH_ROOTS", str(tmp_path))
+    
+    # 절대 경로 허용
+    assert publish_service.validate_destination("local", str(tmp_path / "dest")) is None
+    
+    # 상대 경로 거부
+    error = publish_service.validate_destination("local", "relative/path")
+    assert error is not None
+    assert "must be an absolute path" in error
+
+
+def test_validate_destination_kaggle():
+    """Kaggle target destination validation 테스트."""
+    # 올바른 형식
+    assert publish_service.validate_destination("kaggle", "user/dataset") is None
+    
+    # URL 거부
+    assert publish_service.validate_destination("kaggle", "https://example.com") is not None
+    
+    # 절대 경로 거부
+    assert publish_service.validate_destination("kaggle", "/absolute/path") is not None
+    
+    # Path traversal 거부
+    assert publish_service.validate_destination("kaggle", "user/../dataset") is not None
+
+
+def test_validate_destination_huggingface():
+    """HuggingFace target destination validation 테스트."""
+    # 올바른 형식
+    assert publish_service.validate_destination("huggingface", "user/dataset") is None
+    
+    # 잘못된 형식
+    assert publish_service.validate_destination("huggingface", "invalid") is not None
+
+
+def test_http_publish_targets():
+    """HTTP publish targets에 kaggle과 local이 포함되어 있는지 테스트."""
+    targets = publish_service.HTTP_PUBLISH_TARGETS
+    assert "huggingface" in targets
+    assert "kaggle" in targets
+    assert "local" in targets
+
+
+def test_allowed_options():
+    """target별 허용된 options가 올바른지 테스트."""
+    assert publish_service._ALLOWED_OPTIONS == {
+        "huggingface": {"private": bool},
+        "kaggle": {"public": bool},
+        "local": {},
+    }
+
+
+def test_default_options():
+    """target별 기본 options가 올바른지 테스트."""
+    assert publish_service._DEFAULT_OPTIONS == {
+        "huggingface": {"private": True},
+        "kaggle": {"public": False},
+        "local": {},
+    }
+
+
+def test_resolve_target_kaggle():
+    """Kaggle target resolve 테스트."""
+    target, error = publish_service.resolve_target("kaggle")
+    assert target == "kaggle"
+    assert error is None
+
+
+def test_resolve_target_local():
+    """Local target resolve 테스트."""
+    target, error = publish_service.resolve_target("local")
+    assert target == "local"
+    assert error is None
+
+
+def test_resolve_target_unknown():
+    """알 수 없는 target resolve 테스트."""
+    target, error = publish_service.resolve_target("unknown")
+    assert target is None
+    assert error is not None
+    assert "unknown publish target" in error
+
+
+def test_build_readiness_with_local_destination(tmp_path, monkeypatch):
+    """build_readiness에서 local destination validation이 작동하는지 테스트."""
+    monkeypatch.setenv("KPUBDATA_LOCAL_PUBLISH_ROOTS", str(tmp_path))
+    
+    # 허용된 경로
+    result = publish_service.build_readiness(
+        run_id="test-run",
+        target="local",
+        status="succeeded",
+        manifest={"outputs": [], "errors": []},
+        spec=None,
+        output_root=tmp_path,
+        destination=str(tmp_path / "allowed"),
+    )
+    
+    # local destination validation이 통과해야 함
+    assert "local_destination_not_allowed" not in [b.code for b in result.blockers]
+    assert "local_publish_disabled" not in [b.code for b in result.blockers]
+
+
+def test_build_readiness_local_destination_blocked(tmp_path, monkeypatch):
+    """build_readiness에서 허용되지 않은 local destination이 차단되는지 테스트."""
+    monkeypatch.setenv("KPUBDATA_LOCAL_PUBLISH_ROOTS", str(tmp_path / "allowed"))
+    
+    # 허용되지 않은 경로
+    result = publish_service.build_readiness(
+        run_id="test-run",
+        target="local",
+        status="succeeded",
+        manifest={"outputs": [], "errors": []},
+        spec=None,
+        output_root=tmp_path,
+        destination=str(tmp_path / "not-allowed"),
+    )
+    
+    # local destination validation이 차단해야 함
+    assert "local_destination_not_allowed" in [b.code for b in result.blockers]
+
+
+def test_build_readiness_local_destination_not_configured(tmp_path, monkeypatch):
+    """build_readiness에서 publish가 설정되지 않았을 때 차단되는지 테스트."""
+    monkeypatch.setenv("KPUBDATA_LOCAL_PUBLISH_ROOTS", "")
+    
+    result = publish_service.build_readiness(
+        run_id="test-run",
+        target="local",
+        status="succeeded",
+        manifest={"outputs": [], "errors": []},
+        spec=None,
+        output_root=tmp_path,
+        destination="/any/path",
+    )
+    
+    # local publish disabled blocker가 있어야 함
+    assert "local_publish_disabled" in [b.code for b in result.blockers]


### PR DESCRIPTION
Kaggle과 Local publisher를 HTTP publish service에 안전하게 연동합니다.

## Kaggle HTTP Support
- Gold Stage에서 dataset-metadata.json.id를 placeholder('kpubdata-builder/placeholder')로 설정
- HTTP publish 시 placeholder를 destination으로 동적 override
- Kaggle credential 환경변수(KAGGLE_USERNAME, KAGGLE_KEY) 검증

## Local HTTP Support
- KPUBDATA_LOCAL_PUBLISH_ROOTS 환경변수로 허용된 루트 디렉터리 설정
- destination이 허용된 루트 내에 있는지 검증 (path traversal 방지)
- 절대 경로만 허용 (상대 경로 거부)

## 공통 변경사항
- HTTP_PUBLISH_TARGETS에 'kaggle', 'local' 추가
- target별 허용 옵션 확장 (kaggle: public, local: {})
- build_readiness에 destination 파라미터 추가
- destination validation에 local target 절대 경로 허용

## 테스트
- Kaggle metadata override 기능 (3개)
- Local publish-root validation (8개)
- Kaggle credential blocker (5개)
- Destination validation (6개)
- 통합 테스트 (8개)
- 총 30개 테스트 통과

<!--
PR 제목은 Conventional Commits 형식을 권장합니다: feat/fix/docs/refactor/test/chore
예) docs: add feature process flow diagrams
-->

## 요약
<!-- 이 PR이 무엇을, 왜 바꾸는지 1~3문장으로 설명하세요. -->

## 변경 내용
<!-- 주요 변경 사항을 항목으로 나열하세요. -->
-

## 관련 이슈
<!-- 예) Closes #123, Refs #456 -->

## 검증
<!-- 어떻게 검증했는지 구체적으로 적으세요. -->
- [ ] `uv run ruff check .` 통과
- [ ] `uv run mypy` 통과 (해당 시)
- [ ] 테스트 통과 (`uv run pytest`)
- [ ] 문서 변경 시 `mkdocs build --strict` 통과
- [ ] manifest/골든 테스트 영향 확인 (해당 시)

## 체크리스트
- [ ] 기능 브랜치에서 작업했으며 `main`에 직접 push하지 않았다
- [ ] 커밋 메시지를 영어로 작성했다
- [ ] `kpubdata` provider 로직을 중복 구현하지 않았다
- [ ] 필요한 단위/단계 인지형 테스트를 추가했다
- [ ] 사용자 노출 기능 변경 시 문서를 분류해 갱신했다: 제품 계약→PRD, 향후 의도→ROADMAP, 릴리스 변경→CHANGELOG (해당 시)
