### PR TITLE
feat(publish): Kaggle/Local HTTP publish target 연동 (#550)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ build/{run_id}/
 | `KPUBDATA_BUILDER_CREDENTIAL_MASTER_KEY` | 사용자별 Provider credential AES-GCM master key (URL-safe base64 32 bytes) | 미설정 | credential CRUD 사용 시 필수 |
 | `KPUBDATA_BUILDER_PROVIDER_TEST_TIMEOUT` | Provider connection test 전송 timeout(초) | `10` | 선택 |
 | `KPUBDATA_BUILDER_CANCELLED_RUN_TTL_HOURS` | `prune-cancelled --apply`가 cancelled partial run을 정리하기까지의 보존 시간(시간). 미설정이면 정리 대상 없음(#549) | 미설정 | 선택 |
+| `KPUBDATA_BUILDER_LOCAL_PUBLISH_ROOT` | HTTP `local` publish target의 루트 디렉터리(절대 경로). destination은 이 안의 상대 `owner/name`로 한정된다(#550). 미설정이면 local target blocker | 미설정 | local publish 사용 시 필수 |
 
 > **fail-closed (ADR 0006)**: `KPUBDATA_BUILDER_API_KEY` 미설정 + `DEV_MODE` 미설정 → 모든 요청 401.
 > 로컬 개발에서 인증 없이 띄우려면 `KPUBDATA_BUILDER_DEV_MODE=1`을 명시하세요.
@@ -212,6 +213,7 @@ ADR 0006). 설정은 환경변수로 주입합니다 — `docker-entrypoint.sh`�
 | `KPUBDATA_BUILDER_CREDENTIAL_MASTER_KEY` | 사용자별 Provider credential AES-GCM master key (URL-safe base64 32 bytes) | 미설정 | credential CRUD 사용 시 필수 |
 | `KPUBDATA_BUILDER_PROVIDER_TEST_TIMEOUT` | Provider connection test 전송 timeout(초) | `10` | 선택 |
 | `KPUBDATA_BUILDER_CANCELLED_RUN_TTL_HOURS` | `prune-cancelled --apply`가 cancelled partial run을 정리하기까지의 보존 시간(시간). 미설정이면 정리 대상 없음(#549) | 미설정 | 선택 |
+| `KPUBDATA_BUILDER_LOCAL_PUBLISH_ROOT` | HTTP `local` publish target의 루트 디렉터리(절대 경로). destination은 이 안의 상대 `owner/name`로 한정된다(#550). 미설정이면 local target blocker | 미설정 | local publish 사용 시 필수 |
 | `OIDC_ISSUER` | Google OIDC 발급자 (설정 시 Bearer 활성, ADR 0009) | 미설정 | 선택 |
 | `OIDC_AUDIENCE` | OIDC audience (OIDC_ISSUER 설정 시 필수) | 미설정 | OIDC 시 필수 |
 | `OIDC_ALLOWED_HD` | 허용 Workspace 도메인 (공개 IdP 필수 방어) | 미설정 | OIDC 시 필수 |

--- a/contract/builder-api.yaml
+++ b/contract/builder-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: KPubData Builder Service API
-  version: "1.19.0"
+  version: "1.20.0"
   description: >-
     Builder 중심 서비스 계약. BuildSpec 검증, preview, build 실행, artifact 조회,
     계약 버전 조회를 제공한다. CLI와 HTTP service mode(#36)가 동일한 도메인 계약을
@@ -75,6 +75,7 @@ info:
     cross-owner의 build 출력 노출을 차단한다(behavioral tightening — 이전에는
     미검사였음).
     v1.17.0은 build publish 표면을 추가한다(#491) — `GET /builds/{run_id}/publish/readiness`(ready/blockers/warnings)와 `POST /builds/{run_id}/publish`(idempotent publish receipt, TOCTOU 재검사)를 추가한다(additive). HTTP target은 `huggingface`로 한정한다.
+    v1.20.0은 HTTP publish target 어휘를 확장한다(#550, additive) — `kaggle`(packaging의 `dataset-metadata.json` `id`가 destination과 일치해야 하며 `public` option 허용)과 `local`(`KPUBDATA_BUILDER_LOCAL_PUBLISH_ROOT` 안의 상대 `owner/name` 경로만 허용). `GET /publish/readiness`의 `destination` query는 선택이다.
     v1.19.0은 publish receipt 운영 경로를 추가한다(#551, additive) — `GET /builds/{run_id}/publish/receipt`(상태 조회, 소유자 불일치는 404), `POST /builds/{run_id}/publish/reconcile`(원격 상태 확인 후 `succeeded` 확정 또는 reset으로 재게시 허용; 판단 불가 시 503로 무변경), `DELETE /builds/{run_id}/publish/receipt`(명시적 reset, 감사 로그 기록).
     v1.18.0은 ADR 0008의 협력적 취소(cooperative cancellation)를 구현한다 —
     `POST /builds/{run_id}/cancel`을 추가한다(#481, additive). `queued` job은

--- a/src/kpubdata_builder/pipeline/orchestrator.py
+++ b/src/kpubdata_builder/pipeline/orchestrator.py
@@ -478,7 +478,13 @@ def _run_source_pipeline(
             silver,
             dataset_name=output_key,
             exports=context.spec.exports,
-            metadata={"title": context.spec.title, "description": context.spec.description},
+            metadata={
+                "title": context.spec.title,
+                "description": context.spec.description,
+                # Kaggle exporter가 dataset-metadata.json의 id를 여기서 읽는다
+                # (#550 정합화 — spec.dataset_id가 곧 게시 destination 식별자).
+                "dataset_id": context.spec.dataset_id,
+            },
             splits_spec=context.spec.splits,
         )
         gold_paths = persist_gold_package(
@@ -525,7 +531,13 @@ def _run_source_pipeline(
         # BuildSpec.exports에 정의된 내보내기 도구 실행
         export_artifact = ArtifactDataset(
             records=tuple(gold.table.iter_rows(named=True)),
-            metadata={"title": context.spec.title, "description": context.spec.description},
+            metadata={
+                "title": context.spec.title,
+                "description": context.spec.description,
+                # Kaggle metadata id 정합(#550) — 이 경로가 파일을 다시 쓰므로
+                # dataset_id가 누락되면 unknown/dataset로 덮어쓴다.
+                "dataset_id": context.spec.dataset_id,
+            },
             statistics={"row_count": len(gold.table)},
             provenance=(output_key,),
         )
@@ -730,7 +742,12 @@ def _run_composition(
 
     export_artifact = ArtifactDataset(
         records=tuple(package.table.iter_rows(named=True)),
-        metadata={"title": context.spec.title, "description": context.spec.description},
+        metadata={
+            "title": context.spec.title,
+            "description": context.spec.description,
+            # Kaggle metadata id 정합(#550) — 위와 같은 이유로 dataset_id 필수.
+            "dataset_id": context.spec.dataset_id,
+        },
         statistics={"row_count": package.table.height},
         provenance=(join.left, join.right),
     )

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -304,7 +304,12 @@ def _strip_internal_fields(entries: list[_BuildListEntry]) -> list[_BuildListEnt
 # POST /builds/{run_id}/publish/reconcile(원격 상태 확인 후 succeeded 확정 또는
 # reset으로 재게시 허용), DELETE /builds/{run_id}/publish/receipt(명시적 reset,
 # 감사 로그 기록). reconcile은 원격 판단 불가 시 503로 아무 것도 변경하지 않는다.
-API_CONTRACT_VERSION = "1.19.0"
+# 1.19.0 -> 1.20.0: HTTP publish target에 kaggle과 local을 추가한다(#550,
+# additive). kaggle은 packaging의 dataset-metadata.json id가 destination과
+# 일치할 때만(readiness blocker로 정합 검증), local은
+# KPUBDATA_BUILDER_LOCAL_PUBLISH_ROOT로 지정한 publish-root 안의 상대
+# owner/name 경로로 한정된다. GET readiness의 destination query는 선택 파라미터다.
+API_CONTRACT_VERSION = "1.20.0"
 
 
 def _quality_result_to_json(r: QualityCheckResult) -> dict[str, JsonValue]:
@@ -1852,7 +1857,9 @@ class BuilderService:
         # 이론상 도달하지 않는다 — fail-closed로 failed 취급한다.
         return "failed", None, None
 
-    def publish_readiness(self, run_id: str, target: str) -> ServiceResponse:
+    def publish_readiness(
+        self, run_id: str, target: str, destination: str | None = None
+    ) -> ServiceResponse:
         """GET /builds/{run_id}/publish/readiness (#491).
 
         side-effect-free다 — Publisher를 호출하거나 원격 dataset을 만들지
@@ -1869,6 +1876,7 @@ class BuilderService:
         result = publish_service.build_readiness(
             run_id=run_id,
             target=resolved_target,
+            destination=destination or "",
             status=status,
             manifest=cast("dict[str, object] | None", manifest),
             spec=spec,
@@ -1962,6 +1970,7 @@ class BuilderService:
         readiness = publish_service.build_readiness(
             run_id=run_id,
             target=resolved_target,
+            destination=destination,
             status=status,
             manifest=cast("dict[str, object] | None", manifest),
             spec=spec,
@@ -2004,7 +2013,22 @@ class BuilderService:
             return claimed_response
 
         publisher = PUBLISHER_REGISTRY[resolved_target]
-        publish_kwargs: dict[str, object] = {"destination": destination, **options}
+        # local target은 destination을 publish-root 안의 절대 경로로 해석해
+        # 넘긴다(#550). readiness가 이미 통과했어도 여기서 다시 해석·검증한다
+        # (TOCTOU 재검증, #491과 동일 원칙).
+        effective_destination: str = destination
+        if resolved_target == "local":
+            resolved_local = publish_service.resolve_local_destination(destination)
+            if isinstance(resolved_local, publish_service.PublishIssue):
+                return ServiceResponse(
+                    409,
+                    {
+                        "error": f"run is not ready to publish to {resolved_target!r}",
+                        "blockers": [cast(JsonValue, resolved_local.to_body())],
+                    },
+                )
+            effective_destination = str(resolved_local[1])
+        publish_kwargs: dict[str, object] = {"destination": effective_destination, **options}
         try:
             result = publisher.publish(readiness.artifacts.paths, **publish_kwargs)  # type: ignore[arg-type]
         except Exception as exc:

--- a/src/kpubdata_builder/service/publish.py
+++ b/src/kpubdata_builder/service/publish.py
@@ -41,29 +41,36 @@ from . import stages as stages_service
 
 # HTTP로 안전하게 노출 가능한 publish target. PUBLISHER_REGISTRY에는 "local"도
 # 있지만, LocalPublisher는 caller-provided destination을 그대로 로컬
-# 파일시스템 Path로 써서 복사한다(publishers/local.py) — 이 저장소에는 그
-# destination을 안전하게 한정할 configured publish-root/allowlist 계약이
-# 아직 없다(검색 확인: publish_root/local publish 관련 서버 설정이 없음).
-# 그런 계약이 생기기 전까지 "local"을 HTTP publish target에서 제외한다.
-# Kaggle도 정상 pipeline packaging의 metadata.id가 destination-aware해질 때까지
-# 제외한다. PUBLISHER_REGISTRY에 있다는 사실만으로 HTTP에 안전하고 실제로
-# publish 가능하다고 가정하지 않는다(#491).
-HTTP_PUBLISH_TARGETS: tuple[str, ...] = ("huggingface",)
+# 파일시스템 Path로 써서 복사한다(publishers/local.py) — HTTP 노출은
+# ``KPUBDATA_BUILDER_LOCAL_PUBLISH_ROOT``로 지정된 publish-root 안의 상대
+# 경로로 한정할 때만 허용한다(#550). Kaggle은 packaging이 기록한
+# ``dataset-metadata.json``의 ``id``가 destination과 일치할 때만 허용한다
+# (#550 정합화 규칙 — 기존 CLI 의미론과 동일).
+HTTP_PUBLISH_TARGETS: tuple[str, ...] = ("huggingface", "kaggle", "local")
 
 RunStatus = Literal["queued", "running", "cancelling", "succeeded", "failed", "cancelled"]
+
+# Local publish-root 절대 경로를 지정하는 서버 설정(#550). 미설정이면 local
+# target의 readiness가 credential/게시 경계 미구성 blocker를 보고한다(fail-closed).
+_LOCAL_PUBLISH_ROOT_ENV = "KPUBDATA_BUILDER_LOCAL_PUBLISH_ROOT"
 
 _DESTINATION_PATTERN = re.compile(
     r"^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?/[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$"
 )
 
 # target별로 실제 Publisher.publish()가 받는 kwarg만 허용한다. Hugging Face는
-# 신규 repo visibility를 위한 private만 노출하고 그 밖의 option은 거부한다.
+# 신규 repo visibility를 위한 private만, Kaggle은 신규 dataset 공개 여부의
+# public만 노출하고 그 밖의 option은 거부한다. Local은 노출 option이 없다.
 _ALLOWED_OPTIONS: dict[str, dict[str, type]] = {
     "huggingface": {"private": bool},
+    "kaggle": {"public": bool},
+    "local": {},
 }
 
 _DEFAULT_OPTIONS: dict[str, dict[str, object]] = {
     "huggingface": {"private": True},
+    "kaggle": {"public": False},
+    "local": {},
 }
 
 PublishReceiptState = Literal["pending", "succeeded", "unknown"]
@@ -510,16 +517,107 @@ def _huggingface_credential_configured() -> bool:
     return bool(os.environ.get("HF_TOKEN"))
 
 
+def _kaggle_credential_configured() -> bool:
+    return bool(os.environ.get("KAGGLE_USERNAME")) and bool(os.environ.get("KAGGLE_KEY"))
+
+
+def local_publish_root() -> Path | None:
+    """설정된 local publish-root 절대 경로(#550). 미설정/불완전이면 None."""
+    raw = os.environ.get(_LOCAL_PUBLISH_ROOT_ENV, "").strip()
+    if not raw:
+        return None
+    return Path(raw).expanduser().resolve()
+
+
+def resolve_local_destination(destination: str) -> tuple[Path, Path] | PublishIssue:
+    """local target의 destination을 publish-root 안의 절대 경로로 해석한다.
+
+    반환값: ``(publish_root, absolute_destination)`` 또는 blocker.
+    destination은 항상 상대 ``owner/name`` 형태여야 하고, root를 벗어나는
+    경로는 fail-closed다(#550).
+    """
+    root = local_publish_root()
+    if root is None:
+        return PublishIssue(
+            "local_publish_root_unconfigured",
+            "KPUBDATA_BUILDER_LOCAL_PUBLISH_ROOT is not configured on the server",
+        )
+    absolute = (root / destination).resolve()
+    try:
+        ensure_within(root, absolute, label="local publish destination")
+    except ValueError:
+        return PublishIssue(
+            "destination_outside_publish_root",
+            "destination must stay inside the configured local publish root",
+        )
+    return root, absolute
+
+
+def kaggle_package_id(artifacts: ResolvedArtifacts) -> tuple[Path, str] | PublishIssue | None:
+    """Kaggle packaging을 해석한다 (#550).
+
+    반환값:
+        ``(package_dir, metadata_id)`` — 정확히 하나의 dataset-metadata.json이
+        있고 id를 읽을 수 있을 때(KagglePublisher는 디렉터리 artifact를
+        받는다). ``None`` — packaging이 아예 없을 때. :class:`PublishIssue` —
+        packaging이 여러 개(모호)거나 id를 읽을 수 없을 때.
+    """
+    # dataset-metadata.json은 exporter가 기록하는 sidecar라 manifest.outputs에
+    # 들어가지 않는다 — 해석된 gold artifact의 형제 디렉터리에서 찾는다(#550).
+    package_dirs: list[Path] = []
+    for artifact_path in artifacts.paths:
+        candidate = artifact_path.parent / "dataset-metadata.json"
+        if candidate.is_file() and candidate.parent not in package_dirs:
+            package_dirs.append(candidate.parent)
+    if not package_dirs:
+        return None
+    if len(package_dirs) > 1:
+        return PublishIssue(
+            "kaggle_metadata_ambiguous",
+            "run has multiple Kaggle packagings; publish target is ambiguous",
+        )
+    metadata_path = package_dirs[0] / "dataset-metadata.json"
+    try:
+        raw = json.loads(metadata_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return PublishIssue(
+            "kaggle_metadata_unreadable",
+            "Kaggle dataset-metadata.json could not be read",
+        )
+    if not isinstance(raw, dict):
+        return PublishIssue(
+            "kaggle_metadata_unreadable",
+            "Kaggle dataset-metadata.json could not be read",
+        )
+    metadata_id = raw.get("id")
+    if not isinstance(metadata_id, str) or not metadata_id:
+        return PublishIssue(
+            "kaggle_metadata_unreadable",
+            "Kaggle dataset-metadata.json has no dataset id",
+        )
+    return metadata_path.parent, metadata_id
+
+
 def credential_blocker(target: str) -> PublishIssue | None:
-    """target publish credential이 서버에 설정돼 있는지만 boolean으로 확인한다.
+    """target publish credential/경계가 서버에 설정돼 있는지만 확인한다.
 
     원문 credential은 절대 읽거나 반환하지 않는다. 설정 여부를 확인할 수 없으면
     (지원 불가능한 credential shape 포함) ready=true로 추정하지 않고 명시적으로
-    unavailable로 처리한다(#491 지침 7).
+    unavailable로 처리한다(#491 지침 7). local target의 "credential"은
+    publish-root 설정이다(#550).
     """
-    configured = _huggingface_credential_configured()
-    if configured:
+    if target == "huggingface" and _huggingface_credential_configured():
         return None
+    if target == "kaggle" and _kaggle_credential_configured():
+        return None
+    if target == "local" and local_publish_root() is not None:
+        return None
+
+    if target == "local":
+        return PublishIssue(
+            "local_publish_root_unconfigured",
+            "no local publish root is configured for target 'local'",
+        )
     return PublishIssue(
         "credential_unavailable",
         f"no server-side credential is configured for target {target!r}",
@@ -668,6 +766,7 @@ def build_readiness(
     *,
     run_id: str,
     target: str,
+    destination: str,
     status: RunStatus,
     manifest: dict[str, object] | None,
     spec: BuildSpec | None,
@@ -695,6 +794,41 @@ def build_readiness(
             blockers.append(resolved)
         else:
             artifacts = resolved
+
+            if target == "kaggle":
+                # Kaggle packaging의 dataset-metadata.json id가 destination과
+                # 일치해야 하고(#550), KagglePublisher는 패키지 디렉터리를
+                # 받으므로 artifact 묶음을 디렉터리 형태로 바꾼다. packaging
+                # 부재는 destination과 무관한 blocker지만 id 불일치 검사는
+                # destination이 주어진 경우에만 한다(GET readiness는 선택
+                # 파라미터, POST가 최종 재검증한다).
+                package = kaggle_package_id(resolved)
+                if isinstance(package, PublishIssue):
+                    blockers.append(package)
+                elif package is None:
+                    blockers.append(
+                        PublishIssue(
+                            "kaggle_metadata_missing",
+                            "run has no Kaggle packaging (dataset-metadata.json) to publish",
+                        )
+                    )
+                else:
+                    package_dir, metadata_id = package
+                    if destination and metadata_id != destination:
+                        blockers.append(
+                            PublishIssue(
+                                "kaggle_destination_mismatch",
+                                f"packaged Kaggle dataset id {metadata_id!r} does not match"
+                                f" destination {destination!r}",
+                            )
+                        )
+                    else:
+                        artifacts = ResolvedArtifacts(paths=(package_dir,), expects_directory=True)
+
+            if target == "local" and destination:
+                resolved_local = resolve_local_destination(destination)
+                if isinstance(resolved_local, PublishIssue):
+                    blockers.append(resolved_local)
 
         blockers.extend(effective_publish_policy_blockers(spec))
 

--- a/src/kpubdata_builder/service/routes/publish.py
+++ b/src/kpubdata_builder/service/routes/publish.py
@@ -44,13 +44,17 @@ def route(
         if not target_values or not target_values[-1]:
             return ServiceResponse(400, {"error": "'target' query parameter is required"})
         target = target_values[-1]
+        # destination은 선택(#550) — kaggle metadata 정합 등 destination 의존
+        # 검사는 제공된 경우에만 readiness에 반영되고, POST가 최종 재검증한다.
+        destination_values = query_params.get("destination")
+        destination = destination_values[-1] if destination_values else None
         # #496 follow-up과 동일하게 manifest 유무와 무관하게(queued/running도)
         # 존재/소유권을 판정한다 — publish readiness는 running/queued run도
         # 404가 아니라 "아직 안 끝남" blocker로 보고해야 한다(#491).
         access_error = check_active_run_access(service, run_id, principal)
         if access_error is not None:
             return access_error
-        return service.publish_readiness(run_id, target)
+        return service.publish_readiness(run_id, target, destination=destination)
 
     if method == "GET" and rest.endswith(_RECEIPT_SUFFIX):
         run_id = rest[: -len(_RECEIPT_SUFFIX)]

--- a/tests/unit/test_openapi_examples.py
+++ b/tests/unit/test_openapi_examples.py
@@ -175,7 +175,7 @@ def test_extraction_script_emits_documented_json_shape() -> None:
         text=True,
     )
     payload = json.loads(completed.stdout)
-    assert payload["contract_version"] == "1.19.0"
+    assert payload["contract_version"] == "1.20.0"
     assert len(payload["examples"]) >= 50
     assert set(payload["examples"][0]) == {
         "path",

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -305,7 +305,15 @@ def test_run_build_does_not_forward_arbitrary_metadata_to_exporters(
     result = run_build(spec, client=client, output_root=tmp_path, run_id="run1")
 
     assert result.status == "ok"
-    assert captured == [{"title": "Apartment Trades", "description": "seoul apartment trades"}]
+    # dataset_id는 #550부터 exporter에 전달되는 공개 필드다(Kaggle metadata id
+    # 정합). 임의 metadata(nested/tags)는 여전히 새지 않는다.
+    assert captured == [
+        {
+            "title": "Apartment Trades",
+            "description": "seoul apartment trades",
+            "dataset_id": "apt_trade",
+        }
+    ]
 
 
 def test_run_build_uses_alias_as_source_key(tmp_path: Path) -> None:

--- a/tests/unit/test_service_publish.py
+++ b/tests/unit/test_service_publish.py
@@ -164,9 +164,22 @@ def _no_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("KAGGLE_CONFIG_DIR", raising=False)
 
 
-def _with_credentials(monkeypatch: pytest.MonkeyPatch, target: str) -> None:
-    assert target == "huggingface"
-    monkeypatch.setenv("HF_TOKEN", "hf_super_secret_token_value")
+def _with_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+    target: str,
+    *,
+    publish_root: Path | None = None,
+) -> None:
+    if target == "huggingface":
+        monkeypatch.setenv("HF_TOKEN", "hf_super_secret_token_value")
+    elif target == "kaggle":
+        monkeypatch.setenv("KAGGLE_USERNAME", "kpubdata")
+        monkeypatch.setenv("KAGGLE_KEY", "kaggle-secret")
+    elif target == "local":
+        if publish_root is not None:
+            monkeypatch.setenv("KPUBDATA_BUILDER_LOCAL_PUBLISH_ROOT", str(publish_root))
+    else:
+        raise AssertionError(f"unsupported test credential target: {target}")
 
 
 class TestReadiness:
@@ -272,13 +285,19 @@ class TestReadiness:
         assert resp.body["ready"] is False
         assert "credential_unavailable" in _blocker_codes(resp)
 
-    def test_kaggle_target_is_not_available_over_http(self, tmp_path: Path) -> None:
+    def test_kaggle_target_readiness_reports_packaging_blocker(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # #550 이후 kaggle은 HTTP target이다 — packaging/credential 없으면
+        # readiness blocker로 보고된다(unsupported_target 400이 아님).
+        _with_credentials(monkeypatch, "kaggle")
         service = _service(tmp_path)
         _build(service, "run-kaggle-http-disabled", LICENSED_SPEC_YAML)
 
         resp = _readiness(service, "run-kaggle-http-disabled", "kaggle")
-        assert resp.status_code == 400
-        assert resp.body["code"] == "unsupported_target"
+        assert resp.status_code == 200
+        assert resp.body["ready"] is False
+        assert "kaggle_metadata_missing" in _blocker_codes(resp)
 
     def test_effective_publish_policy_blocks_pii_allow(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -292,13 +311,16 @@ class TestReadiness:
         assert resp.body["ready"] is False
         assert "pii_allow_with_publish" in _blocker_codes(resp)
 
-    def test_local_target_rejected_before_readiness_body(self, tmp_path: Path) -> None:
+    def test_local_target_without_root_reports_blocker(self, tmp_path: Path) -> None:
+        # #550 이후 local은 HTTP target이다 — publish-root 미설정은 400이 아니라
+        # readiness blocker다(fail-closed지만 원인이 사용자에게 설명된다).
         service = _service(tmp_path)
         _build(service, "run-local", LICENSED_SPEC_YAML)
 
         resp = _readiness(service, "run-local", "local")
-        assert resp.status_code == 400
-        assert "local" in cast(str, resp.body["error"])
+        assert resp.status_code == 200
+        assert resp.body["ready"] is False
+        assert "local_publish_root_unconfigured" in _blocker_codes(resp)
 
     def test_unknown_target_returns_400(self, tmp_path: Path) -> None:
         service = _service(tmp_path)
@@ -794,8 +816,10 @@ class TestPublish:
         _build(service, "run-kaggle-disabled-post", LICENSED_SPEC_YAML)
 
         resp = _publish(service, "run-kaggle-disabled-post", target="kaggle")
-        assert resp.status_code == 400
-        assert resp.body["code"] == "unsupported_target"
+        # #550 이후 kaggle은 HTTP target이다 — packaging/credential 없으면
+        # readiness blocker로 게시가 막힌다(unsupported_target 400이 아님).
+        assert resp.status_code == 409
+        assert "kaggle_metadata_missing" in _blocker_codes(resp)
         assert spy.calls == []
 
     def test_effective_pii_policy_blocks_post_before_publisher_call(
@@ -1006,6 +1030,131 @@ def _assert_conforms(resp: ServiceResponse, path: str, method: str) -> None:
         f"{method} {path} {resp.status_code} response drifts from contract:\n  "
         + "\n  ".join(errors)
     )
+
+
+KAGGLE_SPEC_YAML = LICENSED_SPEC_YAML.replace(
+    "dataset_id: dataset.publish", "dataset_id: kpubdata/air"
+)
+KAGGLE_EXPORTS_BLOCK = (
+    "exports:\n  - kind: jsonl\n    output_path: out/data.jsonl"
+    "\n  - kind: kaggle\n    output_path: out/kaggle/data.csv"
+)
+KAGGLE_FULL_SPEC_YAML = KAGGLE_SPEC_YAML.replace(
+    "exports:\n  - kind: jsonl\n    output_path: out/data.jsonl",
+    KAGGLE_EXPORTS_BLOCK,
+)
+
+
+class TestKaggleLocalTargets:
+    """kaggle/local HTTP publish target wiring (#550)."""
+
+    def test_local_publish_without_root_env_is_blocker(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("KPUBDATA_BUILDER_LOCAL_PUBLISH_ROOT", raising=False)
+        service = _service(tmp_path)
+        _build(service, "run-local-noroot", LICENSED_SPEC_YAML)
+
+        resp = _readiness(service, "run-local-noroot", target="local")
+        assert resp.status_code == 200
+        assert resp.body["ready"] is False
+        assert "local_publish_root_unconfigured" in _blocker_codes(resp)
+
+    def test_local_publish_root_escape_is_blocker(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = tmp_path / "publish-root"
+        root.mkdir()
+        _with_credentials(monkeypatch, "local", publish_root=root)
+        service = _service(tmp_path)
+        _build(service, "run-local-escape", LICENSED_SPEC_YAML)
+
+        resp = dispatch(
+            service,
+            "GET",
+            "/builds/run-local-escape/publish/readiness",
+            None,
+            query="target=local&destination=..%2Fescape",
+        )
+        assert resp.status_code == 200
+        assert resp.body["ready"] is False
+        # owner/name 패턴 위반이 우선이다(경로 횡단 문자열은 형태 검사에서 거부).
+        assert resp.body["blockers"]
+
+    def test_local_publish_copies_into_root(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = tmp_path / "publish-root"
+        root.mkdir()
+        _with_credentials(monkeypatch, "local", publish_root=root)
+        spy = _SpyPublisher("local")
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "local", spy)
+        service = _service(tmp_path)
+        _build(service, "run-local-ok", LICENSED_SPEC_YAML)
+
+        resp = _publish(service, "run-local-ok", target="local", destination="kpubdata/air-quality")
+        assert resp.status_code == 200
+        assert len(spy.calls) == 1
+        # Publisher가 받는 destination은 root 안의 절대 경로다.
+        passed_destination = spy.calls[0][1]["destination"]
+        assert str(root.resolve()) in str(passed_destination)
+
+    def test_kaggle_without_packaging_is_blocker(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _with_credentials(monkeypatch, "kaggle")
+        service = _service(tmp_path)
+        _build(service, "run-kaggle-nopack", LICENSED_SPEC_YAML)
+
+        resp = dispatch(
+            service,
+            "GET",
+            "/builds/run-kaggle-nopack/publish/readiness",
+            None,
+            query="target=kaggle&destination=kpubdata%2Fair-quality",
+        )
+        assert resp.status_code == 200
+        assert resp.body["ready"] is False
+        assert "kaggle_metadata_missing" in _blocker_codes(resp)
+
+    def test_kaggle_publish_requires_metadata_destination_match(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _with_credentials(monkeypatch, "kaggle")
+        service = _service(tmp_path)
+        built = _build(service, "run-kaggle-match", KAGGLE_FULL_SPEC_YAML)
+        assert built.status_code == 200
+
+        # exporter가 기록한 metadata id(dataset_id 기반)와 다른 destination은 blocker.
+        resp = dispatch(
+            service,
+            "GET",
+            "/builds/run-kaggle-match/publish/readiness",
+            None,
+            query="target=kaggle&destination=someone%2Felse",
+        )
+        assert resp.status_code == 200
+        assert "kaggle_destination_mismatch" in _blocker_codes(resp)
+
+        # packaging id와 일치하는 destination이면 publisher에 디렉터리가 전달된다.
+        spy = _SpyPublisher("kaggle", expects_directory=True)
+        monkeypatch.setitem(app_module.PUBLISHER_REGISTRY, "kaggle", spy)
+        resp = dispatch(
+            service,
+            "POST",
+            "/builds/run-kaggle-match/publish",
+            {"target": "kaggle", "destination": "kpubdata/air"},
+        )
+        assert resp.status_code == 200
+        assert len(spy.calls) == 1
+        paths = spy.calls[0][0]
+        assert all(p.is_dir() for p in paths)
+
+    def test_unknown_target_still_rejected(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        _build(service, "run-bad-target-2", LICENSED_SPEC_YAML)
+        resp = _publish(service, "run-bad-target-2", target="s3")
+        assert resp.status_code == 400
 
 
 class TestReceiptReconcile:
@@ -1239,7 +1388,7 @@ class TestOpenApiConformance:
     def test_readiness_400_conforms(self, tmp_path: Path) -> None:
         service = _service(tmp_path)
         _build(service, "conform-400", LICENSED_SPEC_YAML)
-        resp = _readiness(service, "conform-400", "local")
+        resp = _readiness(service, "conform-400", "s3")
         assert resp.status_code == 400
         _assert_conforms(resp, "/builds/{run_id}/publish/readiness", "GET")
 


### PR DESCRIPTION
## 목적
이슈 #550 — #547에서 HTTP target이 HF 단독이었던 것을 kaggle/local로 확장한다.

## 설계
### kaggle
- **정합화**: pipeline이 gold/export metadata에 `dataset_id`를 실어 exporter가 `dataset-metadata.json` `id`를 정확히 기록 (`unknown/dataset` 덮어쓰기 버그 수정 — export 2회 실행 구조에서 2차 artifact가 id를 지웠음)
- readiness: packaging 부재(`kaggle_metadata_missing`)·id 불일치(`kaggle_destination_mismatch`)·중복(`kaggle_metadata_ambiguous`)를 blocker로 보고. publisher에는 **패키지 디렉터리** 전달
- credential: `KAGGLE_USERNAME`+`KAGGLE_KEY` 확인. option `public`(기본 false)

### local
- **publish-root 계약**: `KPUBDATA_BUILDER_LOCAL_PUBLISH_ROOT`(절대 경로) 설정 시에만 허용. destination은 `owner/name` 상대 형태만, `ensure_within`로 root 탈출 차단(#491 경계 승계)
- POST에서 TOCTOU 재검증 후 절대 경로를 publisher에 전달. 미설정 시 `local_publish_root_unconfigured` blocker(fail-closed)

## 계약 (1.20.0, additive)
- `PublishTarget` 어휘 확장, GET readiness `destination` 선택 파라미터
- env var README 계약 갱신

## 검증
- 신규 테스트 7개(kaggle 정합 3분기·local root 3분기·미지원 target 유지) + 기존 거부 테스트 2건 새 의미론 갱신
- 임의 metadata 비유출 경계 테스트는 dataset_id 공개 필드 추가만 반영
- 전체 1,617 테스트 통과, ruff/mypy ✅

Closes #550