### PR TITLE
fix: align HTTP request ID handling with API contract

### DIFF
--- a/src/kpubdata_builder/service/http.py
+++ b/src/kpubdata_builder/service/http.py
@@ -249,8 +249,6 @@ def make_handler(service: BuilderService) -> type[BaseHTTPRequestHandler]:
                 self.send_header("Access-Control-Max-Age", "86400")
 
         def _write(self, status_code: int, body: dict[str, JsonValue]) -> None:
-            if hasattr(self, "_request_id"):
-                body.setdefault("request_id", self._request_id)
             payload = json.dumps(body, ensure_ascii=False, default=str).encode("utf-8")
             self.send_response(status_code)
             self.send_header("Content-Type", "application/json; charset=utf-8")

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -11,9 +11,10 @@ from collections.abc import Iterable
 from datetime import date, datetime, timedelta, timezone
 from http.server import HTTPServer
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import pytest
+import yaml
 
 import kpubdata_builder.service.app as app_module
 from kpubdata_builder.service import BuilderService, ServiceResponse, dispatch
@@ -21,6 +22,8 @@ from kpubdata_builder.service.auth import Principal
 from kpubdata_builder.service.http import _clear_cors_cache, make_handler
 from kpubdata_builder.service.ownership import _OWNERSHIP_ENV
 from kpubdata_builder.spec import JsonValue
+
+from ._openapi import response_schema, validate
 
 VALID_SPEC_YAML = (
     """
@@ -123,7 +126,7 @@ class _CloseTrackingClient(_FakeClient):
 
 def _service(tmp_path: Path) -> BuilderService:
     client = _FakeClient({"datago.air_quality": [{"id": "1", "v": 10}, {"id": "2", "v": 20}]})
-    return BuilderService(output_root=tmp_path, client_factory=lambda: client)
+    return BuilderService(output_root=tmp_path, client_factory=lambda **_kwargs: client)
 
 
 class TestVersion:
@@ -1268,12 +1271,47 @@ class TestHttpAdapter:
         base_url, _, _ = http_server_with_auth
         with urllib.request.urlopen(f"{base_url}/healthz", timeout=2.0) as response:
             assert response.status == 200
+            request_id = response.headers["X-Request-ID"]
             body = cast(dict[str, object], json.loads(response.read()))
         assert body["status"] == "ok"
-        assert "request_id" in body
+        assert "request_id" not in body
+        assert request_id
         # 버전·서비스 메타 정보가 누출되지 않아야 한다.
         assert "api_version" not in body
         assert "service" not in body
+
+    @pytest.mark.parametrize("stage", ["bronze", "silver", "gold"])
+    def test_stage_detail_wire_response_conforms_to_openapi(
+        self,
+        http_server: tuple[str, HTTPServer, threading.Thread],
+        stage: str,
+    ) -> None:
+        base_url, _, _ = http_server
+        build_req = urllib.request.Request(
+            f"{base_url}/build",
+            data=json.dumps({"spec": VALID_SPEC_YAML, "run_id": "wire-stage-detail"}).encode(
+                "utf-8"
+            ),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(build_req, timeout=5.0) as response:
+            assert response.status == 200
+
+        url = f"{base_url}/builds/wire-stage-detail/stages/{stage}?source=datago.air_quality"
+        with urllib.request.urlopen(url, timeout=2.0) as response:
+            assert response.status == 200
+            status_code = response.status
+            request_id = response.headers["X-Request-ID"]
+            body = cast(dict[str, object], json.loads(response.read()))
+
+        assert "request_id" not in body
+        assert request_id
+        contract_path = Path(__file__).parents[2] / "contract" / "builder-api.yaml"
+        contract = cast(dict[str, Any], yaml.safe_load(contract_path.read_text(encoding="utf-8")))
+        schema = response_schema(contract, "/builds/{run_id}/stages/{stage}", "GET", status_code)
+        assert schema is not None
+        assert validate(body, schema, contract) == []
 
 
 class TestHttpUploads:


### PR DESCRIPTION
## Summary

Real Builder ↔ Studio E2E에서 Stage Detail 응답이 Studio의 strict schema validation에 실패하는 문제를 수정합니다.

Builder HTTP adapter가 OpenAPI에 정의되지 않은 `request_id`를 모든 JSON response body에 암묵적으로 추가하고 있었습니다.

기존 correlation/tracing 동작은 유지하면서 runtime wire response를 현재 API contract와 다시 일치시켰습니다.

## Root cause

`service/http.py::_write()`에서 canonical `ServiceResponse.body`에 다음 필드를 추가하고 있었습니다.

```python
body.setdefault("request_id", self._request_id)
```
하지만:

request_id는 contract/builder-api.yaml response schema에 정의되어 있지 않음
Stage Detail response는 additionalProperties: false
Studio 역시 해당 contract를 따라 strict validation

따라서 실제 HTTP wire response가 Builder 자신의 OpenAPI contract를 위반했습니다.

Changes
JSON response body의 암묵적 request_id 삽입 제거
X-Request-ID response header 유지
request ID structured logging 유지
실제 HTTP adapter를 통과하는 regression test 보강
Bronze / Silver / Gold Stage Detail wire response를 OpenAPI schema와 검증

API contract와 API_CONTRACT_VERSION은 변경하지 않았습니다.

Verification

Clean test environment 기준:

Contract: 88 passed
HTTP wire regression: 4 passed
Full pytest: 1,610 passed, 4 failed, 9 skipped
Ruff: PASS
mypy: PASS
git diff --check: PASS

남은 full pytest 4건은 Windows 환경 관련 기존 범위입니다.

Path.rename() existing target: 2
subprocess cp949 encoding: 1
POSIX absolute-path interpretation on Windows: 1
E2E impact

수정 전:

Builder Stage Detail
→ HTTP adapter adds request_id
→ Studio strict response parser
→ Unrecognized key: "request_id"

수정 후:

Builder Stage Detail
→ contract-compliant JSON body
→ X-Request-ID header retained
→ Studio Stage Detail parseable

동일 root cause로 영향을 받을 수 있던 다른 strict response consumer에도 적용됩니다.