### PR TITLE
docs: ADR 0016 — 풀스택 OCI 배포 토폴로지 및 배포 산출물

### DIFF
--- a/.env.app.example
+++ b/.env.app.example
@@ -1,0 +1,38 @@
+# .env.app.example — app-01 프로덕션 환경변수 템플릿 (ADR 0016).
+#
+# 사용법:
+#   cp .env.app.example .env
+#   # 아래 placeholder를 실제 값으로 교체
+#   chmod 600 .env
+#
+# 주의:
+#   - 이 파일(.env)은 절대 git에 커밋하지 않는다. committed compose는 ${VAR}
+#     참조만 사용한다. 실제 secret은 VM-local .env(chmod 600)에만 둔다.
+#   - 실제 API 키/마스터 키 원문을 문서/로그/예제에 넣지 않는다 (ADR 0006/0012).
+
+# --- 이미지 (deploy 워크플로가 배포 시 sha 태그로 덮어쓴다) -----------------
+BUILDER_IMAGE=ghcr.io/yeongseon/kpubdata-builder:latest
+
+# --- 인증 (fail-closed, ADR 0006) — 필수 -----------------------------------
+# 미설정 시 컨테이너가 기동을 거부한다. 강한 랜덤 값 사용:
+#   python -c "import secrets; print(secrets.token_urlsafe(32))"
+KPUBDATA_BUILDER_API_KEY=replace-with-strong-random-api-key
+
+# --- CORS (default-deny, ADR 0006) -----------------------------------------
+# Studio(Cloudflare Pages) 오리진만 콤마로 나열. 미설정 시 모든 cross-origin 거부.
+KPUBDATA_BUILDER_ALLOWED_ORIGINS=https://kpubdata-studio.pages.dev
+
+# --- Provider credential master key (ADR 0012) -----------------------------
+# 재기동 사이에 반드시 동일 값 재주입 (교체 시 기존 credential 복호화 불가).
+# URL-safe base64 32 bytes:
+#   python -c "import os,base64;print(base64.urlsafe_b64encode(os.urandom(32)).decode())"
+KPUBDATA_BUILDER_CREDENTIAL_MASTER_KEY=replace-with-urlsafe-base64-32-bytes
+
+# --- Caddy 공개 진입 (--profile caddy 사용 시) ------------------------------
+# 공개 도메인. Cloudflare proxied DNS가 이 호스트의 80/443으로 향한다.
+APP_DOMAIN=builder.example.com
+
+# --- 바인드 (선택) ---------------------------------------------------------
+# Caddy 프로파일 사용 시 Builder 포트를 루프백으로 제한하려면 "127.0.0.1:8000".
+# IP-only 배포(Caddy 미사용)에서는 헬스체크를 위해 "8000"(모든 인터페이스) 유지.
+# BUILDER_BIND=127.0.0.1:8000

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,170 @@
+# Deploy to OCI (single VM: app-01)
+#
+# ADR 0016(풀스택 배포 토폴로지)의 배포 자동화. our-tax의 split-topology
+# deploy.yml(ADR-0005)에서 db-01 배포 job, Alembic migration one-shot, ETL job,
+# CUBRID 관련 secret을 모두 제거한 단순화 버전이다. Builder는 외부 RDBMS 없이
+# /data 볼륨만으로 상태를 영속화하므로 DB 배포/마이그레이션 단계가 없다.
+#
+#   1. Builder 이미지를 GHCR에 빌드/푸시 (linux/amd64, sha 태그).
+#   2. SSH app-01: git pull, .env 렌더, GHCR 로그인, 이미지 pull, 컨테이너 rollout.
+#   3. http://APP_HOST:8000/healthz(무인증)로 헬스 체크.
+#
+# 필요한 secret (Settings → Secrets and variables → Actions):
+#
+#   OCI_SSH_PRIVATE_KEY   PEM 개인키(passphrase 없음). 공개키는 app-01에 등록.
+#   OCI_SSH_USER          SSH 사용자 (보통 `ubuntu` 또는 `opc`).
+#   OCI_APP_HOST          app-01 SSH 접근 주소 (public IP 또는 DNS).
+#   KPUBDATA_BUILDER_API_KEY          fail-closed 인증 키 (ADR 0006). 필수.
+#   KPUBDATA_BUILDER_ALLOWED_ORIGINS  Studio 오리진 콤마 목록 (CORS default-deny).
+#   KPUBDATA_BUILDER_CREDENTIAL_MASTER_KEY  Provider credential master key (ADR 0012).
+#                                           재기동 사이 동일 값 유지 필수.
+#   APP_DOMAIN            (선택) Caddy 공개 도메인. 미설정 시 IP-only 배포.
+#
+# Triggers:
+#   - push to main: 배포 관련 파일 변경 시 자동 배포.
+#   - workflow_dispatch: 수동 트리거.
+
+name: Deploy to OCI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'Dockerfile'
+      - 'docker-entrypoint.sh'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'docker-compose.prod.app.yml'
+      - 'ops/**'
+      - '.github/workflows/deploy.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  BUILDER_IMAGE: ghcr.io/${{ github.repository_owner }}/kpubdata-builder
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Builder 이미지 빌드 & GHCR 푸시.
+  # ---------------------------------------------------------------------------
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      sha: ${{ steps.meta.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: meta
+        run: |
+          sha="${GITHUB_SHA::12}"
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+          echo "[build] resolved image tag: ${sha}"
+          echo "[build] builder image: ${BUILDER_IMAGE}:${sha}"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push builder
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.BUILDER_IMAGE }}:latest
+            ${{ env.BUILDER_IMAGE }}:${{ steps.meta.outputs.sha }}
+          cache-from: type=gha,scope=builder
+          cache-to: type=gha,scope=builder,mode=max
+
+      - name: Summary
+        run: echo "::notice title=Build complete::builder image pushed at sha=${{ steps.meta.outputs.sha }}"
+
+  # ---------------------------------------------------------------------------
+  # app-01: 새 이미지 pull, 컨테이너 rollout.
+  # ---------------------------------------------------------------------------
+  deploy-app:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "${{ secrets.OCI_SSH_PRIVATE_KEY }}" > ~/.ssh/id_oci
+          chmod 600 ~/.ssh/id_oci
+          ssh-keyscan -H ${{ secrets.OCI_APP_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Deploy app-01 stack
+        env:
+          BUILDER_TAG: ${{ needs.build.outputs.sha }}
+          KPUBDATA_BUILDER_API_KEY: ${{ secrets.KPUBDATA_BUILDER_API_KEY }}
+          KPUBDATA_BUILDER_ALLOWED_ORIGINS: ${{ secrets.KPUBDATA_BUILDER_ALLOWED_ORIGINS }}
+          KPUBDATA_BUILDER_CREDENTIAL_MASTER_KEY: ${{ secrets.KPUBDATA_BUILDER_CREDENTIAL_MASTER_KEY }}
+          APP_DOMAIN: ${{ secrets.APP_DOMAIN }}
+        run: |
+          echo "[deploy-app] === START $(date -u +%FT%TZ) host=${{ secrets.OCI_APP_HOST }} sha=${BUILDER_TAG} ==="
+          ssh -i ~/.ssh/id_oci ${{ secrets.OCI_SSH_USER }}@${{ secrets.OCI_APP_HOST }} \
+            "BUILDER_TAG='${BUILDER_TAG}' \
+             KPUBDATA_BUILDER_API_KEY='${KPUBDATA_BUILDER_API_KEY}' \
+             KPUBDATA_BUILDER_ALLOWED_ORIGINS='${KPUBDATA_BUILDER_ALLOWED_ORIGINS}' \
+             KPUBDATA_BUILDER_CREDENTIAL_MASTER_KEY='${KPUBDATA_BUILDER_CREDENTIAL_MASTER_KEY}' \
+             APP_DOMAIN='${APP_DOMAIN}' \
+             GHCR_USER='${{ github.actor }}' GHCR_TOKEN='${{ secrets.GITHUB_TOKEN }}' \
+             GH_REPO='${{ github.repository }}' GH_TOKEN='${{ secrets.GITHUB_TOKEN }}' \
+             REPO_OWNER='${{ github.repository_owner }}' \
+             bash -s" <<'ENDSSH'
+          set -euo pipefail
+          echo "[app-01] connected at $(date -u +%FT%TZ); host=$(hostname); deploying sha=${BUILDER_TAG}"
+          cd ~/kpubdata-builder
+          git fetch "https://x-access-token:${GH_TOKEN}@github.com/${GH_REPO}.git" main
+          git reset --hard FETCH_HEAD
+
+          # VM-local .env 렌더 (chmod 600). committed compose는 ${VAR} 참조만 사용.
+          umask 077
+          cat > .env <<EOF
+          BUILDER_IMAGE=ghcr.io/${REPO_OWNER}/kpubdata-builder:${BUILDER_TAG}
+          KPUBDATA_BUILDER_API_KEY=${KPUBDATA_BUILDER_API_KEY}
+          KPUBDATA_BUILDER_ALLOWED_ORIGINS=${KPUBDATA_BUILDER_ALLOWED_ORIGINS}
+          KPUBDATA_BUILDER_CREDENTIAL_MASTER_KEY=${KPUBDATA_BUILDER_CREDENTIAL_MASTER_KEY}
+          APP_DOMAIN=${APP_DOMAIN}
+          EOF
+
+          echo "[app-01] logging in to GHCR as ${GHCR_USER}"
+          echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USER}" --password-stdin
+          echo "[app-01] pulling builder image (BUILDER_TAG=${BUILDER_TAG})"
+          docker compose -f docker-compose.prod.app.yml pull builder </dev/null
+
+          echo "[app-01] starting builder container"
+          docker compose -f docker-compose.prod.app.yml up -d builder </dev/null
+          docker compose -f docker-compose.prod.app.yml ps builder </dev/null || true
+          echo "[app-01] === END $(date -u +%FT%TZ) ==="
+          ENDSSH
+
+      - name: Health check
+        run: |
+          url="http://${{ secrets.OCI_APP_HOST }}:8000/healthz"
+          echo "[health] probing ${url} (max 30 attempts × 5s = 150s)"
+          for i in $(seq 1 30); do
+            body=$(curl -fsS --max-time 5 "${url}" 2>&1) && {
+              echo "[health] builder /healthz: OK (attempt ${i}) body=${body}"
+              echo "::notice title=Deploy complete::builder healthy at sha=${{ needs.build.outputs.sha }}"
+              exit 0
+            }
+            echo "[health] attempt ${i}/30 failed; retrying in 5s"
+            sleep 5
+          done
+          echo "::error title=Deploy failed::builder did not become healthy after 30 attempts" >&2
+          exit 1

--- a/docker-compose.prod.app.yml
+++ b/docker-compose.prod.app.yml
@@ -1,0 +1,103 @@
+# docker-compose.prod.app.yml — OCI 단일 VM(app-01) 프로덕션 스택.
+#
+# ADR 0016(풀스택 배포 토폴로지)에 따라 Builder는 단일 app VM에서 Docker로
+# 운영한다. our-tax의 split-topology(ADR-0005)와 달리 별도 DB VM(db-01)이나
+# Alembic migration one-shot, ETL 프로파일이 없다 — Builder는 외부 RDBMS 없이
+# /data 볼륨(매니페스트 + 파생 SQLite 인덱스, ADR 0003/0010)만으로 상태를
+# 영속화하기 때문이다.
+#
+# app-01에서의 사용:
+#   cp .env.app.example .env
+#   # .env 편집 (KPUBDATA_BUILDER_API_KEY, ALLOWED_ORIGINS, CREDENTIAL_MASTER_KEY, ...)
+#   docker compose -f docker-compose.prod.app.yml up -d
+#
+#   # Caddy(공개 TLS 진입)를 함께 띄우려면:
+#   docker compose -f docker-compose.prod.app.yml --profile caddy up -d
+#
+# 이미지는 프로덕션에서 GHCR(deploy 워크플로가 BUILDER_IMAGE로 주입)에서 pull한다.
+# 로컬 검증 시에는 build 컨텍스트(.)로 fallback한다.
+
+services:
+  builder:
+    image: ${BUILDER_IMAGE:-ghcr.io/yeongseon/kpubdata-builder:latest}
+    build:
+      context: .
+    container_name: kpubdata-builder
+    restart: unless-stopped
+    environment:
+      # fail-closed (ADR 0006): API 키 없이는 컨테이너가 기동을 거부한다.
+      KPUBDATA_BUILDER_API_KEY: ${KPUBDATA_BUILDER_API_KEY:?KPUBDATA_BUILDER_API_KEY is required (fail-closed, ADR 0006)}
+      KPUBDATA_BUILDER_HOST: 0.0.0.0
+      KPUBDATA_BUILDER_PORT: "8000"
+      # 빌드 산출물/매니페스트/파생 SQLite 인덱스의 영속 루트. builder-data 볼륨에 매핑.
+      KPUBDATA_BUILDER_OUTPUT_DIR: /data
+      # CORS default-deny (ADR 0006): Studio(Cloudflare Pages) 오리진만 명시.
+      KPUBDATA_BUILDER_ALLOWED_ORIGINS: ${KPUBDATA_BUILDER_ALLOWED_ORIGINS:-}
+      # 사용자별 Provider credential AES-GCM master key (ADR 0012). 재기동 사이에
+      # 반드시 동일 값을 재주입한다 — 교체 시 기존 credential 복호화 불가.
+      KPUBDATA_BUILDER_CREDENTIAL_MASTER_KEY: ${KPUBDATA_BUILDER_CREDENTIAL_MASTER_KEY:-}
+    ports:
+      # Caddy 프로파일 사용 시에는 127.0.0.1로 제한하는 것을 권장하나, IP-only
+      # 배포(Caddy 미사용)에서는 모든 인터페이스에 노출해 헬스체크를 가능케 한다.
+      - "${BUILDER_BIND:-8000}:8000"
+    networks:
+      - app-net
+    volumes:
+      # /data는 반드시 로컬 블록 볼륨이어야 한다. SQLite를 네트워크 FS(NFS/Azure
+      # Files)에 올리면 파일 잠금이 불안정하다 (ADR 0010 §5, deploy.md §6).
+      - builder-data:/data
+    healthcheck:
+      # 무인증 /healthz (#372). python-slim에는 curl/wget이 없으므로 이미지에
+      # 포함된 python urllib로 프로브한다 (Dockerfile HEALTHCHECK와 동일 방식).
+      test:
+        - CMD
+        - python
+        - -c
+        - "import urllib.request; urllib.request.urlopen('http://localhost:8000/healthz', timeout=3)"
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+
+  # 공개 진입 리버스 프록시. Cloudflare → Caddy → builder.
+  # Cloudflare SSL mode: Full(strict). `--profile caddy`로 opt-in.
+  caddy:
+    image: caddy:2.8-alpine
+    container_name: kpubdata-builder-caddy
+    restart: unless-stopped
+    profiles:
+      - caddy
+    depends_on:
+      builder:
+        condition: service_healthy
+    environment:
+      APP_DOMAIN: ${APP_DOMAIN:-localhost}
+      BACKEND_UPSTREAM: builder:8000
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./ops/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    networks:
+      - app-net
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+volumes:
+  builder-data:
+  caddy-data:
+  caddy-config:
+
+networks:
+  app-net:
+    name: kpubdata-builder-app-net

--- a/docs/adrs/0016-fullstack-oci-deployment.md
+++ b/docs/adrs/0016-fullstack-oci-deployment.md
@@ -1,0 +1,106 @@
+# ADR 0016 — 풀스택 배포 토폴로지: OCI 단일 VM(Builder) + Cloudflare Pages(Studio)
+
+- 상태: 제안됨(Proposed)
+- 관련 이슈: —
+- 관련 문서: [ADR 0006 — 서비스 인증 & 배포(Docker)](./0006-service-auth-and-deployment.md), [ADR 0010 — ArtifactStore 상태 백엔드](./0010-artifactstore-state-backend.md), [배포 가이드](../deploy.md), [BOUNDARY.md](../BOUNDARY.md)
+- 참고: `our-tax` [ADR-0005 OCI Split-Topology](https://github.com/kpubdata-lab/our-tax/blob/main/docs/adr/0005-oci-split-topology.md)
+
+## 결정 (제안됨)
+
+KPubData 풀스택(Builder 백엔드 + Studio 프론트엔드)을 프로덕션에 배포하기 위한 토폴로지를 다음과 같이 정한다.
+
+1. **Studio(프론트엔드)** → **Cloudflare Pages** 정적 배포. `our-tax` 프론트엔드와 동일한 패턴. 브라우저에서 `VITE_BUILDER_API_URL`로 OCI의 Builder 백엔드를 직접 호출한다.
+2. **Builder(백엔드)** → **OCI 단일 VM(`app-01`)** 위 Docker 컨테이너. GHCR 이미지 + Caddy 리버스 프록시 + 영속 `/data` 볼륨.
+3. **별도 DB 서버(db-01)는 두지 않는다.** `our-tax`가 CUBRID 전용 `db-01`을 분리한 것과 달리, Builder는 **외부 데이터베이스 서버가 필요 없다**(아래 "배경" 참조). 상태는 `/data` 볼륨 내부의 파일(매니페스트 + 파생 SQLite 인덱스)로 충분하다.
+4. **CI/CD**는 GitHub Actions → GHCR 이미지 빌드 → SSH 배포(pull → rollout → health check). `our-tax` `deploy.yml`에서 **db-01 배포 job과 Alembic migration job, CUBRID 관련 secret을 제거**한 단순화된 형태를 사용한다.
+
+> 근거: Builder는 상태를 외부 RDBMS가 아니라 **파일시스템(매니페스트가 source of truth, SQLite는 파생 캐시, 빌드 job 레지스트리는 in-memory)**로 관리한다(ADR 0003, 0010). 따라서 `our-tax`의 2-VM split-topology를 그대로 복제하면 필요 없는 DB VM과 migration 파이프라인을 짊어지게 된다. 최소 운영 부담 원칙에 따라 **단일 app VM + 영속 볼륨**으로 축소한다.
+
+## 배경
+
+`our-tax`는 OCI Always Free 환경에서 CUBRID(`db-01`)와 FastAPI+ETL(`app-01`)을 두 VM으로 분리했다(ADR-0005). 1 GB VM에 CUBRID와 백엔드를 함께 올리면 OOM이 확정적이었기 때문이다. 이 프로젝트는 `our-tax`의 배포 방식을 참조하되, **Builder의 상태 저장 방식이 근본적으로 다르다**는 점을 반영해야 한다.
+
+Builder의 영속성 모델(코드 확인 결과):
+
+- **외부 DB 의존성 없음**: `pyproject.toml`에 SQLAlchemy/psycopg/CUBRID 드라이버/Alembic 등 RDBMS 의존성이 없다.
+- **매니페스트가 source of truth**: 모든 빌드는 `manifest.json`을 생성하며, 이것이 결과물의 감사 기록이다.
+- **SQLite는 파생 인덱스**: `store/`의 BuildIndex는 매니페스트를 스캔해 만든 **재생성 가능한 파생 캐시**다(ADR 0003, `rebuild_index()`). SQLite 파일은 `/data` 하위에 위치한다.
+- **빌드 job 레지스트리는 in-memory**: 비동기 build job 상태는 프로세스 메모리에 있고(ADR 0008), 재기동 시 유실되지만 디스크의 아티팩트/매니페스트는 보존된다.
+- **컨테이너는 `/data` 볼륨을 마운트**: `Dockerfile`의 `VOLUME /data`, `KPUBDATA_BUILDER_OUTPUT_DIR` 기본값 `/data`.
+
+즉 Builder에 필요한 것은 **DB 서버가 아니라 영속 파일 볼륨 하나**다.
+
+## 문제
+
+- `our-tax`의 split-topology를 그대로 따르면 불필요한 `db-01` VM, CUBRID 튜닝, 4중 방어 규칙, Alembic migration one-shot job을 유지해야 한다.
+- Studio는 브라우저 SPA이므로 백엔드와 배포 수명주기를 분리해야 한다(정적 호스팅 vs 컨테이너).
+- Builder는 fail-closed 보안 기본값을 요구한다(ADR 0006): `KPUBDATA_BUILDER_API_KEY` 필수, CORS default-deny, credential master key 안정성. 배포 토폴로지가 이 요구를 깨지 않아야 한다.
+
+## 결정 필요 사항
+
+1. Builder 백엔드 호스팅 형태(단일 VM vs 2-VM vs 관리형).
+2. Studio 프론트엔드 호스팅 형태(정적 호스팅 vs 동일 VM 서빙).
+3. 상태 영속화 방법(외부 DB vs 파일 볼륨).
+4. CI/CD 배포 순서와 secret 표면.
+
+## 검토한 대안
+
+### 백엔드 호스팅
+
+- **A. OCI 단일 VM `app-01` + `/data` 볼륨 (채택)**: Builder 컨테이너 + Caddy만 실행. DB VM 불필요. 최소 운영 부담.
+- **B. `our-tax` 방식 2-VM 유지**: DB VM을 백업/스토리지 용도로 유지. Builder가 외부 DB를 쓰지 않으므로 명분이 약하고 운영 부담만 증가. **기각**.
+- **C. `our-tax` 기존 `app-01` VM에 합승**: 신규 VM 없이 기존 VM에 Builder 컨테이너 추가. 1 GB RAM 제약과 서비스 격리 문제로 위험. 향후 고려로 유보.
+
+### 프론트엔드 호스팅
+
+- **A. Cloudflare Pages (채택)**: `our-tax` 프론트엔드와 동일. TLS/CDN/WAF를 솔로 운영 부담 없이 확보. `VITE_BUILDER_API_URL`로 백엔드 지정.
+- **B. 동일 VM에서 Caddy로 정적 파일 서빙**: 인프라 하나로 통합되지만 CDN/캐싱 이점 상실, VM 부하 증가. **기각**.
+
+### 상태 영속화
+
+- **A. `/data` 파일 볼륨 (채택)**: 매니페스트 + 파생 SQLite. Builder 설계와 정합.
+- **B. 외부 RDBMS(CUBRID/Postgres) 도입**: Builder에 없는 의존성을 새로 만드는 것으로, "kpubdata 로직 중복 금지 / 결정적 동작 우선" 원칙과 상충. **기각**.
+
+> **주의**: `/data`는 **로컬 블록 볼륨**이어야 한다. SQLite 파일을 네트워크 파일시스템(예: Azure Files/NFS)에 두면 파일 락 불안정이 발생한다(ADR 0010 §5, 배포 가이드 §6).
+
+## 핵심 설계 원칙
+
+1. **Public 진입은 Caddy만 노출**. Builder는 internal `8000`, Caddy가 `80/443`을 잡고 리버스 프록시. Cloudflare proxied DNS → `app-01` → Caddy → Builder. TLS는 Cloudflare Full(strict) + Caddy origin 종단(Let's Encrypt 자동 갱신).
+2. **fail-closed 유지**(ADR 0006). 컨테이너는 `KPUBDATA_BUILDER_API_KEY` 없이 기동 거부. `KPUBDATA_BUILDER_DEV_MODE`는 프로덕션에서 사용 금지.
+3. **CORS default-deny**. `KPUBDATA_BUILDER_ALLOWED_ORIGINS`에 Studio의 Cloudflare Pages 오리진만 명시.
+4. **credential master key 안정성**. `KPUBDATA_BUILDER_CREDENTIAL_MASTER_KEY`는 배포·재기동 사이에 동일 값을 재주입한다(교체 시 기존 credential 복호화 불가, ADR 0012).
+5. **Secret은 VM-local `.env.app` 파일**. `chmod 600`, git 미커밋. committed compose는 `${VAR}` 참조만.
+6. **배포 자동화는 GitHub Actions → GHCR → SSH**. 배포 순서: 이미지 빌드 → SSH pull → 컨테이너 rollout → `/version`(또는 헬스) 체크. **migration job 없음**(외부 DB 없음).
+
+## 배포 산출물 (후속 구현 대상)
+
+이 ADR이 승인되면 다음 산출물을 별도 PR로 추가한다.
+
+- `docker-compose.prod.app.yml` — Builder + Caddy 스택(`our-tax` app 스택에서 migrate/etl/CUBRID 제거, `/data` 볼륨 유지).
+- `ops/caddy/Caddyfile` — `app-01` 리버스 프록시 설정.
+- `.env.app.example` — `KPUBDATA_BUILDER_API_KEY`, `KPUBDATA_BUILDER_ALLOWED_ORIGINS`, `KPUBDATA_BUILDER_CREDENTIAL_MASTER_KEY` 등 placeholder.
+- `.github/workflows/deploy.yml` — GHCR 빌드 + SSH 배포(`our-tax` `deploy.yml`에서 `deploy-db`/`run-etl`/migration/CUBRID secret 제거).
+- Studio 저장소: Cloudflare Pages 빌드 설정 + `VITE_USE_REAL_BUILDER=true`, `VITE_BUILDER_API_URL` 지정(별도 PR, studio 저장소).
+
+## 영향
+
+### 긍정적
+
+- 관리 대상 인프라가 VM 1대 + Cloudflare Pages로 최소화된다.
+- Builder 설계(파일 기반 상태)와 배포 토폴로지가 정합한다.
+- Studio/Builder 배포 수명주기가 분리되어 프론트엔드 배포가 백엔드에 영향을 주지 않는다.
+- migration 파이프라인·DB 튜닝·DB 방화벽 4중 방어가 불필요해져 운영 표면이 축소된다.
+- `our-tax`의 Caddy + Cloudflare + GHCR + SSH 패턴을 재사용한다.
+
+### 부정적 / 트레이드오프
+
+- 단일 VM은 SPOF다. Builder는 단일 replica(ADR 0008/0010)이므로 재기동 시 in-memory job 상태가 유실된다(디스크 아티팩트는 보존).
+- `/data`는 로컬 볼륨이어야 하므로 VM 재생성 시 볼륨 백업/복구 절차가 별도로 필요하다.
+- Studio(Cloudflare)와 Builder(OCI)가 서로 다른 오리진이므로 CORS/인증 헤더 구성이 정확해야 한다.
+
+## 미해결 질문
+
+1. `app-01` VM을 신규로 만들지, `our-tax` 기존 VM에 합승할지(메모리 여유 확인 필요).
+2. `/data` 볼륨 백업 주기·방식(OCI Block Volume 스냅샷 vs 오브젝트 스토리지 sync).
+3. Studio ↔ Builder 인증 방식: 정적 `X-API-Key`(브라우저 노출 위험) vs OIDC Bearer(ADR 0015)를 프로덕션에서 어떤 것으로 강제할지.
+4. Cloudflare Pages 프로젝트를 studio 저장소 CI에서 배포할지, 수동 연결할지.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -19,6 +19,7 @@ KPubData Builder의 주요 설계 결정을 기록합니다. 각 ADR은 배경·
 | [0013](./0013-api-contract-release-policy.md) | API 계약 버전과 릴리스 경계 정책 | 승인됨 | #521 |
 | [0014](./0014-source-ingestion-file-url-boundary.md) | Public API·File·URL Source 통합 경계 | 승인됨 | #498 |
 | [0015](./0015-email-password-oidc-idp-keycloak.md) | 사용자 인증 IdP: 이메일/비밀번호-capable OIDC(Keycloak) 전환 | 승인됨 | #515 |
+| [0016](./0016-fullstack-oci-deployment.md) | 풀스택 배포 토폴로지: OCI 단일 VM(Builder) + Cloudflare Pages(Studio) | 제안됨 | — |
 
 ## 작성 규칙
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -170,9 +170,44 @@ startup 비용 대신 강한 취소·수명 격리를 선택한다. 비동기 bu
 포함되는 파일이 바뀌어야 재스캔이 의미 있음). 문서·테스트 전용 변경은 스캔을
 트리거하지 않으므로 기능 PR과 독립적인 신호를 유지한다.
 
+## 9. OCI 단일 VM 프로덕션 배포 (ADR 0016)
+
+풀스택(Studio 프론트엔드 + Builder 백엔드)을 OCI에 배포하는 참조 토폴로지는
+[ADR 0016](./adrs/0016-fullstack-oci-deployment.md)에 정의되어 있다. 핵심은 our-tax의
+split-topology(별도 CUBRID DB VM)와 달리 **DB 서버 없이 단일 app VM + `/data` 볼륨**만
+쓴다는 점이다 — Builder는 매니페스트(source of truth) + 파생 SQLite 인덱스를 파일로
+영속화하기 때문이다(§6, ADR 0003/0010).
+
+| 구성 요소 | 호스팅 | 산출물 |
+| :--- | :--- | :--- |
+| Studio(프론트엔드) | Cloudflare Pages 정적 배포 | studio 저장소 (`VITE_BUILDER_API_URL`=app-01) |
+| Builder(백엔드) | OCI `app-01` Docker + Caddy | `docker-compose.prod.app.yml`, `ops/caddy/Caddyfile` |
+| 상태 | `app-01` 로컬 블록 볼륨 `/data` | `builder-data` 볼륨 (네트워크 FS 금지, §6) |
+| CI/CD | GitHub Actions → GHCR → SSH | `.github/workflows/deploy.yml` |
+
+배포 산출물:
+
+- `docker-compose.prod.app.yml` — Builder + (opt-in) Caddy 스택. migration/ETL/DB 없음.
+- `ops/caddy/Caddyfile` — Cloudflare → Caddy → `builder:8000` 리버스 프록시.
+- `.env.app.example` — VM-local `.env` 템플릿(placeholder secret만). `.env`는 커밋 금지.
+- `.github/workflows/deploy.yml` — 이미지 빌드/푸시 후 `app-01`에 SSH 배포 + `/healthz` 체크.
+
+app-01 최초 준비:
+
+```bash
+cp .env.app.example .env   # 값 채우고 chmod 600
+docker compose -f docker-compose.prod.app.yml up -d            # IP-only
+docker compose -f docker-compose.prod.app.yml --profile caddy up -d  # 공개 TLS 진입
+```
+
+> fail-closed(§2, ADR 0006): `KPUBDATA_BUILDER_API_KEY` 없이는 컨테이너가 기동을 거부한다.
+> `KPUBDATA_BUILDER_CREDENTIAL_MASTER_KEY`는 재기동 사이에 동일 값을 유지해야 한다(ADR 0012).
+
+
 ## 관련
 
 - [ADR 0006](./adrs/0006-service-auth-and-deployment.md) — 인증·배포(fail-closed, Docker)
+- [ADR 0016](./adrs/0016-fullstack-oci-deployment.md) — 풀스택 배포 토폴로지(OCI 단일 VM + Cloudflare Pages, 제안됨)
 - ADR 0009(PR #398) — 사용자 인증(Google OIDC, 제안됨)
 - ADR 0010(PR #399) — 상태 백엔드 분리(제안됨)
 - [ADR 0008](./adrs/0008-async-build-job-model.md) — 비동기 build job 모델(제안됨)

--- a/ops/caddy/Caddyfile
+++ b/ops/caddy/Caddyfile
@@ -1,0 +1,33 @@
+# Caddyfile — app-01 공개 진입 리버스 프록시 (ADR 0016).
+#
+# Cloudflare(proxied DNS, SSL Full(strict)) → Caddy(80/443) → builder:8000.
+# APP_DOMAIN / BACKEND_UPSTREAM은 compose에서 환경변수로 주입한다.
+#
+# TLS: Caddy가 Let's Encrypt로 origin 인증서를 자동 발급/갱신한다. Cloudflare를
+# proxied(orange-cloud)로 두면 Full(strict) 모드에서 origin 인증서를 검증한다.
+
+{
+	# 운영 이메일(ACME 계정). 필요 시 compose 환경변수/빌드 시 치환.
+	# email ops@example.com
+	# 로컬/IP-only 검증 시 자동 HTTPS를 끄려면 아래 주석을 해제한다.
+	# auto_https off
+}
+
+# Caddy 자체 헬스 엔드포인트 (compose healthcheck 및 Cloudflare 상태 확인용).
+:80 {
+	@healthz path /healthz
+	respond @healthz "ok" 200
+}
+
+{$APP_DOMAIN} {
+	encode gzip zstd
+
+	# 무인증 liveness 프로브는 그대로 통과 (Builder /healthz, #372).
+	# 그 외 모든 요청은 Builder 백엔드로 프록시. 인증(X-API-Key / Bearer)은
+	# Builder가 직접 검증한다 (ADR 0006/0015) — Caddy는 인증을 대행하지 않는다.
+	reverse_proxy {$BACKEND_UPSTREAM} {
+		health_uri /healthz
+		health_interval 15s
+		health_timeout 5s
+	}
+}


### PR DESCRIPTION
## 요약

`our-tax` 배포 방식을 참고하되 **DB 서버(CUBRID) 없이** KPubData 풀스택을 프로덕션에 배포하기 위한 ADR과 배포 산출물을 추가합니다.

- **ADR 0016 (제안됨)**: Studio → Cloudflare Pages, Builder → OCI 단일 `app-01` VM + `/data` 볼륨. 별도 DB VM/migration 없음.
- **근거**: Builder는 외부 RDBMS 의존성이 없고, 매니페스트(source of truth) + 파생 SQLite 인덱스를 `/data` 파일 볼륨에 영속화합니다(ADR 0003/0010). 따라서 `our-tax`의 2-VM split-topology 대신 단일 app VM으로 축소했습니다.

## 변경 사항

| 파일 | 내용 |
| :--- | :--- |
| `docs/adrs/0016-fullstack-oci-deployment.md` | ADR 본문 (한국어, 상태 `제안됨`) |
| `docs/adrs/README.md` | ADR 인덱스에 0016 추가 |
| `docs/deploy.md` | §9 "OCI 단일 VM 프로덕션 배포" 절 + 관련 링크 |
| `docker-compose.prod.app.yml` | Builder + opt-in Caddy 스택 (migrate/etl/DB 제거, `/data` 볼륨) |
| `ops/caddy/Caddyfile` | Cloudflare → Caddy → `builder:8000` 리버스 프록시 |
| `.env.app.example` | VM-local secret 템플릿 (placeholder만; `.env`는 커밋 금지) |
| `.github/workflows/deploy.yml` | GHCR 빌드 + SSH 배포 + `/healthz` 헬스체크 (`our-tax`에서 db/migration/etl 제거) |

## 설계 원칙 반영

- **fail-closed (ADR 0006)**: `KPUBDATA_BUILDER_API_KEY` 없이 기동 거부
- **CORS default-deny**: `KPUBDATA_BUILDER_ALLOWED_ORIGINS`에 Studio 오리진만
- **credential master key 안정성 (ADR 0012)**: 재기동 사이 동일 값 유지
- **`/data`는 로컬 블록 볼륨** (네트워크 FS 금지, ADR 0010 §5)

## 검증

- `docker compose -f docker-compose.prod.app.yml config` 통과
- `deploy.yml` YAML 파싱 통과

## 미해결 (ADR 내 명시)

VM 신규/합승 여부, `/data` 백업 방식, Studio↔Builder 인증 방식(X-API-Key vs OIDC), Cloudflare Pages 연결 방법 — 리뷰에서 확정.

> 참고: ADR 상태는 `제안됨`입니다. 배포 산출물은 승인 후 실제 인프라에 적용됩니다.