### PR TITLE
feat(publish): 감사 이력 receipt 독립화 + 조회 API + 원자적 종단 전이 (#563, #564)

### DIFF
--- a/contract/builder-api.yaml
+++ b/contract/builder-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: KPubData Builder Service API
-  version: "1.20.0"
+  version: "1.21.0"
   description: >-
     Builder 중심 서비스 계약. BuildSpec 검증, preview, build 실행, artifact 조회,
     계약 버전 조회를 제공한다. CLI와 HTTP service mode(#36)가 동일한 도메인 계약을
@@ -75,6 +75,7 @@ info:
     cross-owner의 build 출력 노출을 차단한다(behavioral tightening — 이전에는
     미검사였음).
     v1.17.0은 build publish 표면을 추가한다(#491) — `GET /builds/{run_id}/publish/readiness`(ready/blockers/warnings)와 `POST /builds/{run_id}/publish`(idempotent publish receipt, TOCTOU 재검사)를 추가한다(additive). HTTP target은 `huggingface`로 한정한다.
+    v1.21.0은 publish 감사 로그 조회를 추가한다(#563, additive) — `GET /builds/{run_id}/publish/audit`(reconcile/reset 이력, 소유권 게이트, receipt 삭제 후에도 조회).
     v1.20.0은 HTTP publish target 어휘를 확장한다(#550, additive) — `kaggle`(packaging의 `dataset-metadata.json` `id`가 destination과 일치해야 하며 `public` option 허용)과 `local`(`KPUBDATA_BUILDER_LOCAL_PUBLISH_ROOT` 안의 상대 `owner/name` 경로만 허용). `GET /publish/readiness`의 `destination` query는 선택이다.
     v1.19.0은 publish receipt 운영 경로를 추가한다(#551, additive) — `GET /builds/{run_id}/publish/receipt`(상태 조회, 소유자 불일치는 404), `POST /builds/{run_id}/publish/reconcile`(원격 상태 확인 후 `succeeded` 확정 또는 reset으로 재게시 허용; 판단 불가 시 503로 무변경), `DELETE /builds/{run_id}/publish/receipt`(명시적 reset, 감사 로그 기록).
     v1.18.0은 ADR 0008의 협력적 취소(cooperative cancellation)를 구현한다 —

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -309,7 +309,9 @@ def _strip_internal_fields(entries: list[_BuildListEntry]) -> list[_BuildListEnt
 # 일치할 때만(readiness blocker로 정합 검증), local은
 # KPUBDATA_BUILDER_LOCAL_PUBLISH_ROOT로 지정한 publish-root 안의 상대
 # owner/name 경로로 한정된다. GET readiness의 destination query는 선택 파라미터다.
-API_CONTRACT_VERSION = "1.20.0"
+# 1.20.0 -> 1.21.0: publish 감사 로그 조회를 추가한다(#563, additive) —
+# GET /builds/{run_id}/publish/audit(reconcile/reset 이력, 소유권 게이트).
+API_CONTRACT_VERSION = "1.21.0"
 
 
 def _quality_result_to_json(r: QualityCheckResult) -> dict[str, JsonValue]:
@@ -2123,6 +2125,23 @@ class BuilderService:
         if receipt.result is not None:
             body["result"] = cast(JsonValue, receipt.result)
         return ServiceResponse(200, body)
+
+    def publish_audit_log(self, run_id: str, *, principal: Principal) -> ServiceResponse:
+        """GET /builds/{run_id}/publish/audit (#563).
+
+        reconcile/reset 감사 이력을 소유자 단위로 반환한다 — receipt가 이미
+        reset으로 삭제된 경우도 포함한다. 항목은 최소 필드(fingerprint/action/
+        actor/recorded_at)만 담고 credential·경로 원문은 없다.
+        """
+        owner_key = principal.owner_id or principal.label
+        entries = self._publish_receipts.audit_entries(owner_key=owner_key, run_id=run_id)
+        return ServiceResponse(
+            200,
+            {
+                "run_id": run_id,
+                "entries": cast(JsonValue, entries),
+            },
+        )
 
     def reconcile_publish(
         self,

--- a/src/kpubdata_builder/service/publish.py
+++ b/src/kpubdata_builder/service/publish.py
@@ -25,6 +25,7 @@ import os
 import re
 import sqlite3
 import threading
+from contextlib import suppress
 from dataclasses import dataclass, replace
 from datetime import datetime as datetime_module
 from datetime import timezone
@@ -135,18 +136,28 @@ class PublishReceiptStore:
                     """
                 )
                 # reconcile/reset 감사 로그(#551) — credential/path/원문을 담지
-                # 않는 최소 필드만 append한다.
+                # 않는 최소 필드만 append한다. owner_key/run_id를 행에 직접
+                # 저장해 receipt가 reset으로 삭제돼도 감사 이력이 조회되게 한다(#563).
                 connection.execute(
                     """
                     CREATE TABLE IF NOT EXISTS publish_receipt_audit (
                         seq INTEGER PRIMARY KEY AUTOINCREMENT,
                         fingerprint TEXT NOT NULL,
+                        owner_key TEXT,
+                        run_id TEXT,
                         action TEXT NOT NULL,
                         actor TEXT NOT NULL,
                         recorded_at TEXT NOT NULL
                     )
                     """
                 )
+                # #557 시점 스키마(owner/run 컬럼 없음)에서 만든 DB 호환 마이그레이션.
+                for column in ("owner_key", "run_id"):
+                    # 컬럼이 이미 존재하면 ALTER가 OperationalError로 실패한다.
+                    with suppress(sqlite3.OperationalError):
+                        connection.execute(
+                            f"ALTER TABLE publish_receipt_audit ADD COLUMN {column} TEXT"
+                        )
             self._initialized = True
 
     @staticmethod
@@ -336,46 +347,103 @@ class PublishReceiptStore:
             result=result,
             allowed_source_states=("pending", "unknown"),
         )
-        self._append_audit(fingerprint, "reconcile_succeeded")
+        owner_key, run_id = self._receipt_owner_run(fingerprint)
+        self._append_audit(fingerprint, "reconcile_succeeded", owner_key=owner_key, run_id=run_id)
 
     def reset(self, fingerprint: str, *, action: str = "reset") -> bool:
         """receipt를 삭제해 재시도(새 claim)를 허용한다(#551). 감사 로그를 남긴다.
 
         삭제가 실제로 일어났으면 True, 해당 fingerprint가 없으면 False.
+        감사 행에는 receipt의 owner/run을 옮겨 적는다(#563) — receipt 삭제 후에도
+        이력이 소유자·run 단위로 조회되어야 하기 때문이다.
         """
         self._initialize()
-        with self._connect() as connection:
-            cursor = connection.execute(
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                "SELECT owner_key, run_id FROM publish_receipts WHERE fingerprint = ?",
+                (fingerprint,),
+            ).fetchone()
+            if row is None:
+                connection.commit()
+                return False
+            owner_key, run_id = cast(str | None, row[0]), cast(str, row[1])
+            connection.execute(
                 "DELETE FROM publish_receipts WHERE fingerprint = ?",
                 (fingerprint,),
             )
-            deleted = cursor.rowcount == 1
-        if deleted:
-            self._append_audit(fingerprint, action)
-        return deleted
+            self._append_audit_on(
+                connection, fingerprint, action, owner_key=owner_key, run_id=run_id
+            )
+            connection.commit()
+            return True
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
 
-    def _append_audit(self, fingerprint: str, action: str, *, actor: str = "operator") -> None:
-        recorded_at = datetime_module.now(timezone.utc).isoformat(timespec="seconds")
+    def _receipt_owner_run(self, fingerprint: str) -> tuple[str | None, str | None]:
+        """fingerprint에서 receipt의 (owner_key, run_id)를 읽는다(#563)."""
         with self._connect() as connection:
-            connection.execute(
-                """
-                INSERT INTO publish_receipt_audit(fingerprint, action, actor, recorded_at)
-                VALUES (?, ?, ?, ?)
-                """,
-                (fingerprint, action, actor, recorded_at),
+            row = connection.execute(
+                "SELECT owner_key, run_id FROM publish_receipts WHERE fingerprint = ?",
+                (fingerprint,),
+            ).fetchone()
+        if row is None:
+            return None, None
+        return cast(str | None, row[0]), cast(str | None, row[1])
+
+    def _append_audit(
+        self,
+        fingerprint: str,
+        action: str,
+        *,
+        owner_key: str | None = None,
+        run_id: str | None = None,
+        actor: str = "operator",
+    ) -> None:
+        with self._connect() as connection:
+            self._append_audit_on(
+                connection, fingerprint, action, owner_key=owner_key, run_id=run_id, actor=actor
             )
 
+    @staticmethod
+    def _append_audit_on(
+        connection: sqlite3.Connection,
+        fingerprint: str,
+        action: str,
+        *,
+        owner_key: str | None,
+        run_id: str | None,
+        actor: str = "operator",
+    ) -> None:
+        recorded_at = datetime_module.now(timezone.utc).isoformat(timespec="seconds")
+        connection.execute(
+            """
+            INSERT INTO publish_receipt_audit(
+                fingerprint, owner_key, run_id, action, actor, recorded_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (fingerprint, owner_key, run_id, action, actor, recorded_at),
+        )
+
     def audit_entries(self, *, owner_key: str, run_id: str) -> list[dict[str, str]]:
-        """해당 owner/run의 감사 로그를 시간순으로 반환한다(조회 API용)."""
+        """해당 owner/run의 감사 로그를 시간순으로 반환한다.
+
+        receipt가 삭제(reset)된 이후의 행도 포함한다(#563) — 감사 행이 owner/run을
+        스스로 들고 있으므로 JOIN이 필요 없다.
+        """
         self._initialize()
         with self._connect() as connection:
             rows = connection.execute(
                 """
-                SELECT a.fingerprint, a.action, a.actor, a.recorded_at
-                FROM publish_receipt_audit a
-                JOIN publish_receipts r ON r.fingerprint = a.fingerprint
-                WHERE r.owner_key = ? AND r.run_id = ?
-                ORDER BY a.seq
+                SELECT fingerprint, action, actor, recorded_at
+                FROM publish_receipt_audit
+                WHERE owner_key = ? AND run_id = ?
+                ORDER BY seq
                 """,
                 (owner_key, run_id),
             ).fetchall()
@@ -403,18 +471,35 @@ class PublishReceiptStore:
             if result is not None
             else None
         )
-        placeholders = ", ".join("?" for _ in allowed_source_states)
-        with self._connect() as connection:
-            cursor = connection.execute(
-                f"""
+        # BEGIN IMMEDIATE로 전환 순간까지 쓰기 잠금을 잡아 claim()과 같은
+        # 직렬화 수준에서 상태 전이를 확정한다(#564).
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            current = connection.execute(
+                "SELECT state FROM publish_receipts WHERE fingerprint = ?",
+                (fingerprint,),
+            ).fetchone()
+            if current is None or cast(str, current[0]) not in allowed_source_states:
+                connection.commit()
+                raise RuntimeError(
+                    "publish receipt is not in an allowed state for this transition"
+                    f" (allowed: {list(allowed_source_states)})"
+                )
+            connection.execute(
+                """
                 UPDATE publish_receipts
                 SET state = ?, result_json = ?
-                WHERE fingerprint = ? AND state IN ({placeholders})
+                WHERE fingerprint = ?
                 """,
-                (state, result_json, fingerprint, *allowed_source_states),
+                (state, result_json, fingerprint),
             )
-            if cursor.rowcount != 1:
-                raise RuntimeError("publish receipt is not pending")
+            connection.commit()
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
 
 
 @dataclass(frozen=True)

--- a/src/kpubdata_builder/service/routes/publish.py
+++ b/src/kpubdata_builder/service/routes/publish.py
@@ -20,6 +20,7 @@ _READINESS_SUFFIX = "/publish/readiness"
 _PUBLISH_SUFFIX = "/publish"
 _RECEIPT_SUFFIX = "/publish/receipt"
 _RECONCILE_SUFFIX = "/publish/reconcile"
+_AUDIT_SUFFIX = "/publish/audit"
 
 
 def route(
@@ -72,6 +73,16 @@ def route(
         if access_error is not None:
             return access_error
         return service.get_publish_receipt(run_id, target, destination, principal=principal)
+
+    if method == "GET" and rest.endswith(_AUDIT_SUFFIX):
+        run_id = rest[: -len(_AUDIT_SUFFIX)]
+        error = _validate_run_id(run_id)
+        if error is not None:
+            return error
+        access_error = check_active_run_access(service, run_id, principal)
+        if access_error is not None:
+            return access_error
+        return service.publish_audit_log(run_id, principal=principal)
 
     if method == "POST" and rest.endswith(_RECONCILE_SUFFIX):
         run_id = rest[: -len(_RECONCILE_SUFFIX)]

--- a/tests/unit/test_openapi_examples.py
+++ b/tests/unit/test_openapi_examples.py
@@ -178,7 +178,7 @@ def test_extraction_script_emits_documented_json_shape() -> None:
         encoding="utf-8",
     )
     payload = json.loads(completed.stdout)
-    assert payload["contract_version"] == "1.20.0"
+    assert payload["contract_version"] == "1.21.0"
     assert len(payload["examples"]) >= 50
     assert set(payload["examples"][0]) == {
         "path",

--- a/tests/unit/test_service_publish.py
+++ b/tests/unit/test_service_publish.py
@@ -1365,6 +1365,66 @@ class TestReceiptReconcile:
         )
         assert reset_resp.status_code == 403
 
+    def test_reset_audit_survives_and_audit_api_returns_history(self, tmp_path, monkeypatch):
+        """reset 후에도 감사 이력이 owner/run으로 조회되고 API가 이를 반환한다 (#563)."""
+        service = self._unknown_receipt_service(tmp_path, monkeypatch, "run-audit")
+
+        # unknown → reset(감사: reconcile_absent_reset 아닌 manual_reset 경로 사용)
+        reset = dispatch(
+            service,
+            "DELETE",
+            "/builds/run-audit/publish/receipt",
+            None,
+            query="target=huggingface&destination=kpubdata%2Fair-quality",
+        )
+        assert reset.status_code == 200
+
+        # receipt는 사라졌지만 감사 이력은 살아 있다.
+        gone = dispatch(
+            service,
+            "GET",
+            "/builds/run-audit/publish/receipt",
+            None,
+            query="target=huggingface&destination=kpubdata%2Fair-quality",
+        )
+        assert gone.status_code == 404
+
+        audit = dispatch(service, "GET", "/builds/run-audit/publish/audit", None)
+        assert audit.status_code == 200
+        actions = [entry["action"] for entry in audit.body["entries"]]
+        assert "manual_reset" in actions
+        # 감사 항목은 최소 필드만 담는다(credential/경로 원문 없음).
+        for entry in audit.body["entries"]:
+            assert set(entry) == {"fingerprint", "action", "actor", "recorded_at"}
+
+    def test_audit_api_cross_owner_is_blocked(self, tmp_path, monkeypatch):
+        """감사 조회도 run 소유권 게이트를 통과한다 (#563)."""
+        monkeypatch.setenv(_OWNERSHIP_ENV, "true")
+        owner = Principal(kind="oidc", identifier="a", owner_id="oidc:owner-a")
+        monkeypatch.setattr(app_module, "authenticate", lambda **_kwargs: owner)
+        service = self._unknown_receipt_service(tmp_path, monkeypatch, "run-audit-owned")
+
+        other = Principal(kind="oidc", identifier="b", owner_id="oidc:owner-b")
+        monkeypatch.setattr(app_module, "authenticate", lambda **_kwargs: other)
+        audit = dispatch(service, "GET", "/builds/run-audit-owned/publish/audit", None)
+        assert audit.status_code == 403
+
+    def test_reconcile_succeeded_records_owner_run_audit(self, tmp_path, monkeypatch):
+        """reconcile 성공 감사 행도 owner/run을 스스로 들고 있다 (#563)."""
+        service = self._unknown_receipt_service(tmp_path, monkeypatch, "run-rec-audit")
+        monkeypatch.setattr(service, "_probe_remote_publish_target", lambda *_args: True)
+        resp = dispatch(
+            service,
+            "POST",
+            "/builds/run-rec-audit/publish/reconcile",
+            {"target": "huggingface", "destination": "kpubdata/air-quality"},
+        )
+        assert resp.status_code == 200
+
+        audit = dispatch(service, "GET", "/builds/run-rec-audit/publish/audit", None)
+        actions = [entry["action"] for entry in audit.body["entries"]]
+        assert "reconcile_succeeded" in actions
+
 
 class TestOpenApiConformance:
     """실제 dispatch() wire 응답이 OpenAPI 스키마와 정확히 일치하는지 (ADR-0005 방식)."""


### PR DESCRIPTION
## #563 — 감사 이력 고아화 해소
- 감사 테이블에 `owner_key`/`run_id` 컬럼 추가(기존 DB는 ALTER 마이그레이션)
- `reset()`: receipt 삭제 전 소유자/run을 읽어 감사 행에 옮김 — **reset 후에도 이력 조회 가능**
- `reconcile_succeeded` 감사에도 owner/run 기록
- `audit_entries`: receipt JOIN 제거 → 행 자체 조회
- **신규 API** `GET /builds/{run_id}/publish/audit`(소유권 게이트, 계약 1.21.0 additive) — 최소 필드만 반환(credential/경로 원문 없음)

## #564 — 종단 전이 원자화
- `_set_terminal`이 `BEGIN IMMEDIATE`에서 상태 검사 + UPDATE 수행(`claim()`과 동일 직렬화)
- 오류 메시지가 허용 상태 목록을 정확히 반영

## 테스트 (+3)
- reset 후 receipt 404여도 audit API가 이력 반환 + 필드 최소성 단정
- 감사 API 교차 소유자 403
- reconcile 성공 감사 행 owner/run 보유

## 검증
- 전체 1,620 테스트 통과, ruff format/lint·mypy ✅

Closes #563
Closes #564