### PR TITLE
fix: kpubdata #276 from_env 서명 변경에 맞춘 cli 호출 갱신 (cross-repo 회귀)

### DIFF
--- a/src/kpubdata_builder/cli.py
+++ b/src/kpubdata_builder/cli.py
@@ -193,14 +193,15 @@ def _create_client(
     """
     from kpubdata import Client
 
-    overrides: dict[str, object] = {}
-    if provider_keys is not None:
-        overrides["provider_keys"] = provider_keys
-    if timeout is not None:
-        overrides["timeout"] = timeout
-    if cache is not None:
-        overrides["cache"] = cache
-    return cast(SourceClient, Client.from_env(**overrides))
+    # kpubdata #276 이후 from_env는 명시적 파라미터만 받는다(**kwargs 폐기).
+    return cast(
+        SourceClient,
+        Client.from_env(
+            provider_keys=provider_keys,
+            timeout=timeout,
+            cache=cache,
+        ),
+    )
 
 
 def _run_validate(spec_path: str) -> int:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -56,7 +56,9 @@ def test_direct_cli_client_keeps_environment_cache_behavior(
 
     _ = cli_module._create_client()
 
-    assert captured == [{}]
+    # kpubdata #276 이후 from_env는 명시적 파라미터를 받는다 — 미지정값은
+    # None(환경 규칙 적용)으로 전달되고 cache를 강제하지 않는다.
+    assert captured == [{"provider_keys": None, "timeout": None, "cache": None}]
 
 
 def test_build_parser_uses_program_name() -> None:


### PR DESCRIPTION
## 발견
전체 코드 리뷰 중 확인: kpubdata #276(PR #352)이 `Client.from_env`의 `**kwargs: object`를 명시적 파라미터로 전환하면서 **builder mypy 5 에러**(`cli.py:203`) 발생. 런타임은 호환(전달 키가 전부 명시 파라미터)이었으나 타입 검사가 깨짐.

## 수정
- `_create_client`: dict 조립 후 `**overrides` 언팩 → `provider_keys/timeout/cache` 명시 전달
- `test_direct_cli_client_keeps_environment_cache_behavior`: 기대치 `[{}]` → `[{provider_keys: None, timeout: None, cache: None}]`(미지정=환경 규칙 적용, cache 강제 없음은 동일)

## 검증
- mypy 133파일 클린, 전체 테스트 통과