### PR TITLE
fix: harden Builder portability and async credential handling

### DIFF
--- a/scripts/extract_openapi_examples.py
+++ b/scripts/extract_openapi_examples.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import argparse
+import io
 import json
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -105,6 +107,8 @@ def main() -> None:
     document = yaml.safe_load(args.contract.read_text(encoding="utf-8"))
     if not isinstance(document, dict):
         raise ValueError("OpenAPI document must be a mapping")
+    if isinstance(sys.stdout, io.TextIOWrapper):
+        sys.stdout.reconfigure(encoding="utf-8")
     print(json.dumps(extract_examples(document), ensure_ascii=False, indent=2))
 
 

--- a/scripts/pipeline/fetch.py
+++ b/scripts/pipeline/fetch.py
@@ -151,5 +151,8 @@ def _save_checkpoint(path: Path, *, next_index: int, records: list[dict[str, Any
     data = {"next_index": next_index, "records": records}
     # Write atomically via temp file
     tmp = path.with_suffix(".tmp")
-    tmp.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
-    tmp.rename(path)
+    try:
+        tmp.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+        tmp.replace(path)
+    finally:
+        tmp.unlink(missing_ok=True)

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -519,6 +519,9 @@ class BuilderService:
         client = self._create_client()
         try:
             return provider_descriptors(client)
+        except Exception as exc:
+            logger.exception("provider catalog unavailable")
+            return ServiceResponse(502, {"error": f"catalog unavailable: {exc}"})
         finally:
             _close_request_client(client)
 

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -519,8 +519,6 @@ class BuilderService:
         client = self._create_client()
         try:
             return provider_descriptors(client)
-        except Exception:
-            return ServiceResponse(502, {"error": "provider catalog unavailable"})
         finally:
             _close_request_client(client)
 

--- a/src/kpubdata_builder/service/app.py
+++ b/src/kpubdata_builder/service/app.py
@@ -945,6 +945,7 @@ class BuilderService:
         created_by: str | None = None,
         owner_id: str | None = None,
         manifest_owner_id: str | None = None,
+        credential_owner_id: str | None = None,
         principal: Principal | None = None,
         cancellation: CancellationProbe | None = None,
     ) -> ServiceResponse:
@@ -968,6 +969,11 @@ class BuilderService:
         owner_id를 manifest/BuildIndex에는 기록하면서도 file resolver에는
         여전히 owner_id를 넘기지 않는 데 쓴다(#496 follow-up).
 
+        ``credential_owner_id``는 async worker가 submitting principal의 stable
+        identity로 public_api credential만 해석하기 위한 내부 값이다. file source
+        resolver에는 전달하지 않으며, request principal이 있으면 principal의
+        owner_id가 항상 우선한다(ADR 0012, ADR 0014).
+
         ``cancellation``은 async job(#481)에서만 전달되는 협력적 취소 probe다.
         ``None``이면(동기 ``POST /build``, CLI) 파이프라인이 취소 점검을 전혀
         하지 않아 기존 동작과 100% 동일하다 — 동기 build에 취소 상태를 강요하지
@@ -985,10 +991,11 @@ class BuilderService:
         provider_names = tuple(
             source.provider for source in spec_or_error.sources if source.kind == "public_api"
         )
+        provider_owner_id = principal.owner_id if principal is not None else credential_owner_id
         try:
             provider_keys = (
-                self._credential_resolver.provider_keys(principal.owner_id, provider_names)
-                if principal is not None
+                self._credential_resolver.provider_keys(provider_owner_id, provider_names)
+                if principal is not None or credential_owner_id is not None
                 else {}
             )
             client = self._create_client(
@@ -1288,11 +1295,12 @@ class BuilderService:
     ) -> ServiceResponse:
         """async job registry가 부르는 실제 실행 진입점 (#482, #496 follow-up).
 
-        ``build()``에 ``owner_id``는 전달하지 않는다(``None`` 그대로) —
+        ``build()``에 file resolver용 ``owner_id``는 전달하지 않는다(``None`` 그대로) —
         ``kind="file"`` source resolver는 async 경로에서 여전히 stable owner
-        identity를 알지 못한다(#498 async limitation 유지). 대신
-        ``manifest_owner_id``로 registry snapshot에 이미 보존된(``submit_build``
-        가 채운) submitting principal의 owner_id를 넘긴다 — persisted manifest
+        identity를 알지 못한다(#498 async limitation 유지). registry snapshot에
+        이미 보존된(``submit_build``가 채운) submitting principal의 owner_id는
+        public_api credential 해석용 ``credential_owner_id``와 persisted manifest
+        ownership용 ``manifest_owner_id``로만 넘긴다 — persisted manifest
         (및 그 manifest를 그대로 읽어 채우는 BuildIndex, #505 SSOT)는
         ``build()`` 내부에서 단 한 번의 write로 정확한 owner_id를 갖게 되고,
         build 종료 후 manifest를 별도로 사후 수정할 필요가 없다.
@@ -1304,6 +1312,7 @@ class BuilderService:
             run_id=run_id,
             created_by=created_by,
             manifest_owner_id=manifest_owner_id,
+            credential_owner_id=manifest_owner_id,
             # 협력적 취소 probe(#481)를 그대로 pipeline까지 내려보낸다 — service
             # 개념(registry/HTTP/Principal)은 pipeline domain으로 넘기지 않는다.
             cancellation=cancellation,

--- a/src/kpubdata_builder/service/auth.py
+++ b/src/kpubdata_builder/service/auth.py
@@ -291,6 +291,11 @@ def _verify_bearer_token(token: str) -> Principal | AuthError:
         signing_key = client.get_signing_key_from_jwt(token)  # type: ignore[attr-defined]
     except (PyJWKClientError, ConnectionError, OSError):
         return AuthError(reason="auth service unavailable (jwks)", status_code=503)
+    except jwt.PyJWTError:
+        # PyJWKClient parses the unverified JWT header before selecting a key.
+        # Malformed compact serialization/header errors are invalid credentials,
+        # not JWKS infrastructure failures.
+        return AuthError(reason="invalid token")
 
     audience = os.environ.get(_OIDC_AUDIENCE_ENV, "").strip()
     try:

--- a/src/kpubdata_builder/service/providers.py
+++ b/src/kpubdata_builder/service/providers.py
@@ -134,7 +134,7 @@ def provider_descriptors(client: SourceClient) -> tuple[ProviderDescriptor, ...]
         return tuple(ProviderDescriptor(name, name in authenticated) for name in names)
 
     descriptors: list[ProviderDescriptor] = []
-    for name in registry:
+    for name in sorted(registry):
         try:
             adapter = registry.get(name)
             typed_client.datasets.list(provider=name)

--- a/src/kpubdata_builder/service/providers.py
+++ b/src/kpubdata_builder/service/providers.py
@@ -124,9 +124,30 @@ class CredentialResolver:
 def provider_descriptors(client: SourceClient) -> tuple[ProviderDescriptor, ...]:
     """kpubdata 공개 runtime catalog에서 Provider 목록과 인증 필요 여부를 얻는다."""
     typed_client = cast(Client, client)
-    authenticated = frozenset(p.name for p in typed_client.iter_authenticated_providers())
-    names = sorted({dataset.provider for dataset in typed_client.datasets.list()})
-    return tuple(ProviderDescriptor(name, name in authenticated) for name in names)
+    # Built-in adapters are registered lazily.  Resolve them one at a time so an
+    # optional dependency of one adapter (for example KRX -> pandas) cannot make
+    # the catalog for every other provider unavailable.
+    registry = getattr(typed_client, "_registry", None)
+    if registry is None:
+        authenticated = frozenset(p.name for p in typed_client.iter_authenticated_providers())
+        names = sorted({dataset.provider for dataset in typed_client.datasets.list()})
+        return tuple(ProviderDescriptor(name, name in authenticated) for name in names)
+
+    descriptors: list[ProviderDescriptor] = []
+    for name in registry:
+        try:
+            adapter = registry.get(name)
+            typed_client.datasets.list(provider=name)
+        except ModuleNotFoundError as exc:
+            # KRX is the sole built-in provider with this optional dependency.
+            # Do not hide a missing internal module or another provider bug.
+            if name == "krx" and exc.name == "pandas":
+                continue
+            raise
+        descriptors.append(
+            ProviderDescriptor(name, bool(getattr(adapter, "requires_api_key", True)))
+        )
+    return tuple(descriptors)
 
 
 def default_provider_test(client: SourceClient, provider: str) -> None:

--- a/tests/pipeline/test_fetch.py
+++ b/tests/pipeline/test_fetch.py
@@ -188,6 +188,38 @@ def test_save_checkpoint_writes_atomically(tmp_path: Path) -> None:
     assert not (tmp_path / "fetch_checkpoint.tmp").exists()
 
 
+def test_save_checkpoint_replaces_existing_file(tmp_path: Path) -> None:
+    cp = tmp_path / "fetch_checkpoint.json"
+    _save_checkpoint(cp, next_index=1, records=[{"id": "old"}])
+
+    _save_checkpoint(cp, next_index=2, records=[{"id": "old"}, {"id": "new"}])
+
+    data = json.loads(cp.read_text(encoding="utf-8"))
+    assert data == {
+        "next_index": 2,
+        "records": [{"id": "old"}, {"id": "new"}],
+    }
+    assert not (tmp_path / "fetch_checkpoint.tmp").exists()
+
+
+def test_save_checkpoint_cleans_temp_after_replace_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cp = tmp_path / "fetch_checkpoint.json"
+    cp.write_text('{"next_index": 1, "records": []}', encoding="utf-8")
+
+    def fail_replace(_self: Path, _target: Path) -> Path:
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(Path, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="replace failed"):
+        _save_checkpoint(cp, next_index=2, records=[{"id": "new"}])
+
+    assert json.loads(cp.read_text(encoding="utf-8")) == {"next_index": 1, "records": []}
+    assert not (tmp_path / "fetch_checkpoint.tmp").exists()
+
+
 def test_fetch_with_retry_raises_fetch_error_after_exhaustion() -> None:
     """Retryable errors raise FetchError after max_retries is exhausted."""
     failing_ds = MagicMock()

--- a/tests/unit/test_oidc_auth.py
+++ b/tests/unit/test_oidc_auth.py
@@ -64,6 +64,14 @@ class _FailingJWKSClient:
         raise ConnectionError("jwks endpoint unreachable")
 
 
+class _ParsingJWKSClient(_FakeJWKSClient):
+    """PyJWKClient처럼 키 선택 전에 JWT header를 파싱한다."""
+
+    def get_signing_key_from_jwt(self, token: str) -> _FakeSigningKey:
+        jwt.get_unverified_header(token)
+        return super().get_signing_key_from_jwt(token)
+
+
 @pytest.fixture()
 def rsa_keypair() -> tuple[bytes, object]:
     private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
@@ -120,6 +128,30 @@ class TestValidBearerToken:
 
 
 class TestInvalidTokens:
+    @pytest.mark.parametrize(
+        "token",
+        [
+            "invalid-token",
+            "one.two",
+            "not-base64.payload.signature",
+        ],
+    )
+    def test_malformed_jwt_returns_401(
+        self,
+        token: str,
+        monkeypatch: pytest.MonkeyPatch,
+        oidc_env: bytes,
+        rsa_keypair: tuple[bytes, object],
+    ) -> None:
+        import kpubdata_builder.service.auth as auth_module
+
+        _, public_key = rsa_keypair
+        monkeypatch.setattr(auth_module, "_get_jwks_client", lambda: _ParsingJWKSClient(public_key))
+
+        result = authenticate(bearer_token=f"Bearer {token}")
+
+        assert result == AuthError(reason="invalid token", status_code=401)
+
     def test_invalid_signature(self, oidc_env: bytes) -> None:
         # 다른 키로 서명 → fixture의 public key로 검증 실패
         other = rsa.generate_private_key(public_exponent=65537, key_size=2048)

--- a/tests/unit/test_openapi_examples.py
+++ b/tests/unit/test_openapi_examples.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from collections.abc import Iterator
@@ -167,6 +168,8 @@ def test_query_example_has_main_1_9_0_result_fields() -> None:
 
 
 def test_extraction_script_emits_documented_json_shape() -> None:
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "cp949"
     completed = subprocess.run(
         [sys.executable, str(_SCRIPT_PATH)],
         cwd=_ROOT,
@@ -176,8 +179,10 @@ def test_extraction_script_emits_documented_json_shape() -> None:
         # 스크립트가 ensure_ascii=False(한글 원문)로 출력하므로 Windows cp949
         # 기본 디코딩을 쓰지 않는다(#553).
         encoding="utf-8",
+        env=env,
     )
     payload = json.loads(completed.stdout)
+    assert "—" in completed.stdout
     assert payload["contract_version"] == "1.21.0"
     assert len(payload["examples"]) >= 50
     assert set(payload["examples"][0]) == {

--- a/tests/unit/test_provider_credentials.py
+++ b/tests/unit/test_provider_credentials.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import threading
+import time
 import urllib.request
 from collections.abc import Iterable
 from http.server import HTTPServer
@@ -28,6 +29,20 @@ description: Provider credential resolution test
 sources:
   - provider: datago
     dataset: air_quality
+exports:
+  - kind: jsonl
+    output_path: out/data.jsonl
+"""
+
+_FILE_SPEC = """\
+dataset_id: async-file-boundary
+title: Async file boundary
+description: Async file sources remain unsupported
+sources:
+  - kind: file
+    upload_id: {upload_id}
+    format: csv
+    encoding: utf-8
 exports:
   - kind: jsonl
     output_path: out/data.jsonl
@@ -126,6 +141,16 @@ def _service(
         ),
         resolved_factory,
     )
+
+
+def _wait_for_terminal_job(service: BuilderService, run_id: str) -> dict[str, JsonValue]:
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        response = service.build_status(run_id)
+        if response.body.get("status") in {"succeeded", "failed", "cancelled"}:
+            return response.body
+        time.sleep(0.01)
+    raise AssertionError(f"async build did not finish: {run_id}")
 
 
 def test_credential_crud_masks_and_never_returns_raw_secret(
@@ -229,6 +254,142 @@ def test_preview_build_and_test_share_resolution_without_client_cache(
     assert credential_calls[-1] == {"datago": "credential-b"}
     assert seen_by_test == [{"datago": "credential-a"}]
     assert len({id(client) for _, _, _, client in factory.calls}) == len(factory.calls)
+
+
+def test_async_public_api_uses_submitting_user_credential_and_isolates_users(
+    tmp_path: Path, repository: SQLiteCredentialRepository, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("KPUBDATA_DATAGO_API_KEY", "different-server-default")
+    principal_a = Principal("oidc", "user-a", "oidc:owner-a")
+    principal_b = Principal("oidc", "user-b", "oidc:owner-b")
+    repository.put(cast(str, principal_a.owner_id), "datago", "credential-a")
+    repository.put(cast(str, principal_b.owner_id), "datago", "credential-b")
+    service, factory = _service(tmp_path, repository)
+
+    try:
+        assert service.preview(_SPEC, principal=principal_a).status_code == 200
+        submitted = service.submit_build(
+            _SPEC,
+            run_id="async-owner-a",
+            created_by=principal_a.label,
+            owner_id=principal_a.owner_id,
+        )
+        assert submitted.status_code == 202
+        status = _wait_for_terminal_job(service, "async-owner-a")
+
+        assert status["status"] == "succeeded"
+        assert [keys for keys, _, _, _ in factory.calls] == [
+            {"datago": "credential-a"},
+            {"datago": "credential-a"},
+        ]
+        assert all(cache is False for _, _, cache, _ in factory.calls)
+        assert all(client.closed for _, _, _, client in factory.calls)
+    finally:
+        service._async_builds.shutdown()
+
+
+def test_async_public_api_falls_back_to_server_default(
+    tmp_path: Path, repository: SQLiteCredentialRepository, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("KPUBDATA_DATAGO_API_KEY", "server-default")
+    principal = Principal("oidc", "user-without-key", "oidc:owner-without-key")
+    service, factory = _service(tmp_path, repository)
+
+    try:
+        submitted = service.submit_build(
+            _SPEC,
+            run_id="async-server-default",
+            created_by=principal.label,
+            owner_id=principal.owner_id,
+        )
+        assert submitted.status_code == 202
+        status = _wait_for_terminal_job(service, "async-server-default")
+
+        assert status["status"] == "succeeded"
+        assert factory.calls[-1][0] == {"datago": "server-default"}
+        assert factory.calls[-1][2] is False
+        assert factory.calls[-1][3].closed is True
+    finally:
+        service._async_builds.shutdown()
+
+
+def test_async_credential_is_not_persisted_or_exposed(
+    tmp_path: Path, repository: SQLiteCredentialRepository
+) -> None:
+    secret = "async-credential-must-not-leak"
+    principal = Principal("oidc", "user-a", "oidc:owner-a")
+    repository.put(cast(str, principal.owner_id), "datago", secret)
+    service, _ = _service(tmp_path, repository)
+
+    try:
+        submitted = service.submit_build(
+            _SPEC,
+            run_id="async-secret-boundary",
+            created_by=principal.label,
+            owner_id=principal.owner_id,
+        )
+        assert submitted.status_code == 202
+        status = _wait_for_terminal_job(service, "async-secret-boundary")
+        snapshot = service._async_builds.get("async-secret-boundary")
+        events = service.get_build_events("async-secret-boundary", limit=100, tail=False)
+        manifest = (tmp_path / "build" / "async-secret-boundary" / "manifest.json").read_text(
+            encoding="utf-8"
+        )
+
+        assert snapshot is not None
+        exposed = json.dumps(
+            {
+                "submission": submitted.body,
+                "status": status,
+                "snapshot": snapshot.to_body(),
+                "events": events.body,
+            }
+        )
+        assert secret not in exposed
+        assert secret not in manifest
+        assert "owner_id" not in submitted.body
+        assert "owner_id" not in snapshot.to_body()
+    finally:
+        service._async_builds.shutdown()
+
+
+def test_async_credential_owner_does_not_enable_file_source(
+    tmp_path: Path, repository: SQLiteCredentialRepository
+) -> None:
+    principal = Principal("oidc", "user-a", "oidc:owner-a")
+    service, _ = _service(tmp_path, repository)
+
+    try:
+        upload = service.create_upload(
+            b"id,value\n1,10\n",
+            format="csv",
+            encoding="utf-8",
+            original_filename="data.csv",
+            principal=principal,
+        )
+        upload_id = cast(str, upload.body["upload_id"])
+        submitted = service.submit_build(
+            _FILE_SPEC.format(upload_id=upload_id),
+            run_id="async-file-unsupported",
+            created_by=principal.label,
+            owner_id=principal.owner_id,
+        )
+        assert submitted.status_code == 202
+        status = _wait_for_terminal_job(service, "async-file-unsupported")
+
+        assert status["status"] == "failed"
+        response = cast(dict[str, JsonValue], status["response"])
+        outcomes = cast(list[dict[str, JsonValue]], response["outcomes"])
+        assert outcomes[0]["status"] == "failed"
+        assert "authenticated, stable principal owner" in cast(str, outcomes[0]["error"])
+        manifest = json.loads(
+            (tmp_path / "build" / "async-file-unsupported" / "manifest.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert manifest["owner_id"] == principal.owner_id
+    finally:
+        service._async_builds.shutdown()
 
 
 def test_preview_build_test_and_manifest_scrub_raw_secret(

--- a/tests/unit/test_provider_credentials.py
+++ b/tests/unit/test_provider_credentials.py
@@ -19,7 +19,11 @@ from kpubdata_builder.credentials import AesGcmCredentialCipher, SQLiteCredentia
 from kpubdata_builder.service import BuilderService, dispatch
 from kpubdata_builder.service.auth import Principal, compute_owner_id
 from kpubdata_builder.service.http import _clear_cors_cache, make_handler
-from kpubdata_builder.service.providers import run_provider_test
+from kpubdata_builder.service.providers import (
+    ProviderDescriptor,
+    provider_descriptors,
+    run_provider_test,
+)
 from kpubdata_builder.spec import JsonValue
 
 _SPEC = """\
@@ -111,6 +115,67 @@ class _Factory:
         client = _Client(provider_keys or {})
         self.calls.append((dict(provider_keys or {}), timeout, cache, client))
         return client
+
+
+class _LazyRegistry:
+    def __iter__(self) -> Iterable[str]:
+        return iter(("datago", "krx"))
+
+    def get(self, name: str) -> _Provider:
+        if name == "krx":
+            raise ModuleNotFoundError("No module named 'pandas'", name="pandas")
+        return _Provider(name)
+
+
+class _OptionalProviderClient:
+    _registry = _LazyRegistry()
+
+    class _Catalog:
+        @staticmethod
+        def list(*, provider: str) -> list[_Ref]:
+            return [_Ref(provider, "dataset")]
+
+    datasets = _Catalog()
+
+    def close(self) -> None:
+        return None
+
+
+def test_provider_catalog_skips_provider_with_missing_optional_dependency() -> None:
+    assert provider_descriptors(cast(object, _OptionalProviderClient())) == (
+        ProviderDescriptor("datago", True),
+    )
+
+
+def test_providers_service_keeps_available_provider_when_krx_pandas_is_missing(
+    tmp_path: Path, repository: SQLiteCredentialRepository
+) -> None:
+    service = BuilderService(
+        output_root=tmp_path,
+        client_factory=lambda: cast(object, _OptionalProviderClient()),
+        credential_repository=repository,
+    )
+
+    response = service.providers(principal=Principal("oidc", "user-a", "oidc:owner-a"))
+
+    assert response.status_code == 200
+    assert response.body["providers"] == [
+        {"provider": "datago", "requires_credential": True, "configured": False}
+    ]
+
+
+def test_provider_catalog_does_not_hide_unexpected_missing_module() -> None:
+    class BrokenRegistry(_LazyRegistry):
+        def get(self, name: str) -> _Provider:
+            if name == "krx":
+                raise ModuleNotFoundError("No module named 'internal_krx'", name="internal_krx")
+            return _Provider(name)
+
+    class BrokenClient(_OptionalProviderClient):
+        _registry = BrokenRegistry()
+
+    with pytest.raises(ModuleNotFoundError, match="internal_krx"):
+        provider_descriptors(cast(object, BrokenClient()))
 
 
 @pytest.fixture()

--- a/tests/unit/test_publishers.py
+++ b/tests/unit/test_publishers.py
@@ -247,9 +247,12 @@ class TestHuggingFacePublisher:
         # basename으로 폴백해야 한다 (#205).
         calls = _install_fake_hf(monkeypatch)
 
-        result = HuggingFacePublisher().publish(
-            (Path("/tmp/a/f1.parquet"), Path("/var/b/f2.parquet")), destination="org/ds"
-        )
+        if sys.platform == "win32":
+            paths = (Path("C:/tmp/a/f1.parquet"), Path("C:/var/b/f2.parquet"))
+        else:
+            paths = (Path("/tmp/a/f1.parquet"), Path("/var/b/f2.parquet"))
+
+        result = HuggingFacePublisher().publish(paths, destination="org/ds")
 
         repo_paths = {c["path_in_repo"] for c in calls["files"]}
         assert repo_paths == {"f1.parquet", "f2.parquet"}

--- a/tests/unit/test_service_jobs.py
+++ b/tests/unit/test_service_jobs.py
@@ -86,6 +86,7 @@ class _ObservedBuildService(BuilderService):
         created_by: str | None = None,
         owner_id: str | None = None,
         manifest_owner_id: str | None = None,
+        credential_owner_id: str | None = None,
         principal: Principal | None = None,
         cancellation: CancellationProbe | None = None,
     ) -> ServiceResponse:
@@ -96,6 +97,7 @@ class _ObservedBuildService(BuilderService):
                 created_by=created_by,
                 owner_id=owner_id,
                 manifest_owner_id=manifest_owner_id,
+                credential_owner_id=credential_owner_id,
                 principal=principal,
                 cancellation=cancellation,
             )


### PR DESCRIPTION
## 개요

PR #569 위에서 발견된 Builder 잔여 버그를 수정합니다.

## 주요 변경

### Windows portability
- checkpoint 저장 시 기존 파일이 있어도 Windows에서 안전하게 덮어쓰도록 `Path.replace()` 사용
- OpenAPI example extractor stdout을 UTF-8로 고정해 cp949 환경의 `UnicodeEncodeError` 방지
- Hugging Face publisher 경로 테스트를 Windows/POSIX 모두에서 동일 의미로 동작하도록 fixture 보정

### Async Provider credential
- async `POST /builds`에서도 submitting principal의 stable `owner_id`를 이용해 사용자별 Provider credential을 resolve
- credential resolution 순서는 기존 ADR 0012 유지
  - user credential
  - server default
  - not configured
- raw credential은 job snapshot / response / manifest / event에 저장하지 않음
- async file source의 기존 ADR 0014 제한은 그대로 유지

## 검증

- Full pytest: `1620 passed, 9 skipped`
- Ruff: pass
- `mypy src`: pass
- `git diff --check`: pass

## 범위

- Builder API/OpenAPI 변경 없음
- Auth/OIDC 구조 변경 없음
- async file source 지원 추가 없음
- Studio 변경 없음

## 선행 PR

Depends on #569.